### PR TITLE
test(e2e/normalize-chatlog): add full end-to-end coverage

### DIFF
--- a/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
+++ b/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
+// src: scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
+// @(#): normalize-chatlog の統合 E2E テスト
+//       IO / aggregation / structure / reproducibility を一括検証する
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// Deno Test module
+import { assertEquals, assertMatch } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+import type { CommandMockHandle } from '../_helpers/deno-command-mock.ts';
+import { installCommandMock, makeSuccessMock } from '../_helpers/deno-command-mock.ts';
+import type { LogCapture } from '../_helpers/e2e-setup.ts';
+import { captureLog, makeTempDirs, removeTempDirs } from '../_helpers/e2e-setup.ts';
+import { assertAllOutputFiles } from '../_helpers/output-validator.ts';
+
+// test target
+import { findMdFiles, main } from '../../normalize-chatlog.ts';
+import type { HashProvider } from '../../normalize-chatlog.ts';
+
+// ─── full E2E ─────────────────────────────────────────────────────────────────
+
+/**
+ * IO / aggregation / structure / reproducibility を一括で検証する統合 E2E テスト。
+ * 実際の使用シナリオに近い状況で normalize-chatlog のエンドツーエンド動作を確認する。
+ */
+describe('normalize-chatlog - full E2E', () => {
+  // ─── IO: ファイル生成とカウント ────────────────────────────────────────────────
+
+  describe('IO: 複数 MD ファイルから出力ファイルが生成される', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let commandHandle: CommandMockHandle;
+    let logCapture: LogCapture;
+
+    beforeEach(async () => {
+      ({ inputDir, outputDir } = await makeTempDirs());
+
+      await Deno.writeTextFile(
+        `${inputDir}/chat-a.md`,
+        '---\nproject: my-project\n---\n### User\nHow does CI work?\n\n### AI\nCI runs tests automatically.',
+      );
+      await Deno.writeTextFile(
+        `${inputDir}/chat-b.md`,
+        '---\nproject: my-project\n---\n### User\nHow do I deploy?\n\n### AI\nRun the deploy script.',
+      );
+      await Deno.writeTextFile(
+        `${inputDir}/chat-c.md`,
+        '---\nproject: my-project\n---\n### User\nWhat is linting?\n\n### AI\nLinting checks code style.',
+      );
+
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary of topic', body: '### User\nQuestion' },
+      ]);
+      commandHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+      );
+      logCapture = captureLog();
+    });
+
+    afterEach(async () => {
+      commandHandle.restore();
+      logCapture.restore();
+      await removeTempDirs(inputDir, outputDir);
+    });
+
+    it('T-FULL-01: 3 件の入力から 3 件以上の出力ファイルが生成され success=3 がレポートされる', async () => {
+      await main(['--dir', inputDir, '--output', outputDir]);
+
+      // IO: 出力ファイルが生成されている
+      const files = findMdFiles(outputDir);
+      assertEquals(files.length >= 3, true);
+
+      // aggregation: 全件 success に集計されている
+      assertMatch(logCapture.calls.join('\n'), /success=3/);
+    });
+  });
+
+  // ─── structure: 出力ファイルの内部構造 ───────────────────────────────────────
+
+  describe('structure: 出力ファイルが正しい構造を持つ', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let commandHandle: CommandMockHandle;
+    let logCapture: LogCapture;
+
+    beforeEach(async () => {
+      ({ inputDir, outputDir } = await makeTempDirs());
+
+      await Deno.writeTextFile(
+        `${inputDir}/chat.md`,
+        '---\nproject: structured-project\n---\n### User\nExplain TDD.\n\n### AI\nTDD means writing tests first.',
+      );
+
+      const segmentResponse = JSON.stringify([
+        { title: 'TDD Explanation', summary: 'Overview of TDD', body: '### User\nExplain TDD.' },
+      ]);
+      commandHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+      );
+      logCapture = captureLog();
+    });
+
+    afterEach(async () => {
+      commandHandle.restore();
+      logCapture.restore();
+      await removeTempDirs(inputDir, outputDir);
+    });
+
+    it('T-FULL-02: 出力ファイルが YAML frontmatter・## Summary・project フィールドを含む', async () => {
+      await main(['--dir', inputDir, '--output', outputDir]);
+
+      const files = findMdFiles(outputDir);
+      assertEquals(files.length >= 1, true);
+
+      // structure: frontmatter / Summary / project フィールドの検証
+      await assertAllOutputFiles(files, {
+        expectFrontmatterField: { key: 'project', value: 'structured-project' },
+      });
+    });
+  });
+
+  // ─── reproducibility: 再実行時のバックアップと入力不変 ────────────────────────
+
+  describe('reproducibility: 再実行時に既存出力をバックアップし入力を変更しない', () => {
+    let inputDir: string;
+    let outputDir: string;
+    let commandHandle: CommandMockHandle;
+    let logCapture: LogCapture;
+    const inputContent = '---\nproject: repro-project\n---\n### User\nTest reproducibility.\n\n### AI\nOK.';
+
+    beforeEach(async () => {
+      ({ inputDir, outputDir } = await makeTempDirs());
+
+      await Deno.writeTextFile(`${inputDir}/chat.md`, inputContent);
+
+      const segmentResponse = JSON.stringify([
+        { title: 'Reproducibility', summary: 'Test run', body: '### User\nTest.' },
+      ]);
+      commandHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+      );
+      logCapture = captureLog();
+    });
+
+    afterEach(async () => {
+      commandHandle.restore();
+      logCapture.restore();
+      await removeTempDirs(inputDir, outputDir);
+    });
+
+    it('T-FULL-03: 2 回実行後に旧ファイルが .old-01.md にバックアップされ、入力ファイルは不変である', async () => {
+      const fixedHash: HashProvider = () => '0000000';
+
+      // 1 回目: 出力ファイルを生成
+      await main(['--dir', inputDir, '--output', outputDir], fixedHash);
+
+      // 2 回目: バックアップを生成
+      logCapture.calls.splice(0);
+      await main(['--dir', inputDir, '--output', outputDir], fixedHash);
+
+      // reproducibility: 2 回目も success=1
+      assertMatch(logCapture.calls.join('\n'), /success=1/);
+
+      // reproducibility: .old-01.md バックアップが存在する
+      const outputFiles: string[] = [];
+      for await (const entry of Deno.readDir(outputDir)) {
+        outputFiles.push(entry.name);
+      }
+      const backupExists = outputFiles.some((name) => name.includes('.old-01.md'));
+      assertEquals(backupExists, true);
+
+      // reproducibility: 入力ファイルは不変
+      const afterContent = await Deno.readTextFile(`${inputDir}/chat.md`);
+      assertEquals(afterContent, inputContent);
+    });
+  });
+});


### PR DESCRIPTION
## Overview

**Summary**
Add full end-to-end test coverage for the normalize-chatlog script.

**Background / Motivation**
IO・aggregation・structure・reproducibility の各側面が個別テストで断片的にしか検証されていなかった。
実使用シナリオに近い形で一括検証する E2E テストスイートを新設し、エンドツーエンドの品質保証を強化する。

## Changes

- `__tests__/e2e/normalize-chatlog-full.e2e.spec.ts` を新規追加 (+183 行)
  - `T-FULL-01`: 3件の入力 MD ファイルから 3件以上の出力ファイルが生成され、`success=3` がレポートされることを検証
  - `T-FULL-02`: 出力ファイルに YAML frontmatter・`## Summary`・`project` フィールドが含まれることを検証
  - `T-FULL-03`: 再実行時に既存出力が `.old-01.md` にバックアップされ、入力ファイルが不変であることを検証
  - `deno-command-mock`・`e2e-setup`・`output-validator` の共有ヘルパーを活用

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [x] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

テストは `deno-command-mock` によるコマンドスタブを使用しており、実際の AI API 呼び出しを行わずに E2E シナリオを検証できる。`HashProvider` を注入することで再現性テストにおけるハッシュ値の固定が可能。
