### PR TITLE
feat(normalize-chatlog): derive output directory per project

### DIFF
--- a/.claude/commands/scripts/__tests__/_fixtures/runai-markdown/chatlog-edge-03-empty-summary/output-1.md
+++ b/.claude/commands/scripts/__tests__/_fixtures/runai-markdown/chatlog-edge-03-empty-summary/output-1.md
@@ -1,7 +1,5 @@
 ## Summary
 
-
-
 ## Excerpt
 
 ### User

--- a/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
+++ b/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
@@ -167,12 +167,9 @@ describe('normalize-chatlog - full E2E', () => {
       // reproducibility: 2 回目も success=1
       assertMatch(logCapture.calls.join('\n'), /success=1/);
 
-      // reproducibility: .old-01.md バックアップが存在する
-      const outputFiles: string[] = [];
-      for await (const entry of Deno.readDir(outputDir)) {
-        outputFiles.push(entry.name);
-      }
-      const backupExists = outputFiles.some((name) => name.includes('.old-01.md'));
+      // reproducibility: .old-01.md バックアップが存在する（サブディレクトリも含めて再帰検索）
+      const allFiles = findMdFiles(outputDir);
+      const backupExists = allFiles.some((path) => path.includes('.old-01.md'));
       assertEquals(backupExists, true);
 
       // reproducibility: 入力ファイルは不変

--- a/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts
+++ b/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts
@@ -22,6 +22,7 @@ import { captureLog, makeTempDirs, removeTempDirs, silenceLog } from '../_helper
 
 // test target
 import { findMdFiles, main } from '../../normalize-chatlog.ts';
+import type { HashProvider } from '../../normalize-chatlog.ts';
 
 // ─── I/O テスト ────────────────────────────────────────────────────────────────
 
@@ -153,6 +154,155 @@ describe('main - I/O', () => {
 
           assertEquals(exitStub.calls.length >= 1, true);
           assertEquals(exitStub.calls[0].args[0], 1);
+        });
+      });
+    });
+  });
+
+  // ─── T-15-05: chatlog形式入力パスに応じた出力パス構造 ────────────────────────
+
+  /** 正常系: chatlog形式の入力パス (temp/chatlog/<agent>/<yyyy>/<yyyy-mm>) に対して
+   *  出力が normalized-logs/<agent>/<yyyy>/<yyyy-mm>/<project>/ 以下に生成される */
+  describe('Given: chatlog形式ディレクトリ (temp/chatlog/claude/2026/2026-04) と project フロントマターを持つ MD ファイル', () => {
+    const CHATLOG_INPUT_DIR = 'temp/chatlog/claude/2026/2026-04';
+    let outputBase: string;
+    let commandHandle: CommandMockHandle;
+    let logSilencer: LogSilencer;
+
+    before(async () => {
+      await Deno.mkdir(CHATLOG_INPUT_DIR, { recursive: true });
+      await Deno.writeTextFile(
+        `${CHATLOG_INPUT_DIR}/chat.md`,
+        '---\nproject: my-app\n---\n### User\nHello\n\n### AI\nHi',
+      );
+    });
+
+    after(async () => {
+      await Deno.remove('temp/chatlog/claude/2026', { recursive: true });
+    });
+
+    beforeEach(async () => {
+      outputBase = await Deno.makeTempDir();
+
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      commandHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+      );
+      logSilencer = silenceLog();
+    });
+
+    afterEach(async () => {
+      commandHandle.restore();
+      logSilencer.restore();
+      await Deno.remove(outputBase, { recursive: true });
+    });
+
+    describe('When: main(["--dir", CHATLOG_INPUT_DIR, "--output", outputBase]) を呼び出す', () => {
+      describe('Then: Task T-15-05-01 - 出力が <outputBase>/claude/2026/2026-04/my-app/ 以下に生成される', () => {
+        it('T-15-05-01-01: 出力ファイルのパスが <outputBase>/claude/2026/2026-04/my-app/ を含む', async () => {
+          const fixedHash: HashProvider = () => 'abc1234';
+          await main(['--dir', CHATLOG_INPUT_DIR, '--output', outputBase], fixedHash);
+
+          const files = findMdFiles(outputBase);
+          assertEquals(files.length >= 1, true);
+          const expectedSubPath = `claude/2026/2026-04/my-app`;
+          const allUnderExpected = files.every((f) => f.replace(/\\/g, '/').includes(expectedSubPath));
+          assertEquals(allUnderExpected, true);
+        });
+      });
+    });
+  });
+
+  // ─── T-15-06: 任意ディレクトリ入力時は <outputBase>/<project>/ 以下に出力 ───
+
+  /** 正常系: 任意パスの入力ディレクトリに対して出力が <outputBase>/<project>/ 以下に生成される */
+  describe('Given: 任意パスのディレクトリと project フロントマターを持つ MD ファイル', () => {
+    let inputDir: string;
+    let outputBase: string;
+    let commandHandle: CommandMockHandle;
+    let logSilencer: LogSilencer;
+
+    beforeEach(async () => {
+      ({ inputDir, outputDir: outputBase } = await makeTempDirs());
+
+      await Deno.writeTextFile(
+        `${inputDir}/chat.md`,
+        '---\nproject: custom-project\n---\n### User\nHello\n\n### AI\nHi',
+      );
+
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      commandHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+      );
+      logSilencer = silenceLog();
+    });
+
+    afterEach(async () => {
+      commandHandle.restore();
+      logSilencer.restore();
+      await removeTempDirs(inputDir, outputBase);
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputBase]) を呼び出す', () => {
+      describe('Then: Task T-15-06-01 - 出力が <outputBase>/custom-project/ 以下に生成される', () => {
+        it('T-15-06-01-01: 出力ファイルのパスが <outputBase>/custom-project/ を含む', async () => {
+          const fixedHash: HashProvider = () => 'def5678';
+          await main(['--dir', inputDir, '--output', outputBase], fixedHash);
+
+          const files = findMdFiles(outputBase);
+          assertEquals(files.length >= 1, true);
+          const allUnderProject = files.every((f) => f.replace(/\\/g, '/').includes('custom-project'));
+          assertEquals(allUnderProject, true);
+        });
+      });
+    });
+  });
+
+  // ─── T-15-07: project なし（misc フォールバック）────────────────────────────
+
+  /** エッジケース: project フィールドなしの場合、出力が <outputBase>/misc/ 以下に生成される */
+  describe('Given: project フロントマターなしの MD ファイル', () => {
+    let inputDir: string;
+    let outputBase: string;
+    let commandHandle: CommandMockHandle;
+    let logSilencer: LogSilencer;
+
+    beforeEach(async () => {
+      ({ inputDir, outputDir: outputBase } = await makeTempDirs());
+
+      await Deno.writeTextFile(
+        `${inputDir}/chat.md`,
+        '### User\nHello\n\n### AI\nHi',
+      );
+
+      const segmentResponse = JSON.stringify([
+        { title: 'Topic', summary: 'Summary', body: 'Body' },
+      ]);
+      commandHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+      );
+      logSilencer = silenceLog();
+    });
+
+    afterEach(async () => {
+      commandHandle.restore();
+      logSilencer.restore();
+      await removeTempDirs(inputDir, outputBase);
+    });
+
+    describe('When: main(["--dir", inputDir, "--output", outputBase]) を呼び出す', () => {
+      describe('Then: Task T-15-07-01 - project なし時は misc サブディレクトリに出力される', () => {
+        it('T-15-07-01-01: 出力ファイルのパスが <outputBase>/misc/ を含む', async () => {
+          await main(['--dir', inputDir, '--output', outputBase]);
+
+          const files = findMdFiles(outputBase);
+          assertEquals(files.length >= 1, true);
+          const allUnderMisc = files.every((f) => f.replace(/\\/g, '/').includes('/misc/'));
+          assertEquals(allUnderMisc, true);
         });
       });
     });

--- a/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-reproducibility.e2e.spec.ts
+++ b/.claude/commands/scripts/__tests__/e2e/normalize-chatlog-reproducibility.e2e.spec.ts
@@ -19,7 +19,7 @@ import type { LogCapture, LogSilencer } from '../_helpers/e2e-setup.ts';
 import { captureLog, makeTempDirs, removeTempDirs, silenceLog } from '../_helpers/e2e-setup.ts';
 
 // test target
-import { main } from '../../normalize-chatlog.ts';
+import { findMdFiles, main } from '../../normalize-chatlog.ts';
 import type { HashProvider } from '../../normalize-chatlog.ts';
 
 // ─── 再現性テスト ──────────────────────────────────────────────────────────────
@@ -79,12 +79,9 @@ describe('main - reproducibility', () => {
 
           assertMatch(logCapture.calls.join('\n'), /success=1/);
 
-          // Verify the old file was backed up as .old-01.md
-          const outputFiles: string[] = [];
-          for await (const entry of Deno.readDir(outputDir)) {
-            outputFiles.push(entry.name);
-          }
-          const backupExists = outputFiles.some((name) => name.includes('.old-01.md'));
+          // Verify the old file was backed up as .old-01.md (search recursively under outputDir)
+          const allFiles = findMdFiles(outputDir);
+          const backupExists = allFiles.some((path) => path.includes('.old-01.md'));
           assertEquals(backupExists, true);
         });
       });

--- a/.claude/commands/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
+++ b/.claude/commands/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
@@ -18,7 +18,6 @@ import { stub } from '@std/testing/mock';
 import {
   makeCountingMock,
   makeFailMock,
-  makeNotFoundMock,
   makeSuccessMock,
 } from '../_helpers/deno-command-mock.ts';
 

--- a/.claude/commands/scripts/__tests__/system/normalize-chatlog.fixtures-frontmatter.system.spec.ts
+++ b/.claude/commands/scripts/__tests__/system/normalize-chatlog.fixtures-frontmatter.system.spec.ts
@@ -115,8 +115,8 @@ for (const _dirName of _fixtureDirs) {
     describe(`attachFrontmatter — runai-frontmatter/${_dirName}`, () => {
       it(`SFF-${_dirName}-fixture-error: output-*.md が存在しない（フィクスチャ定義漏れ）`, () => {
         throw new Error(
-          `runai-frontmatter/${_dirName} に output-*.md がありません。` +
-            `正常系なら output-N.md を、異常系なら runai-segments/error/ で管理してください。`,
+          `runai-frontmatter/${_dirName} に output-*.md がありません。`
+            + `正常系なら output-N.md を、異常系なら runai-segments/error/ で管理してください。`,
         );
       });
     });

--- a/.claude/commands/scripts/__tests__/system/normalize-chatlog.fixtures-markdown.system.spec.ts
+++ b/.claude/commands/scripts/__tests__/system/normalize-chatlog.fixtures-markdown.system.spec.ts
@@ -36,7 +36,7 @@ const RUNAI_MARKDOWN_DIR = new URL('../_fixtures/runai-markdown', import.meta.ur
 function _extractBodyFromFixture(content: string): string {
   const marker = START_BODY_HEADING + '\n';
   const idx = content.indexOf(marker);
-  if (idx === -1) return '';
+  if (idx === -1) { return ''; }
   return content.slice(idx + marker.length).replace(/^\n+/, '');
 }
 
@@ -95,8 +95,8 @@ for (const _dirName of _fixtureDirs) {
     describe(`generateSegmentFile — runai-markdown/${_dirName}`, () => {
       it(`SFM-${_dirName}-fixture-error: output-*.md が存在しない（フィクスチャ定義漏れ）`, () => {
         throw new Error(
-          `runai-markdown/${_dirName} に output-*.md がありません。` +
-            `正常系なら output-N.md を、異常系なら runai-segments/error/ で管理してください。`,
+          `runai-markdown/${_dirName} に output-*.md がありません。`
+            + `正常系なら output-N.md を、異常系なら runai-segments/error/ で管理してください。`,
         );
       });
     });

--- a/.claude/commands/scripts/__tests__/system/normalize-chatlog.fixtures-segments.system.spec.ts
+++ b/.claude/commands/scripts/__tests__/system/normalize-chatlog.fixtures-segments.system.spec.ts
@@ -18,8 +18,8 @@
 
 // Deno Test module
 import { assertEquals } from '@std/assert';
-import { parse as parseYaml } from '@std/yaml';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+import { parse as parseYaml } from '@std/yaml';
 
 // test helpers
 import {
@@ -90,7 +90,7 @@ async function _collectFixtureDirs(rootDir: string): Promise<string[]> {
 
   async function _walk(dir: string, rel: string): Promise<void> {
     for await (const entry of Deno.readDir(dir)) {
-      if (!entry.isDirectory) continue;
+      if (!entry.isDirectory) { continue; }
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       const childAbs = `${dir}/${entry.name}`;
       try {

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.cli-args.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.cli-args.unit.spec.ts
@@ -15,7 +15,6 @@ import { stub } from '@std/testing/mock';
 // test target
 import {
   parseArgs,
-  resolveOutputDir,
 } from '../../normalize-chatlog.ts';
 
 // ─── parseArgs tests ──────────────────────────────────────────────────────────
@@ -26,208 +25,105 @@ import {
  * 正常系・デフォルト値・エラー終了・パス正規化を検証する。
  */
 describe('parseArgs', () => {
-  /** 正常系: --dir・--agent・--year-month・--dry-run・--concurrency・--output を正しくパースする */
+  /** 正常系: --dir オプションを正しくパースする */
   describe('Given: --dir オプションを含む引数配列', () => {
-    describe('When: parseArgs(["--dir", "/some/path"]) を呼び出す', () => {
-      describe('Then: Task T-08-01 - 全オプションのパース', () => {
-        it('T-08-01-01: args.dir が "/some/path" になる', () => {
-          const result = parseArgs(['--dir', '/some/path']);
+    it('T-08-01-01: args.dir が "/some/path" になる', () => {
+      const result = parseArgs(['--dir', '/some/path']);
 
-          assertEquals(result.dir, '/some/path');
-        });
-      });
+      assertEquals(result.dir, '/some/path');
     });
   });
 
   /** 正常系: 複数オプションが混在しても全フィールドを正しく解析する */
   describe('Given: --agent・--year-month・--dry-run・--concurrency・--output を含む引数配列', () => {
-    describe('When: parseArgs(["--agent","claude","--year-month","2026-03","--dry-run","--concurrency","8","--output","./out"]) を呼び出す', () => {
-      describe('Then: Task T-08-01 - 全オプションのパース', () => {
-        let result: ReturnType<typeof parseArgs>;
-        beforeEach(() => {
-          result = parseArgs([
-            '--agent',
-            'claude',
-            '--year-month',
-            '2026-03',
-            '--dry-run',
-            '--concurrency',
-            '8',
-            '--output',
-            './out',
-          ]);
-        });
+    let result: ReturnType<typeof parseArgs>;
+    beforeEach(() => {
+      result = parseArgs([
+        '--agent',
+        'claude',
+        '--year-month',
+        '2026-03',
+        '--dry-run',
+        '--concurrency',
+        '8',
+        '--output',
+        './out',
+      ]);
+    });
 
-        it('T-08-01-02a: args.agent が "claude" になる', () => {
-          assertEquals(result.agent, 'claude');
-        });
+    it('T-08-01-02a: args.agent が "claude" になる', () => {
+      assertEquals(result.agent, 'claude');
+    });
 
-        it('T-08-01-02b: args.yearMonth が "2026-03" になる', () => {
-          assertEquals(result.yearMonth, '2026-03');
-        });
+    it('T-08-01-02b: args.yearMonth が "2026-03" になる', () => {
+      assertEquals(result.yearMonth, '2026-03');
+    });
 
-        it('T-08-01-02c: args.dryRun が true になる', () => {
-          assertEquals(result.dryRun, true);
-        });
+    it('T-08-01-02c: args.dryRun が true になる', () => {
+      assertEquals(result.dryRun, true);
+    });
 
-        it('T-08-01-02d: args.concurrency が 8 になる', () => {
-          assertEquals(result.concurrency, 8);
-        });
+    it('T-08-01-02d: args.concurrency が 8 になる', () => {
+      assertEquals(result.concurrency, 8);
+    });
 
-        it('T-08-01-02e: args.output が "./out" になる', () => {
-          assertEquals(result.output, './out');
-        });
-      });
+    it('T-08-01-02e: args.output が "./out" になる', () => {
+      assertEquals(result.output, './out');
     });
   });
 
   /** 正常系: 省略時はデフォルト値 (concurrency=4, dryRun=false) が適用される */
   describe('Given: --concurrency・--dry-run を含まない引数配列', () => {
-    describe('When: parseArgs([]) を呼び出す', () => {
-      describe('Then: Task T-08-02 - デフォルト値の適用', () => {
-        let result: ReturnType<typeof parseArgs>;
-        beforeEach(() => {
-          result = parseArgs([]);
-        });
+    let result: ReturnType<typeof parseArgs>;
+    beforeEach(() => {
+      result = parseArgs([]);
+    });
 
-        it('T-08-02-01: args.concurrency が 4 になる', () => {
-          assertEquals(result.concurrency, 4);
-        });
+    it('T-08-02-01: args.concurrency が 4 になる', () => {
+      assertEquals(result.concurrency, 4);
+    });
 
-        it('T-08-02-02: args.dryRun が false になる', () => {
-          assertEquals(result.dryRun, false);
-        });
-      });
+    it('T-08-02-02: args.dryRun が false になる', () => {
+      assertEquals(result.dryRun, false);
     });
   });
 
   /** 異常系: 未知のオプションは Deno.exit(1) を呼び出してエラー終了する */
   describe('Given: 未知のオプションを含む引数配列', () => {
-    describe('When: parseArgs(["--unknown"]) を呼び出す', () => {
-      describe('Then: Task T-08-03 - 未知オプションでのエラー終了', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
+    let exitStub: Stub<typeof Deno, [code?: number], never>;
+    beforeEach(() => {
+      exitStub = stub(Deno, 'exit');
+    });
+    afterEach(() => {
+      exitStub.restore();
+    });
 
-        it('T-08-03-01: Deno.exit(1) が呼ばれる', () => {
-          parseArgs(['--unknown']);
+    it('T-08-03-01: Deno.exit(1) が呼ばれる', () => {
+      parseArgs(['--unknown']);
 
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
-      });
+      assertEquals(exitStub.calls.length, 1);
+      assertEquals(exitStub.calls[0].args[0], 1);
     });
   });
 
-  /** 正常系: バックスラッシュをスラッシュへ正規化し、位置引数をパスとして auto-detect する */
+  /** 正常系: パス正規化と自動 --dir 判定 */
   describe('Given: パス区切り文字の正規化または自動 --dir 判定が必要な引数配列', () => {
-    describe('When: parseArgs(["--dir", "temp\\\\chatlog\\\\claude"]) を呼び出す', () => {
-      describe('Then: Task T-08-04 - パス正規化と自動 --dir 判定', () => {
-        it('T-08-04-01: --dir 値のバックスラッシュがスラッシュに正規化される', () => {
-          const result = parseArgs(['--dir', 'temp\\chatlog\\claude']);
+    it('T-08-04-01: --dir 値のバックスラッシュがスラッシュに正規化される', () => {
+      const result = parseArgs(['--dir', 'temp\\chatlog\\claude']);
 
-          assertEquals(result.dir, 'temp/chatlog/claude');
-        });
-      });
+      assertEquals(result.dir, 'temp/chatlog/claude');
     });
 
-    describe('When: parseArgs(["temp/chatlog/claude/2026/2026-03"]) を呼び出す', () => {
-      describe('Then: Task T-08-04 - パス正規化と自動 --dir 判定', () => {
-        it('T-08-04-02: / を含む位置引数が args.dir に設定される', () => {
-          const result = parseArgs(['temp/chatlog/claude/2026/2026-03']);
+    it('T-08-04-02: / を含む位置引数が args.dir に設定される', () => {
+      const result = parseArgs(['temp/chatlog/claude/2026/2026-03']);
 
-          assertEquals(result.dir, 'temp/chatlog/claude/2026/2026-03');
-        });
-      });
+      assertEquals(result.dir, 'temp/chatlog/claude/2026/2026-03');
     });
 
-    describe('When: parseArgs(["temp\\\\chatlog\\\\claude\\\\2026\\\\2026-03"]) を呼び出す', () => {
-      describe('Then: Task T-08-04 - パス正規化と自動 --dir 判定', () => {
-        it('T-08-04-03: \\ を含む位置引数がスラッシュ正規化されて args.dir に設定される', () => {
-          const result = parseArgs(['temp\\chatlog\\claude\\2026\\2026-03']);
+    it('T-08-04-03: \\ を含む位置引数がスラッシュ正規化されて args.dir に設定される', () => {
+      const result = parseArgs(['temp\\chatlog\\claude\\2026\\2026-03']);
 
-          assertEquals(result.dir, 'temp/chatlog/claude/2026/2026-03');
-        });
-      });
-    });
-  });
-});
-
-// ─── resolveOutputDir tests ──────────────────────────────────────────────────
-
-/**
- * resolveOutputDir のユニットテスト。
- * InputDir と outputBase、project から OutputDir を解決する関数の
- * 正常系 (chatlog形式/任意パス)・エッジケース (project未指定) を検証する。
- */
-describe('resolveOutputDir', () => {
-  /** 正常系: chatlog形式のinputDirから agent/<yyyy>/<yyyy-mm>/<project> を組み立てる */
-  describe('[正常] Normal Cases', () => {
-    describe('Given: chatlog形式のinputDir "temp/chatlog/claude/2026/2026-03" と project "myapp"', () => {
-      describe('When: resolveOutputDir(inputDir, outputBase, project) を呼び出す', () => {
-        describe('Then: Task T-15-01 - chatlog形式のOutputDir生成', () => {
-          it('T-15-01-01: Given chatlog形式のinputDir "temp/chatlog/claude/2026/2026-03" と project "myapp", When resolveOutputDir, Then "base/claude/2026/2026-03/myapp" を返す', () => {
-            const result = resolveOutputDir('temp/chatlog/claude/2026/2026-03', 'base', 'myapp');
-
-            assertEquals(result, 'base/claude/2026/2026-03/myapp');
-          });
-        });
-      });
-    });
-
-    describe('Given: chatlog形式のinputDir と project が undefined', () => {
-      describe('When: resolveOutputDir(inputDir, outputBase, undefined) を呼び出す', () => {
-        describe('Then: Task T-15-02 - projectがundefinedのとき "misc" を使う', () => {
-          it('T-15-02-01: Given projectがundefined, When resolveOutputDir, Then "base/claude/2026/2026-03/misc" を返す', () => {
-            const result = resolveOutputDir('temp/chatlog/claude/2026/2026-03', 'base', undefined);
-
-            assertEquals(result, 'base/claude/2026/2026-03/misc');
-          });
-        });
-      });
-    });
-
-    describe('Given: chatlog形式のinputDir と project が空文字', () => {
-      describe('When: resolveOutputDir(inputDir, outputBase, "") を呼び出す', () => {
-        describe('Then: Task T-15-03 - projectが空文字のとき "misc" を使う', () => {
-          it('T-15-03-01: Given projectが空文字, When resolveOutputDir, Then "base/claude/2026/2026-03/misc" を返す', () => {
-            const result = resolveOutputDir('temp/chatlog/claude/2026/2026-03', 'base', '');
-
-            assertEquals(result, 'base/claude/2026/2026-03/misc');
-          });
-        });
-      });
-    });
-  });
-
-  /** 正常系: 任意パスのinputDirは outputBase/<project> を返す */
-  describe('[正常] Arbitrary Path Cases', () => {
-    describe('Given: 任意パスのinputDir "some/custom/path" と project "proj"', () => {
-      describe('When: resolveOutputDir(inputDir, outputBase, project) を呼び出す', () => {
-        describe('Then: Task T-15-04 - 任意パスのOutputDir生成', () => {
-          it('T-15-04-01: Given 任意パスのinputDir "some/custom/path" と project "proj", When resolveOutputDir, Then "base/proj" を返す', () => {
-            const result = resolveOutputDir('some/custom/path', 'base', 'proj');
-
-            assertEquals(result, 'base/proj');
-          });
-        });
-      });
-    });
-
-    describe('Given: 任意パスのinputDir と project が undefined', () => {
-      describe('When: resolveOutputDir(inputDir, outputBase, undefined) を呼び出す', () => {
-        describe('Then: Task T-15-05 - 任意パス + projectがundefinedのとき "misc" を使う', () => {
-          it('T-15-05-01: Given 任意パスのinputDir と projectがundefined, When resolveOutputDir, Then "base/misc" を返す', () => {
-            const result = resolveOutputDir('some/custom/path', 'base', undefined);
-
-            assertEquals(result, 'base/misc');
-          });
-        });
-      });
+      assertEquals(result.dir, 'temp/chatlog/claude/2026/2026-03');
     });
   });
 });

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.file-gen.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.file-gen.unit.spec.ts
@@ -32,61 +32,49 @@ import {
 describe('withConcurrency', () => {
   /** 正常系: 並列数内のタスクを全件処理し、入力インデックス順に結果を返す */
   describe('[正常] Normal Cases', () => {
-    describe('Given: タスク配列と並列数が与えられる', () => {
-      describe('When: withConcurrency(tasks, concurrency) を呼び出す', () => {
-        describe('Then: Task T-01-01 - 並列実行の基本動作', () => {
-          it('T-01-01-01: Given 4タスク並列数4, When withConcurrency, Then 全4件が入力順に返る', async () => {
-            const tasks = [
-              () => Promise.resolve(1),
-              () => Promise.resolve(2),
-              () => Promise.resolve(3),
-              () => Promise.resolve(4),
-            ];
+    it('T-01-01-01: Given 4タスク並列数4, When withConcurrency, Then 全4件が入力順に返る', async () => {
+      const tasks = [
+        () => Promise.resolve(1),
+        () => Promise.resolve(2),
+        () => Promise.resolve(3),
+        () => Promise.resolve(4),
+      ];
 
-            const result = await withConcurrency(tasks, 4);
+      const result = await withConcurrency(tasks, 4);
 
-            assertEquals(result, [1, 2, 3, 4]);
-          });
+      assertEquals(result, [1, 2, 3, 4]);
+    });
 
-          it('T-01-01-02: Given 6タスク(遅延時間が異なる)並列数2, When withConcurrency, Then 完了順に関わらず入力インデックス順に返る', async () => {
-            const tasks = [0, 1, 2, 3, 4, 5].map((i) => () =>
-              new Promise<number>((resolve) => setTimeout(() => resolve(i), (6 - i) * 10))
-            );
+    it('T-01-01-02: Given 6タスク(遅延時間が異なる)並列数2, When withConcurrency, Then 完了順に関わらず入力インデックス順に返る', async () => {
+      const tasks = [0, 1, 2, 3, 4, 5].map((i) => () =>
+        new Promise<number>((resolve) => setTimeout(() => resolve(i), (6 - i) * 10))
+      );
 
-            const result = await withConcurrency(tasks, 2);
+      const result = await withConcurrency(tasks, 2);
 
-            assertEquals(result, [0, 1, 2, 3, 4, 5]);
-          });
-        });
-      });
+      assertEquals(result, [0, 1, 2, 3, 4, 5]);
     });
   });
 
   /** エッジケース: 空配列・並列数超過など境界条件でも正常動作する */
   describe('[エッジケース] Edge Cases', () => {
-    describe('Given: 空配列または並列数がタスク数を超えるケース', () => {
-      describe('When: withConcurrency(tasks, concurrency) を呼び出す', () => {
-        describe('Then: Task T-01-02 - エッジケースの処理', () => {
-          it('T-01-02-01: Given 空のタスク配列と並列数4, When withConcurrency, Then エラーなく空配列が返される', async () => {
-            const tasks: (() => Promise<never>)[] = [];
+    it('T-01-02-01: Given 空のタスク配列と並列数4, When withConcurrency, Then エラーなく空配列が返される', async () => {
+      const tasks: (() => Promise<never>)[] = [];
 
-            const result = await withConcurrency(tasks, 4);
+      const result = await withConcurrency(tasks, 4);
 
-            assertEquals(result, []);
-          });
+      assertEquals(result, []);
+    });
 
-          it('T-01-02-02: Given 2タスクと並列数10, When withConcurrency, Then 両タスクが完了し結果が返される', async () => {
-            const tasks = [
-              () => Promise.resolve('a'),
-              () => Promise.resolve('b'),
-            ];
+    it('T-01-02-02: Given 2タスクと並列数10, When withConcurrency, Then 両タスクが完了し結果が返される', async () => {
+      const tasks = [
+        () => Promise.resolve('a'),
+        () => Promise.resolve('b'),
+      ];
 
-            const result = await withConcurrency(tasks, 10);
+      const result = await withConcurrency(tasks, 10);
 
-            assertEquals(result, ['a', 'b']);
-          });
-        });
-      });
+      assertEquals(result, ['a', 'b']);
     });
   });
 });
@@ -128,97 +116,81 @@ describe('generateOutputFileName', () => {
 
   /** 正常系: `<baseName>-<XX>-<hash7>.md` 形式のファイル名を返す */
   describe('Given: 標準的な chatlog ファイルパスと index', () => {
-    describe('When: generateOutputFileName(filePath, index) を呼び出す', () => {
-      describe('Then: Task T-06-01 - 標準的なファイル名生成', () => {
-        it('T-06-01-01: index=0 のとき <baseName>-01-<hash7>.md 形式のファイル名を返す', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+    it('T-06-01-01: index=0 のとき <baseName>-01-<hash7>.md 形式のファイル名を返す', async () => {
+      const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-          const result = await generateOutputFileName(filePath, 0);
+      const result = await generateOutputFileName(filePath, 0);
 
-          assertMatch(result, /^test-file-01-[0-9a-f]{7}\.md$/);
-        });
+      assertMatch(result, /^test-file-01-[0-9a-f]{7}\.md$/);
+    });
 
-        it('T-06-01-02: index=1 のとき連番が "02" になる', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+    it('T-06-01-02: index=1 のとき連番が "02" になる', async () => {
+      const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-          const result = await generateOutputFileName(filePath, 1);
+      const result = await generateOutputFileName(filePath, 1);
 
-          assertMatch(result, /^test-file-02-[0-9a-f]{7}\.md$/);
-        });
+      assertMatch(result, /^test-file-02-[0-9a-f]{7}\.md$/);
+    });
 
-        it('T-06-01-03: index=9 のとき連番が "10" になる', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+    it('T-06-01-03: index=9 のとき連番が "10" になる', async () => {
+      const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-          const result = await generateOutputFileName(filePath, 9);
+      const result = await generateOutputFileName(filePath, 9);
 
-          assertMatch(result, /^test-file-10-[0-9a-f]{7}\.md$/);
-        });
-      });
+      assertMatch(result, /^test-file-10-[0-9a-f]{7}\.md$/);
     });
   });
 
   /** 正常系: スタブ固定 + 日付固定で同一入力が同一結果を返す（再現性） */
   describe('Given: crypto と Date をスタブして固定した状態', () => {
-    describe('When: 同一 filePath と同一 index で 2 回呼び出す', () => {
-      describe('Then: Task T-06-02 - スタブによる再現性', () => {
-        it('T-06-02-01: 同一タイムスタンプと固定ランダム値で常に同じファイル名が返る', async () => {
-          const dateStubs = [
-            stub(Date.prototype, 'getFullYear', () => 2026),
-            stub(Date.prototype, 'getMonth', () => 2),
-            stub(Date.prototype, 'getDate', () => 11),
-            stub(Date.prototype, 'getHours', () => 10),
-            stub(Date.prototype, 'getMinutes', () => 30),
-            stub(Date.prototype, 'getSeconds', () => 0),
-          ];
+    it('T-06-02-01: 同一タイムスタンプと固定ランダム値で常に同じファイル名が返る', async () => {
+      const dateStubs = [
+        stub(Date.prototype, 'getFullYear', () => 2026),
+        stub(Date.prototype, 'getMonth', () => 2),
+        stub(Date.prototype, 'getDate', () => 11),
+        stub(Date.prototype, 'getHours', () => 10),
+        stub(Date.prototype, 'getMinutes', () => 30),
+        stub(Date.prototype, 'getSeconds', () => 0),
+      ];
 
-          try {
-            const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+      try {
+        const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-            const first = await generateOutputFileName(filePath, 0);
-            const second = await generateOutputFileName(filePath, 0);
+        const first = await generateOutputFileName(filePath, 0);
+        const second = await generateOutputFileName(filePath, 0);
 
-            assertEquals(first, second);
-            assertMatch(first, /^test-file-01-[0-9a-f]{7}\.md$/);
-          } finally {
-            dateStubs.forEach((s) => s.restore());
-          }
-        });
-      });
+        assertEquals(first, second);
+        assertMatch(first, /^test-file-01-[0-9a-f]{7}\.md$/);
+      } finally {
+        dateStubs.forEach((s) => s.restore());
+      }
     });
   });
 
   /** 正常系: スタブなしで同一入力でも異なるハッシュが生成される（ランダム性） */
   describe('Given: crypto.getRandomValues をスタブせず実際の乱数を使う', () => {
-    describe('When: 同一 filePath と同一 index で 2 回連続して呼び出す', () => {
-      describe('Then: Task T-06-03 - ランダム性によるハッシュの変化', () => {
-        it('T-06-03-01: スタブなしで 2 回呼ぶと異なるファイル名が生成される', async () => {
-          cryptoStub!.restore();
-          cryptoStub = null;
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+    it('T-06-03-01: スタブなしで 2 回呼ぶと異なるファイル名が生成される', async () => {
+      cryptoStub!.restore();
+      cryptoStub = null;
+      const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-          const first = await generateOutputFileName(filePath, 0);
-          const second = await generateOutputFileName(filePath, 0);
+      const first = await generateOutputFileName(filePath, 0);
+      const second = await generateOutputFileName(filePath, 0);
 
-          assertNotEquals(first, second);
-          assertMatch(first, /^test-file-01-[0-9a-f]{7}\.md$/);
-          assertMatch(second, /^test-file-01-[0-9a-f]{7}\.md$/);
-        });
-      });
+      assertNotEquals(first, second);
+      assertMatch(first, /^test-file-01-[0-9a-f]{7}\.md$/);
+      assertMatch(second, /^test-file-01-[0-9a-f]{7}\.md$/);
     });
   });
 
   /** 正常系: 末尾ハッシュ付きのソースファイルでもベース名が正しく抽出される */
   describe('Given: 末尾に -XXXXXXX ハッシュを含むソースファイルパス', () => {
-    describe('When: generateOutputFileName(filePath, 0) を呼び出す', () => {
-      describe('Then: Task T-06-04 - ハッシュ付きソースファイルのベース名処理', () => {
-        it('T-06-04-01: ソースの末尾ハッシュを除去したベース名で出力名を生成する', async () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/2026-03-11-topic-abc1234.md';
+    it('T-06-04-01: ソースの末尾ハッシュを除去したベース名で出力名を生成する', async () => {
+      const filePath = 'temp/chatlog/claude/2026/2026-03/2026-03-11-topic-abc1234.md';
 
-          const result = await generateOutputFileName(filePath, 0);
+      const result = await generateOutputFileName(filePath, 0);
 
-          assertMatch(result, /^2026-03-11-topic-01-[0-9a-f]{7}\.md$/);
-        });
-      });
+      assertMatch(result, /^2026-03-11-topic-01-[0-9a-f]{7}\.md$/);
     });
   });
 });
@@ -232,48 +204,36 @@ describe('generateOutputFileName', () => {
  */
 describe('generateSegmentFile', () => {
   /** 正常系: summary フィールドが `## Summary` セクションとして出力される */
-  describe('Given: { title: "Fix CI pipeline", summary: "Fix CI pipeline", body: "### User\\nHow do I fix CI?" } を持つセグメントオブジェクト', () => {
-    describe('When: generateSegmentFile を呼び出す', () => {
-      describe('Then: Task T-11-01 - セグメントファイルの MD コンテンツ生成', () => {
-        it('T-11-01-01: 返却文字列に `## Summary\\nFix CI pipeline` が含まれる', () => {
-          const seg = { title: 'Fix CI pipeline', summary: 'Fix CI pipeline', body: '### User\nHow do I fix CI?' };
+  describe('Given: { title: "Fix CI pipeline", summary: "Fix CI pipeline", body: "..." } を持つセグメント', () => {
+    it('T-11-01-01: 返却文字列に `## Summary\\nFix CI pipeline` が含まれる', () => {
+      const seg = { title: 'Fix CI pipeline', summary: 'Fix CI pipeline', body: '### User\nHow do I fix CI?' };
 
-          const result = generateSegmentFile(seg);
+      const result = generateSegmentFile(seg);
 
-          assertEquals(result.includes('## Summary\n\nFix CI pipeline'), true);
-        });
-      });
+      assertEquals(result.includes('## Summary\n\nFix CI pipeline'), true);
     });
   });
 
   /** 正常系: body フィールドが START_BODY_HEADING セクションとして出力される */
-  describe('Given: { title: "Debug session", summary: "Debug session", body: "### User\\nHow do I..." } を持つセグメントオブジェクト', () => {
-    describe('When: generateSegmentFile を呼び出す', () => {
-      describe('Then: Task T-11-01 - セグメントファイルの MD コンテンツ生成', () => {
-        it('T-11-01-02: 返却文字列に START_BODY_HEADING + "\\n### User\\nHow do I..." が含まれる', () => {
-          const seg = { title: 'Debug session', summary: 'Debug session', body: '### User\nHow do I...' };
+  describe('Given: { title: "Debug session", summary: "Debug session", body: "..." } を持つセグメント', () => {
+    it('T-11-01-02: 返却文字列に START_BODY_HEADING + "\\n### User\\nHow do I..." が含まれる', () => {
+      const seg = { title: 'Debug session', summary: 'Debug session', body: '### User\nHow do I...' };
 
-          const result = generateSegmentFile(seg);
+      const result = generateSegmentFile(seg);
 
-          assertEquals(result.includes(START_BODY_HEADING + '\n\n### User\nHow do I...'), true);
-        });
-      });
+      assertEquals(result.includes(START_BODY_HEADING + '\n\n### User\nHow do I...'), true);
     });
   });
 
   /** エッジケース: 全フィールドが空でも `## Summary` と START_BODY_HEADING 見出しを含む文字列を返す */
   describe('Given: { title: "", summary: "", body: "" } を持つセグメント', () => {
-    describe('When: generateSegmentFile を呼び出す', () => {
-      describe('Then: Task T-11-02 - 空フィールド', () => {
-        it('T-11-02-01: 返却文字列に `## Summary` と START_BODY_HEADING の両セクション見出しが含まれる', () => {
-          const seg = { title: '', summary: '', body: '' };
+    it('T-11-02-01: 返却文字列に `## Summary` と START_BODY_HEADING の両セクション見出しが含まれる', () => {
+      const seg = { title: '', summary: '', body: '' };
 
-          const result = generateSegmentFile(seg);
+      const result = generateSegmentFile(seg);
 
-          assertEquals(result.includes('## Summary'), true);
-          assertEquals(result.includes(START_BODY_HEADING), true);
-        });
-      });
+      assertEquals(result.includes('## Summary'), true);
+      assertEquals(result.includes(START_BODY_HEADING), true);
     });
   });
 });
@@ -288,79 +248,67 @@ describe('generateSegmentFile', () => {
 describe('attachFrontmatter', () => {
   /** 正常系: sourceMeta の project フィールドを引き継ぎ、AI 生成フィールドを付加する */
   describe('Given: project を含む sourceMeta と title・log_id・summary を含む segmentMeta', () => {
-    describe('When: attachFrontmatter(content, sourceMeta, segmentMeta) を呼び出す', () => {
-      describe('Then: Task T-12-01 - ソースメタデータ引き継ぎによるフロントマター合成', () => {
-        it('T-12-01-01: 出力フロントマターに project: ci-platform が含まれる', () => {
-          const sourceMeta = { project: 'ci-platform', date: '2026-03-01' };
-          const segmentMeta = { title: 'Fix CI', log_id: 'abc1234', summary: 'CI fix' };
-          const content = '## Summary\nFix CI';
+    it('T-12-01-01: 出力フロントマターに project: ci-platform が含まれる', () => {
+      const sourceMeta = { project: 'ci-platform', date: '2026-03-01' };
+      const segmentMeta = { title: 'Fix CI', log_id: 'abc1234', summary: 'CI fix' };
+      const content = '## Summary\nFix CI';
 
-          const result = attachFrontmatter(content, sourceMeta, segmentMeta);
+      const result = attachFrontmatter(content, sourceMeta, segmentMeta);
 
-          assertEquals(result.includes('project: ci-platform'), true);
-        });
+      assertEquals(result.includes('project: ci-platform'), true);
+    });
 
-        it('T-12-01-02: 出力フロントマターに title・log_id・summary が含まれる', () => {
-          const sourceMeta = { project: 'ci-platform' };
-          const segmentMeta = { title: 'Fix CI', log_id: 'abc1234', summary: 'CI fix' };
-          const content = '## Summary\nFix CI';
+    it('T-12-01-02: 出力フロントマターに title・log_id・summary が含まれる', () => {
+      const sourceMeta = { project: 'ci-platform' };
+      const segmentMeta = { title: 'Fix CI', log_id: 'abc1234', summary: 'CI fix' };
+      const content = '## Summary\nFix CI';
 
-          const result = attachFrontmatter(content, sourceMeta, segmentMeta);
+      const result = attachFrontmatter(content, sourceMeta, segmentMeta);
 
-          assertEquals(result.includes('title: Fix CI'), true);
-          assertEquals(result.includes('log_id: abc1234'), true);
-          assertEquals(result.includes('summary: CI fix'), true);
-        });
-      });
+      assertEquals(result.includes('title: Fix CI'), true);
+      assertEquals(result.includes('log_id: abc1234'), true);
+      assertEquals(result.includes('summary: CI fix'), true);
     });
   });
 
   /** エッジケース: sourceMeta が空の場合は AI 生成フィールドのみを含む */
   describe('Given: 空の sourceMeta と title・log_id・summary を含む segmentMeta', () => {
-    describe('When: attachFrontmatter(content, {}, segmentMeta) を呼び出す', () => {
-      describe('Then: Task T-12-02 - ソースフロントマターなし', () => {
-        it('T-12-02-01: 出力フロントマターが AI 生成フィールド（title・log_id・summary）のみを含む', () => {
-          const sourceMeta = {};
-          const segmentMeta = { title: 'Topic', log_id: 'aaabbbb', summary: 'Summary' };
-          const content = '## Summary\nTopic content';
+    it('T-12-02-01: 出力フロントマターが AI 生成フィールド（title・log_id・summary）のみを含む', () => {
+      const sourceMeta = {};
+      const segmentMeta = { title: 'Topic', log_id: 'aaabbbb', summary: 'Summary' };
+      const content = '## Summary\nTopic content';
 
-          const result = attachFrontmatter(content, sourceMeta, segmentMeta);
+      const result = attachFrontmatter(content, sourceMeta, segmentMeta);
 
-          assertEquals(result.includes('title: Topic'), true);
-          assertEquals(result.includes('log_id: aaabbbb'), true);
-          assertEquals(result.includes('summary: Summary'), true);
-          assertEquals(result.includes('project:'), false);
-        });
-      });
+      assertEquals(result.includes('title: Topic'), true);
+      assertEquals(result.includes('log_id: aaabbbb'), true);
+      assertEquals(result.includes('summary: Summary'), true);
+      assertEquals(result.includes('project:'), false);
     });
   });
 
   /** 正常系: 出力が `---` デリミタで囲まれた有効な Markdown フロントマターになる */
   describe('Given: 任意の sourceMeta と segmentMeta', () => {
-    describe('When: attachFrontmatter(content, sourceMeta, segmentMeta) を呼び出す', () => {
-      describe('Then: Task T-12-03 - フロントマターデリミタ', () => {
-        it('T-12-03-01: 出力が `---\\n` で始まりフロントマターブロックが `\\n---\\n` で終わる', () => {
-          const sourceMeta = { project: 'test' };
-          const segmentMeta = { title: 'T', log_id: 'x', summary: 'S' };
-          const content = '## Summary\ntext';
+    it('T-12-03-01: 出力が `---\\n` で始まりフロントマターブロックが `\\n---\\n` で終わる', () => {
+      const sourceMeta = { project: 'test' };
+      const segmentMeta = { title: 'T', log_id: 'x', summary: 'S' };
+      const content = '## Summary\ntext';
 
-          const result = attachFrontmatter(content, sourceMeta, segmentMeta);
+      const result = attachFrontmatter(content, sourceMeta, segmentMeta);
 
-          assertEquals(result.startsWith('---\n'), true);
-          assertEquals(result.includes('\n---\n'), true);
-        });
+      assertEquals(result.startsWith('---\n'), true);
+      assertEquals(result.includes('\n---\n'), true);
+    });
 
-        it('T-12-03-02: コンテンツボディがフロントマターブロックの後に重複なく続く', () => {
-          const sourceMeta = {};
-          const segmentMeta = { title: 'T', log_id: 'x', summary: 'S' };
-          const content = '## Summary\ntext';
+    it('T-12-03-02: コンテンツボディがフロントマターブロックの後に重複なく続く', () => {
+      const sourceMeta = {};
+      const segmentMeta = { title: 'T', log_id: 'x', summary: 'S' };
+      const content = '## Summary\ntext';
 
-          const result = attachFrontmatter(content, sourceMeta, segmentMeta);
+      const result = attachFrontmatter(content, sourceMeta, segmentMeta);
 
-          const contentOccurrences = result.split('## Summary\ntext').length - 1;
-          assertEquals(contentOccurrences, 1);
-        });
-      });
+      const contentOccurrences = result.split('## Summary\ntext').length - 1;
+      assertEquals(contentOccurrences, 1);
     });
   });
 });

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
@@ -62,101 +62,77 @@ function makeThrowingReadDir(): (path: string | URL) => Iterable<Deno.DirEntry> 
 describe('collectMdFiles', () => {
   /** 正常系: .md ファイルのみが results に追加される */
   describe('[正常] Normal Cases', () => {
-    describe('Given: .md ファイルと .txt ファイルが混在するディレクトリ', () => {
-      describe('When: collectMdFiles(dir, results, fakeReadDir) を呼び出す', () => {
-        describe('Then: Task T-CMF-01 - .md ファイルのみが収集される', () => {
-          it('T-CMF-01-01: .md ファイルのみが results に追加される', () => {
-            // arrange
-            const fakeReadDir = makeFakeReadDir([
-              { name: 'chat1.md', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'notes.txt', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'readme.md', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'image.png', isFile: true, isDirectory: false, isSymlink: false },
-            ]);
-            const results: string[] = [];
+    it('T-CMF-01-01: .md ファイルのみが results に追加される', () => {
+      // arrange
+      const fakeReadDir = makeFakeReadDir([
+        { name: 'chat1.md', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'notes.txt', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'readme.md', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'image.png', isFile: true, isDirectory: false, isSymlink: false },
+      ]);
+      const results: string[] = [];
 
-            // act
-            collectMdFiles('testdir', results, fakeReadDir);
+      // act
+      collectMdFiles('testdir', results, fakeReadDir);
 
-            // assert
-            assertEquals(results, ['testdir/chat1.md', 'testdir/readme.md']);
-          });
-        });
-      });
+      // assert
+      assertEquals(results, ['testdir/chat1.md', 'testdir/readme.md']);
     });
 
-    describe('Given: サブディレクトリを含むディレクトリ構造', () => {
-      describe('When: collectMdFiles を呼び出す', () => {
-        describe('Then: Task T-CMF-02 - サブディレクトリを再帰的に収集する', () => {
-          it('T-CMF-02-01: サブディレクトリの .md ファイルも収集される', () => {
-            // arrange
-            const subDirEntries = [
-              { name: 'sub.md', isFile: true, isDirectory: false, isSymlink: false },
-            ];
-            const rootEntries = [
-              { name: 'root.md', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'subdir', isFile: false, isDirectory: true, isSymlink: false },
-            ];
-            const fakeReadDir = (path: string | URL): Iterable<Deno.DirEntry> => {
-              const pathStr = String(path);
-              const entries = pathStr.endsWith('subdir') ? subDirEntries : rootEntries;
-              return entries.map((e) => makeDirEntry(e.name, e)) as Iterable<Deno.DirEntry>;
-            };
-            const results: string[] = [];
+    it('T-CMF-02-01: サブディレクトリの .md ファイルも収集される', () => {
+      // arrange
+      const subDirEntries = [
+        { name: 'sub.md', isFile: true, isDirectory: false, isSymlink: false },
+      ];
+      const rootEntries = [
+        { name: 'root.md', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'subdir', isFile: false, isDirectory: true, isSymlink: false },
+      ];
+      const fakeReadDir = (path: string | URL): Iterable<Deno.DirEntry> => {
+        const pathStr = String(path);
+        const entries = pathStr.endsWith('subdir') ? subDirEntries : rootEntries;
+        return entries.map((e) => makeDirEntry(e.name, e)) as Iterable<Deno.DirEntry>;
+      };
+      const results: string[] = [];
 
-            // act
-            collectMdFiles('testdir', results, fakeReadDir);
+      // act
+      collectMdFiles('testdir', results, fakeReadDir);
 
-            // assert
-            assertEquals(results, ['testdir/root.md', 'testdir/subdir/sub.md']);
-          });
-        });
-      });
+      // assert
+      assertEquals(results, ['testdir/root.md', 'testdir/subdir/sub.md']);
     });
   });
 
   /** 異常系: 存在しないディレクトリは例外をスローせず何も追加しない */
   describe('[異常] Error Cases', () => {
-    describe('Given: 存在しないディレクトリパスが与えられる', () => {
-      describe('When: collectMdFiles を呼び出す', () => {
-        describe('Then: Task T-CMF-03 - 例外をスローせず results が空のまま', () => {
-          it('T-CMF-03-01: NotFound 例外をスローせず results に何も追加しない', () => {
-            // arrange
-            const throwingReadDir = makeThrowingReadDir();
-            const results: string[] = [];
+    it('T-CMF-03-01: NotFound 例外をスローせず results に何も追加しない', () => {
+      // arrange
+      const throwingReadDir = makeThrowingReadDir();
+      const results: string[] = [];
 
-            // act (例外がスローされないことを確認)
-            collectMdFiles('nonexistent/dir', results, throwingReadDir);
+      // act (例外がスローされないことを確認)
+      collectMdFiles('nonexistent/dir', results, throwingReadDir);
 
-            // assert
-            assertEquals(results, []);
-          });
-        });
-      });
+      // assert
+      assertEquals(results, []);
     });
   });
 
   /** エッジケース: .md ファイルが1件もないとき */
   describe('[エッジケース] Edge Cases', () => {
-    describe('Given: .md ファイルが1件もないディレクトリ', () => {
-      describe('When: collectMdFiles を呼び出す', () => {
-        describe('Then: Task T-CMF-04 - results が空のまま', () => {
-          it('T-CMF-04-01: .md ファイルがないとき results が空配列のまま', () => {
-            // arrange
-            const fakeReadDir = makeFakeReadDir([
-              { name: 'notes.txt', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'image.png', isFile: true, isDirectory: false, isSymlink: false },
-            ]);
-            const results: string[] = [];
+    it('T-CMF-04-01: .md ファイルがないとき results が空配列のまま', () => {
+      // arrange
+      const fakeReadDir = makeFakeReadDir([
+        { name: 'notes.txt', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'image.png', isFile: true, isDirectory: false, isSymlink: false },
+      ]);
+      const results: string[] = [];
 
-            // act
-            collectMdFiles('testdir', results, fakeReadDir);
+      // act
+      collectMdFiles('testdir', results, fakeReadDir);
 
-            // assert
-            assertEquals(results, []);
-          });
-        });
-      });
+      // assert
+      assertEquals(results, []);
     });
   });
 });
@@ -170,50 +146,38 @@ describe('collectMdFiles', () => {
 describe('findMdFiles', () => {
   /** 正常系: .md ファイルが複数あるとき、ソートされた配列を返す */
   describe('[正常] Normal Cases', () => {
-    describe('Given: 複数の .md ファイルを含むディレクトリ', () => {
-      describe('When: findMdFiles(dir, fakeReadDir) を呼び出す', () => {
-        describe('Then: Task T-FMF-01 - ソートされた .md ファイルパス配列を返す', () => {
-          it('T-FMF-01-01: ソートされた .md ファイルパスの配列を返す', () => {
-            // arrange
-            const fakeReadDir = makeFakeReadDir([
-              { name: 'chat-b.md', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'chat-a.md', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'notes.txt', isFile: true, isDirectory: false, isSymlink: false },
-              { name: 'chat-c.md', isFile: true, isDirectory: false, isSymlink: false },
-            ]);
+    it('T-FMF-01-01: ソートされた .md ファイルパスの配列を返す', () => {
+      // arrange
+      const fakeReadDir = makeFakeReadDir([
+        { name: 'chat-b.md', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'chat-a.md', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'notes.txt', isFile: true, isDirectory: false, isSymlink: false },
+        { name: 'chat-c.md', isFile: true, isDirectory: false, isSymlink: false },
+      ]);
 
-            // act
-            const result = findMdFiles('testdir', fakeReadDir);
+      // act
+      const result = findMdFiles('testdir', fakeReadDir);
 
-            // assert
-            assertEquals(result, [
-              'testdir/chat-a.md',
-              'testdir/chat-b.md',
-              'testdir/chat-c.md',
-            ]);
-          });
-        });
-      });
+      // assert
+      assertEquals(result, [
+        'testdir/chat-a.md',
+        'testdir/chat-b.md',
+        'testdir/chat-c.md',
+      ]);
     });
   });
 
   /** エッジケース: ディレクトリが空のとき、空配列を返す */
   describe('[エッジケース] Edge Cases', () => {
-    describe('Given: .md ファイルが存在しないディレクトリ', () => {
-      describe('When: findMdFiles を呼び出す', () => {
-        describe('Then: Task T-FMF-02 - 空配列を返す', () => {
-          it('T-FMF-02-01: ディレクトリが空のとき空配列を返す', () => {
-            // arrange
-            const fakeReadDir = makeFakeReadDir([]);
+    it('T-FMF-02-01: ディレクトリが空のとき空配列を返す', () => {
+      // arrange
+      const fakeReadDir = makeFakeReadDir([]);
 
-            // act
-            const result = findMdFiles('emptydir', fakeReadDir);
+      // act
+      const result = findMdFiles('emptydir', fakeReadDir);
 
-            // assert
-            assertEquals(result, []);
-          });
-        });
-      });
+      // assert
+      assertEquals(result, []);
     });
   });
 });
@@ -237,101 +201,77 @@ describe('writeOutput', () => {
 
   /** 正常系: dryRun=false のとき、ファイルが書き込まれ stats.success が 1 増える */
   describe('[正常] Normal Cases', () => {
-    describe('Given: dryRun=false で有効な outputPath が与えられる', () => {
-      describe('When: writeOutput を呼び出す', () => {
-        describe('Then: Task T-WO-01 - ファイルが書き込まれ stats.success が増える', () => {
-          it('T-WO-01-01: ファイルが書き込まれ stats.success が 1 増える', async () => {
-            // arrange
-            const outputPath = `${tmpDir}/output.md`;
-            const content = '# Test Content\nHello World';
-            const stats: Stats = { success: 0, skip: 0, fail: 0 };
+    it('T-WO-01-01: ファイルが書き込まれ stats.success が 1 増える', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const content = '# Test Content\nHello World';
+      const stats: Stats = { success: 0, skip: 0, fail: 0 };
 
-            // act
-            await writeOutput(outputPath, content, false, stats);
+      // act
+      await writeOutput(outputPath, content, false, stats);
 
-            // assert
-            const written = await Deno.readTextFile(outputPath);
-            assertEquals(written, content);
-            assertEquals(stats.success, 1);
-          });
-        });
-      });
+      // assert
+      const written = await Deno.readTextFile(outputPath);
+      assertEquals(written, content);
+      assertEquals(stats.success, 1);
     });
 
-    describe('Given: 既存ファイルが存在する outputPath が与えられる', () => {
-      describe('When: writeOutput を呼び出す', () => {
-        describe('Then: Task T-WO-02 - バックアップを作成して新ファイルを書く', () => {
-          it('T-WO-02-01: 既存ファイルが .old-01.md にバックアップされ新ファイルが書かれる', async () => {
-            // arrange
-            const outputPath = `${tmpDir}/output.md`;
-            const oldContent = 'old content';
-            const newContent = 'new content';
-            await Deno.writeTextFile(outputPath, oldContent);
-            const stats: Stats = { success: 0, skip: 0, fail: 0 };
+    it('T-WO-02-01: 既存ファイルが .old-01.md にバックアップされ新ファイルが書かれる', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const oldContent = 'old content';
+      const newContent = 'new content';
+      await Deno.writeTextFile(outputPath, oldContent);
+      const stats: Stats = { success: 0, skip: 0, fail: 0 };
 
-            // act
-            await writeOutput(outputPath, newContent, false, stats);
+      // act
+      await writeOutput(outputPath, newContent, false, stats);
 
-            // assert
-            const backupPath = `${tmpDir}/output.old-01.md`;
-            const backupContent = await Deno.readTextFile(backupPath);
-            const written = await Deno.readTextFile(outputPath);
-            assertEquals(backupContent, oldContent);
-            assertEquals(written, newContent);
-            assertEquals(stats.success, 1);
-          });
-        });
-      });
+      // assert
+      const backupPath = `${tmpDir}/output.old-01.md`;
+      const backupContent = await Deno.readTextFile(backupPath);
+      const written = await Deno.readTextFile(outputPath);
+      assertEquals(backupContent, oldContent);
+      assertEquals(written, newContent);
+      assertEquals(stats.success, 1);
     });
   });
 
   /** 異常系: dryRun=true のとき、ファイルは書き込まれず stats が変化しない */
   describe('[異常] Dry-run Cases', () => {
-    describe('Given: dryRun=true が指定される', () => {
-      describe('When: writeOutput を呼び出す', () => {
-        describe('Then: Task T-WO-03 - ファイルは書き込まれず stats.success が増えない', () => {
-          it('T-WO-03-01: dryRun=true のときファイルは書き込まれず stats.success が増えない', async () => {
-            // arrange
-            const outputPath = `${tmpDir}/output-dryrun.md`;
-            const stats: Stats = { success: 0, skip: 0, fail: 0 };
+    it('T-WO-03-01: dryRun=true のときファイルは書き込まれず stats.success が増えない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output-dryrun.md`;
+      const stats: Stats = { success: 0, skip: 0, fail: 0 };
 
-            // act
-            await writeOutput(outputPath, 'content', true, stats);
+      // act
+      await writeOutput(outputPath, 'content', true, stats);
 
-            // assert
-            let fileExists = true;
-            try {
-              await Deno.stat(outputPath);
-            } catch {
-              fileExists = false;
-            }
-            assertEquals(fileExists, false);
-            assertEquals(stats.success, 0);
-          });
-        });
-      });
+      // assert
+      let fileExists = true;
+      try {
+        await Deno.stat(outputPath);
+      } catch {
+        fileExists = false;
+      }
+      assertEquals(fileExists, false);
+      assertEquals(stats.success, 0);
     });
   });
 
   /** 異常系: R-010 ガード — outputPath に temp/chatlog/ が含まれるとき Error をスロー */
   describe('[異常] R-010 Guard Cases', () => {
-    describe('Given: outputPath が temp/chatlog/ を含む', () => {
-      describe('When: writeOutput を呼び出す', () => {
-        describe('Then: Task T-WO-04 - R-010 ガードで Error をスローする', () => {
-          it('T-WO-04-01: outputPath に temp/chatlog/ が含まれるとき Error をスロー', async () => {
-            // arrange
-            const outputPath = 'temp/chatlog/agent/2026/2026-01/output.md';
-            const stats: Stats = { success: 0, skip: 0, fail: 0 };
+    it('T-WO-04-01: outputPath に temp/chatlog/ が含まれるとき Error をスロー', async () => {
+      // arrange
+      const outputPath = 'temp/chatlog/agent/2026/2026-01/output.md';
+      const stats: Stats = { success: 0, skip: 0, fail: 0 };
 
-            // act & assert
-            await assertRejects(
-              () => writeOutput(outputPath, 'content', false, stats),
-              Error,
-              'R-010',
-            );
-          });
-        });
-      });
+      // act & assert
+      await assertRejects(
+        () => writeOutput(outputPath, 'content', false, stats),
+        Error,
+        'R-010',
+      );
     });
   });
 });
@@ -353,92 +293,68 @@ describe('segmentChatlog', () => {
 
   /** 正常系: AI が有効な JSON 配列を返すとき Segment 配列を返す */
   describe('[正常] Normal Cases', () => {
-    describe('Given: AI が有効な JSON 配列を返す', () => {
-      describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
-        describe('Then: Task T-SC-01 - Segment 配列を返す', () => {
-          it('T-SC-01-01: AI が有効な JSON 配列を返すとき Segment 配列を返す', async () => {
-            // arrange
-            const segments = [
-              { title: 'Topic 1', summary: 'Summary 1', body: 'Body 1' },
-              { title: 'Topic 2', summary: 'Summary 2', body: 'Body 2' },
-            ];
-            const stdout = new TextEncoder().encode(JSON.stringify(segments));
-            mockHandle = installCommandMock(makeSuccessMock(stdout));
+    it('T-SC-01-01: AI が有効な JSON 配列を返すとき Segment 配列を返す', async () => {
+      // arrange
+      const segments = [
+        { title: 'Topic 1', summary: 'Summary 1', body: 'Body 1' },
+        { title: 'Topic 2', summary: 'Summary 2', body: 'Body 2' },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(segments));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
 
-            // act
-            const result = await segmentChatlog('test.md', 'content');
+      // act
+      const result = await segmentChatlog('test.md', 'content');
 
-            // assert
-            assertEquals(result, segments);
-          });
-        });
-      });
+      // assert
+      assertEquals(result, segments);
     });
   });
 
   /** 異常系: AI が非ゼロ exit code で終了するとき null を返す */
   describe('[異常] Error Cases', () => {
-    describe('Given: AI が非ゼロ exit code で終了する', () => {
-      describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
-        describe('Then: Task T-SC-02 - null を返す', () => {
-          it('T-SC-02-01: AI が非ゼロ exit code で終了するとき null を返す', async () => {
-            // arrange
-            mockHandle = installCommandMock(makeFailMock(1));
+    it('T-SC-02-01: AI が非ゼロ exit code で終了するとき null を返す', async () => {
+      // arrange
+      mockHandle = installCommandMock(makeFailMock(1));
 
-            // act
-            const result = await segmentChatlog('test.md', 'content');
+      // act
+      const result = await segmentChatlog('test.md', 'content');
 
-            // assert
-            assertEquals(result, null);
-          });
-        });
-      });
+      // assert
+      assertEquals(result, null);
     });
 
-    describe('Given: AI が JSON でない文字列を返す', () => {
-      describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
-        describe('Then: Task T-SC-03 - null を返す', () => {
-          it('T-SC-03-01: AI が JSON でない文字列を返すとき null を返す', async () => {
-            // arrange
-            const stdout = new TextEncoder().encode('This is not JSON at all.');
-            mockHandle = installCommandMock(makeSuccessMock(stdout));
+    it('T-SC-03-01: AI が JSON でない文字列を返すとき null を返す', async () => {
+      // arrange
+      const stdout = new TextEncoder().encode('This is not JSON at all.');
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
 
-            // act
-            const result = await segmentChatlog('test.md', 'content');
+      // act
+      const result = await segmentChatlog('test.md', 'content');
 
-            // assert
-            assertEquals(result, null);
-          });
-        });
-      });
+      // assert
+      assertEquals(result, null);
     });
   });
 
   /** エッジケース: セグメントが MAX_SEGMENTS(10) を超えるとき先頭10件のみ返す */
   describe('[エッジケース] Edge Cases', () => {
-    describe('Given: AI が MAX_SEGMENTS(10) を超えるセグメントを返す', () => {
-      describe('When: segmentChatlog(filePath, content) を呼び出す', () => {
-        describe('Then: Task T-SC-04 - 先頭10件のみ返す', () => {
-          it('T-SC-04-01: 12件のセグメントが返るとき先頭10件のみに制限される', async () => {
-            // arrange
-            const segments = Array.from({ length: 12 }, (_, i) => ({
-              title: `Topic ${i + 1}`,
-              summary: `Summary ${i + 1}`,
-              body: `Body ${i + 1}`,
-            }));
-            const stdout = new TextEncoder().encode(JSON.stringify(segments));
-            mockHandle = installCommandMock(makeSuccessMock(stdout));
+    it('T-SC-04-01: 12件のセグメントが返るとき先頭10件のみに制限される', async () => {
+      // arrange
+      const segments = Array.from({ length: 12 }, (_, i) => ({
+        title: `Topic ${i + 1}`,
+        summary: `Summary ${i + 1}`,
+        body: `Body ${i + 1}`,
+      }));
+      const stdout = new TextEncoder().encode(JSON.stringify(segments));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
 
-            // act
-            const result = await segmentChatlog('test.md', 'content');
+      // act
+      const result = await segmentChatlog('test.md', 'content');
 
-            // assert
-            assertEquals(result?.length, 10);
-            assertEquals(result?.[0].title, 'Topic 1');
-            assertEquals(result?.[9].title, 'Topic 10');
-          });
-        });
-      });
+      // assert
+      assertEquals(result?.length, 10);
+      assertEquals(result?.[0].title, 'Topic 1');
+      assertEquals(result?.[9].title, 'Topic 10');
     });
   });
 });

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.input-dir.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.input-dir.unit.spec.ts
@@ -23,11 +23,11 @@ import {
  * resolveInputDir の単体テスト。
  * 純粋関数として、FS副作用なしにパス解決結果 (ResolveResult) を返すことを検証する。
  */
-describe('Given: resolveInputDir (純粋関数)', () => {
+describe('resolveInputDir', () => {
   // ─── T-01: --dir 指定 ──────────────────────────────────────────────────────
 
-  describe('When: --dir オプションが指定される', () => {
-    /** 正常系: --dir 指定時に { ok: true, dir: <指定値> } が返る */
+  /** 正常系: --dir 指定時に { ok: true, dir: <指定値> } が返る */
+  describe('Given: --dir オプションが指定される', () => {
     it('Then: [正常] - { ok: true, dir: <指定値> } を返す', () => {
       const result = resolveInputDir({ dir: '/some/path' });
 
@@ -37,8 +37,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
   // ─── T-02: --agent + --yearMonth 指定 ─────────────────────────────────────
 
-  describe('When: --agent と --yearMonth が指定される', () => {
-    /** 正常系: temp/chatlog/<agent>/<year>/<yearMonth> のパスが返る */
+  /** 正常系: temp/chatlog/<agent>/<year>/<yearMonth> のパスが返る */
+  describe('Given: --agent と --yearMonth が指定される', () => {
     it('Then: [正常] - { ok: true, dir: "temp/chatlog/<agent>/<year>/<yearMonth>" } を返す', () => {
       const result = resolveInputDir({ agent: 'claude', yearMonth: '2026-03' });
 
@@ -48,8 +48,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
   // ─── T-03: --dir と --agent/--yearMonth の優先順位 ────────────────────────
 
-  describe('When: --dir と --agent/--yearMonth が両方指定される', () => {
-    /** エッジケース: --dir が --agent/--yearMonth より優先される */
+  /** エッジケース: --dir が --agent/--yearMonth より優先される */
+  describe('Given: --dir と --agent/--yearMonth が両方指定される', () => {
     it('Then: [エッジケース] - --dir が優先されて { ok: true, dir: <dir値> } を返す', () => {
       const result = resolveInputDir({ dir: '/explicit/dir', agent: 'claude', yearMonth: '2026-03' });
 
@@ -59,8 +59,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
   // ─── T-04: 引数なし ────────────────────────────────────────────────────────
 
-  describe('When: 引数が空オブジェクト {}', () => {
-    /** 異常系: 必須オプションなしで { ok: false, error: ... } が返る */
+  /** 異常系: 必須オプションなしで { ok: false, error: ... } が返る */
+  describe('Given: 引数が空オブジェクト {}', () => {
     it('Then: [異常] - { ok: false, error: エラーメッセージ } を返す', () => {
       const result = resolveInputDir({});
 
@@ -73,8 +73,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
   // ─── T-05: --agent のみ指定（yearMonth なし） ─────────────────────────────
 
-  describe('When: --agent のみ指定（--yearMonth なし）', () => {
-    /** 異常系: --yearMonth が欠けているため { ok: false, error: ... } が返る */
+  /** 異常系: --yearMonth が欠けているため { ok: false, error: ... } が返る */
+  describe('Given: --agent のみ指定（--yearMonth なし）', () => {
     it('Then: [異常] - { ok: false, error: エラーメッセージ } を返す', () => {
       const result = resolveInputDir({ agent: 'claude' });
 
@@ -87,8 +87,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
   // ─── T-06: --yearMonth のみ指定（agent なし） ─────────────────────────────
 
-  describe('When: --yearMonth のみ指定（--agent なし）', () => {
-    /** 異常系: --agent が欠けているため { ok: false, error: ... } が返る */
+  /** 異常系: --agent が欠けているため { ok: false, error: ... } が返る */
+  describe('Given: --yearMonth のみ指定（--agent なし）', () => {
     it('Then: [異常] - { ok: false, error: エラーメッセージ } を返す', () => {
       const result = resolveInputDir({ yearMonth: '2026-03' });
 
@@ -101,8 +101,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
   // ─── T-07: yearMonth から year の正しい抽出 ───────────────────────────────
 
-  describe('When: yearMonth="2026-03" が指定される', () => {
-    /** エッジケース: yearMonth の先頭4文字が year として抽出されパスに反映される */
+  /** エッジケース: yearMonth の先頭4文字が year として抽出されパスに反映される */
+  describe('Given: yearMonth="2026-03" が指定される', () => {
     it('Then: [エッジケース] - dir パスに "2026/2026-03" が含まれる', () => {
       const result = resolveInputDir({ agent: 'claude', yearMonth: '2026-03' });
 
@@ -114,8 +114,8 @@ describe('Given: resolveInputDir (純粋関数)', () => {
 
 // ─── validateInputDir 単体テスト ──────────────────────────────────────────────
 
-describe('Given: validateInputDir (statFn注入)', () => {
-  describe('When: statFn が成功（例外なし）', () => {
+describe('validateInputDir', () => {
+  describe('Given: statFn が成功（例外なし）', () => {
     it('Then: [正常] - true を返す', () => {
       const statFn = (_path: string) => ({ isDirectory: true });
       const result = validateInputDir('/any/path', statFn);
@@ -124,7 +124,7 @@ describe('Given: validateInputDir (statFn注入)', () => {
     });
   });
 
-  describe('When: statFn が例外をスロー', () => {
+  describe('Given: statFn が例外をスロー', () => {
     it('Then: [異常] - false を返す', () => {
       const statFn = (_path: string): unknown => {
         throw new Deno.errors.NotFound('not found');
@@ -135,7 +135,7 @@ describe('Given: validateInputDir (statFn注入)', () => {
     });
   });
 
-  describe('When: statFn が undefined として渡される', () => {
+  describe('Given: statFn が undefined として渡される', () => {
     it('Then: [エッジケース] - Deno.statSync をデフォルトとして使用し、存在するディレクトリには true を返す', () => {
       // undefined を明示的に渡す（falsyフォールバックのテスト）
       // 実際のFS（カレントディレクトリ "."）を使う
@@ -145,7 +145,7 @@ describe('Given: validateInputDir (statFn注入)', () => {
     });
   });
 
-  describe('When: statFn が undefined として渡され、存在しないパス', () => {
+  describe('Given: statFn が undefined として渡され、存在しないパス', () => {
     it('Then: [エッジケース] - Deno.statSync をデフォルトとして使用し、存在しないパスには false を返す', () => {
       const result = validateInputDir('/nonexistent/path/xyz', undefined);
 

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.output-dir.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.output-dir.unit.spec.ts
@@ -1,0 +1,128 @@
+// src: scripts/__tests__/unit/normalize-chatlog.output-dir.unit.spec.ts
+// @(#): 出力ディレクトリ解決のユニットテスト
+//       対象: resolveOutputDir
+//       テスト種別: 正常系 / 異常系 / エッジケース
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// Deno Test module
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// test target
+import { resolveOutputDir } from '../../normalize-chatlog.ts';
+
+// ─── resolveOutputDir 単体テスト ──────────────────────────────────────────────
+
+/**
+ * resolveOutputDir の単体テスト。
+ * chatlog 形式パスのミラー構造と任意パスのフォールバックを検証する。
+ */
+describe('resolveOutputDir', () => {
+  // ─── T-20-01: chatlog 形式 → agent/year/yearMonth がミラーされる ──────────
+
+  /** 正常系: agent/year/yearMonth が outputBase 配下にミラーされ project が末尾に付く */
+  describe('Given: inputDir が chatlog 形式 "temp/chatlog/<agent>/<year>/<yearMonth>"', () => {
+    it('Then: [正常] - <outputBase>/<agent>/<year>/<yearMonth>/<project> を返す', () => {
+      const result = resolveOutputDir(
+        'temp/chatlog/claude/2026/2026-03',
+        '/out',
+        'my-app',
+      );
+
+      assertEquals(result, '/out/claude/2026/2026-03/my-app');
+    });
+  });
+
+  // ─── T-20-02: chatlog 形式 + project なし → misc フォールバック ─────────
+
+  /** エッジケース: project 未指定時は "misc" がフォールバックとして使われる */
+  describe('Given: inputDir が chatlog 形式で project が undefined', () => {
+    it('Then: [エッジケース] - <outputBase>/<agent>/<year>/<yearMonth>/misc を返す', () => {
+      const result = resolveOutputDir(
+        'temp/chatlog/gemini/2025/2025-12',
+        '/out',
+        undefined,
+      );
+
+      assertEquals(result, '/out/gemini/2025/2025-12/misc');
+    });
+  });
+
+  // ─── T-20-03: chatlog 形式 + project 空文字 → misc フォールバック ────────
+
+  /** エッジケース: project が空文字列の場合も "misc" にフォールバックする */
+  describe('Given: inputDir が chatlog 形式で project が空文字列', () => {
+    it('Then: [エッジケース] - <outputBase>/<agent>/<year>/<yearMonth>/misc を返す', () => {
+      const result = resolveOutputDir(
+        'temp/chatlog/claude/2026/2026-04',
+        '/out',
+        '',
+      );
+
+      assertEquals(result, '/out/claude/2026/2026-04/misc');
+    });
+  });
+
+  // ─── T-20-04: 任意パス → <outputBase>/<project> ──────────────────────────
+
+  /** 正常系: chatlog 形式でない場合は <outputBase>/<project> が返る */
+  describe('Given: inputDir が任意パス（chatlog 形式でない）', () => {
+    it('Then: [正常] - <outputBase>/<project> を返す', () => {
+      const result = resolveOutputDir(
+        '/home/user/chatlogs',
+        '/out',
+        'custom-project',
+      );
+
+      assertEquals(result, '/out/custom-project');
+    });
+  });
+
+  // ─── T-20-05: 任意パス + project なし → misc フォールバック ─────────────
+
+  /** エッジケース: chatlog 形式でなく project も未指定の場合は <outputBase>/misc */
+  describe('Given: inputDir が任意パスで project が undefined', () => {
+    it('Then: [エッジケース] - <outputBase>/misc を返す', () => {
+      const result = resolveOutputDir(
+        '/home/user/chatlogs',
+        '/out',
+        undefined,
+      );
+
+      assertEquals(result, '/out/misc');
+    });
+  });
+
+  // ─── T-20-06: agent の値がパスに正確に反映される ─────────────────────────
+
+  /** 正常系: agent 名がそのまま出力パスに反映される */
+  describe('Given: inputDir の agent が "chatgpt"', () => {
+    it('Then: [正常] - 出力パスに "chatgpt" が含まれる', () => {
+      const result = resolveOutputDir(
+        'temp/chatlog/chatgpt/2026/2026-01',
+        '/out',
+        'proj',
+      );
+
+      assertEquals(result, '/out/chatgpt/2026/2026-01/proj');
+    });
+  });
+
+  // ─── T-20-07: yearMonth が出力パスに正確にミラーされる ───────────────────
+
+  /** 正常系: yearMonth が year/yearMonth として出力パスに正確にミラーされる */
+  describe('Given: inputDir の yearMonth が "2025-11"', () => {
+    it('Then: [正常] - 出力パスに "2025/2025-11" が含まれる', () => {
+      const result = resolveOutputDir(
+        'temp/chatlog/claude/2025/2025-11',
+        '/normalized',
+        'blog',
+      );
+
+      assertEquals(result, '/normalized/claude/2025/2025-11/blog');
+    });
+  });
+});

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.side-effects.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.side-effects.unit.spec.ts
@@ -16,7 +16,6 @@ import { stub } from '@std/testing/mock';
 
 // test helpers
 import {
-  makeCountingMock,
   makeFailMock,
   makeNotFoundMock,
   makeSuccessMock,
@@ -32,105 +31,63 @@ import type { Stats } from '../../normalize-chatlog.ts';
 // ─── reportResults tests ──────────────────────────────────────────────────────
 
 describe('reportResults', () => {
+  let logStub: Stub;
+  let logCalls: string[];
+
+  beforeEach(() => {
+    logCalls = [];
+    logStub = stub(console, 'log', (...args: unknown[]) => {
+      logCalls.push(args.map(String).join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logStub.restore();
+  });
+
   /** 正常系: success/skip/fail カウントを stdout に集計レポートとして出力する */
   describe('Given: success/skip/fail カウントを持つ stats', () => {
-    let logStub: Stub;
-    let logCalls: string[];
+    it('T-14-01-01: stdout に成功件数が含まれる', () => {
+      const stats: Stats = { success: 5, skip: 2, fail: 1 };
 
-    // T-14-01-TF: stub console.log, collect call args
-    beforeEach(() => {
-      logCalls = [];
-      logStub = stub(console, 'log', (...args: unknown[]) => {
-        logCalls.push(args.map(String).join(' '));
-      });
+      reportResults(stats);
+
+      const output = logCalls.join('\n');
+      assertMatch(output, /success.*5|5.*success|成功.*5|5.*成功/i);
     });
 
-    afterEach(() => {
-      logStub.restore();
-    });
+    it('T-14-01-02: stdout にスキップ数と失敗数が含まれる', () => {
+      const stats: Stats = { success: 3, skip: 1, fail: 2 };
 
-    describe('When: reportResults を呼び出す', () => {
-      describe('Then: Task T-14-01 - stdout への集計レポート (R-009)', () => {
-        it('T-14-01-01: stdout に成功件数が含まれる', () => {
-          const stats: Stats = { success: 5, skip: 2, fail: 1 };
+      reportResults(stats);
 
-          reportResults(stats);
-
-          const output = logCalls.join('\n');
-          assertMatch(output, /success.*5|5.*success|成功.*5|5.*成功/i);
-        });
-
-        it('T-14-01-02: stdout にスキップ数と失敗数が含まれる', () => {
-          const stats: Stats = { success: 3, skip: 1, fail: 2 };
-
-          reportResults(stats);
-
-          const output = logCalls.join('\n');
-          assertMatch(output, /1/);
-          assertMatch(output, /2/);
-        });
-      });
+      const output = logCalls.join('\n');
+      assertMatch(output, /1/);
+      assertMatch(output, /2/);
     });
   });
 
   /** エッジケース: 全カウントが 0 でもスローせず出力する */
   describe('Given: 全カウントが 0 の stats', () => {
-    let logStub: Stub;
-    let logCalls: string[];
+    it('T-14-02-01: throw せずに stdout に出力される', () => {
+      const stats: Stats = { success: 0, skip: 0, fail: 0 };
 
-    // T-14-02-TF: stub console.log, collect call args
-    beforeEach(() => {
-      logCalls = [];
-      logStub = stub(console, 'log', (...args: unknown[]) => {
-        logCalls.push(args.map(String).join(' '));
-      });
-    });
+      reportResults(stats);
 
-    afterEach(() => {
-      logStub.restore();
-    });
-
-    describe('When: reportResults を呼び出す', () => {
-      describe('Then: Task T-14-02 - ゼロ件でもエラーなし', () => {
-        it('T-14-02-01: throw せずに stdout に出力される', () => {
-          const stats: Stats = { success: 0, skip: 0, fail: 0 };
-
-          reportResults(stats);
-
-          assertNotEquals(logCalls.length, 0);
-          assertNotEquals(logCalls.join(''), '');
-        });
-      });
+      assertNotEquals(logCalls.length, 0);
+      assertNotEquals(logCalls.join(''), '');
     });
   });
 
   /** 正常系: fail が非ゼロのとき失敗件数を stdout に明示する */
   describe('Given: fail が非ゼロの stats', () => {
-    let logStub: Stub;
-    let logCalls: string[];
+    it('T-14-03-01: stdout に失敗件数が明示される', () => {
+      const stats: Stats = { success: 0, skip: 0, fail: 3 };
 
-    beforeEach(() => {
-      logCalls = [];
-      logStub = stub(console, 'log', (...args: unknown[]) => {
-        logCalls.push(args.map(String).join(' '));
-      });
-    });
+      reportResults(stats);
 
-    afterEach(() => {
-      logStub.restore();
-    });
-
-    describe('When: reportResults を呼び出す', () => {
-      describe('Then: Task T-14-03 - 失敗件数の明示 (R-009)', () => {
-        it('T-14-03-01: stdout に失敗件数が明示される', () => {
-          const stats: Stats = { success: 0, skip: 0, fail: 3 };
-
-          reportResults(stats);
-
-          const output = logCalls.join('\n');
-          assertMatch(output, /fail.*3|3.*fail|失敗.*3|3.*失敗/i);
-        });
-      });
+      const output = logCalls.join('\n');
+      assertMatch(output, /fail.*3|3.*fail|失敗.*3|3.*失敗/i);
     });
   });
 });
@@ -145,154 +102,119 @@ describe('reportResults', () => {
 describe('runAI', () => {
   /** 正常系: Claude CLI が exit code 0 で終了し、stdout テキストが返る */
   describe('Given: Claude CLI が exit code 0 で正常終了する', () => {
-    /**
-     * When: 標準的な model・systemPrompt・userPrompt を渡して runAI を呼び出す。
-     */
-    describe('When: runAI("claude-sonnet-4-6", "You are a helper.", "Summarize this") を呼び出す', () => {
-      /**
-       * Task T-02-01: Claude CLI の正常呼び出し。
-       * exit code 0 のとき stdout テキストをデコードして返し、渡した引数が CLI に正しく伝わることを確認する。
-       */
-      describe('Then: Task T-02-01 - Claude CLI の正常呼び出し', () => {
-        let savedCommand: unknown;
-        beforeEach(() => {
-          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
-        });
-        afterEach(() => {
-          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
-        });
+    let savedCommand: unknown;
+    beforeEach(() => {
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+    });
+    afterEach(() => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+    });
 
-        it('exit code 0 のとき stdout テキストをデコードして返す', async () => {
-          const stdoutText = 'Summary result';
-          const mock = makeSuccessMock(new TextEncoder().encode(stdoutText));
-          (Deno as unknown as Record<string, unknown>).Command = mock;
+    it('exit code 0 のとき stdout テキストをデコードして返す', async () => {
+      const stdoutText = 'Summary result';
+      const mock = makeSuccessMock(new TextEncoder().encode(stdoutText));
+      (Deno as unknown as Record<string, unknown>).Command = mock;
 
-          const result = await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
+      const result = await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
 
-          assertEquals(result, stdoutText);
-        });
+      assertEquals(result, stdoutText);
+    });
 
-        it('model・systemPrompt・安全オプションが CLI に渡される', async () => {
-          const captured = { value: [] as string[] };
-          const mock = makeSuccessMock(new TextEncoder().encode('ok'), captured);
-          (Deno as unknown as Record<string, unknown>).Command = mock;
+    it('model・systemPrompt・安全オプションが CLI に渡される', async () => {
+      const captured = { value: [] as string[] };
+      const mock = makeSuccessMock(new TextEncoder().encode('ok'), captured);
+      (Deno as unknown as Record<string, unknown>).Command = mock;
 
-          await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
+      await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
 
-          assertEquals(captured.value, [
-            '-p',
-            '--system-prompt',
-            'You are a helper.',
-            '--output-format',
-            'text',
-            '--permission-mode',
-            'acceptEdits',
-            '--strict-mcp-config',
-            '--mcp-config',
-            '{"mcpServers":{}}',
-            '--model',
-            'claude-sonnet-4-6',
-          ]);
-        });
+      assertEquals(captured.value, [
+        '-p',
+        '--system-prompt',
+        'You are a helper.',
+        '--output-format',
+        'text',
+        '--permission-mode',
+        'acceptEdits',
+        '--strict-mcp-config',
+        '--mcp-config',
+        '{"mcpServers":{}}',
+        '--model',
+        'claude-sonnet-4-6',
+      ]);
+    });
 
-        it('-p と --system-prompt が分離されており systemPrompt が -p の引数になっていない', async () => {
-          const captured = { value: [] as string[] };
-          const mock = makeSuccessMock(new TextEncoder().encode('ok'), captured);
-          (Deno as unknown as Record<string, unknown>).Command = mock;
+    it('-p と --system-prompt が分離されており systemPrompt が -p の引数になっていない', async () => {
+      const captured = { value: [] as string[] };
+      const mock = makeSuccessMock(new TextEncoder().encode('ok'), captured);
+      (Deno as unknown as Record<string, unknown>).Command = mock;
 
-          await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
+      await runAI('claude-sonnet-4-6', 'You are a helper.', 'Summarize this');
 
-          const pIdx = captured.value.indexOf('-p');
-          const spIdx = captured.value.indexOf('--system-prompt');
-          // -p は単独フラグ（直後が --system-prompt であること）
-          assertEquals(captured.value[pIdx + 1], '--system-prompt');
-          // --system-prompt の直後に systemPrompt の値があること
-          assertEquals(captured.value[spIdx + 1], 'You are a helper.');
-        });
-      });
+      const pIdx = captured.value.indexOf('-p');
+      const spIdx = captured.value.indexOf('--system-prompt');
+      // -p は単独フラグ（直後が --system-prompt であること）
+      assertEquals(captured.value[pIdx + 1], '--system-prompt');
+      // --system-prompt の直後に systemPrompt の値があること
+      assertEquals(captured.value[spIdx + 1], 'You are a helper.');
     });
   });
 
   /** 異常系: CLI が非ゼロ exit code で終了したとき Error をスローする */
   describe('Given: Claude CLI が非ゼロ exit code で終了する', () => {
-    describe('When: runAI("claude-sonnet-4-6", "sys", "user") を呼び出す', () => {
-      /**
-       * Task T-02-02: Claude CLI 失敗時の処理。
-       * 非ゼロ exit code のとき、exit code を含む Error がスローされることを確認する。
-       */
-      describe('Then: Task T-02-02 - Claude CLI 失敗時の処理', () => {
-        let savedCommand: unknown;
-        beforeEach(() => {
-          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
-          (Deno as unknown as Record<string, unknown>).Command = makeFailMock(1);
-        });
-        afterEach(() => {
-          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
-        });
+    let savedCommand: unknown;
+    beforeEach(() => {
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      (Deno as unknown as Record<string, unknown>).Command = makeFailMock(1);
+    });
+    afterEach(() => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+    });
 
-        it('非ゼロ exit code のとき exit code を含む Error をスローする', async () => {
-          await assertRejects(
-            () => runAI('claude-sonnet-4-6', 'sys', 'user'),
-            Error,
-            '1',
-          );
-        });
-      });
+    it('非ゼロ exit code のとき exit code を含む Error をスローする', async () => {
+      await assertRejects(
+        () => runAI('claude-sonnet-4-6', 'sys', 'user'),
+        Error,
+        '1',
+      );
     });
   });
 
   /** 異常系: `claude` コマンドが見つからず Deno.errors.NotFound が伝播する */
   describe('Given: `claude` コマンドが存在しない', () => {
-    describe('When: runAI("claude-sonnet-4-6", "sys", "user") を呼び出す', () => {
-      /**
-       * Task T-02-03: Claude CLI 失敗時の処理（コマンド不在）。
-       * spawn が NotFound をスローした場合、そのエラーが呼び出し元に伝播することを確認する。
-       */
-      describe('Then: Task T-02-03 - Claude CLI 失敗時の処理（コマンド不在）', () => {
-        let savedCommand: unknown;
-        beforeEach(() => {
-          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
-          (Deno as unknown as Record<string, unknown>).Command = makeNotFoundMock();
-        });
-        afterEach(() => {
-          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
-        });
+    let savedCommand: unknown;
+    beforeEach(() => {
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      (Deno as unknown as Record<string, unknown>).Command = makeNotFoundMock();
+    });
+    afterEach(() => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+    });
 
-        it('spawn が Deno.errors.NotFound をスローしたとき、エラーが呼び出し元に伝播する', async () => {
-          await assertRejects(
-            () => runAI('claude-sonnet-4-6', 'sys', 'user'),
-            Deno.errors.NotFound,
-          );
-        });
-      });
+    it('spawn が Deno.errors.NotFound をスローしたとき、エラーが呼び出し元に伝播する', async () => {
+      await assertRejects(
+        () => runAI('claude-sonnet-4-6', 'sys', 'user'),
+        Deno.errors.NotFound,
+      );
     });
   });
 
   /** 正常系: stdout の前後空白・改行を trim して返す */
   describe('Given: Claude CLI の stdout に前後の空白が含まれる', () => {
-    describe('When: runAI("claude-sonnet-4-6", "sys", "user") を呼び出す', () => {
-      /**
-       * Task T-02-04: 出力のトリミング。
-       * stdout の前後に空白や改行が含まれる場合、trim した文字列が返ることを確認する。
-       */
-      describe('Then: Task T-02-04 - 出力のトリミング', () => {
-        let savedCommand: unknown;
-        beforeEach(() => {
-          savedCommand = (Deno as unknown as Record<string, unknown>).Command;
-          (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
-            new TextEncoder().encode('  Summary result\n'),
-          );
-        });
-        afterEach(() => {
-          (Deno as unknown as Record<string, unknown>).Command = savedCommand;
-        });
+    let savedCommand: unknown;
+    beforeEach(() => {
+      savedCommand = (Deno as unknown as Record<string, unknown>).Command;
+      (Deno as unknown as Record<string, unknown>).Command = makeSuccessMock(
+        new TextEncoder().encode('  Summary result\n'),
+      );
+    });
+    afterEach(() => {
+      (Deno as unknown as Record<string, unknown>).Command = savedCommand;
+    });
 
-        it('stdout の前後の空白を除去した文字列を返す', async () => {
-          const result = await runAI('claude-sonnet-4-6', 'sys', 'user');
+    it('stdout の前後の空白を除去した文字列を返す', async () => {
+      const result = await runAI('claude-sonnet-4-6', 'sys', 'user');
 
-          assertEquals(result, 'Summary result');
-        });
-      });
+      assertEquals(result, 'Summary result');
     });
   });
 });

--- a/.claude/commands/scripts/__tests__/unit/normalize-chatlog.string-utils.unit.spec.ts
+++ b/.claude/commands/scripts/__tests__/unit/normalize-chatlog.string-utils.unit.spec.ts
@@ -28,75 +28,59 @@ import {
 describe('cleanYaml', () => {
   /** 正常系: コードフェンスや前置テキストを除去してクリーンな YAML を返す */
   describe('Given: ```yaml...``` コードフェンスで囲まれた YAML 文字列', () => {
-    describe('When: cleanYaml(raw, "title") を呼び出す', () => {
-      describe('Then: Task T-03-01 - コードフェンスの除去', () => {
-        it('開始フェンス行と終了フェンス行を除去して YAML コンテンツだけを返す', () => {
-          const raw = '```yaml\ntitle: foo\ndate: 2026-04-05\n```';
+    it('開始フェンス行と終了フェンス行を除去して YAML コンテンツだけを返す', () => {
+      const raw = '```yaml\ntitle: foo\ndate: 2026-04-05\n```';
 
-          const result = cleanYaml(raw, 'title');
+      const result = cleanYaml(raw, 'title');
 
-          assertEquals(result, 'title: foo\ndate: 2026-04-05');
-        });
+      assertEquals(result, 'title: foo\ndate: 2026-04-05');
+    });
 
-        it('firstField より前の非 YAML 行をすべて除去する', () => {
-          const raw = 'Here is the YAML:\ntitle: foo\ndate: 2026-04-05';
+    it('firstField より前の非 YAML 行をすべて除去する', () => {
+      const raw = 'Here is the YAML:\ntitle: foo\ndate: 2026-04-05';
 
-          const result = cleanYaml(raw, 'title');
+      const result = cleanYaml(raw, 'title');
 
-          assertEquals(result, 'title: foo\ndate: 2026-04-05');
-        });
-      });
+      assertEquals(result, 'title: foo\ndate: 2026-04-05');
     });
   });
 
   /** エッジケース: フェンスなし・末尾改行のみの入力でも正しく trim する */
   describe('Given: フェンスも余分な行もなく末尾に改行がある YAML 文字列', () => {
-    describe('When: cleanYaml(raw, "title") を呼び出す', () => {
-      describe('Then: Task T-03-02 - エッジケースの処理', () => {
-        it('末尾の改行をトリムしてクリーンな YAML コンテンツを返す', () => {
-          const raw = 'title: foo\ndate: 2026-04-05\n';
+    it('末尾の改行をトリムしてクリーンな YAML コンテンツを返す', () => {
+      const raw = 'title: foo\ndate: 2026-04-05\n';
 
-          const result = cleanYaml(raw, 'title');
+      const result = cleanYaml(raw, 'title');
 
-          assertEquals(result, 'title: foo\ndate: 2026-04-05');
-        });
-      });
+      assertEquals(result, 'title: foo\ndate: 2026-04-05');
     });
   });
 
   /** エッジケース: 空文字列入力でスローされず空文字列を返す */
   describe('Given: raw が空文字列', () => {
-    describe('When: cleanYaml("", "title") を呼び出す', () => {
-      describe('Then: Task T-03-03 - エッジケースの処理（空文字列）', () => {
-        it('例外をスローせず空文字列を返す', () => {
-          const result = cleanYaml('', 'title');
+    it('例外をスローせず空文字列を返す', () => {
+      const result = cleanYaml('', 'title');
 
-          assertEquals(result, '');
-        });
-      });
+      assertEquals(result, '');
     });
   });
 
   /** エッジケース: firstField が存在しないケース */
   describe('Given: firstField を含まない YAML 文字列が与えられる', () => {
-    describe('When: cleanYaml(raw, "nonexistent") を呼び出す', () => {
-      describe('Then: stripped 全体を trim して返す', () => {
-        it('T-CY-E-01: firstField が見つからないとき、stripped 全体を trim して返す', () => {
-          const raw = 'some: value\nother: data';
+    it('T-CY-E-01: firstField が見つからないとき、stripped 全体を trim して返す', () => {
+      const raw = 'some: value\nother: data';
 
-          const result = cleanYaml(raw, 'nonexistent');
+      const result = cleanYaml(raw, 'nonexistent');
 
-          assertEquals(result, 'some: value\nother: data');
-        });
+      assertEquals(result, 'some: value\nother: data');
+    });
 
-        it('T-CY-E-02: コードフェンスがあっても stripped してから全体を返す', () => {
-          const raw = '```yaml\nsome: value\nother: data\n```';
+    it('T-CY-E-02: コードフェンスがあっても stripped してから全体を返す', () => {
+      const raw = '```yaml\nsome: value\nother: data\n```';
 
-          const result = cleanYaml(raw, 'nonexistent');
+      const result = cleanYaml(raw, 'nonexistent');
 
-          assertEquals(result, 'some: value\nother: data');
-        });
-      });
+      assertEquals(result, 'some: value\nother: data');
     });
   });
 });
@@ -111,63 +95,51 @@ describe('cleanYaml', () => {
 describe('parseFrontmatter', () => {
   /** 正常系: `---` で囲まれたフロントマターを meta と fullBody に分解する */
   describe('Given: フロントマターブロックを含む Markdown テキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
-      describe('Then: Task T-04-01 - フロントマターありのファイル', () => {
-        it('meta に project と date フィールドが含まれる', () => {
-          const text = '---\nproject: ci-platform\ndate: 2026-03-01\n---\n# Body';
+    it('meta に project と date フィールドが含まれる', () => {
+      const text = '---\nproject: ci-platform\ndate: 2026-03-01\n---\n# Body';
 
-          const { meta } = parseFrontmatter(text);
+      const { meta } = parseFrontmatter(text);
 
-          assertEquals(meta, { project: 'ci-platform', date: '2026-03-01' });
-        });
+      assertEquals(meta, { project: 'ci-platform', date: '2026-03-01' });
+    });
 
-        it('fullBody に閉じ --- 以降のテキストが含まれる', () => {
-          const text = '---\nproject: ci-platform\ndate: 2026-03-01\n---\n# Body';
+    it('fullBody に閉じ --- 以降のテキストが含まれる', () => {
+      const text = '---\nproject: ci-platform\ndate: 2026-03-01\n---\n# Body';
 
-          const { fullBody } = parseFrontmatter(text);
+      const { fullBody } = parseFrontmatter(text);
 
-          assertEquals(fullBody, '\n# Body');
-        });
-      });
+      assertEquals(fullBody, '\n# Body');
     });
   });
 
   /** 正常系: フロントマターなしの場合は meta を空にして fullBody を元テキスト全体とする */
   describe('Given: --- で始まらない Markdown テキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
-      describe('Then: Task T-04-02 - フロントマターなしのファイル', () => {
-        it('meta が空のレコードである', () => {
-          const text = '# No Frontmatter\n\nSome content.';
+    it('meta が空のレコードである', () => {
+      const text = '# No Frontmatter\n\nSome content.';
 
-          const { meta } = parseFrontmatter(text);
+      const { meta } = parseFrontmatter(text);
 
-          assertEquals(meta, {});
-        });
+      assertEquals(meta, {});
+    });
 
-        it('fullBody が元のテキスト全体と等しい', () => {
-          const text = '# No Frontmatter\n\nSome content.';
+    it('fullBody が元のテキスト全体と等しい', () => {
+      const text = '# No Frontmatter\n\nSome content.';
 
-          const { fullBody } = parseFrontmatter(text);
+      const { fullBody } = parseFrontmatter(text);
 
-          assertEquals(fullBody, text);
-        });
-      });
+      assertEquals(fullBody, text);
     });
   });
 
   /** 異常系: 開き `---` はあるが閉じ `---` がない不正なフロントマターは無視する */
   describe('Given: --- で始まるが閉じ --- がない Markdown テキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
-      describe('Then: Task T-04-03 - 不正なフロントマター', () => {
-        it('meta が空で fullBody が元のテキスト全体を含む', () => {
-          const text = '---\nproject: ci-platform\n';
+    it('meta が空で fullBody が元のテキスト全体を含む', () => {
+      const text = '---\nproject: ci-platform\n';
 
-          const { meta, fullBody } = parseFrontmatter(text);
+      const { meta, fullBody } = parseFrontmatter(text);
 
-          assertEquals(meta, {});
-          assertEquals(fullBody, text);
-        });
-      });
+      assertEquals(meta, {});
+      assertEquals(fullBody, text);
     });
   });
 });
@@ -182,51 +154,43 @@ describe('parseFrontmatter', () => {
 describe('extractBaseName', () => {
   /** 正常系: ディレクトリ・.md 拡張子・末尾 7 桁ハッシュを除去する */
   describe('Given: ディレクトリパスと .md 拡張子を含むファイルパス', () => {
-    describe('When: extractBaseName(filePath) を呼び出す', () => {
-      describe('Then: Task T-05-01 - ベース名の抽出', () => {
-        it('T-05-01-01: ディレクトリと .md 拡張子を除去したファイル名を返す', () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
+    it('T-05-01-01: ディレクトリと .md 拡張子を除去したファイル名を返す', () => {
+      const filePath = 'temp/chatlog/claude/2026/2026-03/test-file.md';
 
-          const result = extractBaseName(filePath);
+      const result = extractBaseName(filePath);
 
-          assertEquals(result, 'test-file');
-        });
+      assertEquals(result, 'test-file');
+    });
 
-        it('T-05-01-02: 末尾の -XXXXXXX (7桁 hex) を除去する', () => {
-          const filePath = 'temp/chatlog/claude/2026/2026-03/2026-03-11-topic-abc1234.md';
+    it('T-05-01-02: 末尾の -XXXXXXX (7桁 hex) を除去する', () => {
+      const filePath = 'temp/chatlog/claude/2026/2026-03/2026-03-11-topic-abc1234.md';
 
-          const result = extractBaseName(filePath);
+      const result = extractBaseName(filePath);
 
-          assertEquals(result, '2026-03-11-topic');
-        });
+      assertEquals(result, '2026-03-11-topic');
+    });
 
-        it('T-05-01-03: 末尾が 7 桁 hex でない場合はハッシュ除去しない', () => {
-          const filePath = 'path/to/2026-03-11-topic.md';
+    it('T-05-01-03: 末尾が 7 桁 hex でない場合はハッシュ除去しない', () => {
+      const filePath = 'path/to/2026-03-11-topic.md';
 
-          const result = extractBaseName(filePath);
+      const result = extractBaseName(filePath);
 
-          assertEquals(result, '2026-03-11-topic');
-        });
-      });
+      assertEquals(result, '2026-03-11-topic');
     });
   });
 
   /** エッジケース: ディレクトリなし・拡張子なし */
   describe('Given: ディレクトリなしのファイル名', () => {
-    describe('When: extractBaseName(filePath) を呼び出す', () => {
-      describe('Then: Task T-05-02 - エッジケースの処理', () => {
-        it('T-05-02-01: ディレクトリなしでも .md 拡張子を除去して返す', () => {
-          const result = extractBaseName('simple-file.md');
+    it('T-05-02-01: ディレクトリなしでも .md 拡張子を除去して返す', () => {
+      const result = extractBaseName('simple-file.md');
 
-          assertEquals(result, 'simple-file');
-        });
+      assertEquals(result, 'simple-file');
+    });
 
-        it('T-05-02-02: 拡張子がない場合はファイル名をそのまま返す', () => {
-          const result = extractBaseName('no-extension');
+    it('T-05-02-02: 拡張子がない場合はファイル名をそのまま返す', () => {
+      const result = extractBaseName('no-extension');
 
-          assertEquals(result, 'no-extension');
-        });
-      });
+      assertEquals(result, 'no-extension');
     });
   });
 });
@@ -241,76 +205,60 @@ describe('extractBaseName', () => {
 describe('parseJsonArray', () => {
   /** 正常系: `[` 始まりの JSON 配列を直接パースして返す */
   describe('Given: `[` で始まる有効な JSON 配列文字列', () => {
-    describe('When: parseJsonArray を呼び出す', () => {
-      describe('Then: Task T-10-01 - 直接 JSON 配列パース', () => {
-        it('T-10-01-01: 1 オブジェクトを含む配列が返される', () => {
-          const rawDirect = '[{"title":"T1","summary":"S1","body":"B1"}]';
+    it('T-10-01-01: 1 オブジェクトを含む配列が返される', () => {
+      const rawDirect = '[{"title":"T1","summary":"S1","body":"B1"}]';
 
-          const result = parseJsonArray(rawDirect);
+      const result = parseJsonArray(rawDirect);
 
-          assertEquals(Array.isArray(result), true);
-          assertEquals((result as unknown[]).length, 1);
-          assertEquals((result as { title: string }[])[0].title, 'T1');
-        });
-      });
+      assertEquals(Array.isArray(result), true);
+      assertEquals((result as unknown[]).length, 1);
+      assertEquals((result as { title: string }[])[0].title, 'T1');
     });
   });
 
   /** 正常系: 前置テキストがあっても正規表現フォールバックで JSON 配列を抽出する */
   describe('Given: 前置テキストを含む文字列（非貪欲マッチで JSON 配列を抽出可能）', () => {
-    describe('When: parseJsonArray を呼び出す', () => {
-      describe('Then: Task T-10-02 - テキスト混在時のフォールバック抽出', () => {
-        it('T-10-02-01: 配列が抽出されて返される', () => {
-          const rawWithPrefix = 'Here is the result:\n[{"title":"T"}]';
+    it('T-10-02-01: 配列が抽出されて返される', () => {
+      const rawWithPrefix = 'Here is the result:\n[{"title":"T"}]';
 
-          const result = parseJsonArray(rawWithPrefix);
+      const result = parseJsonArray(rawWithPrefix);
 
-          assertEquals(Array.isArray(result), true);
-          assertEquals((result as unknown[]).length, 1);
-          assertEquals((result as { title: string }[])[0].title, 'T');
-        });
-      });
+      assertEquals(Array.isArray(result), true);
+      assertEquals((result as unknown[]).length, 1);
+      assertEquals((result as { title: string }[])[0].title, 'T');
     });
   });
 
   /** 正常系: 非貪欲マッチが失敗した場合は貪欲マッチで配列全体を抽出する */
   describe('Given: 非貪欲マッチでは不完全な配列しか取れない文字列（貪欲マッチが必要）', () => {
-    describe('When: parseJsonArray を呼び出す', () => {
-      describe('Then: Task T-10-02 - テキスト混在時のフォールバック抽出', () => {
-        it('T-10-02-02: 貪欲マッチの結果 length 2 の配列が返される', () => {
-          const rawGreedy = 'result: [{"title":"A"},{"title":"B"}] and more text';
+    it('T-10-02-02: 貪欲マッチの結果 length 2 の配列が返される', () => {
+      const rawGreedy = 'result: [{"title":"A"},{"title":"B"}] and more text';
 
-          const result = parseJsonArray(rawGreedy);
+      const result = parseJsonArray(rawGreedy);
 
-          assertEquals(Array.isArray(result), true);
-          assertEquals((result as unknown[]).length, 2);
-          assertEquals((result as { title: string }[])[0].title, 'A');
-          assertEquals((result as { title: string }[])[1].title, 'B');
-        });
-      });
+      assertEquals(Array.isArray(result), true);
+      assertEquals((result as unknown[]).length, 2);
+      assertEquals((result as { title: string }[])[0].title, 'A');
+      assertEquals((result as { title: string }[])[1].title, 'B');
     });
   });
 
   /** 異常系: JSON 配列が見つからない入力はスローせず null を返す */
   describe('Given: 有効な JSON 配列を含まないプレーンテキスト', () => {
-    describe('When: parseJsonArray を呼び出す', () => {
-      describe('Then: Task T-10-03 - パース不可能な入力', () => {
-        it('T-10-03-01: null が返される', () => {
-          const rawPlain = 'This is plain text with no JSON array';
+    it('T-10-03-01: null が返される', () => {
+      const rawPlain = 'This is plain text with no JSON array';
 
-          const result = parseJsonArray(rawPlain);
+      const result = parseJsonArray(rawPlain);
 
-          assertEquals(result, null);
-        });
+      assertEquals(result, null);
+    });
 
-        it('T-10-03-02: 空文字列でスローされずに null が返される', () => {
-          const rawEmpty = '';
+    it('T-10-03-02: 空文字列でスローされずに null が返される', () => {
+      const rawEmpty = '';
 
-          const result = parseJsonArray(rawEmpty);
+      const result = parseJsonArray(rawEmpty);
 
-          assertEquals(result, null);
-        });
-      });
+      assertEquals(result, null);
     });
   });
 });

--- a/.claude/commands/scripts/normalize-chatlog.ts
+++ b/.claude/commands/scripts/normalize-chatlog.ts
@@ -735,10 +735,7 @@ export async function main(argv?: string[], hashFn?: HashProvider): Promise<void
     Deno.exit(1);
   }
   const inputDir = resolved.dir;
-  const outputDir = args.output ?? DEFAULT_OUTPUT_DIR;
-
-  // Ensure output directory exists
-  await Deno.mkdir(outputDir, { recursive: true });
+  const outputBase = args.output ?? DEFAULT_OUTPUT_DIR;
 
   const mdFiles = findMdFiles(inputDir);
   const stats: Stats = { success: 0, skip: 0, fail: 0 };
@@ -752,6 +749,9 @@ export async function main(argv?: string[], hashFn?: HashProvider): Promise<void
       stats.fail++;
       return;
     }
+
+    const outputDir = resolveOutputDir(inputDir, outputBase, sourceMeta['project']);
+    await Deno.mkdir(outputDir, { recursive: true });
 
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i];


### PR DESCRIPTION
## Overview

**Summary**
Derive output directory per project using `resolveOutputDir` in `normalize-chatlog`

**Background / Motivation**
これまで `normalize-chatlog` は出力先ディレクトリを固定的に決定していたため、プロジェクトが異なっても同じ出力先に書き出されていた。
本ブランチでは `sourceMeta['project']` を利用して `resolveOutputDir` から出力先を算出することで、プロジェクト単位で出力ディレクトリを分離できるようにした。

---

## Changes

- `.claude/commands/scripts/normalize-chatlog.ts`: `outputDir` を事前に固定せず、各ファイル処理直前に `resolveOutputDir(inputDir, outputBase, project)` で算出。出力ディレクトリの作成処理も各ファイル処理直前へ移動
- `normalize-chatlog.output-dir.unit.spec.ts`: `resolveOutputDir` のユニットテストを新規追加
- `normalize-chatlog-io.e2e.spec.ts`: 出力パス導出の E2E テストを新規追加
- `normalize-chatlog-full.e2e.spec.ts` / `normalize-chatlog-reproducibility.e2e.spec.ts`: バックアップを再帰的に検索するよう修正
- 各ユニットテストファイル (`cli-args`, `file-gen`, `file-ops`, `input-dir`, `side-effects`, `string-utils`): テスト構造をフラット化してリファクタリング

---

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

> Closes #7

---

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

テスト確認項目:

- 異なるプロジェクト名を持つチャットログで出力先が分離されること
- バックアップファイルが再帰的に検索されること
- 既存の E2E テスト (`normalize-chatlog-full`, `normalize-chatlog-reproducibility`) がパスすること