### PR TITLE
docs(claude): add CLAUDE.md and development rules

### DIFF
--- a/.claude/rules/coding-guidelines.md
+++ b/.claude/rules/coding-guidelines.md
@@ -1,0 +1,19 @@
+# コーディング規約
+
+## 基本方針
+- 正しさ > 速さ：動くコードより正しいコードを優先する
+- 最小変更：依頼された範囲のみ変更し、不要なリファクタや改善を加えない
+- 推測せず確認：既存コードを読んでから提案・変更する
+
+## TypeScript
+- `strict` モードを前提とする
+- 型は明示的に書く（`any` 禁止）
+- インポート/エクスポートは明示的に行う（`export *` 乱用禁止）
+
+## テスト
+- 新機能には必ずユニットテストを追加する
+- テストは `skills/<module>/__tests__/` 配下に配置する
+- テストファイル名: `<name>.<type>.spec.ts`（例: `backup.unit.spec.ts`）
+
+@.claude/rules/naming-conventions.md
+@.claude/rules/directory-structure.md

--- a/.claude/rules/directory-structure.md
+++ b/.claude/rules/directory-structure.md
@@ -1,0 +1,13 @@
+# ディレクトリ構成ルール
+
+## `skills/_scripts/` 共通定義
+
+スクリプト間で共通して使う型・定数は実装ファイルに直書きせず、以下に集約する。
+
+| ディレクトリ                 | 用途                                    |
+| ---------------------------- | --------------------------------------- |
+| `skills/_scripts/types/`     | 共通型・インターフェース (`*.types.ts`) |
+| `skills/_scripts/constants/` | 共通定数 (`*.constants.ts`)             |
+| `skills/_scripts/libs/`      | 共通ユーティリティ関数                  |
+
+実装ファイルは `types/` や `constants/` から import し、re-export で後方互換を維持する。

--- a/.claude/rules/naming-conventions.md
+++ b/.claude/rules/naming-conventions.md
@@ -1,0 +1,28 @@
+# 命名規則
+
+## 内部関数
+
+export しないプライベートなヘルパー関数は `_` プレフィックスで始める。
+
+```typescript
+// Good
+function _buildTimestamp(): string { ... }
+function _sha256Hex(input: string): Promise<string> { ... }
+
+// Bad
+function buildTimestamp(): string { ... }
+```
+
+## 関数型エイリアス
+
+コールバック・テスト用インジェクタブル依存として定義する関数型は `Provider` サフィックスで終わらせる（`Fn` は使わない）。
+
+```typescript
+// Good
+export type HashProvider = () => string;
+export type ListDirProvider = (dir: string) => Promise<string[]>;
+
+// Bad
+export type HashFn = () => string;
+export type ListDirFn = (dir: string) => Promise<string[]>;
+```

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,16 @@
+# 開発ワークフロー
+
+## ブランチ戦略
+- ブランチ名: `<type>-<issue-number>/<scope>/<description>`
+  - 例: `feat-42/export/add-filter`, `fix-55/normalize/fix-encoding`
+- `main` への直接 push 禁止
+
+## コミットメッセージ
+- Conventional Commits 準拠: `type(scope): description`
+- 使用可能な type: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- 例: `feat(export): add noise filter for system logs`
+
+## タスク完了時チェックリスト
+1. `dprint fmt --check` でフォーマット確認（問題あれば `dprint fmt` を実行）
+2. `deno task test:unit` でユニットテスト実行
+3. Conventional Commits 形式でコミット

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — chatlog-exporter
+
+## プロジェクト概要
+AIエージェント（Claude, ChatGPT 等）のセッション履歴をエクスポート・分類・編集し、Obsidian へのインポート用に整備するツール群。
+Claude Code スキルとして実装されており、`/export-chatlog` 等のコマンドで呼び出す。
+
+## 技術スタック
+- **言語**: TypeScript（Deno ランタイム）
+- **パッケージ管理**: JSR（`@std/yaml`, `@std/assert`, `@std/testing`）
+- **フォーマッタ**: dprint（行幅 120、インデント 2 スペース、LF）
+- **Git hooks**: lefthook（commitlint / betterleaks / secretlint）
+- **外部 CLI**: claude, codex
+
+## 主要コマンド
+```bash
+# テスト
+deno task test              # 全テスト
+deno task test:unit         # ユニットテストのみ
+deno task test:module unit <module>  # 特定モジュール
+
+# フォーマット
+dprint fmt --check          # チェック
+dprint fmt                  # 自動修正
+
+# 環境セットアップ
+bash scripts/setup-dev-env.sh
+```
+
+## プロジェクト構造
+```
+skills/
+├── _scripts/          # 共通実装（types/, constants/, libs/）
+├── classify-chatlog/  # プロジェクト別分類
+├── export-chatlog/    # ログエクスポート
+├── filter-chatlog/    # ノイズフィルタ
+├── normalize-chatlog/ # 形式正規化
+└── set-frontmatter/   # メタデータ付与
+assets/dics/           # 辞書ファイル（category, tags 等）
+assets/prompts/        # AI プロンプト
+```
+
+## 禁止事項
+- `main` への直接 push
+- テストなしの新機能追加
+- `any` 型の使用
+- `_scripts/` 配下の型・定数を実装ファイルに直書き
+- 依頼範囲を超えたリファクタリング・機能追加
+
+## ルール・規約
+@.claude/rules/coding-guidelines.md
+@.claude/rules/workflow.md


### PR DESCRIPTION
## Overview

**Summary**
Add CLAUDE.md and four development rule files to document project guidelines for Claude Code.

**Background / Motivation**
Claude Code がプロジェクトのコンテキストを正確に把握し、一貫した開発規約に従って作業できるよう、プロジェクトガイドと開発ルールを文書化する必要があった。
CLAUDE.md を起点に、コーディング規約・ディレクトリ構成・命名規則・ワークフローを `.claude/rules/` 配下の個別ファイルに整理した。

## Changes

- `CLAUDE.md` — プロジェクト概要（技術スタック、主要コマンド、プロジェクト構造）と禁止事項をまとめたメインガイド。
  `@.claude/rules/` への参照を含む
- `.claude/rules/coding-guidelines.md` — TypeScript の `strict` モード・`any` 禁止・明示的インポートなどのコーディング規約
- `.claude/rules/directory-structure.md` — `skills/_scripts/` 配下の `types/`・`constants/`・`libs/` への共通定義集約ルール
- `.claude/rules/naming-conventions.md` — 内部関数への `_` プレフィックスと関数型エイリアスへの `Provider` サフィックスの命名規則
- `.claude/rules/workflow.md` — ブランチ命名規則・Conventional Commits 準拠のコミットメッセージ規約・タスク完了チェックリスト

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

ドキュメントのみの変更のため、コードの動作には影響しない。
