### PR TITLE
fix(tests/integration): relocate fixtures and add project dictionary for classify-chatlog

### DIFF
--- a/skills/classify-chatlog/scripts/__tests__/integration/assets/projects.dic
+++ b/skills/classify-chatlog/scripts/__tests__/integration/assets/projects.dic
@@ -1,0 +1,6 @@
+# プロジェクト一覧 (file-ops integration test 専用)
+app1
+app2
+infra
+dev-tools
+misc

--- a/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.file-ops.integration.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.file-ops.integration.spec.ts
@@ -13,7 +13,7 @@ import { loadFileMeta, loadProjects } from '../../classify-chatlog.ts';
 
 // ─── フィクスチャパス ──────────────────────────────────────────────────────────
 
-const FIXTURES_DIR = new URL('../_fixtures/classify-chatlog', import.meta.url)
+const ASSETS_DIR = new URL('./assets', import.meta.url)
   .pathname
   .replace(/^\/([A-Z]:)/, '$1'); // Windows: /C:/... → C:/...
 
@@ -26,7 +26,7 @@ describe('loadProjects', () => {
     describe('When: loadProjects(dicsDir) を呼び出す', () => {
       describe('Then: T-CL-LP-01 - コメント行と misc を除外してプロジェクト一覧を返す', () => {
         it('T-CL-LP-01-01: app1, app2, infra, dev-tools が含まれる', async () => {
-          const projects = await loadProjects(FIXTURES_DIR);
+          const projects = await loadProjects(ASSETS_DIR);
 
           assertEquals(projects.includes('app1'), true);
           assertEquals(projects.includes('app2'), true);
@@ -35,19 +35,19 @@ describe('loadProjects', () => {
         });
 
         it('T-CL-LP-01-02: misc は除外される', async () => {
-          const projects = await loadProjects(FIXTURES_DIR);
+          const projects = await loadProjects(ASSETS_DIR);
 
           assertEquals(projects.includes('misc'), false);
         });
 
         it('T-CL-LP-01-03: コメント行（# で始まる行）は含まれない', async () => {
-          const projects = await loadProjects(FIXTURES_DIR);
+          const projects = await loadProjects(ASSETS_DIR);
 
           assertEquals(projects.every((p) => !p.startsWith('#')), true);
         });
 
         it('T-CL-LP-01-04: 空文字列が含まれない', async () => {
-          const projects = await loadProjects(FIXTURES_DIR);
+          const projects = await loadProjects(ASSETS_DIR);
 
           assertEquals(projects.every((p) => p.length > 0), true);
         });


### PR DESCRIPTION
## Overview

**Summary**
Relocate integration test fixtures to a self-contained `assets/` directory and
add project dictionary for classify-chatlog tests.

**Background / Motivation**
`classify-chatlog` のインテグレーションテストがシステム依存パス (`../_fixtures/classify-chatlog`) を参照しており、
テスト実行環境によって不安定になる問題があった。
フィクスチャをテストファイルと同一ディレクトリ内の `assets/` に移動することで、テスト環境を独立・自己完結させ、ポータビリティと保守性を向上させる。

## Changes

- `skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.file-ops.integration.spec.ts`
  - フィクスチャ参照先を `../_fixtures/classify-chatlog` から `./assets` に変更
  - `loadProjects` の各テストで `FIXTURES_DIR` の代わりに `ASSETS_DIR` を使用するよう修正
- `skills/classify-chatlog/scripts/__tests__/integration/assets/projects.dic`
  - ファイル操作インテグレーションテスト用のプロジェクト一覧を追加 (`app1`, `app2`, `infra`, `dev-tools`, `misc`)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

テストフィクスチャをシステム依存のパスから独立したディレクトリ構成へ移行するリファクタリングの一環。
テスト本体とアセットを同一ディレクトリ配下にまとめることで、テスト環境のポータビリティと保守性が向上する。
