### PR TITLE
config(assets): add classification dictionaries, prompt pipeline, and project config updates

### DIFF
--- a/.claude/commands/scripts/deno.json
+++ b/.claude/commands/scripts/deno.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "lib": ["deno.ns", "es2022", "dom"]
-  }
-}

--- a/.vscode/cspell/dicts/project.dic
+++ b/.vscode/cspell/dicts/project.dic
@@ -1,4 +1,6 @@
 # this files is words list for check spell on cSpell
+dics
+Metas
+shdoc
 shellspec
 shellspecrc
-shdoc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,25 @@
+//
 {
+  //  chatlog dictionary files
+  "files.associations": {
+    "*.dic": "yaml"
+  },
+  // deno settings
   "deno.enable": true,
   "deno.enablePaths": [
     ".claude/commands/scripts"
   ],
-  "deno.config": ".claude/commands/scripts/deno.json"
+  "deno.config": "deno.json",
+  // trusted JSON schema hosts
+  "json.schemaDownload.enable": true,
+  "json.schemaDownload.trustedDomains": {
+    "https://schemastore.azurewebsites.net/": true,
+    "https://raw.githubusercontent.com/microsoft/vscode/": true,
+    "https://raw.githubusercontent.com/devcontainers/spec/": true,
+    "https://www.schemastore.org/": true,
+    "https://json.schemastore.org/": true,
+    "https://json-schema.org/": true,
+    "https://developer.microsoft.com/json-schemas/": true,
+    "https://raw.githubusercontent.com/denoland/": true
+  }
 }

--- a/assets/dics/category.dic
+++ b/assets/dics/category.dic
@@ -1,0 +1,142 @@
+# src: ./assets/dics/category.dic — チャットログ分類用カテゴリ辞書
+# @(#) ログカテゴリ分類用辞書
+#
+# 構造: key / def（AI判断用・キーを端的に定義する短文）/ desc（人間向け説明）/ rules（判断補助）
+#
+# 設計方針:
+#   ログの「領域」を大きく仕切る軸。1ログに1カテゴリのみ割り当てる。
+#   迷ったら broader な方を選ぶ。topics より粒度が大きい。
+
+development:
+  def: Logs centered on writing, modifying, designing, or reviewing software code or logic
+  desc: ソフトウェア開発全般（プログラミング・設計・デバッグ・テスト・リファクタリング・実装議論）
+  rules:
+    when:
+      - コード・ロジックの実装・修正が主目的
+      - バグを調査・修正した（エラー起点でも実装変更が伴う）
+      - テストを設計・実装した
+      - 実装・設計・技術選択に対して最終判断を下した
+    while:
+      - ツール設定を含んでいても、コード実装が主軸であれば development を選ぶ
+    not:
+      - ツールの導入・設定が主目的でコード実装を伴わない（→ tooling）
+      - チーム・CI・共有環境に影響する設定が主目的（→ infrastructure）
+      - 判断材料の収集が目的で最終決定に至っていない（→ knowledge）
+    where:
+      - 「実装した」または「設計判断を確定した」が成立すれば development が最優先
+
+infrastructure:
+  def: Logs centered on execution environment, CI/CD pipeline control, or deployment operations
+  desc: DevOps・CI/CD・クラウド・システム運用・パイプライン構築・セキュリティ設定
+  rules:
+    when:
+      - チーム・CI・共有環境に影響する設定・構成変更が主目的
+      - GitHub Actionsワークフローを構築・設定・デバッグした
+      - クラウドリソース・サーバーの設定・運用を行った
+      - セキュリティポリシー・権限管理を整備した
+      - デプロイ・リリースパイプラインを操作した
+    while:
+      - 変更がチーム全体・CI環境に影響する場合に限る（個人環境は tooling）
+    not:
+      - パイプライン内の処理ロジック実装が主目的（→ development）
+      - 個人またはローカル環境に閉じた設定（→ tooling）
+    where:
+      - 「共有・チーム・CI」が影響範囲かどうかが infrastructure vs tooling の分岐点
+
+tooling:
+  def: Logs centered on introducing, configuring, or learning developer tools as the primary goal
+  desc: 開発ツールの選定・設定・活用（CLI・エディタ・パッケージ管理・開発環境構築）
+  rules:
+    when:
+      - 個人またはローカル環境に閉じたツール導入・設定が主目的
+      - エディタ・シェル・パッケージマネージャの環境整備
+      - ツールの使い方を調査・試した
+    while:
+      - ツールの設定変更が主であり、コード・ロジックの実装を伴わない
+    not:
+      - コード・ロジック実装が主目的（→ development）
+      - チーム・CI・共有環境に影響する設定（→ infrastructure）
+    where:
+      - 「どのツールを使うか・どう設定するか」が主題であれば tooling
+
+ai:
+  def: Logs centered on LLM usage, AI agent design, or prompt engineering as the primary subject
+  desc: AI関連技術全般（LLM・AIエージェント・AIツール開発・AI活用ワークフロー・プロンプト設計）
+  rules:
+    when:
+      - AIそのものの設計・評価・ワークフロー改善が主目的
+      - LLM・AIモデルの性能・挙動・比較の評価が主題
+      - AIエージェント・MCPサーバーの設計・実装
+      - プロンプト設計・改善・分析が主目的
+    while:
+      - AIが「何をしているか」が主題であるとき（AIが道具として使われているだけなら ai にしない）
+    not:
+      - AIを使って他カテゴリの作業を行っているだけ（成果物の内容で分類する）
+      - AIを使ったコード実装（→ development）
+      - AIを使ったドキュメント作成（→ writing）
+    where:
+      - 「AIの設計・評価」が主題か「AIを道具として使った結果」が主題かで分岐する
+
+writing:
+  def: Logs where the primary output is a structured document intended to be read by others
+  desc: 技術文書・記事・仕様書の作成と整理（README・ブログ・ドキュメント設計・校閲）
+  rules:
+    when:
+      - 他者が読むことを前提とした構造化ドキュメントを作成・編集した
+      - README・仕様書・設計文書・技術ブログを書いた
+      - プロンプト文書・スキル定義の文面を作成・整備した
+    while:
+      - 成果物が「他者が読む文章」である場合に限る（自分用メモは除く）
+    not:
+      - 成果物を生成せず理解・調査が目的（→ knowledge）
+      - 自分用の作業メモや会話内の要約（→ knowledge）
+      - コードのコメント追加のみ（→ development）
+    where:
+      - 「公開・共有を前提とした構造化文書」が成果物であることが判断基準
+
+knowledge:
+  def: Logs centered on researching or learning where no structured document artifact is produced
+  desc: 技術知識の整理・習得・調査（設計思想・アーキテクチャ議論・技術比較・チュートリアル）
+  rules:
+    when:
+      - 判断材料の収集・整理が目的で最終的な設計判断に至っていない
+      - 概念・アーキテクチャ・ベストプラクティスを学んだ
+      - 成果物を生成しない質問・回答・比較・調査
+    while:
+      - 実装も明示的な決定も構造化文書も生まれていない状態
+    not:
+      - 実装・修正を行った（→ development）
+      - 実装・選択に対して最終判断を下した（→ development）
+      - 他者が読む構造化ドキュメントを生成した（→ writing）
+    where:
+      - 「調べた・学んだ」が主目的で、それが何かの決定や実装につながっていない場合
+
+creative:
+  def: Logs centered on roleplay, character design, storytelling, or creative ideation
+  desc: 創作・アイデア生成・ロールプレイ（キャラ設計・ネーミング・ストーリー・AIキャラクター運用）
+  rules:
+    when:
+      - AIキャラクターの設定・ロールプレイセッション
+      - ネーミング・ストーリー・シナリオの創作
+      - アイデア出し・ブレインストーミングが主目的
+    while:
+      - 技術的な目的がなく、創作・表現が主軸である
+    not:
+      - 技術的な設計議論（→ development または knowledge）
+    where:
+      - 成果物が「物語・キャラクター・アイデア」であれば creative
+
+casual:
+  def: Logs consisting of everyday conversation, non-technical questions, or general consultation
+  desc: 雑談・思考整理・技術外の相談・日常的な質問（ガジェット・アプリ・アイデア議論）
+  rules:
+    when:
+      - 他カテゴリに明確に該当しない場合のみ（最後の手段）
+      - 技術外の日常的な質問・相談・雑談
+      - ガジェット・アプリ・生活上の疑問
+    while:
+      - 他のいずれのカテゴリにも当てはまらないことを確認した後にのみ選ぶ
+    not:
+      - 技術的な内容を含む（他カテゴリを必ず優先）
+    where:
+      - casual はフォールバック。技術的要素が1つでもあれば他カテゴリを優先する

--- a/assets/dics/namespaces.dic
+++ b/assets/dics/namespaces.dic
@@ -1,0 +1,102 @@
+# src: ./assets/dics/namespaces.dic /sr namespaces.dic — タグネームスペース定義
+# @(#) タグのネームスペース定義辞書
+#
+# 構造: key / def（AI判断用・キーを端的に定義する短文）/ desc（人間向け説明）/ rules（判断補助）
+#
+# 設計方針:
+#   ネームスペースは「何の観点でタグを付けるか」を表す分類軸。
+#   タグは <namespace>:<value> 形式で使用する。
+
+ai:
+  def: Tags for AI models, tools, and agent technologies used in the log
+  desc: AIモデル・AIツール・AIエージェント・プロンプト技術に関するタグ
+  rules:
+    when:
+      - 使用・言及したAIモデルやAI技術を記録する
+    not:
+      - AIを道具として使っただけで内容が別カテゴリの場合は内容側で分類する
+
+lang:
+  def: Tags for programming languages and data formats actually written or edited
+  desc: 使用されたプログラミング言語・スクリプト言語・データ形式
+  rules:
+    when:
+      - そのログでコードを実際に書いた・編集した言語に限定する
+    not:
+      - 単に話題に出ただけでは付けない
+
+tool:
+  def: Tags for development tools and CLI commands directly operated in the log
+  desc: 使用された開発ツール・CLIツール・ライブラリ・フレームワーク
+  rules:
+    when:
+      - そのログでツールを直接操作・設定した場合に付ける
+    not:
+      - ツール名が話題に出ただけでは付けない
+
+os:
+  def: Tags for the operating system or runtime environment actually used
+  desc: 対象OS・実行環境・ディストリビューション
+  rules:
+    when:
+      - そのログで実際に動かした・設定した環境に付ける
+    not:
+      - 理論上対応しているOSには付けない
+
+infra:
+  def: Tags for infrastructure operations such as CI/CD, cloud, and security
+  desc: CI/CD・クラウド・DevOps・システム運用基盤
+  rules:
+    when:
+      - システム運用基盤として何をしたかを記録する
+
+dev:
+  def: Tags for development practices such as testing, debugging, and design decisions
+  desc: 開発手法・品質管理・実装パターン（テスト・デバッグ・設計等）
+  rules:
+    when:
+      - 開発作業として何をしたかを記録する
+    not:
+      - tool/lang と重複しない（tool=何を使ったか、dev=何をしたか）
+
+workflow:
+  def: Tags for development process context such as PR, review, and branching
+  desc: 開発プロセス・作業フロー・ブランチ戦略・レビュープロセス
+  rules:
+    when:
+      - どの開発プロセスの文脈で動いていたかを記録する
+
+doc:
+  def: Tags for the type of document produced or edited in the log
+  desc: ドキュメント種別・技術文書・記事・仕様書
+  rules:
+    when:
+      - 何を書いたか・何の文書を扱ったかを記録する
+    not:
+      - 文書を読んで調査しただけでは付けない
+
+meta:
+  def: Tags for project management context such as planning, release, and versioning
+  desc: プロジェクト管理・バージョン管理・リリース・タスク管理
+  rules:
+    when:
+      - プロジェクト管理の文脈で動いていたかを記録する
+
+target:
+  def: Tags for the component or layer that was the subject of the work
+  desc: 作業対象のコンポーネント・レイヤー（CLI・API・レジストリ・バンドラー等）
+  rules:
+    when:
+      - 「何に対して作業したか」を明示したい場合に付ける
+      - 特に設計ログ・複数コンポーネントを扱うログで有効
+    not:
+      - 実装のついでに触った周辺コンポーネントには付けない
+
+concept:
+  def: Tags for architectural or design concepts central to the log
+  desc: 設計思想・アーキテクチャ概念（抽象化・レイヤー分割・責務分離等）
+  rules:
+    when:
+      - 設計思想・アーキテクチャ概念が主題または核心にある場合に付ける
+    not:
+      - 表面的に言及しただけでは付けない（設計判断の根拠になっている場合のみ）

--- a/assets/dics/projects.dic
+++ b/assets/dics/projects.dic
@@ -1,0 +1,171 @@
+# src: ./assets/dics/projects.dic — プロジェクト辞書
+# @(#) プロジェクト分類用辞書
+#
+# 構造: key / def（AI判断用・キーを端的に定義する短文）/ category / desc（人間向け説明）/ rules（判断補助）
+# classify-chatlog スキルが Claude CLI に渡してプロジェクト分類に使用する
+
+# ── ソフトウェア開発プロジェクト ─────────────────────────
+
+aplys:
+  def: A CLI tool project for API specification design and implementation
+  category: development
+  desc: aplys CLIツール。API仕様設計・CLI設計・実装を行う開発プロジェクト
+  rules:
+    when:
+      - aplys コマンド・API仕様・CLI実装に関するログ
+
+deckrd:
+  def: A document-driven development framework for requirements and task management
+  category: development
+  desc: ドキュメント駆動開発フレームワーク。要件定義・仕様設計・タスク管理のワークフロー実装
+  rules:
+    when:
+      - deckrd コマンド・要件定義・仕様設計フローに関するログ
+
+gstack:
+  def: A CLI dispatcher tool supporting multiple subcommands and multilingual output
+  category: development
+  desc: gstack CLIツール。ディスパッチャ化・多言語対応などの機能開発
+  rules:
+    when:
+      - gstack コマンド・ディスパッチャ設計に関するログ
+
+voift:
+  def: A project focused on CLAUDE.md design, requirements review, and spec improvement
+  category: development
+  desc: voift プロジェクト。CLAUDE.md設計・要件レビュー・仕様改善を行う開発プロジェクト
+  rules:
+    when:
+      - voift の設計・仕様・CLAUDE.md に関するログ
+
+ci-platform:
+  def: A CI/CD platform project for GitHub Actions design and security hardening
+  category: infrastructure
+  desc: CI/CDプラットフォーム整備。GitHub Actions設計・セキュリティ修正・ghalint対応
+  rules:
+    when:
+      - GitHub Actionsワークフロー・CI/CD基盤・ghalintに関するログ
+
+project-starter-template:
+  def: A starter template project for bootstrapping new applications with runner API
+  category: development
+  desc: プロジェクトスターターテンプレート。runner API設計・アプリ雛形の整備
+  rules:
+    when:
+      - スターターテンプレート・runner API・雛形設計に関するログ
+
+bdd-coder:
+  def: A BDD coding agent that implements code through Red-Green-Refactor cycles
+  category: development
+  desc: BDDコーダーエージェント。Red-Green-Refactorサイクルによるコード実装支援ツール
+  rules:
+    when:
+      - BDDコーダー・Red-Green-Refactorサイクルに関するログ
+
+reusable-workflows:
+  def: A collection of reusable GitHub Actions workflows for shared CI/CD patterns
+  category: infrastructure
+  desc: 再利用可能なGitHub Actionsワークフロー集。共通CI/CDパターンの整備
+  rules:
+    when:
+      - 再利用可能ワークフロー・共通CIパターンに関するログ
+
+esta:
+  def: The esta project
+  category: development
+  desc: esta プロジェクト
+  rules:
+    when:
+      - esta に関するログ
+
+lcl:
+  def: The lcl project
+  category: development
+  desc: lcl プロジェクト
+  rules:
+    when:
+      - lcl に関するログ
+
+# ── 開発ツール・環境構築 ─────────────────────────────────
+
+dev-tooling:
+  def: Development environment and tool configuration including WSL, Git, and editors
+  category: tooling
+  desc: 開発環境・ツール設定全般。WSL・APT・Git・エディタ設定・パッケージ管理
+  rules:
+    when:
+      - WSL・APT・Git・エディタ・パッケージ管理など開発環境全般のログ
+    not:
+      - 特定プロジェクトのツール設定（そのプロジェクト名で分類）
+
+obsidian:
+  def: Obsidian note-taking tool configuration and plugin management
+  category: tooling
+  desc: Obsidianおよび関連ツールの設定・活用。ノート管理・プラグイン設定
+  rules:
+    when:
+      - Obsidian・関連プラグインの設定・活用に関するログ
+
+# ── AI・プロンプト関連 ───────────────────────────────────
+
+prompt-review:
+  def: AI prompt review and improvement for blog and article generation workflows
+  category: ai
+  desc: AIプロンプトのレビュー・改善・分析。ブログレビュープロンプト・記事作成プロンプトの設計
+  rules:
+    when:
+      - プロンプト設計・改善・レビューが主目的のログ
+
+ai-tools:
+  def: Evaluation and comparison of AI tools including Copilot, ChatGPT, and Claude
+  category: ai
+  desc: AIツールの調査・比較・活用。GitHub Copilot・ChatGPT・Claude等のツール評価
+  rules:
+    when:
+      - AIツールの調査・比較・評価に関するログ
+
+tech-blog-review:
+  def: Technical blog article proofreading and quality improvement using AI prompts
+  category: writing
+  desc: 技術ブログ記事の校閲・レビュー。記事作成プロンプトの実行・記事品質改善
+  rules:
+    when:
+      - 技術ブログ記事の校閲・品質改善に関するログ
+
+sandbox-chatgpt:
+  def: A sandbox for testing ChatGPT prompts and verifying model behaviors
+  category: ai
+  desc: ChatGPT用サンドボックス。プロンプト動作確認・機能検証・実験的セッション
+  rules:
+    when:
+      - ChatGPTのプロンプト動作確認・実験的セッションのログ
+
+sandbox-ailogs:
+  def: A sandbox for developing AI log processing tools including frontmatter generation
+  category: ai
+  desc: AIログ処理ツールのサンドボックス。JSONL変換・フロントマター生成・分類スクリプトの開発
+  rules:
+    when:
+      - AIログ処理・フロントマター生成・分類スクリプト開発のログ
+
+# ── ロールプレイ・創作 ───────────────────────────────────
+
+roleplay:
+  def: Roleplay sessions and character design for AI characters such as Tsumugi
+  category: creative
+  desc: AIキャラクター（つむぎ等）のロールプレイセッション・キャラクター設定・自己紹介作成
+  rules:
+    when:
+      - AIキャラクターのロールプレイ・設定定義に関するログ
+
+# ── 未分類・雑多 ─────────────────────────────────────────
+
+misc:
+  def: Miscellaneous logs that do not belong to any specific project
+  category: casual
+  desc: 特定プロジェクトに属さない雑多なログ。日常的な質問・技術外の相談・一時的な調査
+  rules:
+    when:
+      - 特定プロジェクトに分類できないログ
+    not:
+      - 少しでも特定プロジェクトに関連する（そのプロジェクト名で分類）

--- a/assets/dics/tags.dic
+++ b/assets/dics/tags.dic
@@ -1,0 +1,738 @@
+# src/assets/dics/tags.dic
+# @(#) タグ定義辞書
+#
+# 構造: <namespace>:<value> / namespace / def（AI判断用・キーを端的に定義する短文）/ desc（人間向け説明）/ rules（判断補助）
+# ネームスペース定義は namespaces.dic を参照
+#
+# 設計方針:
+#   タグは「文脈・実際の行動」を記録する再検索用の軸。
+#   「何を使ったか」(tool/lang/os) と「何をしたか」(dev/workflow/infra) と
+#   「どんな成果物か」(doc) と「どのプロジェクト管理文脈か」(meta) を区別する。
+#   迷ったら付けない。常に付くタグは意味を失う。
+
+# ── ai: 使用・言及したAIモデル・技術 ────────────────────
+
+ai:claude:
+  namespace: ai
+  def: Anthropic Claude was used as the primary AI model
+  desc: Anthropic Claude を主として使用しているログ
+  rules:
+    when:
+      - Claude CLIまたはClaude APIを直接使用した
+    not:
+      - AIを話題にしただけ
+
+ai:chatgpt:
+  namespace: ai
+  def: OpenAI ChatGPT was used as the primary AI model
+  desc: OpenAI ChatGPT を主として使用しているログ
+  rules:
+    when:
+      - ChatGPT を直接使用した
+    not:
+      - AIを話題にしただけ
+
+ai:codex:
+  namespace: ai
+  def: OpenAI Codex CLI was used for coding assistance
+  desc: OpenAI Codex CLI を使用しているログ
+  rules:
+    when:
+      - Codex CLIを直接操作した
+
+ai:copilot:
+  namespace: ai
+  def: GitHub Copilot was used or evaluated
+  desc: GitHub Copilot を使用・評価しているログ
+  rules:
+    when:
+      - GitHub Copilotを実際に使用・評価した
+
+ai:mcp:
+  namespace: ai
+  def: MCP server or tools were designed, implemented, or operated
+  desc: MCPサーバー・MCPツールの設計・実装・運用に関するログ
+  rules:
+    when:
+      - MCPサーバーの実装・設定・デバッグを行った
+      - MCPツールの設計・呼び出しが主題
+
+ai:agent:
+  namespace: ai
+  def: An AI agent was designed, implemented, or orchestrated
+  desc: AIエージェントのオーケストレーション・ツール呼び出し設計に関するログ
+  rules:
+    when:
+      - AIエージェントの設計・実装・運用を行った
+    not:
+      - 単にAIに質問した
+
+ai:prompt:
+  namespace: ai
+  def: Prompt design or improvement was the primary purpose
+  desc: プロンプト設計・改善・分析が主目的のログ
+  rules:
+    when:
+      - プロンプトの設計・改善・テストが主目的
+
+ai:character:
+  namespace: ai
+  def: An AI character was defined or a roleplay session was conducted
+  desc: AIキャラクター設定・ロールプレイに関するログ
+  rules:
+    when:
+      - AIキャラクターの設定・ロールプレイが主目的
+
+# ── lang: 実際に使用した言語・形式 ──────────────────────
+
+lang:bash:
+  namespace: lang
+  def: Bash scripts were actually written or debugged
+  desc: Bashスクリプトを実際に書いた・デバッグしたログ
+  rules:
+    when:
+      - Bashスクリプトを実際に書いた・修正した
+    not:
+      - Bashコマンドを実行しただけ（操作の道具）
+
+lang:powershell:
+  namespace: lang
+  def: PowerShell scripts were actually written or debugged
+  desc: PowerShellスクリプトを実際に書いた・デバッグしたログ
+  rules:
+    when:
+      - PowerShellスクリプトを実際に書いた・修正した
+
+lang:javascript:
+  namespace: lang
+  def: JavaScript code was actually written or debugged
+  desc: JavaScriptコードを実際に書いた・デバッグしたログ
+  rules:
+    when:
+      - JavaScriptコードを実際に書いた・修正した
+
+lang:typescript:
+  namespace: lang
+  def: TypeScript code was actually written or debugged
+  desc: TypeScriptコードを実際に書いた・デバッグしたログ
+  rules:
+    when:
+      - TypeScriptコードを実際に書いた・修正した
+    not:
+      - 設定ファイル（tsconfig等）の変更のみ（→ dev:configuration）
+
+lang:python:
+  namespace: lang
+  def: Python code was actually written or debugged
+  desc: Pythonコードを実際に書いた・デバッグしたログ
+  rules:
+    when:
+      - Pythonコードを実際に書いた・修正した
+
+lang:yaml:
+  namespace: lang
+  def: YAML configuration files were designed or edited
+  desc: YAML設定ファイルを実際に編集・設計したログ
+  rules:
+    when:
+      - YAMLファイルを設計・編集した（CI設定・Docker Compose等）
+    not:
+      - フロントマターの編集のみ（→ doc:frontmatter）
+
+lang:markdown:
+  namespace: lang
+  def: Markdown files were created or edited as primary content
+  desc: Markdownファイルを実際に作成・編集したログ
+  rules:
+    when:
+      - Markdownドキュメントを作成・編集した
+    not:
+      - 単にMarkdownで回答した（ツールは手段）
+
+# ── tool: 実際に操作・設定したツール ────────────────────
+
+tool:git:
+  namespace: tool
+  def: Git commands were directly operated for branching, commits, or tags
+  desc: gitコマンドを実際に操作したログ（ブランチ・コミット・タグ等）
+  rules:
+    when:
+      - git操作（ブランチ・コミット・マージ・タグ）が主目的
+    not:
+      - GitHubのUI操作（→ tool:github）
+
+tool:github:
+  namespace: tool
+  def: GitHub UI, API, or settings were directly operated
+  desc: GitHubのUI・API・設定を直接操作したログ
+  rules:
+    when:
+      - GitHubの設定・Issue・PR・Releasesを直接操作した
+
+tool:github-actions:
+  namespace: tool
+  def: GitHub Actions workflows were created, edited, or debugged
+  desc: GitHub Actionsのワークフローを作成・編集・デバッグしたログ
+  rules:
+    when:
+      - ワークフローYAMLを作成・編集した
+      - CI失敗の調査・修正を行った
+
+tool:github-cli:
+  namespace: tool
+  def: The gh command was directly used
+  desc: ghコマンドを実際に使用したログ
+  rules:
+    when:
+      - gh コマンドを直接実行した
+
+tool:deno:
+  namespace: tool
+  def: Deno runtime was used to run or develop scripts
+  desc: Denoランタイムでスクリプトを実行・開発したログ
+  rules:
+    when:
+      - Denoでスクリプトを実行・開発した
+
+tool:pnpm:
+  namespace: tool
+  def: pnpm was used to manage or operate packages
+  desc: pnpmでパッケージを管理・操作したログ
+  rules:
+    when:
+      - pnpmコマンドでパッケージを操作した
+
+tool:shellspec:
+  namespace: tool
+  def: ShellSpec was used to write or run shell script tests
+  desc: ShellSpecでシェルスクリプトのテストを書いた・実行したログ
+  rules:
+    when:
+      - ShellSpecのテストを書いた・実行した
+
+tool:shellcheck:
+  namespace: tool
+  def: ShellCheck was used to statically analyze shell scripts
+  desc: ShellCheckでシェルスクリプトを静的解析したログ
+  rules:
+    when:
+      - ShellCheckを実行して警告を解消した
+
+tool:textlint:
+  namespace: tool
+  def: textlint was used to proofread or configure text rules
+  desc: textlintで文章を校正・ルール設定したログ
+  rules:
+    when:
+      - textlintを実行・設定した
+
+tool:ghalint:
+  namespace: tool
+  def: ghalint was used to validate GitHub Actions policies
+  desc: ghalintでGitHub Actionsポリシーを検証したログ
+  rules:
+    when:
+      - ghalintを実行・設定した
+
+tool:aplys:
+  namespace: tool
+  def: aplys (the internal Bash tool system) was developed, operated, or designed
+  desc: 内製ツール aplys を開発・運用・設計したログ
+  rules:
+    when:
+      - aplysの実装・設計・テスト・運用が主題
+
+tool:deckrd:
+  namespace: tool
+  def: deckrd (the internal document-driven framework) was used or developed
+  desc: 内製フレームワーク deckrd を使用・開発したログ
+  rules:
+    when:
+      - deckrdの設計・実装・運用が主題
+
+tool:ci-platform:
+  namespace: tool
+  def: A CI/CD platform (other than GitHub Actions) was configured or operated
+  desc: GitHub Actions以外のCIプラットフォームを設定・運用したログ
+  rules:
+    when:
+      - 特定のCIプラットフォームの設定・操作が主題
+    not:
+      - GitHub Actions（→ tool:github-actions）
+
+# ── os: 対象OS・実行環境 ────────────────────────────────
+
+os:linux:
+  namespace: os
+  def: Work was performed on a Linux environment
+  desc: Linux環境上での作業・設定・動作確認を行ったログ
+  rules:
+    when:
+      - Linux固有の設定・コマンド・パスを扱った
+    not:
+      - WSL環境（→ os:wsl）
+
+os:windows:
+  namespace: os
+  def: Work was performed on a Windows environment
+  desc: Windows環境上での作業・設定・動作確認を行ったログ
+  rules:
+    when:
+      - Windows固有のパス・設定・コマンドを扱った
+
+os:wsl:
+  namespace: os
+  def: WSL environment was configured or its interoperability was addressed
+  desc: WSL環境の構築・設定・トラブルシューティングを行ったログ
+  rules:
+    when:
+      - WSL固有の設定・相互運用・問題を扱った
+
+os:debian:
+  namespace: os
+  def: Debian-specific package management or configuration was performed
+  desc: Debian固有のパッケージ管理・設定を行ったログ
+  rules:
+    when:
+      - apt・Debian固有の設定を扱った
+
+# ── infra: 運用基盤の文脈 ───────────────────────────────
+
+infra:ci_cd:
+  namespace: infra
+  def: A CI/CD pipeline was built, configured, or troubleshot
+  desc: CIパイプラインの構築・設定・運用・トラブルシューティングを行ったログ
+  rules:
+    when:
+      - CIパイプラインの設計・構築・修正が主目的
+
+infra:security:
+  namespace: infra
+  def: Security vulnerabilities, access control, or security policies were handled
+  desc: 脆弱性対応・セキュリティ設定・権限管理・インシデント対応を行ったログ
+  rules:
+    when:
+      - セキュリティ上の問題・設定・対策が主題
+
+infra:runner:
+  namespace: infra
+  def: GitHub Actions runner environment was configured or diagnosed
+  desc: GitHub Actionsランナー環境の設定・動作確認を行ったログ
+  rules:
+    when:
+      - ランナー固有の設定・問題を扱った
+
+# ── dev: 実装行為の文脈 ─────────────────────────────────
+
+dev:testing:
+  namespace: dev
+  def: Tests were designed, implemented, or executed as a primary activity
+  desc: テストを設計・実装・実行した（テスト戦略・フレームワーク活用を含む）
+  rules:
+    when:
+      - テストコードの作成・修正・実行が主目的
+    not:
+      - 動作確認のみ（修正の副産物）
+
+dev:debugging:
+  namespace: dev
+  def: Bug root cause was investigated and identified without applying a fix
+  desc: バグの原因を調査・特定した（エラーログ解析・再現手順確認を含む）。修正作業は含まない。
+  rules:
+    when:
+      - エラーログ解析・原因特定が主目的
+    while:
+      - 修正は行っておらず、調査・特定のみで終わっている状態
+    not:
+      - 原因特定後に修正も行った（修正が主なら不要）
+      - 修正のみで調査プロセスがない
+    where:
+      - 「調査した」が主目的のとき。修正まで行ったなら不要
+
+dev:refactoring:
+  namespace: dev
+  def: Existing code was restructured or renamed without changing behavior
+  desc: 既存コードを動作を保ちながら改善した（構造整理・命名改善等）
+  rules:
+    when:
+      - 動作を変えずに構造・命名・整理を改善した
+    while:
+      - 外部動作・インタフェースを変えずに内部構造を改善している状態
+    where:
+      - 動作が変わる変更は refactoring ではない
+
+dev:configuration:
+  namespace: dev
+  def: Configuration files or environment variables were managed or changed
+  desc: 設定ファイル・環境変数・ツール設定を管理・変更した
+  rules:
+    when:
+      - 設定ファイルの変更が主目的
+    while:
+      - コード・ロジックの変更を伴わず、設定値・設定ファイルの変更が主体
+    not:
+      - スクリプト・コードの修正を伴う（→ lang:* を使う）
+    where:
+      - 「何の値を変えたか」が主題。設計判断を伴う場合は dev:design-decision も追加
+
+dev:encoding:
+  namespace: dev
+  def: Character encoding, Unicode, emoji, or line ending issues were handled
+  desc: 文字コード・エンコーディング・Unicode・絵文字・改行コードなどの問題を扱ったログ
+  rules:
+    when:
+      - 文字化け・エンコーディング問題・Unicode処理を扱った
+    where:
+      - エンコーディングの問題が主題のとき。OS固有の問題なら os:* も追加
+
+dev:design-decision:
+  namespace: dev
+  def: Architecture, specification, or policy was discussed and decided
+  desc: アーキテクチャ・仕様・方針を議論・検討・確定したログ（設計判断の記録として再参照価値が高い）
+  rules:
+    when:
+      - アーキテクチャ・設計・方針の確定が主目的
+      - type が discussion のログには必ず付ける
+    while:
+      - 将来の実装・運用に影響する不可逆な決定が明示されている状態
+    not:
+      - 単なる実装作業（→ 不要）
+      - 設計を検討・レビューしたが確定していない（→ dev:design-review）
+    where:
+      - 「決定した」が成立するとき。「検討した」だけなら dev:design-review
+
+dev:design-review:
+  namespace: dev
+  def: A design or specification was critically reviewed — with feedback or revision
+  desc: 設計・仕様のレビューと改善提案・修正が行われたログ
+  rules:
+    when:
+      - 設計・仕様に対してフィードバック・修正・議論が主目的
+    while:
+      - 設計の批評・改善提案が行われているが、最終確定には至っていない状態
+    not:
+      - 単に設計を確定した（→ dev:design-decision）
+      - コードレビュー（→ workflow:code-review）
+    where:
+      - dev:design-decision との違い：review は「評価・改善」、decision は「確定」
+
+dev:api-design:
+  namespace: dev
+  def: An API interface (REST, CLI flags, function signatures) was designed or revised
+  desc: API・インタフェース設計（エンドポイント・フラグ・関数シグネチャ）を行ったログ
+  rules:
+    when:
+      - APIのエンドポイント・CLIフラグ・関数シグネチャの設計・変更が主題
+    while:
+      - 外部に公開するインタフェースの形を決める作業が主体
+    where:
+      - 内部コンポーネント間の契約は dev:interface-design。外部公開インタフェースが api-design
+
+dev:cli-design:
+  namespace: dev
+  def: A CLI command structure, subcommands, or options were designed or revised
+  desc: CLIコマンド構造・サブコマンド・オプション設計を行ったログ
+  rules:
+    when:
+      - CLIのコマンド構造・サブコマンド・オプションの設計・変更が主題
+    while:
+      - ユーザーが触れるコマンドラインインタフェースの形を決める作業が主体
+    where:
+      - dev:api-design との違い：cli-design はコマンドライン UX、api-design は API 契約
+
+dev:architecture-design:
+  namespace: dev
+  def: System or module architecture was designed or restructured
+  desc: システム・モジュールのアーキテクチャ設計・再構成を行ったログ
+  rules:
+    when:
+      - システム構成・モジュール分割・依存関係の設計が主題
+    while:
+      - 複数コンポーネントの関係・構成を設計している状態
+    where:
+      - 単一コンポーネントの内部設計は dev:interface-design。システム全体の構成が architecture-design
+
+dev:data-model:
+  namespace: dev
+  def: Data schema, data structure, or serialization format was designed or revised
+  desc: データスキーマ・データ構造・シリアライズ形式の設計を行ったログ
+  rules:
+    when:
+      - データ構造・スキーマ・シリアライズ形式の設計・変更が主題
+    while:
+      - 「何のデータをどう持つか」が設計の中心になっている状態
+    where:
+      - データの型・構造・形式が主題のとき。DBスキーマも含む
+
+dev:interface-design:
+  namespace: dev
+  def: Internal interfaces, abstractions, or contracts between components were designed
+  desc: コンポーネント間のインタフェース・抽象化・契約を設計したログ
+  rules:
+    when:
+      - コンポーネント間の境界・抽象化・プロトコルの設計が主題
+    while:
+      - 内部モジュール間の契約・境界を定める作業が主体
+    not:
+      - 公開APIの設計（→ dev:api-design）
+    where:
+      - 「内部コンポーネント間の境界」が主題。外部に見せるAPIは dev:api-design
+
+# ── workflow: 開発プロセスの文脈 ────────────────────────
+
+workflow:pull-request:
+  namespace: workflow
+  def: A pull request was created, reviewed, or merged
+  desc: PRの作成・レビュー・マージのプロセスで動いていたログ
+  rules:
+    when:
+      - PRの作成・レビュー・マージが主題
+
+workflow:idd:
+  namespace: workflow
+  def: Issue-driven development process was followed
+  desc: Issue駆動開発（IDD）のプロセスで動いていたログ
+  rules:
+    when:
+      - IDD（Issue駆動）プロセスで進めていたログ
+
+workflow:code-review:
+  namespace: workflow
+  def: Code or document review feedback was given or addressed
+  desc: コードレビュー・ドキュメントレビューのプロセスで動いていたログ
+  rules:
+    when:
+      - コードレビューのフィードバック・対応が主題
+
+workflow:git-flow:
+  namespace: workflow
+  def: Git branching strategy, commit conventions, or merge flow were the focus
+  desc: Gitブランチ戦略・コミット規約・マージフローの文脈で動いていたログ
+  rules:
+    when:
+      - ブランチ戦略・コミット規約・マージフローが主題
+
+# ── doc: 成果物の種別 ────────────────────────────────────
+
+doc:spec:
+  namespace: doc
+  def: A specification or design document was created or edited
+  desc: 仕様書・設計文書を作成・編集したログ
+  rules:
+    when:
+      - 仕様書・設計文書を作成・編集した
+    not:
+      - 仕様を読んで調査しただけ
+
+doc:architecture:
+  namespace: doc
+  def: An architecture document or component structure definition was created or edited
+  desc: アーキテクチャ設計・構造定義・コンポーネント関係を記述した文書を扱ったログ
+  rules:
+    when:
+      - アーキテクチャ文書・構造定義を作成・編集した
+      - dev:design-decision と併用することが多い
+
+doc:readme:
+  namespace: doc
+  def: A README file was created or substantially updated
+  desc: READMEを作成・更新したログ
+  rules:
+    when:
+      - README.md を作成・大幅更新した
+    not:
+      - README を読んで調査した
+
+doc:blog:
+  namespace: doc
+  def: A technical blog article was written, edited, or prepared for publication
+  desc: 技術ブログ記事を執筆・校閲・公開準備したログ
+  rules:
+    when:
+      - 技術ブログ記事の執筆・校閲が主目的
+
+doc:frontmatter:
+  namespace: doc
+  def: Markdown frontmatter or metadata was designed, added, or corrected
+  desc: Markdownフロントマター・メタデータを設計・整備したログ
+  rules:
+    when:
+      - フロントマターの設計・付加・修正が主目的
+
+doc:refactoring:
+  namespace: doc
+  def: Existing documents were restructured or reorganized without changing content
+  desc: 既存ドキュメントを内容を保ちながら構造を整理・再編したログ
+  rules:
+    when:
+      - ドキュメントの構造整理・セクション再編が主目的
+    not:
+      - 内容の追記・修正を伴う（→ doc:spec や doc:readme 等）
+
+doc:restructure:
+  namespace: doc
+  def: Document structure or directory layout was redesigned
+  desc: ドキュメント構成・ディレクトリ構造を再設計したログ
+  rules:
+    when:
+      - 複数ドキュメントのディレクトリ構成・配置を変更・再設計した
+
+doc:split:
+  namespace: doc
+  def: A document was divided into multiple separate documents
+  desc: 単一ドキュメントを複数に分割したログ
+  rules:
+    when:
+      - 1つの文書を複数ファイルに分割した
+
+# ── meta: プロジェクト管理の文脈 ────────────────────────
+
+meta:planning:
+  namespace: meta
+  def: An implementation plan, task breakdown, or sprint plan was created
+  desc: 実装計画・タスク分解・スプリント計画を立てたログ
+  rules:
+    when:
+      - 実装計画・タスク分解・スプリント計画の立案が主目的
+    not:
+      - 計画を実際に実装した（→ task）
+
+meta:release:
+  namespace: meta
+  def: A release was published, or release notes were created
+  desc: リリース作業・バージョン公開・リリースノート作成を行ったログ
+  rules:
+    when:
+      - リリース作業・バージョン公開・リリースノート作成が主目的
+
+meta:versioning:
+  namespace: meta
+  def: Version numbers or semantic versioning conventions were managed
+  desc: バージョン番号管理・セマンティックバージョニングの文脈で動いていたログ
+  rules:
+    when:
+      - バージョン番号の管理・セマンティックバージョニングが主題
+
+meta:repository:
+  namespace: meta
+  def: Repository structure or project directory layout was organized
+  desc: リポジトリ構成・プロジェクト構造の整備を行ったログ
+  rules:
+    when:
+      - リポジトリ構成・ディレクトリ構造の整備が主目的
+
+# ── target: 設計・実装の対象コンポーネント ──────────────
+# 「何に対して作業したか」を記録する軸
+# 設計ログの検索精度向上が主目的。実装ログにも適用可。
+
+target:cli:
+  namespace: target
+  def: The CLI interface or command layer was the subject of the work
+  desc: CLIインタフェース・コマンド層が作業対象のログ
+  rules:
+    when:
+      - CLIコマンドの設計・実装・修正が対象
+    where:
+      - 「CLIという層を触った」ことを表す。dev:cli-design と組み合わせて使う
+
+target:api:
+  namespace: target
+  def: An API (REST, internal, or library API) was the subject of the work
+  desc: API（REST・内部API・ライブラリAPI）が作業対象のログ
+  rules:
+    when:
+      - APIのエンドポイント・インタフェースの設計・実装が対象
+    where:
+      - 「APIという層を触った」ことを表す。dev:api-design と組み合わせて使う
+
+target:registry:
+  namespace: target
+  def: A registry or package management component was the subject of the work
+  desc: レジストリ・パッケージ管理コンポーネントが作業対象のログ
+  rules:
+    when:
+      - レジストリの設計・実装・運用が対象
+    where:
+      - コンポーネント名が「レジストリ」である場合。パッケージ管理の文脈で使う
+
+target:bundler:
+  namespace: target
+  def: A bundler or build pipeline component was the subject of the work
+  desc: バンドラー・ビルドパイプラインが作業対象のログ
+  rules:
+    when:
+      - バンドラーの設計・実装・デバッグが対象
+    where:
+      - ビルド・バンドル処理を担うコンポーネントが主題のとき
+
+target:provider:
+  namespace: target
+  def: A provider or plugin abstraction layer was the subject of the work
+  desc: プロバイダー・プラグイン抽象化層が作業対象のログ
+  rules:
+    when:
+      - プロバイダー・プラグインの設計・実装が対象
+    where:
+      - 外部実装を差し替え可能にする抽象化層が主題のとき。concept:abstraction と併用する
+
+target:dispatcher:
+  namespace: target
+  def: A dispatcher, router, or event handler was the subject of the work
+  desc: ディスパッチャー・ルーター・イベントハンドラーが作業対象のログ
+  rules:
+    when:
+      - ディスパッチャー・ルーティング・イベント処理の設計・実装が対象
+    where:
+      - 入力を受け取り処理を振り分けるコンポーネントが主題のとき
+
+# ── concept: 設計思想・抽象概念 ─────────────────────────
+# 「どのような設計思想・アーキテクチャ概念を扱ったか」を記録する軸
+# 設計ログの再参照性向上が主目的。
+
+concept:abstraction:
+  namespace: concept
+  def: Abstraction layers or interfaces were designed to hide implementation details
+  desc: 実装詳細を隠蔽する抽象化層・インタフェースの設計を扱ったログ
+  rules:
+    when:
+      - 抽象化・インタフェース分離の設計が主題
+    while:
+      - 具体的な実装を隠すための設計判断が対話の核心にある状態
+    where:
+      - 「具体をどう隠すか」が設計の中心。concept:separation-of-concerns と組み合わせることが多い
+
+concept:layering:
+  namespace: concept
+  def: Architectural layers (e.g., presentation/domain/infra) were designed or restructured
+  desc: アーキテクチャのレイヤー分割・階層構造を設計・再構成したログ
+  rules:
+    when:
+      - レイヤーアーキテクチャの設計・整理が主題
+    while:
+      - 「どの層に何を置くか」が設計の中心になっている状態
+    where:
+      - レイヤー間の依存方向・責務配置が主題のとき。dev:architecture-design と併用する
+
+concept:separation-of-concerns:
+  namespace: concept
+  def: Responsibilities were separated between components or modules
+  desc: コンポーネント・モジュール間の責務分離を設計・議論したログ
+  rules:
+    when:
+      - 責務分離・関心の分離の設計・議論が主題
+    while:
+      - 「どこまでが誰の責任か」を確定・整理する議論が主体
+    where:
+      - concept:abstraction との違い：abstraction は「隠す」、separation-of-concerns は「分ける」
+
+concept:toolchain:
+  namespace: concept
+  def: A toolchain, pipeline, or tool composition strategy was designed
+  desc: ツールチェーン・パイプライン・ツール組み合わせ戦略を設計したログ
+  rules:
+    when:
+      - ツールチェーンの設計・構成・統合戦略が主題
+    while:
+      - 複数ツールをどう組み合わせるかが設計の核心になっている状態
+    where:
+      - 「ツールをどうつなぐか」が主題。個別ツールの設定は tool:* で表す

--- a/assets/dics/topics.dic
+++ b/assets/dics/topics.dic
@@ -1,0 +1,389 @@
+# topics.dic — チャットログ分類用トピック辞書
+# 構造: key / def（AI判断用・キーを端的に定義する短文）/ desc（人間向け説明）/ rules（判断補助）
+#
+# 設計方針:
+#   2層構造: domain（何の話か・必須1つ）+ aspect（どういう観点か・0〜2つ）
+#   domain = category と完全一致（categoryの下位に従属）
+#   aspect = 「それとして扱う」と言える観点・行為
+#   tech系（git/yaml等）はtagsへ完全移行。topicsには含めない。
+#
+# domain の一覧（= category と完全一致）:
+#   development / infrastructure / tooling / ai / writing / knowledge / creative / casual
+#
+# aspect の一覧:
+#   思考・意思系: learning / decision / discussion / analysis
+#   実体・成果系: architecture / behavior / content
+#   補助・品質系: configuration / validation / workflow / security / testing / review
+#   対話系: chat
+#
+# 選定ルール:
+#   RULE 1: domain を必ず1つ選ぶ（= 選んだ category と一致させる）
+#   RULE 2: aspect は観点を補完する場合のみ選ぶ（0〜2個）
+#   RULE 3: tech系キーワード（git/yaml/powershell等）はtags専用、topicsには使わない
+#   RULE 4: 合計最大3つ（domain 1 + aspect 0〜2）
+#   RULE 5: domain は category と一致させる。category: writing → domain: writing
+#   RULE 6: 同系統のaspectは1つまで
+#           - 思考・意思系（learning / decision / discussion / analysis）から最大1つ
+#           - 実体・成果系（architecture / behavior / content）から最大1つ
+#   RULE 7: chat → discussion の昇格条件
+#           技術的判断・検討が対話の主軸として継続した場合のみ discussion に昇格する。
+#           単発の技術コメントや1ターンだけの判断では昇格しない。
+#           chat    = ターンが進んでも話題の次元が変わらない（感情・行動の繰り返し）
+#           discussion = 技術的判断・方針検討が対話を通じて主軸として続いている
+#   RULE 8: 設計対象の種類（API/CLI/データ/セキュリティ等）は必ず tags 側で表現すること。
+#           topics の architecture は「設計行為である」だけを表し、種類は dev:api-design / target:cli 等で補う。
+#   RULE 9: 修正・デバッグ・検証を伴うログでは validation を優先的に付与すること。
+#           Lint通過・修正確認・テスト成功など「正しさの確認」が伴う場合は behavior ではなく validation を選ぶ。
+#           behavior は「どう動くか」の観察・調査であり、「正しいかの確認」は validation。
+#   RULE 10: type と aspect を整合させること。
+#           - type: decision → decision を含む
+#           - type: incident → behavior または validation を含む
+#           - type: execution → behavior を含む
+#
+# 判定チェック:
+#   Q1: domain は category と一致しているか？  → 必ず YES にする
+#   Q2: 同系統のaspectを2つ以上選んでいないか？ → NO であること
+
+# ── domain: ジャンル軸（必須1つ・category と一致）────────────────────────────
+
+development:
+  def: "[domain] The log is about software development — code, design, debugging, or implementation"
+  desc: ソフトウェア開発全般（コード実装・設計・デバッグ・テスト・リファクタリング）
+  rules:
+    when:
+      - コード・ロジックの実装・修正・設計が主題
+      - バグ調査・テスト・リファクタリングが主題
+    while:
+      - ツール設定を含んでいても、コード実装が主軸であれば development を選ぶ
+    not:
+      - ツール導入・環境構築が主題（→ tooling または infrastructure）
+      - AI技術そのものが主題（→ ai）
+    where:
+      - category が development であるときのみ選ぶ（domain は category と一致させる）
+
+infrastructure:
+  def: "[domain] The log is about CI/CD, shared environments, deployment, or team-wide system operations"
+  desc: CI/CD・共有環境・デプロイ・パイプライン構築・セキュリティ設定
+  rules:
+    when:
+      - チーム・CI・共有環境に影響する設定・構成変更が主題
+      - GitHub Actionsワークフロー・デプロイパイプラインが主題
+    while:
+      - 変更がチーム全体・CI環境に影響する場合に限る
+    not:
+      - コード・ロジック実装が主目的（→ development）
+      - 個人またはローカル環境に閉じた設定（→ tooling）
+    where:
+      - category が infrastructure であるときのみ選ぶ
+
+tooling:
+  def: "[domain] The log is about developer tools, local environment setup, or tool configuration"
+  desc: 開発ツールの選定・設定・活用（CLI・エディタ・パッケージ管理・ローカル環境構築）
+  rules:
+    when:
+      - 個人またはローカル環境に閉じたツール導入・設定が主題
+      - エディタ・シェル・パッケージマネージャの環境整備
+    while:
+      - ツールの設定変更が主であり、コード・ロジックの実装を伴わない
+    not:
+      - コード・ロジック実装が主目的（→ development）
+      - チーム・CI・共有環境に影響する設定（→ infrastructure）
+    where:
+      - category が tooling であるときのみ選ぶ
+
+ai:
+  def: "[domain] The log is about AI/LLM technology, agents, prompts, or AI workflows"
+  desc: AI技術全般（LLM・AIエージェント・プロンプト設計・AIワークフロー・MCP）
+  rules:
+    when:
+      - AIそのものの設計・評価・ワークフロー改善が主目的
+      - AIエージェント・MCPサーバーの設計・実装が主題
+      - プロンプト・スキル定義の設計・改善が主題
+    while:
+      - AIが「何をしているか」が主題であるとき（AIを道具として使っているだけなら選ばない）
+    not:
+      - AIを使って別カテゴリの作業をしている（内容のdomainを選ぶ）
+    where:
+      - category が ai であるときのみ選ぶ
+
+writing:
+  def: "[domain] The log is about creating or editing structured documents intended for readers"
+  desc: 他者が読むことを前提とした構造化ドキュメントの作成・整備（README・仕様書・記事・プロンプト文面）
+  rules:
+    when:
+      - 他者が読むことを前提とした構造化ドキュメントを作成・編集した
+      - README・仕様書・技術ブログ・チュートリアルを書いた
+      - プロンプト文書・スキル定義の文面を作成・整備した
+    while:
+      - 成果物が「他者が読む文章」である場合に限る（自分用メモは除く）
+    not:
+      - 成果物を生成せず理解・調査が目的（→ knowledge）
+      - 自分用の作業メモや会話内の要約（→ knowledge）
+    where:
+      - category が writing であるときのみ選ぶ
+
+knowledge:
+  def: "[domain] The log is about researching, learning, or understanding without producing a document or decision"
+  desc: 技術知識の整理・習得・調査（概念理解・技術比較・ベストプラクティス調査）
+  rules:
+    when:
+      - 判断材料の収集・整理が目的で最終的な設計判断に至っていない
+      - 概念・アーキテクチャ・ベストプラクティスを学んだ
+      - 成果物を生成しない質問・回答・比較・調査
+    while:
+      - 実装も明示的な決定も構造化文書も生まれていない状態
+    not:
+      - 実装・修正を行った（→ development）
+      - 実装・選択に対して最終判断を下した（→ development）
+      - 他者が読む構造化ドキュメントを生成した（→ writing）
+    where:
+      - category が knowledge であるときのみ選ぶ
+
+creative:
+  def: "[domain] The log is about roleplay, character design, storytelling, or creative ideation"
+  desc: 創作・アイデア生成・ロールプレイ（キャラクター設定・ネーミング・ストーリー創作）
+  rules:
+    when:
+      - AIキャラクターの設定・ロールプレイセッションが主目的
+      - ネーミング・ストーリー・シナリオの創作が主目的
+    while:
+      - 技術的な目的がなく、創作・表現が主軸である
+    not:
+      - 技術的な設計議論（→ development または knowledge）
+    where:
+      - category が creative であるときのみ選ぶ
+
+casual:
+  def: "[domain] The log does not fit any specific domain — everyday questions or general consultation"
+  desc: 特定ジャンルに属さない雑談・日常相談・技術外の質問
+  rules:
+    when:
+      - 他のdomainに明確に該当しない場合のみ（最後の手段）
+      - 技術外の日常的な質問・生活上の相談
+    while:
+      - 他のいずれのdomainにも当てはまらないことを確認した後にのみ選ぶ
+    not:
+      - 技術的な内容を含む（他domainを必ず優先）
+    where:
+      - category が casual であるときのみ選ぶ。フォールバック専用
+
+# ── aspect: 観点軸（0〜2個）────────────────────────────────
+# 「このログをどういう観点・行為として扱うか」で選ぶ
+# RULE 6: 同系統から最大1つ（思考・意思系 / 実体・成果系）
+
+# ── 思考・意思系（最大1つ）
+
+learning:
+  def: "[aspect] The interaction was about understanding, learning, or investigating — without implementation"
+  desc: 理解・調査・学習・概念把握の観点（実装や決定を伴わない）
+  rules:
+    when:
+      - 技術・仕様・概念の調査・理解が主目的
+      - 実装を伴わない質問・回答・比較
+    while:
+      - 実装も明示的な決定も生まれていない状態
+    not:
+      - 調査後に実装した（→ architecture または behavior を追加）
+      - 調査後に決定した（→ decision を追加）
+    where:
+      - 「何かを知った」だけで終わっている場合。次のアクションにつながっていない
+
+analysis:
+  def: "[aspect] The interaction focused on analyzing structure, breaking down problems, or evaluating design — without final decision"
+  desc: 設計の検証・分解・評価フェーズの観点（最終判断に至らない分析・評価）
+  rules:
+    when:
+      - 既存設計・構造・問題を分解・評価した
+      - 設計案のトレードオフ・影響範囲を分析した（結論なし）
+    while:
+      - 分析・評価が行われているが、最終判断に至っていない状態
+    not:
+      - 分析後に決定した（→ decision）
+      - 単なる調査・学習（→ learning）
+    where:
+      - learning との違い：learning は「理解」、analysis は「評価・分解」。対象が既存の設計や構造
+
+decision:
+  def: "[aspect] The interaction involved making choices, evaluating options, or establishing policies"
+  desc: 意思決定・選択・方針策定の観点（結論に至った）
+  rules:
+    when:
+      - 技術選定・アプローチ選択・方針確定を行った
+      - トレードオフを検討して決定した
+      - type: decision のログには必ず付与する（RULE 10）
+    while:
+      - 将来の実装・運用に影響する不可逆な決定が明示されている状態
+    not:
+      - 結論に至らず議論・探索が主体（→ discussion）
+      - 決定を実装に落とし込んだ（→ architecture）
+    where:
+      - 「決めた」「採用する」「〜方針とする」など明示的な確定表現があること
+
+discussion:
+  def: "[aspect] The interaction involved questions that evolved — with design judgment as the sustained main axis"
+  desc: 技術的判断・方針検討が対話を通じて主軸として続いた観点
+  rules:
+    when:
+      - 技術的判断・方針検討が対話全体を通じて主軸として継続した
+      - 設計選択・技術検討に対して提案・反論・修正が繰り返された
+    while:
+      - 対話が続くにつれて問いの深さ・次元が変化し続けている状態
+    not:
+      - 単発の技術コメントや1ターンだけの判断（→ chat のまま）
+      - 議論の結果として明確な決定を下した（→ decision）
+    where:
+      - decision との違い：decision は「確定した」、discussion は「検討が主軸として続いた」
+
+# ── 実体・成果系（最大1つ）
+
+architecture:
+  def: "[aspect] The interaction focused on how something is designed, structured, or composed — including data schemas"
+  desc: システム設計・構造・インタフェース・データスキーマ設計の観点
+  rules:
+    when:
+      - システム設計・モジュール構造・API設計を設計・変更した
+      - データフォーマット・スキーマ・シリアライズを設計・変更した
+      - コードの構造改善・リファクタリングが主目的
+    while:
+      - 「どう設計するか・どう構成するか」が主軸になっている状態
+    not:
+      - 動作・挙動の確認が主目的（→ behavior）
+      - 設計対象の種類（API/CLI等）はタグで表現する（→ dev:api-design, target:cli 等）
+    where:
+      - RULE 8: 設計対象の種類は tags に書く。architecture は「設計行為である」だけを表す
+
+behavior:
+  def: "[aspect] The interaction focused on how something works, runs, or responds — observation and diagnosis without correctness verification"
+  desc: 動作・挙動・実行結果・エラーの観点（正確性確認ではなく動作観察・診断）
+  rules:
+    when:
+      - コードの実行動作・挙動を観察・診断した
+      - エラー・バグの症状や原因を調査した（修正確認は含まない）
+    while:
+      - type: incident または execution のログで付与する（RULE 10）
+    not:
+      - 構造・設計の変更が主目的（→ architecture）
+      - Lint通過・修正確認・テスト成功など正しさの確認が主（→ validation）
+    where:
+      - 「どう動くか」の観察・診断。「正しいか」の確認は validation に委ねる（RULE 9）
+
+content:
+  def: "[aspect] The interaction focused on the substance of documents, articles, or written artifacts"
+  desc: 文書・記事・仕様書・プロンプト文面など成果物の内容の観点
+  rules:
+    when:
+      - README・仕様書・記事・ブログの内容を作成・改訂した
+      - プロンプト・スキル定義の文面を設計・改善した
+    while:
+      - category が writing のログで主に使う
+    not:
+      - 文書を管理するコードの設計（→ architecture）
+      - 技術調査の結果整理（→ learning）
+    where:
+      - 「何を書いたか」の内容が主題。文書の構成・整理は doc:restructure 等のタグで補う
+
+# ── 補助・品質系（系統制限なし、必要な場合のみ）
+
+configuration:
+  def: "[aspect] The interaction focused on settings, values, or environment files"
+  desc: 設定値・設定ファイルの記述・変更・管理の観点
+  rules:
+    when:
+      - 設定ファイル・設定値の記述・変更が主目的
+      - 依存関係・パッケージバージョンの管理が主題
+    while:
+      - コード・ロジックの実装を伴わず、設定変更が主体である状態
+    not:
+      - 設定の構成方針・設計判断（→ architecture）
+    where:
+      - 「何の値を設定したか」が主題。設計判断を伴う場合は architecture を優先
+
+workflow:
+  def: "[aspect] The interaction involved PR, issue, branch, or development collaboration process"
+  desc: PR・Issue・ブランチ・開発フロープロセスの観点
+  rules:
+    when:
+      - PR作成・レビュー・マージのプロセスが重要な側面
+      - Issueの起票・クローズ・トリアージが主題の一部
+    while:
+      - 開発フロープロセス自体が注目点になっている状態
+    not:
+      - PR内のコード変更（→ architecture/behavior）
+    where:
+      - 「どう進めたか」のプロセスが主題。コード変更の内容は他の aspect で表す
+
+validation:
+  def: "[aspect] The interaction involved verification, linting, schema checking, or correctness confirmation"
+  desc: 検証・Lint・修正確認・テスト成功確認など「正しさを確かめる」観点
+  rules:
+    when:
+      - Lintツール通過・修正確認・テスト成功など正しさの確認が伴う
+      - スキーマ・フォーマット検証が重要な要素
+      - デバッグ・修正後の動作確認が主目的
+    while:
+      - type: incident または execution のログで正確性確認を含む場合（RULE 10）
+    not:
+      - 動作の観察・挙動の診断のみ（→ behavior）
+    where:
+      - RULE 9: 修正・デバッグ・検証を伴うログでは behavior より validation を優先する
+      - 「正しいか」を確認する行為。「どう動くか」を観察するのは behavior
+
+security:
+  def: "[aspect] The interaction involved security vulnerabilities, access controls, or secret management"
+  desc: セキュリティ脆弱性・アクセス制御・シークレット管理の観点
+  rules:
+    when:
+      - セキュリティ脆弱性・権限管理が重要な側面
+      - シークレット・トークン管理が主題の一部
+    while:
+      - セキュリティが主要な関心事として対話に現れている状態
+    not:
+      - セキュリティツールのインストールのみ（→ configuration）
+    where:
+      - 「セキュリティ上の正しさ」が主題のとき。ツール導入だけなら configuration
+
+testing:
+  def: "[aspect] The interaction involved test design, implementation, or execution"
+  desc: テスト設計・実装・実行の観点
+  rules:
+    when:
+      - テストコードを書いた・実行した
+      - テスト戦略・テスト設計を議論・確定した
+    while:
+      - テストが主目的の活動として行われている状態
+    not:
+      - テスト結果を見てバグ修正（→ behavior のみ）
+    where:
+      - 「テストを書く・設計する」が主題。テスト結果からバグを直す行為は behavior
+
+review:
+  def: "[aspect] The interaction involved evaluation, critique, or feedback on code, design, or artifacts"
+  desc: コード・設計・文書に対するレビュー・評価・フィードバックの観点
+  rules:
+    when:
+      - コードレビュー・設計レビューを実施・受けた
+      - 記事・仕様書へのフィードバック・批評が主題の一部
+    while:
+      - 評価・フィードバックの授受が対話の主軸になっている状態
+    not:
+      - レビュー後の修正実装（→ architecture/behavior を優先）
+      - Lintによる自動検証（→ validation）
+    where:
+      - 「人間が評価・批評する」行為。自動検証は validation、修正実装は architecture/behavior
+
+# ── 対話系
+
+chat:
+  def: "[aspect] The interaction repeated the same dimension across turns with no evolution of questions"
+  desc: 問いが進化しない雑談・ロールプレイの観点（ターンを経ても次元が変わらない）
+  rules:
+    when:
+      - ターンが進んでも話題の次元・深さが変わらない（感情・行動の繰り返し）
+      - 技術的判断・方針検討が対話の主軸として継続しない
+    while:
+      - 対話が進んでも問いの構造が変化しない状態
+    not:
+      - 技術的判断が継続的に深まっている（→ discussion）
+      - 技術的判断・方針検討が対話全体を通じて主軸として続いた（→ discussion に昇格）
+    where:
+      - discussion との違い：chat は次元が変わらない。discussion は判断・検討が深化し続ける

--- a/assets/dics/types.dic
+++ b/assets/dics/types.dic
@@ -1,0 +1,98 @@
+# src: ./assets/dics/types.dic
+# @(#) ログ種別分類用辞書
+#
+# 構造: key / def（AI判断用・キーを端的に定義する短文）/ desc（人間向け説明）/ rules（判断補助）
+#
+# 確定タイプ: execution / incident / discussion / research / writing（5種別）
+#
+# 判定優先順位（この順序で確認すること）:
+#   STEP 1: incident signal が実際に発生して行動を引き起こしたか？ → incident（無条件）
+#   STEP 2: 成果物が文書・仕様・記事・プロンプト文面か？          → writing
+#   STEP 3: コード/設定変更が主目的か（文書除く・incident修正除く）→ execution
+#   STEP 4: 将来の実装に影響する明示的・不可逆な決定があるか？    → discussion
+#   STEP 5: 理解・比較が主目的で実装も明示的決定もないか？        → research
+#
+# incident signal（これが1つでもあればSTEP 1で確定）:
+#   - エラーメッセージ・スタックトレース・CI失敗が会話の起点
+#   - 「動かない」「失敗した」「不整合」「期待と違う挙動」が出発点
+#   - 障害・バグの症状報告から始まっている
+#
+# なぜincident優先か:
+#   外形分類（何をやったか）と因果分類（なぜ始まったか）は別物。
+#   incident後に修正→execution, 調査→research, 方針決定→discussionが
+#   続いても、ログの「起点」はincidentのまま変わらない。
+
+execution:
+  def: A log where the primary purpose was implementing or modifying code, scripts, or configuration — not triggered by an error
+  desc: ファイル変更（コード・設定・スクリプト）が主目的の実作業ログ。成果物はコミットされたファイル変更。
+  rules:
+    when:
+      - 実装・変更が主目的であり、エラー・障害が起点ではない
+      - 既存機能の追加・拡張・リファクタリングを行った（incident なし）
+      - テストを実装・修正した（incident なし）
+    not:
+      - エラー・障害が会話の起点（→ incident が優先・無条件）
+      - ファイル変更がない計画・方針確定（→ discussion）
+      - 文書・記事の作成が主体（→ writing）
+  structure: 指示 → 実装 → 確認
+
+incident:
+  def: A log where an error, failure, or unexpected behavior was the starting point — this type dominates regardless of what follows
+  desc: エラー・障害が起点。後続に実装・調査・方針決定が含まれても type は incident のまま変わらない。
+  rules:
+    when:
+      - エラーメッセージ・スタックトレース・CI失敗が会話の起点になっている
+      - 「動かない」「失敗した」「不整合」「期待と違う挙動」が出発点
+      - 障害・バグの症状報告から始まっている
+    always:
+      - 起点がエラー・障害であれば、その後に実装・調査・方針決定が続いても type は incident のまま
+      - incident signal が1つでも確認できれば他のステップより優先される
+    not:
+      - 新機能の実装でエラーなく進行した（→ execution）
+      - エラーが出たが原因調査のみで修正なし（→ research）
+      - 計画中にリスクを議論しただけ（→ discussion）
+  structure: 症状 → 原因 → 解決 → 確認
+
+discussion:
+  def: A log where an explicit, irreversible decision affecting future implementation was the primary outcome — without code changes
+  desc: 将来の実装・運用に影響する不可逆な決定の明示が主目的。ファイル変更はないか副次的。
+  rules:
+    when:
+      - 将来の実装・運用に影響する不可逆な決定が明示されている（「〜に決定」「〜を採用」「〜方針とする」等）
+      - アーキテクチャ・設計・方針・仕様の確定が主目的（コード変更なし）
+      - 技術選定・命名規則・運用方針を議論して決定した
+    not:
+      - 決定を実装に落とし込んだ（→ execution）
+      - 技術調査のみで明示的決定に至らなかった（→ research）
+      - エラーが起点の対処方針検討（→ incident）
+      - 意見・好み・懸念の表明のみで確定していない（→ research）
+  structure: 課題 → 検討 → 決定
+
+research:
+  def: A log where the primary purpose is information gathering, comparison, or conceptual understanding — with no explicit decision and no implementation
+  desc: 調査・質問・情報収集・概念理解が主体。明示的な決定も実装もない。
+  rules:
+    when:
+      - 調査・理解が主目的であり、明示的な決定も実装もない
+      - 技術・ツール・概念の調査・比較検討が主目的
+      - 実装を伴わない質問・回答・議論
+      - ドキュメント・記事を読んで理解した
+    not:
+      - 調査後にコードを実装した（→ execution）
+      - 調査結果をもとに設計判断が明示的に確定した（→ discussion）
+      - エラーが起点の原因調査（→ incident）
+  structure: 問い → 調査・回答 → 結論
+
+writing:
+  def: A log where the primary outcome is a written document, article, specification, or prompt text
+  desc: 文書・記事・仕様書・プロンプトの作成・整備が主体。成果物は公開可能な文章またはドキュメント。
+  rules:
+    when:
+      - README・仕様書・ブログ記事・設計文書を新規作成・大幅改訂した
+      - プロンプト文書・スキル定義を作成した
+      - 文章の校閲・構成改善が主目的
+    not:
+      - 設計判断の議論が主体（→ discussion）
+      - コードのコメント追加のみ（→ execution）
+      - 内部設計文書の意思決定が主体（→ discussion）
+  structure: 題材 → 執筆 → 校閲

--- a/assets/prompts/category-rules.yaml
+++ b/assets/prompts/category-rules.yaml
@@ -6,6 +6,12 @@
 # 目的:
 #   typeはcategoryを「決めない」。typeは「何に注目してcategoryを判断するか」のヒントを与えるだけ。
 #   categoryはログの内容・対象ドメインから独立して決定される。
+#
+# 設計方針（重要）:
+#   各ガイドは「誘導」であり「決定ロジック」ではない。
+#   「→ category名」を直接記述しない。
+#   「often indicate」「may suggest」「tends to」で弱める。
+#   最終判断は常に category.dic の PRIMARY PURPOSE ルールに従う。
 
 execution: |
   WHEN  evaluating an execution log — look at the FILE PATHS and TARGETS that were modified:

--- a/assets/prompts/category-rules.yaml
+++ b/assets/prompts/category-rules.yaml
@@ -1,0 +1,67 @@
+# src: ./assets/prompts/category-rules.yaml
+# @(#) typeごとのcategory判定フォーカスガイド
+#
+# 構造: type → フォーカスガイド文字列（プロンプトに直接埋め込まれる）
+#
+# 目的:
+#   typeはcategoryを「決めない」。typeは「何に注目してcategoryを判断するか」のヒントを与えるだけ。
+#   categoryはログの内容・対象ドメインから独立して決定される。
+
+execution: |
+  WHEN  evaluating an execution log — look at the FILE PATHS and TARGETS that were modified:
+        - `.github/workflows/`, `.github/` → infrastructure signal
+        - `src/`, `lib/`, `packages/` → development signal
+        - `*.config.*`, `.eslintrc`, `mise.toml` → tooling signal
+        - prompt files, AI-related scripts → ai signal
+        - `.md`, `.rst` with no code changes → writing signal
+  WHILE reading path patterns — treat them as signals only, not decisions
+  NOT   choosing a category based on file extension alone
+  WHERE the purpose of the change matters more than where the file lives:
+        a script in `src/` that configures CI may still be infrastructure
+
+incident: |
+  WHEN  evaluating an incident log — look at WHERE the failure OCCURRED:
+        - CI pipeline / GitHub Actions / workflow job failure → infrastructure signal
+        - Local CLI tool / shell command / config parsing error → tooling signal
+        - Runtime code error / application crash / test failure → development signal
+        - AI API error / LLM agent failure / prompt execution failure → ai signal
+  WHILE identifying the failure location — use it as a signal, not a verdict
+  NOT   choosing infrastructure merely because the error appeared in a CI log;
+        check whether the ROOT CAUSE is in shared infrastructure or in application code
+  WHERE the fix target defines the category — not the tool used to detect the error
+
+discussion: |
+  WHEN  evaluating a discussion log — look at the SUBJECT MATTER being decided:
+        - CI/CD operations / deployment policy / release process → infrastructure signal
+        - API design / code architecture / module structure → development signal
+        - Tool selection / dev environment setup → tooling signal
+        - AI usage policy / agent design / prompt strategy → ai signal
+        - Concept clarification / learning without decision → knowledge signal
+        - Document structure / content strategy → writing signal
+  WHILE reading the discussion — focus on WHAT DOMAIN the decision belongs to, not how it was discussed
+  NOT   letting conversational format (Q&A, debate) influence the category choice
+  WHERE ambiguous: ask "What domain will be affected by this decision?"
+
+research: |
+  WHEN  evaluating a research log — look at the TECHNOLOGY or CONCEPT being researched:
+        - GitHub Actions / CI/CD systems / deployment pipelines → infrastructure signal
+        - Package managers / CLI tools (ShellSpec, mise, asdf) → tooling signal
+        - Programming languages / algorithms / frameworks → development signal
+        - LLM / prompt engineering / AI agents / Claude API → ai signal
+        - General software engineering concepts / design patterns → knowledge signal
+        - Writing techniques / documentation styles → writing signal
+  WHILE reading — focus on the SUBJECT DOMAIN of what is being researched
+  NOT   choosing based on the method of research (chat, reading docs, running commands)
+  WHERE the research target is the signal — not the process used to research it
+
+writing: |
+  WHEN  evaluating a writing log — look at the TYPE OF DOCUMENT and its intended audience:
+        - README / blog post / tutorial / release notes for external or team readers → writing signal
+        - ADR / tech spec that drives implementation decisions → may lean toward the target domain
+        - Operations runbook / deployment guide → may lean toward infrastructure
+        - Prompt files / AI usage guides → may lean toward ai
+  WHILE evaluating — ask: "Is this document a standalone deliverable, or a driver for implementation?"
+  NOT   classifying as writing if the document is a byproduct of a decision or implementation process
+  WHERE the boundary is:
+        standalone artifact for readers → writing
+        internal spec that directly drives implementation → corresponding domain (development/infrastructure/etc.)

--- a/assets/prompts/category.yaml
+++ b/assets/prompts/category.yaml
@@ -1,0 +1,40 @@
+# src: ./assets/prompts/category.yaml
+# @(#) Phase 3a: category判定プロンプトテンプレート
+#
+# 変数:
+#   ${category_list} — category.dic から生成したcategory一覧（カンマ区切り）
+#   ${focus_guide}   — category-rules.yaml から取得したtypeごとのフォーカスガイド
+#   ${body}          — ログ本文
+
+system: |
+  You are a log categorizer. Output the category name only, nothing else.
+  Choose the single best category based on the CONTENT and SUBJECT MATTER of the log, not the type.
+
+user: |
+  Classify the log into one of the following categories.
+
+  Categories (must choose exactly one): ${category_list}
+
+  ${focus_guide}
+
+  CLASSIFICATION RULES:
+
+  WHEN  the primary purpose of the log falls clearly into one domain
+        → choose that domain's category
+  WHEN  multiple domains seem applicable
+        → choose the broader and more dominant one (lean toward what the log was fundamentally trying to accomplish)
+
+  WHILE evaluating — always ask: "What was this log fundamentally trying to accomplish?"
+        Not: "What tools were touched?" or "What files changed?"
+
+  NOT   letting the log type directly determine the category
+  NOT   using surface signals alone (file paths, tool names, error location) without checking PRIMARY PURPOSE
+  NOT   choosing infrastructure merely because a CI error occurred — check what the log was fixing or designing
+
+  WHERE the decision boundary is unclear:
+        - infrastructure vs development: infrastructure = shared/team environment; development = code logic
+        - tooling vs development: tooling = tool setup without code changes; development = code implementation
+        - knowledge vs writing: knowledge = no structured artifact; writing = document produced for readers
+
+  ---
+  ${body}

--- a/assets/prompts/category.yaml
+++ b/assets/prompts/category.yaml
@@ -9,6 +9,7 @@
 system: |
   You are a log categorizer. Output the category name only, nothing else.
   Choose the single best category based on the CONTENT and SUBJECT MATTER of the log, not the type.
+  The decision MUST be based on the PRIMARY PURPOSE of the log (what the log is trying to accomplish).
 
 user: |
   Classify the log into one of the following categories.

--- a/assets/prompts/meta.yaml
+++ b/assets/prompts/meta.yaml
@@ -1,0 +1,81 @@
+# src: ./assets/prompts/meta.yaml
+# @(#) Phase 3b: フロントマター生成プロンプトテンプレート
+#
+# 変数:
+#   ${log_type}        — 判定済みtype
+#   ${log_category}    — 判定済みcategory
+#   ${topic_list}      — topics.dic から生成したtopic一覧（when/not付き）
+#   ${tags_list}       — tags.dic から生成したtag一覧（カンマ区切り）
+#   ${body}            — ログ本文
+
+system: |
+  You are a metadata generator for engineering logs.
+  Output YAML only. No code fences, no extra text. No questions, no explanations.
+
+user: |
+  Generate metadata for the following engineering log.
+
+  Log type: ${log_type}
+  Log category: ${log_category}
+
+  General requirements:
+  - Summary must read as a log summary (what happened, what was done, what was found)
+  - Tags must be chosen only from the provided list based on actual content appearance
+  - Output YAML only. No code fences, no extra text.
+  - Do NOT ask questions. Do NOT add explanations. Generate metadata from the log as-is.
+
+  ## TOPICS ASSIGNMENT RULES
+
+  ### STRUCTURE
+  Topics follow a 2-layer structure:
+  - Layer 1 — domain (1 required): ALWAYS equals the provided Log category. Never infer or change it.
+  - Layer 2 — aspect (0–2 optional): the angle or mode of the interaction
+
+  ### WHEN to select an aspect
+  WHEN  the aspect clearly describes a meaningful angle of the log's content → add it
+  WHEN  no aspect adds meaningful information → use 0 aspects (domain only is valid)
+
+  ### WHILE selecting aspects — group constraints apply
+  WHILE choosing from the thought/intent group (learning / decision / discussion / analysis):
+        → pick at most ONE
+  WHILE choosing from the output/artifact group (architecture / behavior / content):
+        → pick at most ONE
+  WHILE choosing auxiliary aspects (validation / security / testing / configuration / workflow / review / chat):
+        → no group restriction; combine freely with others
+
+  ### NOT allowed
+  NOT   putting tech keywords (git, yaml, powershell, shell, etc.) in topics — use tags only
+  NOT   exceeding 3 topics total (domain 1 + aspect 0–2)
+  NOT   choosing "discussion" for a single isolated turn of judgment — requires sustained main axis
+  NOT   putting design target type (API/CLI/data) in topics — use tags (dev:api-design, target:cli, etc.)
+  NOT   choosing "behavior" when correctness was being confirmed — use "validation" instead
+
+  ### WHERE the boundaries are
+  WHERE behavior vs validation:
+        behavior   = observing or diagnosing how something works or runs
+        validation = confirming that something is correct (Lint passed, fix confirmed, test succeeded)
+  WHERE chat vs discussion:
+        chat       = turns repeat the same dimension with no depth change
+        discussion = technical judgment or policy review is the SUSTAINED MAIN AXIS throughout
+  WHERE architecture is used:
+        architecture = "design occurred" only. Design target type (API/CLI) belongs in tags.
+
+  ### Type–aspect alignment (required)
+  WHEN  type is "decision"  → MUST include "decision" aspect
+  WHEN  type is "incident"  → MUST include "behavior" or "validation"
+  WHEN  type is "execution" → MUST include "behavior"
+
+  ### Available aspects (domain is already fixed — choose aspects only from this list)
+  ${topic_list}
+
+  Schema:
+  title: string
+  summary: |
+    string (multiline, 2-4 sentences)
+  topics:
+    - string  # follow the when/not rules above
+  tags:
+    - string  # must be from: ${tags_list}
+
+  ---
+  ${body}

--- a/assets/prompts/review.yaml
+++ b/assets/prompts/review.yaml
@@ -1,0 +1,79 @@
+# src: ./assets/prompts/review.yaml
+# @(#) Phase 3.5: フロントマターレビュープロンプトテンプレート
+#
+# 変数:
+#   ${type_list}        — types.dic から生成したtype一覧（when/not付き）
+#   ${topic_list}       — topics.dic から生成したtopic一覧（簡略版）
+#   ${category_list}    — category.dic から生成したcategory一覧（カンマ区切り）
+#   ${tags_list}        — tags.dic から生成したtag一覧（カンマ区切り）
+#   ${result_type}      — 生成済みtype
+#   ${result_category}  — 生成済みcategory
+#   ${result_yaml}      — 生成済みYAML（title/summary/topics/tags）
+
+system: |
+  You are a strict frontmatter reviewer.
+  Output YAML only. No code fences, no extra text. No questions, no explanations.
+
+user: |
+  Review the following frontmatter against these rules:
+
+  ## RULE 0 — type
+  Must be one of the following. Choose the best match for the PRIMARY purpose.
+  ${type_list}
+
+  ## RULE 1 — category
+  Must match the primary domain (not surface tools).
+  Must be one of: ${category_list}
+
+  ## RULE 2 — topics
+  Must follow a 2-layer structure (domain + aspect). Must be from:
+  ${topic_list}
+
+  WHEN  domain is missing or does not match category → flag as error
+  WHEN  aspect violates group constraint → flag as error
+  WHEN  type–aspect alignment is broken → flag as error:
+        type=decision requires "decision" aspect
+        type=incident requires "behavior" or "validation"
+        type=execution requires "behavior"
+
+  WHILE reviewing aspects — apply group constraints:
+        Thought/intent group (learning / decision / discussion / analysis): max 1
+        Output/artifact group (architecture / behavior / content): max 1
+        Auxiliary aspects (validation / security / testing / configuration / workflow / review / chat): no restriction
+
+  NOT   allowing tech/tool names in topics (git, yaml, powershell, shell, node, etc.) → tags only
+  NOT   allowing: debugging, troubleshooting, investigating, ci_cd, programming, configuring → expressed by type or category
+  NOT   exceeding 3 topics total (domain 1 + aspect 0–2)
+  NOT   putting design target type (API/CLI/data) in topics → use tags (dev:api-design, target:cli, etc.)
+
+  WHERE behavior vs validation:
+        behavior   = observing or diagnosing how something works
+        validation = confirming correctness (Lint passed / fix confirmed / test succeeded)
+  WHERE chat vs discussion:
+        chat       = same dimension repeated across turns
+        discussion = technical judgment is the sustained main axis throughout
+
+  ## RULE 3 — tags
+  Must reflect actual tools, environment, and technical traits.
+  Must be from: ${tags_list}
+  Avoid redundancy between topics and tags.
+
+  Output schema:
+  validity: pass or fail
+  errors:
+    - string  # list violations; empty list if pass
+  corrected_frontmatter:
+    type: string
+    category: string
+    title: string
+    summary: |
+      string
+    topics:
+      - string
+    tags:
+      - string
+
+  ---
+  type: ${result_type}
+  category: ${result_category}
+  ${result_yaml}

--- a/assets/prompts/type.yaml
+++ b/assets/prompts/type.yaml
@@ -1,0 +1,56 @@
+# src: ./assets/prompts/type.yaml
+# @(#) Phase 2: type判定プロンプトテンプレート
+#
+# 変数:
+#   ${type_list} — types.dic から生成したtype一覧
+#   ${body}      — ログ本文
+
+system: |
+  You are a log classifier. Output the type name only, nothing else.
+  Choose the single best type based on the PRIMARY purpose of the log.
+
+user: |
+  Classify the log into one of the following types.
+
+  Types:
+  ${type_list}
+
+  CLASSIFICATION RULES — evaluate in order. Assign the FIRST matching type. Do not continue after a match.
+
+  [incident]
+    WHEN  the log opens with a problem signal:
+          error message / stack trace / CI failure / "doesn't work" / mismatch / unexpected behavior
+    WHILE the problem signal was an actual event that triggered the conversation (not a hypothetical)
+    NOT DO continue to the next rule — incident dominates all others
+    WHERE any subsequent fix, investigation, or decision in the same log does NOT change the type;
+          the starting point defines the type, not what follows
+
+  [writing]
+    WHEN  the primary outcome is a written artifact: document / article / specification / prompt text
+    WHILE the log was NOT triggered by an error signal
+    NOT DO classify as writing if the document is a side effect of a decision or incident
+
+  [execution]
+    WHEN  code, scripts, or configuration files were modified as the PRIMARY purpose
+    WHILE the log was NOT triggered by an error signal
+    NOT DO classify as execution if changes were made only to fix an incident,
+          or if the primary outcome is a document
+    WHERE "primary purpose" means modification was the goal, not the side effect
+
+  [discussion]
+    WHEN  an explicit, irreversible decision affecting future implementation or operations was stated
+    WHILE no code files were modified as a primary outcome
+    NOT DO classify as discussion for opinions, preferences, or "we might" — must be confirmed ("decided", "we will use X", "adopted", "finalized as Y")
+    WHERE the decision must be forward-looking and binding, not just a conclusion within the log
+
+  [research]
+    WHEN  the primary purpose was understanding, comparison, or learning
+    WHILE no implementation occurred AND no explicit decision was confirmed
+    NOT DO classify as research if the investigation led to a confirmed decision (→ discussion)
+          or if it was triggered by an error (→ incident)
+    WHERE this is the fallback — assign only when no other type fits
+
+  Output the type name only (e.g. "execution"), nothing else.
+
+  ---
+  ${body}

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,18 @@
+{
+  "imports": {
+    "@std/yaml": "jsr:@std/yaml@^1.0.12",
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@std/testing": "jsr:@std/testing@^1.0.0"
+  },
+  "lint": {
+    "rules": {
+    },
+    "exclude": []
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "es2022", "dom"]
+  },
+  "tasks": {
+    "test": "deno test --allow-read --allow-write ."
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,7 +26,7 @@ pre-commit:
 prepare-commit-msg:
   commands:
     prepare-message-script:
-      run: bash -c './scripts/prepare-commit-msg.sh --model sonnet --output "{1}"'
+      run: bash -c './scripts/prepare-commit-msg.sh --model gpt-5.4 --output "{1}"'
 
 # check commit message as Conventional Commit
 commit-msg:


### PR DESCRIPTION
## Overview

**Summary**
Add classification dictionaries, prompt pipeline, and update project configuration files.

**Background / Motivation**
チャットログ分類システムの中核となる辞書ファイル群とプロンプトパイプラインを追加し、プロジェクトの設定ファイルを整備した。

分類モデルを再設計し、タイプ体系を7種から5種（execution / incident / discussion / research / writing）に整理した。カテゴリ辞書・トピック辞書・
タグ辞書・プロジェクト辞書・名前空間辞書を新規追加し、分類ルールをスキーマとして明文化した（when / not / where 形式）。

プロンプトは、タイプ判定（Phase 2）→ カテゴリ判定（Phase 3a）→ フロントマター生成（Phase 3b）→ レビュー（Phase 3.5）という4段階パイプラインとして設計した。
各プロンプトはプレースホルダー変数（`${type_list}` など）を通じて辞書データを動的に注入する構造になっている。

## Changes

### 分類辞書

- `assets/dics/types.dic` を新規追加: タイプ体系（5種）の定義と分類ルール
- `assets/dics/category.dic` を新規追加: カテゴリ辞書（development / infrastructure / tooling / ai / knowledge / writing）
- `assets/dics/topics.dic` を新規追加: トピック分類（domain + aspect の2層構造）
- `assets/dics/tags.dic` を新規追加: タグ体系（ルール付き）
- `assets/dics/projects.dic` を新規追加: プロジェクト分類（フォールバック付き）
- `assets/dics/namespaces.dic` を新規追加: 名前空間定義

### プロンプトパイプライン

- `assets/prompts/type.yaml` を新規追加: Phase 2 タイプ判定プロンプト
- `assets/prompts/category.yaml` を新規追加: Phase 3a カテゴリ判定プロンプト
- `assets/prompts/category-rules.yaml` を新規追加: タイプ別カテゴリ判断フォーカスガイド
- `assets/prompts/meta.yaml` を新規追加: Phase 3b フロントマター生成プロンプト
- `assets/prompts/review.yaml` を新規追加: Phase 3.5 フロントマターレビュープロンプト

### 設定ファイル

- `deno.json` を新規追加: Deno設定をルートへ移動（imports / test / lint を追加）
- `.claude/commands/scripts/deno.json` を削除: 旧 deno.json（ルートへ統合）
- `.vscode/settings.json` を更新: `.dic` ファイルのYAML関連付け、Denoスキーマ設定
- `.vscode/cspell/dicts/project.dic` を更新: `dics`、`shdoc`、`Metas` を追記
- `lefthook.yml` を更新: `prepare-commit-msg` のモデルを `gpt-5.4` へ変更

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #2

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

### 設計上の重要な決定事項

**タイプとカテゴリの分離原則**
タイプはカテゴリを直接決定しない。タイプは「何に注目してカテゴリを判断するか」のヒントを与えるだけであり、カテゴリはログの内容・対象ドメインから独立して決定される（`category-rules.yaml` の設計方針）。

**PRIMARY PURPOSE ベースの分類**
分類の基準は「ファイルパスやツール名などの表面的シグナル」ではなく、「ログが何を達成しようとしていたか（PRIMARY PURPOSE）」に置く。

**辞書スキーマの統一**
全辞書は `key / def / desc / rules` 形式で統一し、`rules` 内を `when / not / where` の3項目で記述する標準スキーマを採用した。

### Test Plan

辞書ファイルおよびプロンプトテンプレートは YAML 形式で記述されている。Deno テスト環境（`deno test --allow-read --allow-write .`）を使用して読み込み・パース検証が実施可能。
