### PR TITLE
test(scripts/normalize-chatlog): restructure test suite into layered test levels

### DIFF
--- a/.claude/commands/scripts/__tests__/_fixtures/chatlog/2026-03-11-1-api-a4a84394.md
+++ b/.claude/commands/scripts/__tests__/_fixtures/chatlog/2026-03-11-1-api-a4a84394.md
@@ -1,0 +1,387 @@
+---
+session_id: a4a84394-6140-4668-b1ed-de0b50d8ffb1
+date: 2026-03-11
+project: aplys
+slug: sharded-questing-starfish
+---
+
+# 1 API設計 現在 aplys <domain>/<target> <action> [files...] これは 良い設計。 理由 filesystem dispatch と一致 na
+
+## 会話ログ
+
+### User
+
+1 API設計
+
+現在
+
+aplys <domain>/<target> <action> [files...]
+
+これは 良い設計。
+
+理由
+
+filesystem dispatch と一致
+
+namespace 衝突回避
+
+CLI短い
+
+ここは 変更不要。
+
+ただし仕様に 1行追加した方がよい。
+
+domain / target validation
+[A-Za-z0-9_-]+
+
+.は禁止。
+
+理由
+
+path traversal
+2 exit code
+
+現在
+
+code 意味
+0 success
+1 lint/test error
+2 aplys error
+3 invalid argument
+
+これは良い。
+
+ただし 1つ追加した方がよい。
+
+127 = tool not found
+
+理由
+
+shellcheck missing
+
+を区別できる。
+
+3 APLYS_ARGS
+
+issue内では
+
+APLYS_ARGS=("a.sh" "b c.sh")
+export APLYS_ARGS
+
+となっている。
+
+これは bash仕様的に正しくない。
+
+配列は export できない。
+
+つまり
+
+subshell
+
+では壊れる。
+
+推奨
+
+APLYS_ARGS_JSON
+
+または
+
+"$@"
+
+直接渡す。
+
+実装は
+
+exec "$script" "$@"
+
+が最も安全。
+
+4 git ls-files
+
+現在
+
+git ls-files <dir> '*.sh'
+
+となっている。
+
+これは git の仕様上 誤動作する可能性がある。
+
+安全な形は
+
+git ls-files -- '*.sh'
+git ls-files -- "$dir"/*.sh
+
+または
+
+git ls-files "$dir" | grep '\.shに対応
+5 extension mapping
+
+issueには
+
+<ext> は target に依存
+
+とあるが
+
+仕様として弱い。
+
+推奨
+
+表を追加する。
+
+例
+
+target extension
+shell sh
+markdown md
+yaml yml
+6 APLYS_LIBS
+
+現在
+
+APLYS_LIBS='./_libs'
+
+これは 相対パス問題がある。
+
+推奨
+
+APLYS_LIBS="$APLYS_ROOT/_libs"
+7 dispatcher仕様が不足
+
+issueに
+
+aplyss/aplys
+
+の仕様がほぼ書かれていない。
+
+最低限これが必要。
+
+dispatcher algorithm
+validate domain
+validate target
+validate action
+
+script="$APLYS_ROOT/$domain/$target/$action"
+
+exec "$script" "$@"
+8 XDGディレクトリ
+
+今回の議論では
+
+APLYS_CONFIG_HOME
+APLYS_DATA_DIR
+APLYS_CACHE_DIR
+
+が決まった。
+
+しかし issue に まだ書かれていない。
+
+追記すべき。
+
+APLYS_CONFIG_HOME=~~/.config/aplys
+APLYS_DATA_DIR=~~/.local/share/aplys
+APLYS_CACHE_DIR=~/.cache/aplys
+9 セキュリティ仕様
+
+issueには 安全仕様がない。
+
+最低限これを書く。
+
+path validation
+^[a-z][a-z0-9_-]*$
+dispatcher safety
+set -euo pipefail
+PATH=/usr/bin:/bin
+10 shellcheck runner
+
+ここは 非常に良い。
+
+shellcheck -s bash
+-S warning
+--format=gcc
+
+CIとの相性も良い。
+
+ただし1つだけ追加推奨
+
+--external-sources
+11 acceptance criteria
+
+かなり良いが
+1つ不足している。
+
+追加
+
+aplys list
+
+のテスト。
+
+12 tasks構造
+
+今
+
+Phase 1
+Phase 2
+
+になっている。
+
+ただし OSS issue としては
+
+implementation tasks
+
+が少ない。
+
+追加推奨
+
+dispatcher implementation
+validation
+error handling
+総合評価
+
+設計品質
+
+API設計 A
+CLI設計 A
+tool runner設計 A
+実装仕様 B
+安全仕様 C
+
+つまり
+
+設計は非常に良いが
+安全仕様と dispatcher仕様が不足している。
+
+修正するとかなり完成度が上がるポイント
+
+以下を issue に追記する。
+
+domain/target validation
+
+dispatcher algorithm
+
+XDG directories
+
+exit code 127
+
+APLYS_ARGS export 問題
+
+git ls-files 修正
+
+これで
+
+OSS公開レベルの仕様になる。
+
+マスターに一つだけ。
+
+この issue を見た限り
+aplys は
+
+toolchain API layer
+
+としてかなり良い設計になっている。
+
+ただし 1点だけまだ決まっていない重要仕様がある。
+
+aplys version policyに対応
+
+### Assistant
+
+まず現在のissueとプロジェクト構造を確認します。
+
+### Assistant
+
+調査結果を確認しました。現在のプロジェクトには `aplys` コマンドの実装はなく、これから設計するissueを作成するタスクだと理解しました。
+
+ユーザーのメッセージを整理します：
+
+ユーザーは既存のissue（GitHub上にある）に対して、以下の改善点を追加する提案をしています：
+
+1. domain/target validation (`[A-Za-z0-9_-]+`, `.`禁止)
+2. exit code 127 (tool not found)
+3. APLYS_ARGS export問題 → `exec "$script" "$@"` に変更
+4. `git ls-files` の修正
+5. extension mapping 表の追加
+6. `APLYS_LIBS` の相対パス問題修正
+7. dispatcher仕様の追記
+8. XDGディレクトリの追記
+9. セキュリティ仕様の追記
+10. shellcheck `--external-sources` 追加
+11. `aplys list` のテスト追加
+12. implementation tasks追加（dispatcher, validation, error handling）
+13. **aplys version policy** (最後の重要仕様)
+
+### Assistant
+
+いくつか確認させてください。
+
+### Assistant
+
+ありがとうございます。既存のGitHub Issueを特定するため確認します。
+
+### Assistant
+
+GitHub上の既存issueを確認します。
+
+### Assistant
+
+Issueが存在しないようです。新規作成の可能性を確認します。
+
+### Assistant
+
+GitHubにissueが存在しないことが確認できました。ユーザーが参照している「既存のissue」は別の場所にある可能性があります。
+
+### User
+
+temp\idd\issues\new-20260311-000000-task-aplys-runner-spec.mdがissueの下描きなので、coreを既存と見なし更新する。また、上記の議論全てをissueには書かず、詳細はdocs/specsなどに作成する
+
+### Assistant
+
+了解しました。下書きファイルを確認します。
+
+### Assistant
+
+下書きの内容を把握しました。次に既存のdocsディレクトリ構造を確認します。
+
+### Assistant
+
+全体を把握しました。プランを作成します。
+
+**整理:**
+
+- `temp/idd/issues/new-20260311-000000-task-aplys-runner-spec.md` が既存のissue下書き
+- `docs/` ディレクトリは未作成
+- ユーザーの指示: issueはコアのみ保持・更新し、詳細仕様は `docs/specs/` 等に分離する
+- 追加すべき内容: 12項目の改善点 + version policy
+
+### Assistant
+
+プランを作成します。
+
+### Assistant
+
+プランの概要:
+
+**変更ファイル:**
+
+1. `temp/idd/issues/new-20260311-000000-task-aplys-runner-spec.md` — issueをコア仕様のみに整理・更新
+2. `docs/specs/aplys-api-spec.md` — 詳細仕様を新規作成（分離）
+
+**issueの主な更新内容:**
+
+- exit code 127 (tool not found) 追加
+- APLYS_ARGS → `exec "$script" "$@"` 方式に変更
+- APLYS_LIBS を `$APLYS_ROOT/_libs` に修正
+- XDG ディレクトリ変数追加
+- `aplys list` テスト追加
+- Phase 3 implementation tasks 追加
+- version policy への参照追記
+- `additional_context` の詳細を docs/specs へ移動
+
+**docs/specs/aplys-api-spec.md の新規内容:**
+
+- dispatcher アルゴリズム
+- domain/target validation (`^[a-z][a-z0-9_-]*$`)
+- `git ls-files -- '*.sh'` 正しい構文
+- extension mapping 表
+- セキュリティ仕様
+- shellcheck `--external-sources`
+- version policy (SemVer、minor=後方互換、Go/Linux kernelスタイル)

--- a/.claude/commands/scripts/__tests__/_helpers/deno-command-mock.ts
+++ b/.claude/commands/scripts/__tests__/_helpers/deno-command-mock.ts
@@ -1,0 +1,164 @@
+// src: scripts/__tests__/_helpers/deno-command-mock.ts
+// @(#): Deno.Command モック用ヘルパー (runAI / segmentChatlog テスト用)
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// ─── 型定義 ────────────────────────────────────────────────────────────────────
+
+/** Deno.Command の最小インターフェイス。テスト用モッククラスが実装する型。 */
+export type DenoCommandLike = new(cmd: string, opts: { args: string[] }) => {
+  spawn(): {
+    stdin: { getWriter(): { write(d: Uint8Array): Promise<void>; close(): Promise<void> } };
+    output(): Promise<{ success: boolean; code: number; stdout: Uint8Array }>;
+  };
+};
+
+// ─── 抽象基底クラス ────────────────────────────────────────────────────────────
+
+/** spawn() 共通骨格と no-op stdin writer を提供する抽象基底クラス。 */
+export abstract class BaseMockCommand {
+  /** no-op stdin writer を返す。全サブクラスで共有する。 */
+  protected static makeStdin() {
+    return {
+      getWriter() {
+        return {
+          write(_data: Uint8Array) {
+            return Promise.resolve();
+          },
+          close() {
+            return Promise.resolve();
+          },
+        };
+      },
+    };
+  }
+
+  /** spawn() の共通骨格。makeOutput() をサブクラスで実装する。 */
+  spawn() {
+    return {
+      stdin: BaseMockCommand.makeStdin(),
+      output: () => this.makeOutput(),
+    };
+  }
+
+  /** サブクラスごとに success/code/stdout を返す抽象メソッド。 */
+  protected abstract makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }>;
+}
+
+// ─── 具体クラス ────────────────────────────────────────────────────────────────
+
+/**
+ * 正常終了(exit 0)を模倣するモッククラス。
+ * stdout の内容と constructor に渡された args を検査できる。
+ */
+export class SuccessMockCommand extends BaseMockCommand {
+  private readonly stdout: Uint8Array;
+  private readonly capturedArgs?: { value: string[] };
+
+  constructor(
+    _cmd: string,
+    opts: { args: string[] },
+    stdout: Uint8Array,
+    capturedArgs?: { value: string[] },
+  ) {
+    super();
+    this.stdout = stdout;
+    this.capturedArgs = capturedArgs;
+    if (this.capturedArgs) { this.capturedArgs.value = opts.args; }
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
+  }
+}
+
+/** 非ゼロ exit code を模倣するモッククラス。 */
+export class FailMockCommand extends BaseMockCommand {
+  private readonly code: number;
+
+  constructor(_cmd: string, _opts: unknown, code: number) {
+    super();
+    this.code = code;
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: false, code: this.code, stdout: new Uint8Array() });
+  }
+}
+
+/** spawn() で Deno.errors.NotFound をスローするモッククラス。 */
+export class NotFoundMockCommand extends BaseMockCommand {
+  constructor(_cmd: string, _opts: unknown) {
+    super();
+  }
+
+  override spawn(): never {
+    throw new Deno.errors.NotFound('claude');
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    // 到達しない（spawn がスローする）
+    return Promise.resolve({ success: false, code: 1, stdout: new Uint8Array() });
+  }
+}
+
+/** 呼び出し回数をカウントするモッククラス。 */
+export class CountingMockCommand extends BaseMockCommand {
+  private readonly responseText: string;
+
+  constructor(_cmd: string, _opts: unknown, responseText: string, counter: { calls: number }) {
+    super();
+    this.responseText = responseText;
+    counter.calls++;
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: new TextEncoder().encode(this.responseText),
+    });
+  }
+}
+
+// ─── ファクトリヘルパー ────────────────────────────────────────────────────────
+
+/**
+ * SuccessMockCommand を DenoCommandLike として返すヘルパー。
+ * Deno.Command の置き換えに使用する。
+ */
+export function makeSuccessMock(
+  stdout: Uint8Array,
+  capturedArgs?: { value: string[] },
+): DenoCommandLike {
+  return class extends SuccessMockCommand {
+    constructor(cmd: string, opts: { args: string[] }) {
+      super(cmd, opts, stdout, capturedArgs);
+    }
+  };
+}
+
+/** FailMockCommand を DenoCommandLike として返すヘルパー。 */
+export function makeFailMock(code: number): DenoCommandLike {
+  return class extends FailMockCommand {
+    constructor(cmd: string, opts: unknown) {
+      super(cmd, opts, code);
+    }
+  } as unknown as DenoCommandLike;
+}
+
+/** NotFoundMockCommand を DenoCommandLike として返すヘルパー。 */
+export function makeNotFoundMock(): DenoCommandLike {
+  return NotFoundMockCommand as unknown as DenoCommandLike;
+}
+
+/** CountingMockCommand を DenoCommandLike として返すヘルパー。 */
+export function makeCountingMock(responseText: string, counter: { calls: number }): DenoCommandLike {
+  return class extends CountingMockCommand {
+    constructor(cmd: string, opts: unknown) {
+      super(cmd, opts, responseText, counter);
+    }
+  } as unknown as DenoCommandLike;
+}

--- a/.claude/commands/scripts/__tests__/e2e/normalize-chatlog.e2e.spec.ts
+++ b/.claude/commands/scripts/__tests__/e2e/normalize-chatlog.e2e.spec.ts
@@ -1,0 +1,544 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
+// src: scripts/__tests__/e2e/normalize-chatlog.e2e.spec.ts
+// @(#): main() のエンドツーエンドテスト
+//       実ファイルシステム + モック AI による統合オーケストレーション検証
+//       parseArgs → resolveInputDir → findMdFiles → withConcurrency →
+//       segmentChatlog → generateSegmentFile + attachFrontmatter → writeOutput → reportResults
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// Deno Test module
+import { assertEquals, assertMatch } from '@std/assert';
+import { after, afterEach, before, beforeEach, describe, it } from '@std/testing/bdd';
+import type { Stub } from '@std/testing/mock';
+import { stub } from '@std/testing/mock';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/** outputDir 配下の .md ファイルを再帰的に収集する */
+async function collectMdFilesRecursive(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    const fullPath = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      const nested = await collectMdFilesRecursive(fullPath);
+      files.push(...nested);
+    } else if (entry.isFile && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+// test helpers
+import {
+  makeSuccessMock,
+} from '../_helpers/deno-command-mock.ts';
+
+// test target
+import {
+  main,
+} from '../../normalize-chatlog.ts';
+
+// ─── main() tests ─────────────────────────────────────────────────────────────
+
+/**
+ * main() のユニットテスト。
+ * parseArgs → resolveInputDir → findMdFiles → withConcurrency → segmentChatlog
+ * → generateSegmentFile + attachFrontmatter → writeOutput → reportResults の
+ * エンドツーエンドオーケストレーションを検証する。
+ */
+describe('main', () => {
+  // ─── T-15-01: --dir エンドツーエンド処理 ─────────────────────────────────────
+
+  /** 正常系: --dir で指定したディレクトリの MD ファイルを処理してセグメント出力ファイルを生成する */
+  describe('Given: マルチトピック MD ファイルが存在するディレクトリを --dir で指定する', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      // 2 MD files with frontmatter
+      await Deno.writeTextFile(
+        `${inputDir}/chat-a.md`,
+        '---\nproject: test\n---\n### User\nHello\n\n### AI\nHi',
+      );
+      await Deno.writeTextFile(
+        `${inputDir}/chat-b.md`,
+        '---\nproject: test\n---\n### User\nFix CI\n\n### AI\nSure',
+      );
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      // Mock AI: returns 1 segment per call
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic A', summary: 'Summary A', body: '### User\nHello' },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+      describe('Then: Task T-15-01-01 - 収集した全 MD ファイルを処理してセグメント出力ファイルを生成する', () => {
+        it('T-15-01-01-01: outputDir 配下に 2 件以上のセグメント出力ファイルが生成される', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const files = await collectMdFilesRecursive(outputDir);
+          assertEquals(files.length >= 2, true);
+        });
+
+        it('T-15-01-01-02: 各出力ファイルが ---\\n で始まる YAML frontmatter を含む', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const files = await collectMdFilesRecursive(outputDir);
+          for (const filePath of files) {
+            const content = await Deno.readTextFile(filePath);
+            assertEquals(content.startsWith('---\n'), true);
+          }
+        });
+      });
+    });
+  });
+
+  /** 正常系: 複数 MD ファイルを並列処理し全件成功レポートを出力する */
+  describe('Given: 4 件の MD ファイルを含むディレクトリとデフォルト並列数 4', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      for (let i = 1; i <= 4; i++) {
+        await Deno.writeTextFile(
+          `${inputDir}/chat-${i}.md`,
+          `### User\nQuestion ${i}\n\n### AI\nAnswer ${i}`,
+        );
+      }
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+      describe('Then: Task T-15-01-02 - withConcurrency を使ってファイルを並列処理する', () => {
+        it('T-15-01-02-01: 全 4 件が処理されて結果レポートに success=4 が含まれる', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const output = logCalls.join('\n');
+          assertMatch(output, /success=4/);
+        });
+      });
+    });
+  });
+
+  // ─── T-15-02: --agent/--year-month エンドツーエンド ──────────────────────────
+
+  /** 正常系: --agent/--year-month で temp/chatlog/<agent>/<year>/<year-month>/ を解決して処理する */
+  describe('Given: --agent claude --year-month 2026-03 と対応パスが存在する', () => {
+    const AGENT_DIR = 'temp/chatlog/claude/2026/2026-03';
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    before(async () => {
+      await Deno.mkdir(AGENT_DIR, { recursive: true });
+      await Deno.writeTextFile(
+        `${AGENT_DIR}/sample.md`,
+        '### User\nHello\n\n### AI\nHi',
+      );
+    });
+
+    after(async () => {
+      await Deno.remove('temp/chatlog/claude/2026', { recursive: true });
+    });
+
+    beforeEach(async () => {
+      outputDir = await Deno.makeTempDir();
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--agent","claude","--year-month","2026-03","--output",outputDir]) を呼び出す', () => {
+      describe('Then: Task T-15-02-01 - temp/chatlog/<agent>/<year>/<year-month>/ から入力を解決してファイルを処理する', () => {
+        it('T-15-02-01-01: temp/chatlog/claude/2026/2026-03/ 内のファイルが処理されて出力が生成される', async () => {
+          await main(['--agent', 'claude', '--year-month', '2026-03', '--output', outputDir]);
+
+          const output = logCalls.join('\n');
+          assertMatch(output, /success=1/);
+        });
+      });
+    });
+  });
+
+  // ─── T-15-03: エラー処理 ──────────────────────────────────────────────────────
+
+  /** 異常系: 存在しない --dir パスで exit code 1 で終了する */
+  describe('Given: 存在しない --dir /nonexistent/path/xyz', () => {
+    let exitStub: Stub<typeof Deno, [code?: number], never>;
+    let savedCommand: unknown;
+
+    beforeEach(() => {
+      exitStub = stub(Deno, 'exit');
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(new Uint8Array());
+    });
+
+    afterEach(() => {
+      exitStub.restore();
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+    });
+
+    describe('When: main(["--dir", "/nonexistent/path/xyz"]) を呼び出す', () => {
+      describe('Then: Task T-15-03-01 - 存在しない入力パスでのエラー終了', () => {
+        it('T-15-03-01-01: Deno.exit(1) が呼ばれる', async () => {
+          await main(['--dir', '/nonexistent/path/xyz']);
+
+          assertEquals(exitStub.calls.length >= 1, true);
+          assertEquals(exitStub.calls[0].args[0], 1);
+        });
+      });
+    });
+  });
+
+  /** 異常系: 3 件のうち 1 件が AI エラー → success=2, fail=1 */
+  describe('Given: 3 件の MD ファイルのうち 1 件が AI エラーを起こす', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      for (let i = 1; i <= 3; i++) {
+        await Deno.writeTextFile(
+          `${inputDir}/chat-0${i}.md`,
+          `### User\nQ${i}\n\n### AI\nA${i}`,
+        );
+      }
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+
+      // Selective mock: fail on the 3rd call
+      let callCount = 0;
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      const successBytes = new TextEncoder().encode(segmentResponse);
+      (Deno as unknown as Record<string, unknown>).Command = class {
+        private readonly shouldFail: boolean;
+        constructor(_cmd: string, _opts: unknown) {
+          callCount++;
+          this.shouldFail = callCount === 3;
+        }
+        spawn() {
+          const shouldFail = this.shouldFail;
+          return {
+            stdin: {
+              getWriter() {
+                return {
+                  write(_d: Uint8Array) {
+                    return Promise.resolve();
+                  },
+                  close() {
+                    return Promise.resolve();
+                  },
+                };
+              },
+            },
+            output(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+              if (shouldFail) {
+                return Promise.resolve({ success: false, code: 1, stdout: new Uint8Array() });
+              }
+              return Promise.resolve({ success: true, code: 0, stdout: successBytes });
+            },
+          };
+        }
+      };
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+      describe('Then: Task T-15-03-02 - 1 ファイルの AI 呼び出し失敗でも残りファイルの処理を継続する', () => {
+        it('T-15-03-02-01: success=2 かつ fail=1 がレポートに含まれる', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const output = logCalls.join('\n');
+          assertMatch(output, /success=2/);
+          assertMatch(output, /fail=1/);
+        });
+      });
+    });
+  });
+
+  // ─── T-15-04: エッジケース ────────────────────────────────────────────────────
+
+  /** エッジケース: 空ディレクトリで 0 件レポートを出力する */
+  describe('Given: .md ファイルが存在しない空ディレクトリ', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(new Uint8Array());
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+      describe('Then: Task T-15-04-01 - 空ディレクトリでも完了し 0 件レポートを出力する', () => {
+        it('T-15-04-01-01: success=0, skip=0, fail=0 がレポートに含まれる', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const output = logCalls.join('\n');
+          assertMatch(output, /success=0.*skip=0.*fail=0/);
+        });
+      });
+    });
+  });
+
+  /** エッジケース: 再実行時に既存出力ファイルをスキップする */
+  describe('Given: 出力ファイルがすでに存在する処理済み入力ファイル', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      await Deno.writeTextFile(
+        `${inputDir}/chat.md`,
+        '### User\nHello\n\n### AI\nHi',
+      );
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main() を同一入力で 2 回呼び出す', () => {
+      describe('Then: Task T-15-04-02 - 再実行時に既存出力ファイルをスキップする', () => {
+        it('T-15-04-02-01: 2 回目の呼び出しで skip=1 がレポートに含まれる', async () => {
+          // Fixed hash so both runs generate the same output filename
+          const fixedHash = () => '0000000';
+
+          // First run: creates output
+          await main(['--dir', inputDir, '--output', outputDir], fixedHash);
+
+          // Reset log capture
+          logCalls = [];
+
+          // Second run: should skip existing output
+          await main(['--dir', inputDir, '--output', outputDir], fixedHash);
+
+          const output = logCalls.join('\n');
+          assertMatch(output, /skip=1/);
+        });
+      });
+    });
+  });
+
+  /** エッジケース: 実行後も入力ファイルの内容が変化しない (R-010) */
+  describe('Given: 既知の内容を持つ入力 MD ファイル', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+    const inputContent = '---\nproject: test\n---\n### User\nHello\n\n### AI\nHi';
+
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      await Deno.writeTextFile(`${inputDir}/input.md`, inputContent);
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main() が完了する', () => {
+      describe('Then: Task T-15-04-03 - 実行全体を通じて入力ファイルが変更されない', () => {
+        it('T-15-04-03-01: 入力ファイルの内容が main() 実行後も変化しない', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const afterContent = await Deno.readTextFile(`${inputDir}/input.md`);
+          assertEquals(afterContent, inputContent);
+        });
+      });
+    });
+  });
+
+  /** エッジケース: 単一トピックのチャットログから出力ファイルが正確に 1 件生成される */
+  describe('Given: 単一トピックのチャットログファイルを含むディレクトリ', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    beforeEach(async () => {
+      inputDir = await Deno.makeTempDir();
+      outputDir = await Deno.makeTempDir();
+
+      await Deno.writeTextFile(
+        `${inputDir}/single-topic.md`,
+        '### User\nHow do I fix CI?\n\n### AI\nUse deno test.',
+      );
+
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      // AI returns exactly 1 segment
+      const segmentResponse = JSON.stringify([
+        { title: 'Fix CI', summary: 'Fix CI pipeline', body: '### User\nHow do I fix CI?' },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(inputDir, { recursive: true });
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+      describe('Then: Task T-15-04-04 - 単一トピックの MD ファイルから出力ファイルが正確に 1 件生成される', () => {
+        it('T-15-04-04-01: outputDir 配下に正確に 1 件の .md ファイルが生成される', async () => {
+          await main(['--dir', inputDir, '--output', outputDir]);
+
+          const files = await collectMdFilesRecursive(outputDir);
+          assertEquals(files.length, 1);
+        });
+      });
+    });
+  });
+});

--- a/.claude/commands/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
+++ b/.claude/commands/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
+// src: scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
+// @(#): 外部依存をモックで代替する関数テスト
+//       対象: runAI (Deno.Command モック), segmentChatlog (runAI モック経由)
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// Deno Test module
+import { assertEquals, assertRejects } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// test helpers
+import {
+  makeCountingMock,
+  makeFailMock,
+  makeNotFoundMock,
+  makeSuccessMock,
+} from '../_helpers/deno-command-mock.ts';
+
+// test target
+import {
+  runAI,
+  segmentChatlog,
+} from '../../normalize-chatlog.ts';
+
+// ─── runAI tests ──────────────────────────────────────────────────────────────
+
+/**
+ * runAI のユニットテスト。
+ * Claude CLI をサブプロセスとして起動し、stdout をデコードして返す関数の
+ * 正常系・異常系・出力トリミングを検証する。
+ */
+describe('runAI', () => {
+  /** 正常系: Claude CLI が exit code 0 で終了し、stdout テキストが返る */
+  describe('Given: Claude CLI が exit code 0 で正常終了する', () => {
+    /**
+     * When: 標準的な model・systemPrompt・userPrompt を渡して runAI を呼び出す。
+     */
+    describe('When: runAI("claude-sonnet-4-6", "You are a helper.", "Summarize this") を呼び出す', () => {
+      /**
+       * Task T-02-01: Claude CLI の正常呼び出し。
+       * exit code 0 のとき stdout テキストをデコードして返し、渡した引数が CLI に正しく伝わることを確認する。
+       */
+      describe('Then: Task T-02-01 - Claude CLI の正常呼び出し', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('exit code 0 のとき stdout テキストをデコードして返す', async () => {
+          const stdoutText = 'Summary result';
+          const mock = makeSuccessMock(new TextEncoder().encode(stdoutText));
+          (Deno as unknown as Record<string, unknown>).Command = mock;
+
+          const result = await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
+
+          assertEquals(result, stdoutText);
+        });
+
+        it('model・systemPrompt・安全オプションが CLI に渡される', async () => {
+          const captured = { value: [] as string[] };
+          const mock = makeSuccessMock(new TextEncoder().encode('ok'), captured);
+          (Deno as unknown as Record<string, unknown>).Command = mock;
+
+          await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
+
+          assertEquals(captured.value, [
+            '-p',
+            'You are a helper.',
+            '--output-format',
+            'text',
+            '--permission-mode',
+            'acceptEdits',
+            '--strict-mcp-config',
+            '--mcp-config',
+            '{"mcpServers":{}}',
+            '--model',
+            'claude-sonnet-4-6',
+          ]);
+        });
+      });
+    });
+  });
+
+  /** 異常系: CLI が非ゼロ exit code で終了したとき Error をスローする */
+  describe('Given: Claude CLI が非ゼロ exit code で終了する', () => {
+    describe('When: runAI("claude-sonnet-4-6", "sys", "user") を呼び出す', () => {
+      /**
+       * Task T-02-02: Claude CLI 失敗時の処理。
+       * 非ゼロ exit code のとき、exit code を含む Error がスローされることを確認する。
+       */
+      describe('Then: Task T-02-02 - Claude CLI 失敗時の処理', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+          (Deno as unknown as Record<string, unknown>).Command = makeFailMock(1);
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('非ゼロ exit code のとき exit code を含む Error をスローする', async () => {
+          await assertRejects(
+            () => runAI('claude-sonnet-4-6', 'sys', 'user'),
+            Error,
+            '1',
+          );
+        });
+      });
+    });
+  });
+
+  /** 異常系: `claude` コマンドが見つからず Deno.errors.NotFound が伝播する */
+  describe('Given: `claude` コマンドが存在しない', () => {
+    describe('When: runAI("claude-sonnet-4-6", "sys", "user") を呼び出す', () => {
+      /**
+       * Task T-02-03: Claude CLI 失敗時の処理（コマンド不在）。
+       * spawn が NotFound をスローした場合、そのエラーが呼び出し元に伝播することを確認する。
+       */
+      describe('Then: Task T-02-03 - Claude CLI 失敗時の処理（コマンド不在）', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+          (Deno as unknown as Record<string, unknown>).Command = makeNotFoundMock();
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('spawn が Deno.errors.NotFound をスローしたとき、エラーが呼び出し元に伝播する', async () => {
+          await assertRejects(
+            () => runAI('claude-sonnet-4-6', 'sys', 'user'),
+            Deno.errors.NotFound,
+          );
+        });
+      });
+    });
+  });
+
+  /** 正常系: stdout の前後空白・改行を trim して返す */
+  describe('Given: Claude CLI の stdout に前後の空白が含まれる', () => {
+    describe('When: runAI("claude-sonnet-4-6", "sys", "user") を呼び出す', () => {
+      /**
+       * Task T-02-04: 出力のトリミング。
+       * stdout の前後に空白や改行が含まれる場合、trim した文字列が返ることを確認する。
+       */
+      describe('Then: Task T-02-04 - 出力のトリミング', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+          (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+            new TextEncoder().encode('  Summary result\n'),
+          );
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('stdout の前後の空白を除去した文字列を返す', async () => {
+          const result = await runAI('claude-sonnet-4-6', 'sys', 'user');
+
+          assertEquals(result, 'Summary result');
+        });
+      });
+    });
+  });
+});
+
+// ─── segmentChatlog tests ─────────────────────────────────────────────────────
+
+/**
+ * segmentChatlog のユニットテスト。
+ * チャットログコンテンツを AI に渡してセグメント配列 `{title, summary, body}[]` を取得する関数の
+ * 正常系・エラー耐性・上限制御を検証する。
+ */
+describe('segmentChatlog', () => {
+  /** 正常系: runAI が有効な JSON 配列を返したときセグメント配列を返す */
+  describe('Given: runAI が有効な JSON セグメント配列を返す', () => {
+    describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
+      /**
+       * Task T-09-01: 正常なセグメント配列の返却。
+       * セグメントが正しく配列として返され、runAI がちょうど1回呼ばれることを確認する。
+       */
+      describe('Then: Task T-09-01 - 正常なセグメント配列の返却', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('T-09-01-01: {title, summary, body}[] の2件以上の配列を返す', async () => {
+          const segments = [
+            { title: 'Topic A', summary: 'Summary A', body: 'Body A' },
+            { title: 'Topic B', summary: 'Summary B', body: 'Body B' },
+          ];
+          const mock = makeSuccessMock(new TextEncoder().encode(JSON.stringify(segments)));
+          (Deno as unknown as Record<string, unknown>).Command = mock;
+
+          const result = await segmentChatlog('path/to/file.md', 'some chat content');
+
+          assertEquals(Array.isArray(result), true);
+          assertEquals((result as unknown[]).length >= 2, true);
+          assertEquals((result as { title: string }[])[0].title, 'Topic A');
+          assertEquals((result as { summary: string }[])[0].summary, 'Summary A');
+          assertEquals((result as { body: string }[])[0].body, 'Body A');
+        });
+
+        it('T-09-01-02: 1呼び出しにつき runAI をちょうど1回だけ呼び出す', async () => {
+          const counter = { calls: 0 };
+          const segments = [
+            { title: 'Topic A', summary: 'Summary A', body: 'Body A' },
+            { title: 'Topic B', summary: 'Summary B', body: 'Body B' },
+          ];
+          const mock = makeCountingMock(JSON.stringify(segments), counter);
+          (Deno as unknown as Record<string, unknown>).Command = mock;
+
+          await segmentChatlog('path/to/file.md', 'some chat content');
+
+          assertEquals(counter.calls, 1);
+        });
+      });
+    });
+  });
+
+  /** 異常系: runAI がエラーまたは非 JSON を返した場合は null を返す */
+  describe('Given: runAI がエラーをスローする', () => {
+    describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
+      /**
+       * Task T-09-02: エラー時の null 返却。
+       * runAI がエラーをスロー、または非 JSON を返した場合に null が返ることを確認する。
+       */
+      describe('Then: Task T-09-02 - エラー時の null 返却', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('T-09-02-01: null を返す', async () => {
+          (Deno as unknown as Record<string, unknown>).Command = makeFailMock(1);
+
+          const result = await segmentChatlog('path/to/file.md', 'some chat content');
+
+          assertEquals(result, null);
+        });
+
+        it('T-09-02-02: runAI が "not json" を返す場合に null を返す', async () => {
+          const mock = makeSuccessMock(new TextEncoder().encode('not json'));
+          (Deno as unknown as Record<string, unknown>).Command = mock;
+
+          const result = await segmentChatlog('path/to/file.md', 'some chat content');
+
+          assertEquals(result, null);
+        });
+      });
+    });
+  });
+
+  /** 正常系: セグメント数が上限 (10件) を超えた場合は最初の10件のみ返す */
+  describe('Given: runAI が 15件のセグメントを返す', () => {
+    describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
+      /**
+       * Task T-09-03: セグメント数の上限適用。
+       * runAI が10件を超えるセグメントを返した場合、最初の10件のみに絞られることを確認する。
+       */
+      describe('Then: Task T-09-03 - セグメント数の上限適用', () => {
+        let savedCommand: unknown;
+        beforeEach(() => {
+          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+        });
+        afterEach(() => {
+          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+        });
+
+        it('T-09-03-01: ちょうど10件のみ返される', async () => {
+          const segments = Array.from({ length: 15 }, (_, i) => ({
+            title: `Topic ${i + 1}`,
+            summary: `Summary ${i + 1}`,
+            body: `Body ${i + 1}`,
+          }));
+          const mock = makeSuccessMock(new TextEncoder().encode(JSON.stringify(segments)));
+          (Deno as unknown as Record<string, unknown>).Command = mock;
+
+          const result = await segmentChatlog('path/to/file.md', 'some chat content');
+
+          assertEquals((result as unknown[]).length, 10);
+        });
+      });
+    });
+  });
+});

--- a/.claude/commands/scripts/__tests__/integration/normalize-chatlog.integration.spec.ts
+++ b/.claude/commands/scripts/__tests__/integration/normalize-chatlog.integration.spec.ts
@@ -1,0 +1,432 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
+// src: scripts/__tests__/integration/normalize-chatlog.integration.spec.ts
+// @(#): 実ファイルシステムを使った統合テスト
+//       対象: findMdFiles, collectMdFiles, resolveInputDir, writeOutput
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// Deno Test module
+import { assertEquals, assertRejects } from '@std/assert';
+import { after, afterEach, before, beforeEach, describe, it } from '@std/testing/bdd';
+import type { Stub } from '@std/testing/mock';
+import { stub } from '@std/testing/mock';
+
+// test target
+import {
+  collectMdFiles,
+  findMdFiles,
+  resolveInputDir,
+  writeOutput,
+} from '../../normalize-chatlog.ts';
+import type { Stats } from '../../normalize-chatlog.ts';
+
+// ─── findMdFiles / collectMdFiles tests ──────────────────────────────────────
+
+/**
+ * findMdFiles / collectMdFiles のユニットテスト。
+ * ディレクトリを再帰的に走査して .md ファイルを辞書順で収集する関数の
+ * 正常系・フィルタリング・エラー耐性を検証する。
+ */
+describe('findMdFiles', () => {
+  /** 正常系: サブディレクトリを再帰的に走査して .md ファイルを辞書順で収集する */
+  describe('Given: 異なる深さに3つの.mdファイルを持つディレクトリツリー', () => {
+    describe('When: findMdFiles(dir) を呼び出す', () => {
+      /**
+       * Task T-06-01: 再帰的MD収集。
+       * 全 .md ファイルが収集され、返却配列が辞書順にソートされていることを確認する。
+       */
+      describe('Then: Task T-06-01 - 再帰的MD収集', () => {
+        let dir: string;
+        beforeEach(() => {
+          dir = Deno.makeTempDirSync();
+        });
+        afterEach(() => {
+          Deno.removeSync(dir, { recursive: true });
+        });
+
+        it('T-06-01-01: 全3つのファイルパスが返される', () => {
+          Deno.mkdirSync(`${dir}/sub1`);
+          Deno.mkdirSync(`${dir}/sub1/sub2`);
+          Deno.writeTextFileSync(`${dir}/a.md`, '');
+          Deno.writeTextFileSync(`${dir}/sub1/b.md`, '');
+          Deno.writeTextFileSync(`${dir}/sub1/sub2/c.md`, '');
+
+          const result = findMdFiles(dir);
+
+          assertEquals(result.length, 3);
+        });
+
+        it('T-06-01-02: 返却配列が辞書順にソートされている', () => {
+          Deno.writeTextFileSync(`${dir}/c.md`, '');
+          Deno.writeTextFileSync(`${dir}/a.md`, '');
+          Deno.writeTextFileSync(`${dir}/b.md`, '');
+
+          const result = findMdFiles(dir);
+
+          const sorted = [...result].sort();
+          assertEquals(result, sorted);
+        });
+      });
+    });
+  });
+
+  /** 正常系: .md 以外の拡張子と空ディレクトリはスキップし .md のみを返す */
+  describe('Given: .md、.txt、.yamlファイルを含むディレクトリ', () => {
+    describe('When: collectMdFiles(dir, results) を呼び出す', () => {
+      /**
+       * Task T-06-02: 非MDファイルと空ディレクトリ。
+       * .md 以外の拡張子はスキップされ、.md が0件の場合は空配列が返ることを確認する。
+       */
+      describe('Then: Task T-06-02 - 非MDファイルと空ディレクトリ', () => {
+        let dir: string;
+        beforeEach(() => {
+          dir = Deno.makeTempDirSync();
+        });
+        afterEach(() => {
+          Deno.removeSync(dir, { recursive: true });
+        });
+
+        it('T-06-02-01: .mdファイルのみが結果に含まれる', () => {
+          Deno.writeTextFileSync(`${dir}/a.md`, '');
+          Deno.writeTextFileSync(`${dir}/b.txt`, '');
+          Deno.writeTextFileSync(`${dir}/c.yaml`, '');
+
+          const results: string[] = [];
+          collectMdFiles(dir, results);
+
+          assertEquals(results.length, 1);
+          assertEquals(results[0].endsWith('.md'), true);
+        });
+
+        it('T-06-02-02: .mdファイルが0件のディレクトリで空配列を返す', () => {
+          Deno.writeTextFileSync(`${dir}/b.txt`, '');
+          Deno.writeTextFileSync(`${dir}/c.yaml`, '');
+
+          const result = findMdFiles(dir);
+
+          assertEquals(result, []);
+        });
+      });
+    });
+  });
+
+  /** エッジケース: 存在しないパスはエラーをスローせず空のまま返す */
+  describe('Given: ファイルシステムに存在しないパス', () => {
+    describe('When: collectMdFiles(nonExistentPath, results) を呼び出す', () => {
+      /**
+       * Task T-06-03: 存在しないディレクトリ。
+       * 存在しないパスを渡してもエラーがスローされず、results が空のまま返ることを確認する。
+       */
+      describe('Then: Task T-06-03 - 存在しないディレクトリ', () => {
+        it('T-06-03-01: エラーがスローされず results が空のままである', () => {
+          const nonExistentPath = '/this/path/does/not/exist/at/all/9999';
+
+          const results: string[] = [];
+          collectMdFiles(nonExistentPath, results);
+
+          assertEquals(results, []);
+        });
+      });
+    });
+  });
+});
+
+// ─── resolveInputDir tests ────────────────────────────────────────────────────
+
+/**
+ * resolveInputDir のユニットテスト。
+ * --dir・--agent/--year-month オプションから入力ディレクトリパスを解決し、
+ * 存在しない場合は Deno.exit(1) を呼び出す関数の正常系・異常系を検証する。
+ */
+describe('resolveInputDir', () => {
+  /** 正常系: 存在する --dir パスをそのまま返す */
+  describe('Given: 存在する --dir パスが与えられる', () => {
+    describe('When: resolveInputDir({ dir }) を呼び出す', () => {
+      /**
+       * Task T-07-01: --dir オプションによる解決。
+       * 存在するパスが指定された場合、そのまま返されることを確認する。
+       */
+      describe('Then: Task T-07-01 - --dir オプションによる解決', () => {
+        let dir: string;
+        beforeEach(() => {
+          dir = Deno.makeTempDirSync();
+        });
+        afterEach(() => {
+          Deno.removeSync(dir, { recursive: true });
+        });
+
+        it('T-07-01-01: 存在する --dir パスをそのまま返す', () => {
+          const result = resolveInputDir({ dir });
+
+          assertEquals(result, dir);
+        });
+      });
+    });
+  });
+
+  /** 異常系: 存在しないパスが指定された場合は Deno.exit(1) を呼び出す */
+  describe('Given: 存在しない --dir パスが与えられる', () => {
+    describe('When: resolveInputDir({ dir: "/nonexistent/path/xyz" }) を呼び出す', () => {
+      /**
+       * Task T-07-03: 存在しないパスでのエラー終了。
+       * 解決先パスが存在しない場合、Deno.exit(1) が呼ばれることを確認する。
+       */
+      describe('Then: Task T-07-03 - 存在しないパスでのエラー終了', () => {
+        let exitStub: Stub<typeof Deno, [code?: number], never>;
+        beforeEach(() => {
+          exitStub = stub(Deno, 'exit');
+        });
+        afterEach(() => {
+          exitStub.restore();
+        });
+
+        it('T-07-03-01: Deno.exit(1) が呼ばれる', () => {
+          resolveInputDir({ dir: '/nonexistent/path/xyz' });
+
+          assertEquals(exitStub.calls.length, 1);
+          assertEquals(exitStub.calls[0].args[0], 1);
+        });
+      });
+    });
+  });
+
+  /** 異常系: 必須オプションが一切ない場合は Deno.exit(1) を呼び出す */
+  describe('Given: --dir も --agent/--yearMonth も与えられない', () => {
+    describe('When: resolveInputDir({}) を呼び出す', () => {
+      /**
+       * Task T-07-04: 必須オプションの欠落。
+       * --dir も --agent/--yearMonth も指定されない場合、Deno.exit(1) が呼ばれることを確認する。
+       */
+      describe('Then: Task T-07-04 - 必須オプションの欠落', () => {
+        let exitStub: Stub<typeof Deno, [code?: number], never>;
+        beforeEach(() => {
+          exitStub = stub(Deno, 'exit');
+        });
+        afterEach(() => {
+          exitStub.restore();
+        });
+
+        it('T-07-04-01: Deno.exit(1) が呼ばれる', () => {
+          resolveInputDir({});
+
+          assertEquals(exitStub.calls.length, 1);
+          assertEquals(exitStub.calls[0].args[0], 1);
+        });
+      });
+    });
+  });
+
+  /** 異常系: --agent/--year-month で解決されたパスが存在しない場合は Deno.exit(1) を呼び出す */
+  describe('Given: agent="claude", yearMonth="1999-01" が与えられ解決先パスが存在しない', () => {
+    describe('When: resolveInputDir({ agent: "claude", yearMonth: "1999-01" }) を呼び出す', () => {
+      /**
+       * Task T-07-05: 存在しないパスでのエラー終了（--agent/--year-month 経由）。
+       * --agent/--year-month から構築したパスが存在しない場合、Deno.exit(1) が呼ばれることを確認する。
+       */
+      describe('Then: Task T-07-05 - 存在しないパスでのエラー終了（--agent/--year-month 経由）', () => {
+        let exitStub: Stub<typeof Deno, [code?: number], never>;
+        beforeEach(() => {
+          exitStub = stub(Deno, 'exit');
+        });
+        afterEach(() => {
+          exitStub.restore();
+        });
+
+        it('T-07-05-01: Deno.exit(1) が呼ばれる', () => {
+          resolveInputDir({ agent: 'claude', yearMonth: '1999-01' });
+
+          assertEquals(exitStub.calls.length, 1);
+          assertEquals(exitStub.calls[0].args[0], 1);
+        });
+      });
+    });
+  });
+
+  /** 正常系: --agent/--year-month で `temp/chatlog/<agent>/<year>/<yearMonth>` を解決して返す */
+  describe('Given: agent="claude", yearMonth="2026-03" が与えられ対応パスが存在する', () => {
+    describe('When: resolveInputDir({ agent, yearMonth }) を呼び出す', () => {
+      /**
+       * Task T-07-02: --agent/--year-month による解決。
+       * `temp/chatlog/<agent>/<year>/<yearMonth>` のパスが正しく構築・返却されることを確認する。
+       */
+      describe('Then: Task T-07-02 - --agent/--year-month による解決', () => {
+        const AGENT = 'claude';
+        const YEAR_MONTH_2026 = '2026-03';
+        const DIR_2026 = `temp/chatlog/${AGENT}/2026/${YEAR_MONTH_2026}`;
+        const YEAR_MONTH_2025 = '2025-11';
+        const DIR_2025 = `temp/chatlog/${AGENT}/2025/${YEAR_MONTH_2025}`;
+
+        before(async () => {
+          await Deno.mkdir(DIR_2026, { recursive: true });
+          await Deno.mkdir(DIR_2025, { recursive: true });
+        });
+
+        after(async () => {
+          await Deno.remove(`temp/chatlog/${AGENT}/2026`, { recursive: true });
+          await Deno.remove(`temp/chatlog/${AGENT}/2025`, { recursive: true });
+        });
+
+        it('T-07-02-01: temp/chatlog/<agent>/<year>/<yearMonth> のパスを返す', () => {
+          const result = resolveInputDir({ agent: AGENT, yearMonth: YEAR_MONTH_2026 });
+
+          assertEquals(result, DIR_2026);
+        });
+
+        it('T-07-02-02: yearMonth="2025-11" のとき返却パスが "2025/2025-11" のサブパスを含む', () => {
+          const result = resolveInputDir({ agent: AGENT, yearMonth: YEAR_MONTH_2025 });
+
+          assertEquals(result.includes('2025/2025-11'), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── writeOutput tests ────────────────────────────────────────────────────────
+
+/**
+ * writeOutput のユニットテスト。
+ * アトミックなファイル書き込み、既存ファイルのスキップ、ドライランモードを検証する。
+ */
+describe('writeOutput', () => {
+  /** 正常系: 存在しない出力パスにアトミックにファイルを書き込む */
+  describe('Given: 存在しない出力パスと dryRun=false', () => {
+    let tmpDir: string;
+    let stats: Stats;
+    const content = '---\ntitle: test\n---\n## Summary\nbody';
+
+    beforeEach(async () => {
+      tmpDir = await Deno.makeTempDir();
+      stats = { success: 0, skip: 0, fail: 0 };
+    });
+
+    afterEach(async () => {
+      await Deno.remove(tmpDir, { recursive: true });
+    });
+
+    describe('When: writeOutput を呼び出す', () => {
+      describe('Then: Task T-13-01 - アトミックなファイル書き込み', () => {
+        it('T-13-01-01: ファイルが作成され stats.success がインクリメントされる', async () => {
+          const outputPath = `${tmpDir}/entry.md`;
+
+          await writeOutput(outputPath, content, false, stats);
+
+          const written = await Deno.readTextFile(outputPath);
+          assertEquals(written, content);
+          assertEquals(stats.success, 1);
+        });
+
+        it('T-13-01-02: .tmp ファイルが最終的に存在せず出力ファイルが作成される', async () => {
+          const outputPath = `${tmpDir}/entry.md`;
+          const tmpPath = outputPath + '.tmp';
+
+          await writeOutput(outputPath, content, false, stats);
+
+          // Final output file must exist
+          const written = await Deno.readTextFile(outputPath);
+          assertEquals(written, content);
+          // .tmp file must not remain
+          let tmpExists = false;
+          try {
+            await Deno.stat(tmpPath);
+            tmpExists = true;
+          } catch {
+            tmpExists = false;
+          }
+          assertEquals(tmpExists, false);
+          assertEquals(stats.success, 1);
+        });
+      });
+    });
+  });
+
+  /** エッジケース: すでに存在するファイルはスキップされる */
+  describe('Given: すでに存在する出力パス', () => {
+    let tmpDir: string;
+    let stats: Stats;
+
+    beforeEach(async () => {
+      tmpDir = await Deno.makeTempDir();
+      stats = { success: 0, skip: 0, fail: 0 };
+      await Deno.writeTextFile(`${tmpDir}/existing.md`, 'existing content');
+    });
+
+    afterEach(async () => {
+      await Deno.remove(tmpDir, { recursive: true });
+    });
+
+    describe('When: writeOutput を呼び出す', () => {
+      describe('Then: Task T-13-02 - 既存出力のスキップ (R-011)', () => {
+        it('T-13-02-01: stats.skip がインクリメントされ既存ファイルが上書きされない', async () => {
+          const outputPath = `${tmpDir}/existing.md`;
+
+          await writeOutput(outputPath, 'new content', false, stats);
+
+          const fileContent = await Deno.readTextFile(outputPath);
+          assertEquals(fileContent, 'existing content');
+          assertEquals(stats.skip, 1);
+          assertEquals(stats.success, 0);
+        });
+      });
+    });
+  });
+
+  /** 正常系: dryRun=true のときファイルを作成しない */
+  describe('Given: dryRun=true と存在しない出力パス', () => {
+    let tmpDir: string;
+    let stats: Stats;
+
+    beforeEach(async () => {
+      tmpDir = await Deno.makeTempDir();
+      stats = { success: 0, skip: 0, fail: 0 };
+    });
+
+    afterEach(async () => {
+      await Deno.remove(tmpDir, { recursive: true });
+    });
+
+    describe('When: writeOutput を呼び出す', () => {
+      describe('Then: Task T-13-03 - ドライランモード', () => {
+        it('T-13-03-01: ファイルが作成されない', async () => {
+          const dryPath = `${tmpDir}/dry.md`;
+
+          await writeOutput(dryPath, '## Summary\nbody', true, stats);
+
+          let fileExists = false;
+          try {
+            Deno.statSync(dryPath);
+            fileExists = true;
+          } catch {
+            fileExists = false;
+          }
+          assertEquals(fileExists, false);
+          assertEquals(stats.success, 0);
+        });
+      });
+    });
+  });
+
+  /** 異常系: R-010 ガード — temp/chatlog/ 配下への書き込みはエラーをスローする */
+  describe('[異常] Error Cases', () => {
+    describe('Given: temp/chatlog/ 配下の入力パスを出力先に指定する', () => {
+      describe('When: writeOutput(inputPath, content, false, stats) を呼び出す', () => {
+        describe('Then: Task T-13-04 - R-010 ガードによるエラー', () => {
+          it('T-13-04-01: temp/chatlog/ 配下のパスへの書き込みが行われない (R-010)', async () => {
+            const stats: Stats = { success: 0, skip: 0, fail: 0 };
+            const inputPath = 'temp/chatlog/claude/2026/2026-03/sample.md';
+
+            await assertRejects(
+              async () => {
+                await writeOutput(inputPath, 'overwrite', false, stats);
+              },
+              Error,
+              'R-010',
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/.claude/commands/scripts/__tests__/system/normalize-chatlog.system.spec.ts
+++ b/.claude/commands/scripts/__tests__/system/normalize-chatlog.system.spec.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
+// src: scripts/__tests__/system/normalize-chatlog.system.spec.ts
+// @(#): 実ファイルを使ったシステムテスト
+//       対象: main() — fixtures/chatlog/ の実 MD ファイルを入力として正規化パイプライン全体を検証する
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// cspell:words aplys
+
+// Deno Test module
+import { assertEquals, assertMatch } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+import type { Stub } from '@std/testing/mock';
+import { stub } from '@std/testing/mock';
+
+// test helpers
+import { makeSuccessMock } from '../_helpers/deno-command-mock.ts';
+
+// test target
+import { findMdFiles, main } from '../../normalize-chatlog.ts';
+
+// ─── fixtures パス ────────────────────────────────────────────────────────────
+
+/** fixtures/chatlog/ に置いた実 chatlog ファイルのディレクトリ */
+const FIXTURE_DIR = new URL('../_fixtures/chatlog', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+
+// ─── system tests ─────────────────────────────────────────────────────────────
+
+/**
+ * main() のシステムテスト。
+ * fixtures/chatlog/ に置いた実際のチャットログ MD ファイルを入力として使い、
+ * 正規化パイプライン全体 (parseArgs → resolveInputDir → findMdFiles →
+ * segmentChatlog → generateSegmentFile + attachFrontmatter → writeOutput →
+ * reportResults) が実ファイルで正常動作することを確認する。
+ *
+ * AI 呼び出し (runAI) は Deno.Command モックで代替する。
+ */
+describe('main — 実ファイルを使った正規化パイプライン', () => {
+  /** 正常系: 実 chatlog ファイルを読み込みセグメント出力ファイルが生成される */
+  describe('Given: fixtures/chatlog/ に実 MD ファイルが 1 件存在する', () => {
+    let outputDir: string;
+    let savedCommand: unknown;
+    let logCalls: string[];
+    let logStub: Stub;
+
+    beforeEach(async () => {
+      outputDir = await Deno.makeTempDir();
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+
+      // モック AI: 実ファイルのフロントマターと会話内容に対して 2 セグメントを返す
+      const segmentResponse = JSON.stringify([
+        {
+          title: 'API設計',
+          summary: 'aplys の API 設計方針について議論した',
+          body: '### User\n1 API設計\n\n現在\n\naplys <domain>/<target> <action> [files...]',
+        },
+        {
+          title: 'exit code 仕様',
+          summary: 'exit code の仕様を確認・追加した',
+          body: '### User\n2 exit code\n\n現在\n\ncode    意味',
+        },
+      ]);
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode(segmentResponse),
+      );
+
+      logCalls = [];
+      logStub = stub(console, 'log', (...args: unknown[]) => {
+        logCalls.push(args.map(String).join(' '));
+      });
+    });
+
+    afterEach(async () => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+      logStub.restore();
+      await Deno.remove(outputDir, { recursive: true });
+    });
+
+    describe('When: main(["--dir", FIXTURE_DIR, "--output", outputDir]) を呼び出す', () => {
+      describe('Then: S-01-01 - 実ファイルから正規化されたセグメント出力が生成される', () => {
+        it('S-01-01-01: outputDir に 1 件以上の .md ファイルが生成される', async () => {
+          await main(['--dir', FIXTURE_DIR, '--output', outputDir]);
+
+          const files = findMdFiles(outputDir);
+          assertEquals(files.length >= 1, true);
+        });
+
+        it('S-01-01-02: 各出力ファイルが YAML frontmatter (---\\n) で始まる', async () => {
+          await main(['--dir', FIXTURE_DIR, '--output', outputDir]);
+
+          for (const filePath of findMdFiles(outputDir)) {
+            const content = await Deno.readTextFile(filePath);
+            assertEquals(content.startsWith('---\n'), true, `${filePath} は frontmatter で始まる必要がある`);
+          }
+        });
+
+        it('S-01-01-03: 各出力ファイルが ## Summary セクションを含む', async () => {
+          await main(['--dir', FIXTURE_DIR, '--output', outputDir]);
+
+          for (const filePath of findMdFiles(outputDir)) {
+            const content = await Deno.readTextFile(filePath);
+            assertEquals(content.includes('## Summary'), true, `${filePath} は ## Summary を含む必要がある`);
+          }
+        });
+
+        it('S-01-01-04: frontmatter に project フィールドが伝播している', async () => {
+          await main(['--dir', FIXTURE_DIR, '--output', outputDir]);
+
+          for (const filePath of findMdFiles(outputDir)) {
+            const content = await Deno.readTextFile(filePath);
+            // 実ファイルの frontmatter に project: aplys があるため伝播するはず
+            assertEquals(content.includes('project: aplys'), true, `${filePath} は project: aplys を含む必要がある`);
+          }
+        });
+
+        it('S-01-01-05: 処理結果レポートに success>=1 が含まれる', async () => {
+          await main(['--dir', FIXTURE_DIR, '--output', outputDir]);
+
+          const output = logCalls.join('\n');
+          assertMatch(output, /success=[1-9]/);
+        });
+
+        it('S-01-01-06: 入力ファイルの内容が main() 実行後も変化しない (R-010)', async () => {
+          const inputFile = `${FIXTURE_DIR}/2026-03-11-1-api-a4a84394.md`;
+          const before = await Deno.readTextFile(inputFile);
+
+          await main(['--dir', FIXTURE_DIR, '--output', outputDir]);
+
+          const after = await Deno.readTextFile(inputFile);
+          assertEquals(after, before);
+        });
+      });
+    });
+  });
+});

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.unit.spec.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
 // src: scripts/__tests__/unit/normalize-chatlog.unit.spec.ts
 // @(#): 純粋関数・副作用なし関数のユニットテスト
-//       対象: withConcurrency, cleanYaml, parseFrontmatter, generateLogId,
-//             parseArgs, parseJsonArray, generateSegmentFile, attachFrontmatter, reportResults
+//       対象: withConcurrency, cleanYaml, parseFrontmatter, extractBaseName,
+//             generateOutputFileName, parseArgs, parseJsonArray, generateSegmentFile,
+//             attachFrontmatter, reportResults
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -20,14 +21,17 @@ import { stub } from '@std/testing/mock';
 import {
   attachFrontmatter,
   cleanYaml,
-  generateLogId,
+  extractBaseName,
+  generateOutputFileName,
   generateSegmentFile,
   parseArgs,
   parseFrontmatter,
   parseJsonArray,
   reportResults,
+  resolveOutputDir,
   withConcurrency,
 } from '../../normalize-chatlog.ts';
+// Note: generateLogId was removed from normalize-chatlog.ts and replaced by generateOutputFileName
 import type { Stats } from '../../normalize-chatlog.ts';
 
 /**
@@ -242,74 +246,191 @@ describe('parseFrontmatter', () => {
   });
 });
 
-// ─── generateLogId tests ──────────────────────────────────────────────────────
+// ─── extractBaseName tests ────────────────────────────────────────────────────
 
 /**
- * generateLogId のユニットテスト。
- * ファイルパス・エージェント名・タイトル・インデックスから
- * `<date>-<agent>-<title-slug>-<hash7>` 形式の一意な ID を生成する関数の
- * 正常系・決定論的動作・スラッグ正規化を検証する。
+ * extractBaseName のユニットテスト。
+ * ファイルパスからディレクトリ・拡張子・末尾ハッシュ(-XXXXXXX)を除去して
+ * ベース名を返す純粋関数の正常系・エッジケースを検証する。
  */
-describe('generateLogId', () => {
-  /** 正常系: `<date>-<agent>-<title-slug>-<hash7>` 形式の ID を生成する */
-  describe('Given: 標準的な chatlog ファイルパス・エージェント名・タイトル・インデックス', () => {
-    describe('When: generateLogId(filePath, agentName, title, index) を呼び出す', () => {
-      describe('Then: Task T-05-01 - 標準的な log_id 生成', () => {
-        it('<date>-<agent>-<title-slug>-<hash7> 形式の ID を返す', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test.md';
-          const agentName = 'claude';
-          const title = 'CI/CD Pipeline Fix';
-          const index = 0;
+describe('extractBaseName', () => {
+  /** 正常系: ディレクトリ・.md 拡張子・末尾 7 桁ハッシュを除去する */
+  describe('Given: ディレクトリパスと .md 拡張子を含むファイルパス', () => {
+    describe('When: extractBaseName(filePath) を呼び出す', () => {
+      describe('Then: Task T-05-01 - ベース名の抽出', () => {
+        it('T-05-01-01: ディレクトリと .md 拡張子を除去したファイル名を返す', () => {
+          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-          const result = await generateLogId(filePath, agentName, title, index);
+          const result = extractBaseName(filePath);
 
-          assertMatch(result, /^\d{8}-claude-[a-z0-9-]+-[0-9a-f]{7}$/);
+          assertEquals(result, 'test-file');
         });
 
-        it('タイトルスラッグが小文字ハイフン区切りになる', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test.md';
-          const agentName = 'claude';
-          const title = 'Deno/TypeScript Setup & Config';
-          const index = 0;
+        it('T-05-01-02: 末尾の -XXXXXXX (7桁 hex) を除去する', () => {
+          const filePath = 'temp/chatlog/claude/2026/2026-03/2026-03-11-topic-abc1234.md';
 
-          const result = await generateLogId(filePath, agentName, title, index);
+          const result = extractBaseName(filePath);
 
-          // Format: YYYYMMDD-agentName-<slug>-<hash7>
-          // Verify the slug segment (between agentName and hash7) contains only lowercase
-          // alphanumeric chars and hyphens — no uppercase, `/`, `&`, or spaces
-          assertMatch(result, /^\d{8}-[^-]+-[a-z0-9][a-z0-9-]*[a-z0-9]-[0-9a-f]{7}$/);
+          assertEquals(result, '2026-03-11-topic');
+        });
+
+        it('T-05-01-03: 末尾が 7 桁 hex でない場合はハッシュ除去しない', () => {
+          const filePath = 'path/to/2026-03-11-topic.md';
+
+          const result = extractBaseName(filePath);
+
+          assertEquals(result, '2026-03-11-topic');
         });
       });
     });
   });
 
-  /** 正常系: index が異なれば hash7 が変わり、同一入力では常に同一 ID を返す（決定論的） */
-  describe('Given: 同一の filePath・agentName・title で index だけ異なる', () => {
-    describe('When: index=0 と index=1 でそれぞれ generateLogId を呼び出す', () => {
-      describe('Then: Task T-05-02 - ハッシュの安定性とインデックス差別化', () => {
-        it('index が異なれば hash7 が異なる', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test.md';
-          const agentName = 'claude';
-          const title = 'CI/CD Pipeline Fix';
+  /** エッジケース: ディレクトリなし・拡張子なし */
+  describe('Given: ディレクトリなしのファイル名', () => {
+    describe('When: extractBaseName(filePath) を呼び出す', () => {
+      describe('Then: Task T-05-02 - エッジケースの処理', () => {
+        it('T-05-02-01: ディレクトリなしでも .md 拡張子を除去して返す', () => {
+          const result = extractBaseName('simple-file.md');
 
-          const id0 = await generateLogId(filePath, agentName, title, 0);
-          const id1 = await generateLogId(filePath, agentName, title, 1);
-
-          const hash0 = id0.split('-').at(-1);
-          const hash1 = id1.split('-').at(-1);
-          assertNotEquals(hash0, hash1);
+          assertEquals(result, 'simple-file');
         });
 
-        it('同一入力は常に同一の log_id を返す（決定論的）', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test.md';
-          const agentName = 'claude';
-          const title = 'CI/CD Pipeline Fix';
-          const index = 0;
+        it('T-05-02-02: 拡張子がない場合はファイル名をそのまま返す', () => {
+          const result = extractBaseName('no-extension');
 
-          const first = await generateLogId(filePath, agentName, title, index);
-          const second = await generateLogId(filePath, agentName, title, index);
+          assertEquals(result, 'no-extension');
+        });
+      });
+    });
+  });
+});
 
-          assertEquals(first, second);
+// ─── generateOutputFileName tests ─────────────────────────────────────────────
+
+/**
+ * generateOutputFileName のユニットテスト。
+ * `<baseName>-<XX>-<hash7>.md` 形式の出力ファイル名を生成する関数の
+ * フォーマット・連番・ハッシュのランダム性を検証する。
+ *
+ * hash7 は `<baseName>-<XX>-<timestamp12>-<random8>` の SHA-256 先頭 7 文字。
+ * ランダム要素を含むため、`crypto.getRandomValues` をスタブして再現性を担保する。
+ */
+describe('generateOutputFileName', () => {
+  let cryptoStub: Stub | null = null;
+
+  /** 固定バイト列スタブをセットする。テストが自前で restore した場合は null にしておく。 */
+  function setupCryptoStub(): void {
+    cryptoStub = stub(crypto, 'getRandomValues', (arr: ArrayBufferView) => {
+      const u8 = new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+      for (let i = 0; i < u8.length; i++) {
+        u8[i] = i;
+      }
+      return arr;
+    });
+  }
+
+  beforeEach(() => {
+    setupCryptoStub();
+  });
+
+  afterEach(() => {
+    if (cryptoStub !== null) {
+      cryptoStub.restore();
+      cryptoStub = null;
+    }
+  });
+
+  /** 正常系: `<baseName>-<XX>-<hash7>.md` 形式のファイル名を返す */
+  describe('Given: 標準的な chatlog ファイルパスと index', () => {
+    describe('When: generateOutputFileName(filePath, index) を呼び出す', () => {
+      describe('Then: Task T-06-01 - 標準的なファイル名生成', () => {
+        it('T-06-01-01: index=0 のとき <baseName>-01-<hash7>.md 形式のファイル名を返す', async () => {
+          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+
+          const result = await generateOutputFileName(filePath, 0);
+
+          assertMatch(result, /^test-file-01-[0-9a-f]{7}\.md$/);
+        });
+
+        it('T-06-01-02: index=1 のとき連番が "02" になる', async () => {
+          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+
+          const result = await generateOutputFileName(filePath, 1);
+
+          assertMatch(result, /^test-file-02-[0-9a-f]{7}\.md$/);
+        });
+
+        it('T-06-01-03: index=9 のとき連番が "10" になる', async () => {
+          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+
+          const result = await generateOutputFileName(filePath, 9);
+
+          assertMatch(result, /^test-file-10-[0-9a-f]{7}\.md$/);
+        });
+      });
+    });
+  });
+
+  /** 正常系: スタブ固定 + 日付固定で同一入力が同一結果を返す（再現性） */
+  describe('Given: crypto と Date をスタブして固定した状態', () => {
+    describe('When: 同一 filePath と同一 index で 2 回呼び出す', () => {
+      describe('Then: Task T-06-02 - スタブによる再現性', () => {
+        it('T-06-02-01: 同一タイムスタンプと固定ランダム値で常に同じファイル名が返る', async () => {
+          const dateStubs = [
+            stub(Date.prototype, 'getFullYear', () => 2026),
+            stub(Date.prototype, 'getMonth', () => 2),
+            stub(Date.prototype, 'getDate', () => 11),
+            stub(Date.prototype, 'getHours', () => 10),
+            stub(Date.prototype, 'getMinutes', () => 30),
+            stub(Date.prototype, 'getSeconds', () => 0),
+          ];
+
+          try {
+            const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+
+            const first = await generateOutputFileName(filePath, 0);
+            const second = await generateOutputFileName(filePath, 0);
+
+            assertEquals(first, second);
+            assertMatch(first, /^test-file-01-[0-9a-f]{7}\.md$/);
+          } finally {
+            dateStubs.forEach((s) => s.restore());
+          }
+        });
+      });
+    });
+  });
+
+  /** 正常系: スタブなしで同一入力でも異なるハッシュが生成される（ランダム性） */
+  describe('Given: crypto.getRandomValues をスタブせず実際の乱数を使う', () => {
+    describe('When: 同一 filePath と同一 index で 2 回連続して呼び出す', () => {
+      describe('Then: Task T-06-03 - ランダム性によるハッシュの変化', () => {
+        it('T-06-03-01: スタブなしで 2 回呼ぶと異なるファイル名が生成される', async () => {
+          cryptoStub!.restore();
+          cryptoStub = null;
+          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+
+          const first = await generateOutputFileName(filePath, 0);
+          const second = await generateOutputFileName(filePath, 0);
+
+          assertNotEquals(first, second);
+          assertMatch(first, /^test-file-01-[0-9a-f]{7}\.md$/);
+          assertMatch(second, /^test-file-01-[0-9a-f]{7}\.md$/);
+        });
+      });
+    });
+  });
+
+  /** 正常系: 末尾ハッシュ付きのソースファイルでもベース名が正しく抽出される */
+  describe('Given: 末尾に -XXXXXXX ハッシュを含むソースファイルパス', () => {
+    describe('When: generateOutputFileName(filePath, 0) を呼び出す', () => {
+      describe('Then: Task T-06-04 - ハッシュ付きソースファイルのベース名処理', () => {
+        it('T-06-04-01: ソースの末尾ハッシュを除去したベース名で出力名を生成する', async () => {
+          const filePath = 'temp/chatlog/claude/2026/2026-03/2026-03-11-topic-abc1234.md';
+
+          const result = await generateOutputFileName(filePath, 0);
+
+          assertMatch(result, /^2026-03-11-topic-01-[0-9a-f]{7}\.md$/);
         });
       });
     });
@@ -675,6 +796,81 @@ describe('attachFrontmatter', () => {
 
           const contentOccurrences = result.split('## Summary\ntext').length - 1;
           assertEquals(contentOccurrences, 1);
+        });
+      });
+    });
+  });
+});
+
+// ─── resolveOutputDir tests ──────────────────────────────────────────────────
+
+/**
+ * resolveOutputDir のユニットテスト。
+ * InputDir と outputBase、project から OutputDir を解決する関数の
+ * 正常系 (chatlog形式/任意パス)・エッジケース (project未指定) を検証する。
+ */
+describe('resolveOutputDir', () => {
+  /** 正常系: chatlog形式のinputDirから agent/<yyyy>/<yyyy-mm>/<project> を組み立てる */
+  describe('[正常] Normal Cases', () => {
+    describe('Given: chatlog形式のinputDir "temp/chatlog/claude/2026/2026-03" と project "myapp"', () => {
+      describe('When: resolveOutputDir(inputDir, outputBase, project) を呼び出す', () => {
+        describe('Then: Task T-15-01 - chatlog形式のOutputDir生成', () => {
+          it('T-15-01-01: Given chatlog形式のinputDir "temp/chatlog/claude/2026/2026-03" と project "myapp", When resolveOutputDir, Then "base/claude/2026/2026-03/myapp" を返す', () => {
+            const result = resolveOutputDir('temp/chatlog/claude/2026/2026-03', 'base', 'myapp');
+
+            assertEquals(result, 'base/claude/2026/2026-03/myapp');
+          });
+        });
+      });
+    });
+
+    describe('Given: chatlog形式のinputDir と project が undefined', () => {
+      describe('When: resolveOutputDir(inputDir, outputBase, undefined) を呼び出す', () => {
+        describe('Then: Task T-15-02 - projectがundefinedのとき "misc" を使う', () => {
+          it('T-15-02-01: Given projectがundefined, When resolveOutputDir, Then "base/claude/2026/2026-03/misc" を返す', () => {
+            const result = resolveOutputDir('temp/chatlog/claude/2026/2026-03', 'base', undefined);
+
+            assertEquals(result, 'base/claude/2026/2026-03/misc');
+          });
+        });
+      });
+    });
+
+    describe('Given: chatlog形式のinputDir と project が空文字', () => {
+      describe('When: resolveOutputDir(inputDir, outputBase, "") を呼び出す', () => {
+        describe('Then: Task T-15-03 - projectが空文字のとき "misc" を使う', () => {
+          it('T-15-03-01: Given projectが空文字, When resolveOutputDir, Then "base/claude/2026/2026-03/misc" を返す', () => {
+            const result = resolveOutputDir('temp/chatlog/claude/2026/2026-03', 'base', '');
+
+            assertEquals(result, 'base/claude/2026/2026-03/misc');
+          });
+        });
+      });
+    });
+  });
+
+  /** 正常系: 任意パスのinputDirは outputBase/<project> を返す */
+  describe('[正常] Arbitrary Path Cases', () => {
+    describe('Given: 任意パスのinputDir "some/custom/path" と project "proj"', () => {
+      describe('When: resolveOutputDir(inputDir, outputBase, project) を呼び出す', () => {
+        describe('Then: Task T-15-04 - 任意パスのOutputDir生成', () => {
+          it('T-15-04-01: Given 任意パスのinputDir "some/custom/path" と project "proj", When resolveOutputDir, Then "base/proj" を返す', () => {
+            const result = resolveOutputDir('some/custom/path', 'base', 'proj');
+
+            assertEquals(result, 'base/proj');
+          });
+        });
+      });
+    });
+
+    describe('Given: 任意パスのinputDir と project が undefined', () => {
+      describe('When: resolveOutputDir(inputDir, outputBase, undefined) を呼び出す', () => {
+        describe('Then: Task T-15-05 - 任意パス + projectがundefinedのとき "misc" を使う', () => {
+          it('T-15-05-01: Given 任意パスのinputDir と projectがundefined, When resolveOutputDir, Then "base/misc" を返す', () => {
+            const result = resolveOutputDir('some/custom/path', 'base', undefined);
+
+            assertEquals(result, 'base/misc');
+          });
         });
       });
     });


### PR DESCRIPTION
## Overview

**Summary**
Restructure normalize-chatlog test suite from monolithic spec into layered unit/functional/integration/e2e/system levels.

**Background / Motivation**
The existing `normalize-chatlog.spec.ts` was a single monolithic file that mixed concerns across different test boundaries.
This made it difficult to isolate failures, reason about coverage, and maintain tests independently.
Splitting into five dedicated layers improves clarity, maintainability, and failure isolation.

## Changes

- Added `_helpers/deno-command-mock.ts` — reusable `Deno.Command` mock helpers for test isolation
- Added `_fixtures/chatlog/2026-03-11-1-api-a4a84394.md` — real chatlog fixture for system-level tests
- Added `unit/normalize-chatlog.unit.spec.ts` — pure function tests (helpers, path resolution, output logic)
- Added `functional/normalize-chatlog.functional.spec.ts` — `runAI` and `segmentChatlog` behavior tests
- Added `integration/normalize-chatlog.integration.spec.ts` — filesystem, input resolution, and write behavior
- Added `e2e/normalize-chatlog.e2e.spec.ts` — full `main()` workflow with batch processing and skip behavior
- Added `system/normalize-chatlog.system.spec.ts` — `main()` against real fixtures with recursive output validation
- Removed `normalize-chatlog.spec.ts` — legacy monolithic spec deleted after all coverage was migrated

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [x] Other

## Related Issues

None.

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

Test-only PR. No source code changes. Run the full suite with:

```sh
deno test --allow-all .claude/commands/scripts/__tests__/
```
