### PR TITLE
test(deno): add module-based test runner and route test tasks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,11 +13,13 @@
     "lib": ["deno.ns", "es2022", "dom"]
   },
   "tasks": {
-    "test": "deno test --allow-read --allow-write **/__tests__/",
-    "test:unit": "deno test --allow-read --allow-write **/__tests__/unit/",
-    "test:integration": "deno test --allow-read --allow-write **/__tests__/integration/",
-    "test:functional": "deno test --allow-read --allow-write **/__tests__/functional/",
-    "test:e2e": "deno test --allow-read --allow-write **/__tests__/e2e/",
-    "test:system": "deno test --allow-read --allow-write **/__tests__/system"
+    "test": "deno task test:module all",
+    "test:unit": "deno task test:module unit",
+    "test:integration": "deno task test:module integration",
+    "test:functional": "deno task test:module functional",
+    "test:e2e": "deno task test:module e2e",
+    "test:system": "deno task test:module system",
+    "test:fixtures": "deno task test:module fixtures",
+    "test:module": "deno run --allow-read --allow-write --allow-run scripts/test-module.ts"
   }
 }

--- a/scripts/test-module.ts
+++ b/scripts/test-module.ts
@@ -1,0 +1,98 @@
+/**
+ * test-module.ts
+ * モジュール名（スキル名）によるテスト絞り込みスクリプト
+ *
+ * 使用方法:
+ *   deno task test:module <test-type> [module-name]
+ *
+ * 例:
+ *   deno task test:module all
+ *   deno task test:module unit
+ *   deno task test:module unit classify-chatlog
+ *   deno task test:module all classify-chatlog
+ */
+
+const VALID_MODULES = [
+  'classify-chatlog',
+  'export-chatlog',
+  'filter-chatlog',
+  'normalize-chatlog',
+  'set-frontmatter',
+] as const;
+
+const VALID_TYPES = [
+  'unit',
+  'functional',
+  'integration',
+  'e2e',
+  'system',
+  'fixtures',
+] as const;
+
+// --allow-run が必要なテストタイプ
+const TYPES_REQUIRING_RUN = new Set<string>(['system', 'fixtures']);
+
+type ValidModule = typeof VALID_MODULES[number];
+type ValidType = typeof VALID_TYPES[number];
+
+function printUsage(): void {
+  console.error('使用方法: deno task test:module <test-type> [module-name]');
+  console.error('');
+  console.error('テストタイプ (必須、all で全タイプ):');
+  console.error('  all');
+  VALID_TYPES.forEach((t) => console.error(`  ${t}`));
+  console.error('');
+  console.error('モジュール名 (省略時または all で全モジュール):');
+  console.error('  all');
+  VALID_MODULES.forEach((m) => console.error(`  ${m}`));
+}
+
+const args = Deno.args;
+
+if (args.length === 0) {
+  console.error('エラー: テストタイプを指定してください。');
+  printUsage();
+  Deno.exit(1);
+}
+
+const testType = args[0];
+const moduleName = args[1] as ValidModule | undefined;
+
+if (testType !== 'all' && !(VALID_TYPES as readonly string[]).includes(testType)) {
+  console.error(`エラー: 不明なテストタイプ "${testType}"`);
+  printUsage();
+  Deno.exit(1);
+}
+
+if (moduleName !== undefined && moduleName !== 'all' && !(VALID_MODULES as readonly string[]).includes(moduleName)) {
+  console.error(`エラー: 不明なモジュール名 "${moduleName}"`);
+  printUsage();
+  Deno.exit(1);
+}
+
+const targetTypes = (testType === 'all') ? [...VALID_TYPES] : [testType as ValidType];
+const baseGlob = (moduleName === undefined || moduleName === 'all')
+  ? '**/__tests__'
+  : `**/${moduleName}/**/__tests__`;
+
+const targetPaths = targetTypes.map((type) => `${baseGlob}/${type}/**/`);
+
+const needsAllowRun = targetTypes.some((type) => TYPES_REQUIRING_RUN.has(type));
+
+const denoTestArgs = [
+  'test',
+  '--allow-read',
+  '--allow-write',
+  ...(needsAllowRun ? ['--allow-run'] : []),
+  ...targetPaths,
+];
+
+const command = new Deno.Command(Deno.execPath(), {
+  args: denoTestArgs,
+  stdin: 'inherit',
+  stdout: 'inherit',
+  stderr: 'inherit',
+});
+
+const { code } = await command.output();
+Deno.exit(code);


### PR DESCRIPTION
## Overview

**Summary**
Add `scripts/test-module.ts` as a module-aware test runner and route all `deno task test:*` tasks through it.

**Background / Motivation**
従来の `deno task test:*` は直接 `deno test` コマンドに glob パターンを渡していたため、特定モジュールのみのテスト実行が難しく、テストタイプの追加・変更時にも `deno.json` を個別に修正する必要があった。

`scripts/test-module.ts` を導入することで、モジュール名とテストタイプを引数で指定するだけで柔軟にテスト対象を絞り込めるようになり、CI・開発時の利便性が向上した。

---

## Changes

- `scripts/test-module.ts` を新規追加
  - テストタイプ (`unit`, `functional`, `integration`, `e2e`, `system`, `fixtures`) とモジュール名をコマンドライン引数で受け取る
  - `all` 指定で全タイプ・全モジュールを対象に実行
  - `system` / `fixtures` テストタイプには `--allow-run` を自動付与
  - 不正な引数時は使用方法を表示して終了
- `deno.json` を更新
  - `test`, `test:unit`, `test:integration`, `test:functional`, `test:e2e`, `test:system` を `deno task test:module <type>` 経由に変更
  - `test:fixtures` タスクを追加
  - `test:module` タスク (`deno run --allow-read --allow-write --allow-run scripts/test-module.ts`) を追加

---

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

> Related to #2

---

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

テスト実行例:

```bash
# 全テスト
deno task test

# unit テストのみ
deno task test:unit

# 特定モジュールの unit テストのみ
deno task test:module unit filter-chatlog

# fixtures テスト (--allow-run 自動付与)
deno task test:fixtures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
