### PR TITLE
refactor(export-chatlog): fix date handling, add session skip and user instruction stripping

### DIFF
--- a/chatlogs/.gitignore
+++ b/chatlogs/.gitignore
@@ -1,0 +1,16 @@
+# src: .gitignore
+# @(#) : ignore outputed chatlogs
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# ignore words for Python files, including pycache and pybuilder
+# cspell:words pycache codz pybuilder
+
+## ignore all directories
+/*
+
+# track git settings
+!.git*

--- a/skills/export-chatlog/SKILL.md
+++ b/skills/export-chatlog/SKILL.md
@@ -43,7 +43,7 @@ Glob ツールで `**/commands/export-chatlog.md` を検索し、そのディレ
 ```bash
 SKILL_DIR   = <export-chatlog.md が存在するディレクトリの絶対パス>
 SCRIPT_PATH = $SKILL_DIR/scripts/export-chatlog.ts
-OUTPUT      = <cwd>/temp/chatlog
+OUTPUT      = <cwd>/chatlogs
 ```
 
 ## ステップ2: スクリプト実行
@@ -81,7 +81,7 @@ deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] 
 ## 出力ディレクトリ構造
 
 ```bash
-temp/chatlog/
+chatlogs/
   └── <agent>/
        └── YYYY/
             └── YYYY-MM/

--- a/skills/export-chatlog/scripts/__tests__/unit/session-skip.unit.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/unit/session-skip.unit.spec.ts
@@ -1,0 +1,108 @@
+// src: scripts/__tests__/unit/session-skip.unit.spec.ts
+// @(#): セッション単位スキップ判定関数のユニットテスト
+//       対象: isSkippableSession
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+import { isSkippableSession } from '../../export-chatlog.ts';
+
+// ─── isSkippableSession ───────────────────────────────────────────────────────
+
+/**
+ * `isSkippableSession` のユニットテストスイート。
+ *
+ * セッションの最初のユーザーテキストの先頭行にある `name:` または `title:` の
+ * value に SESSION_SKIP_KEYWORDS のいずれかが含まれる場合に true を返すことを検証する。
+ *
+ * @see isSkippableSession
+ * @see SESSION_SKIP_KEYWORDS
+ */
+describe('isSkippableSession', () => {
+  describe('Given: name: の value にスキップキーワードを含む YAML 行', () => {
+    describe('When: isSkippableSession("name: commit-message-generator\\n...") を呼び出す', () => {
+      it('T-SS-01: Then: [正常] - true を返す（セッションをスキップ）', () => {
+        const text = 'name: commit-message-generator\ndescription: ...';
+        assertEquals(isSkippableSession(text), true);
+      });
+    });
+  });
+
+  describe('Given: name: の value に大文字を含むスキップキーワード', () => {
+    describe('When: isSkippableSession("name: Commit Message Generator\\n...") を呼び出す', () => {
+      it('T-SS-02: Then: [正常] - true を返す（大文字小文字不問）', () => {
+        const text = 'name: Commit Message Generator\ndescription: ...';
+        assertEquals(isSkippableSession(text), true);
+      });
+    });
+  });
+
+  describe('Given: title: の value にスキップキーワードを含む YAML 行', () => {
+    describe('When: isSkippableSession("title: Git Commit Message Generator\\n...") を呼び出す', () => {
+      it('T-SS-03: Then: [正常] - true を返す（セッションをスキップ）', () => {
+        const text = 'title: Git Commit Message Generator\ndescription: AI agent';
+        assertEquals(isSkippableSession(text), true);
+      });
+    });
+  });
+
+  describe('Given: name: の value がスキップキーワードを含まない YAML 行', () => {
+    describe('When: isSkippableSession("name: my-agent\\n...") を呼び出す', () => {
+      it('T-SS-04: Then: [正常] - false を返す（スキップ対象外）', () => {
+        const text = 'name: my-agent\ndescription: ...';
+        assertEquals(isSkippableSession(text), false);
+      });
+    });
+  });
+
+  describe('Given: name: キーを含まない通常テキスト', () => {
+    describe('When: isSkippableSession("mcpの設定を...") を呼び出す', () => {
+      it('T-SS-05: Then: [正常] - false を返す（スキップ対象外）', () => {
+        assertEquals(isSkippableSession('mcpの設定をしてください'), false);
+      });
+    });
+  });
+
+  describe('Given: 空文字列', () => {
+    describe('When: isSkippableSession("") を呼び出す', () => {
+      it('T-SS-06: Then: [エッジケース] - false を返す', () => {
+        assertEquals(isSkippableSession(''), false);
+      });
+    });
+  });
+
+  describe('Given: name: の value にスキップキーワードを含む行が 11 行目にある', () => {
+    describe('When: isSkippableSession(text) を呼び出す', () => {
+      it('T-SS-07: Then: [エッジケース] - false を返す（先頭 10 行対象外）', () => {
+        const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`);
+        lines.push('name: commit-message-generator');
+        const text = lines.join('\n');
+        assertEquals(isSkippableSession(text), false);
+      });
+    });
+  });
+
+  describe('Given: YAML コメント行のあとに name: の value が commit-message のテキスト', () => {
+    describe('When: isSkippableSession("# Claude Code 必須要素\\nname: commit-message\\n...") を呼び出す', () => {
+      it('T-SS-08: Then: [正常] - true を返す（value が commit-message にマッチ）', () => {
+        const text = '# Claude Code 必須要素\nname: commit-message\ndescription: ...';
+        assertEquals(isSkippableSession(text), true);
+      });
+    });
+  });
+
+  describe('Given: name:/title: がなく本文に "commit message generator" を含むテキストを渡す', () => {
+    describe('When: isSkippableSession(text) を呼び出す', () => {
+      it('T-SS-09: Then: [正常] - true を返す（セッションをスキップ）', () => {
+        const text =
+          '// Copyright (c) 2025 atsushifx\n//\nYou are a Git commit message generator.\n- Analyze the provided logs and diff.';
+        assertEquals(isSkippableSession(text), true);
+      });
+    });
+  });
+});

--- a/skills/export-chatlog/scripts/constants/skip-rules.constants.ts
+++ b/skills/export-chatlog/scripts/constants/skip-rules.constants.ts
@@ -58,15 +58,23 @@ export const SKIP_EXACT = new Set([
 ]);
 
 /**
- * スキップ対象と判定するプレフィックスの配列。
+ * セッションの先頭行にある `name:` または `title:` の value にこれらのキーワードのいずれかが
+ * 含まれる場合（大文字小文字不問）、セッション全体をエクスポート対象から除外する。
  *
- * CLI コマンド（"/clear", "/help" 等）、システムメッセージ（"<system-reminder" 等）、
- * ツール通知（"Tool loaded." 等）が対象。これらは AI との実質的な会話ではなく
- * 操作ログに過ぎないため、チャットログのエクスポート対象から除外する。
- * `isSkippable()` が `String.prototype.startsWith` で照合する。
+ * SESSION_SKIP_KEYWORDS_HEAD_LINES 行以内の `name:`/`title:` 行を対象とする。
  *
- * @see isSkippable
+ * @see isSkippableSession
  */
+export const SESSION_SKIP_KEYWORDS: string[] = [
+  'commit message generator',
+  'commit-message',
+];
+
+/**
+ * SESSION_SKIP_KEYWORDS の検索対象とする先頭行数。
+ */
+export const SESSION_SKIP_KEYWORDS_HEAD_LINES = 10;
+
 export const SKIP_PREFIXES = [
   '/clear',
   '/help',

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -20,7 +20,13 @@
 
 import { KNOWN_AGENTS } from './constants/agents.constants.ts';
 import { DEFAULT_EXPORT_CONFIG } from './constants/defaults.constants.ts';
-import { SHORT_AFFIRMATION_MAX_LEN, SKIP_EXACT, SKIP_PREFIXES } from './constants/skip-rules.constants.ts';
+import {
+  SESSION_SKIP_KEYWORDS,
+  SESSION_SKIP_KEYWORDS_HEAD_LINES,
+  SHORT_AFFIRMATION_MAX_LEN,
+  SKIP_EXACT,
+  SKIP_PREFIXES,
+} from './constants/skip-rules.constants.ts';
 import { exportClaude, findClaudeSessions, parseClaudeSession } from './exporter/claude-exporter.ts';
 import { exportCodex, findCodexSessions, parseCodexSession } from './exporter/codex-exporter.ts';
 import type { ExportConfig } from './types/export-config.types.ts';
@@ -50,20 +56,38 @@ export function homeDir(): string {
 }
 
 /**
- * ISO8601 タイムスタンプ文字列を YYYY-MM-DD 形式の日付文字列に変換する。
+ * ISO8601 タイムスタンプをローカル時刻の年・月（0始まり）・日に分解する内部ヘルパー。
+ *
+ * UTC タイムスタンプを `new Date()` でパースした後、ローカル時刻の
+ * `getFullYear()` / `getMonth()` / `getDate()` で年月日を取得する。
+ * これにより JST+9 環境でも UTC と日付がズレない（例: `2025-12-31T15:00:00Z` → `2026-01-01`）。
+ *
+ * パース失敗（NaN）の場合は `null` を返す。
+ *
+ * @param iso ISO8601 形式のタイムスタンプ文字列（例: "2025-12-31T15:00:00Z"）
+ * @returns `{ y, m0, d }` ローカル年・月(0始まり)・日。パース失敗時は `null`
+ */
+function _isoToLocalParts(iso: string): { y: number; m0: number; d: number } | null {
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) { return null; }
+  return { y: date.getFullYear(), m0: date.getMonth(), d: date.getDate() };
+}
+
+/**
+ * ISO8601 タイムスタンプ文字列を YYYY-MM-DD 形式の日付文字列（ローカル時刻基準）に変換する。
  *
  * `SessionMeta.date` の生成および出力パスの年月ディレクトリ名の確定に使用する。
+ * JST+9 環境では UTC 文字列からローカル日付を正しく取得するため、
+ * `_isoToLocalParts()` を介してローカル年月日を取得する。
  * パース失敗時はエクスポートを中断せず 'unknown' を返してフォールバックする。
  *
- * @param iso ISO8601 形式のタイムスタンプ文字列（例: "2026-03-15T10:00:00.000Z"）
- * @returns YYYY-MM-DD 形式の日付文字列。パース失敗時は 'unknown'
+ * @param iso ISO8601 形式のタイムスタンプ文字列（例: "2025-12-31T15:00:00Z"）
+ * @returns YYYY-MM-DD 形式の日付文字列（ローカル時刻基準）。パース失敗時は 'unknown'
  */
 export function isoToDate(iso: string): string {
-  try {
-    return new Date(iso).toISOString().slice(0, 10);
-  } catch {
-    return 'unknown';
-  }
+  const p = _isoToLocalParts(iso);
+  if (!p) { return 'unknown'; }
+  return `${p.y}-${String(p.m0 + 1).padStart(2, '0')}-${String(p.d).padStart(2, '0')}`;
 }
 
 /**
@@ -152,6 +176,37 @@ export function isSkippable(text: string): boolean {
   return false;
 }
 
+/**
+ * セッションの最初のユーザーテキストの先頭行に SESSION_SKIP_KEYWORDS のいずれかが
+ * 含まれるか判定する（大文字小文字不問）。
+ *
+ * 以下の 2 段階でチェックする:
+ * 1. 先頭 SESSION_SKIP_KEYWORDS_HEAD_LINES 行中の `name:`/`title:` の value にキーワードが含まれるか
+ * 2. 先頭 SESSION_SKIP_KEYWORDS_HEAD_LINES 行のテキスト本文にキーワードが直接含まれるか
+ *
+ * マッチした場合、セッション全体をエクスポート対象から除外すべきと判断する。
+ * サブエージェント呼び出し（commit-message-generator 等）のような
+ * 再利用価値のないセッションを除外するために使用する。
+ *
+ * @param firstUserText セッションの最初のユーザーメッセージテキスト
+ * @returns スキップすべき場合 true
+ * @see SESSION_SKIP_KEYWORDS
+ */
+export function isSkippableSession(firstUserText: string): boolean {
+  const headLines = firstUserText.split('\n').slice(0, SESSION_SKIP_KEYWORDS_HEAD_LINES);
+  // チェック1: name:/title: の value にキーワードが含まれるか
+  const hasYamlKeyword = headLines.some((line) => {
+    const match = line.match(/^(?:name|title)\s*:\s*(.+)$/i);
+    if (!match) { return false; }
+    const value = match[1].toLowerCase();
+    return SESSION_SKIP_KEYWORDS.some((keyword) => value.includes(keyword.toLowerCase()));
+  });
+  if (hasYamlKeyword) { return true; }
+  // チェック2: 本文テキストにキーワードが直接含まれるか（大文字小文字不問）
+  const headText = headLines.join('\n').toLowerCase();
+  return SESSION_SKIP_KEYWORDS.some((keyword) => headText.includes(keyword.toLowerCase()));
+}
+
 // ─────────────────────────────────────────────
 // 期間フィルタ
 // ─────────────────────────────────────────────
@@ -196,18 +251,24 @@ export function parsePeriod(period: string | undefined): PeriodRange {
  * ISO8601 タイムスタンプが指定した期間範囲内にあるかを判定する。
  *
  * `PeriodRange` は半開区間 [startMs, endMs) であり、startMs の値を含み
- * endMs の値を含まない。`isoToMs()` でミリ秒変換してから比較する。
+ * endMs の値を含まない。
+ * タイムスタンプを `_isoToLocalParts()` でローカル年月日に変換した後、
+ * ローカル日付の 00:00:00 ミリ秒値として `PeriodRange` と比較する。
+ * これにより UTC タイムスタンプでも JST 環境のローカル日付基準でフィルタリングできる。
+ * パース失敗時は `false` を返す。
  *
  * `parseClaudeSession` および `parseCodexSession` が各エントリの
  * タイムスタンプ照合に使用する。
  *
  * @param isoTimestamp 判定対象の ISO8601 タイムスタンプ文字列
  * @param range `parsePeriod()` が生成した半開区間フィルタ
- * @returns タイムスタンプが範囲内（startMs ≤ ms < endMs）の場合 `true`
+ * @returns タイムスタンプが範囲内（startMs ≤ localDayMs < endMs）の場合 `true`
  */
 export function inPeriod(isoTimestamp: string, range: PeriodRange): boolean {
-  const ms = isoToMs(isoTimestamp);
-  return ms >= range.startMs && ms < range.endMs;
+  const p = _isoToLocalParts(isoTimestamp);
+  if (!p) { return false; }
+  const localDayMs = new Date(p.y, p.m0, p.d).getTime();
+  return localDayMs >= range.startMs && localDayMs < range.endMs;
 }
 
 // ─────────────────────────────────────────────
@@ -443,7 +504,7 @@ export async function main(argv?: string[]): Promise<void> {
   console.error(`対象 agent: ${agent}`);
   if (period) { console.error(`対象期間: ${period}`); }
 
-  let result: { exportedCount: number; outputPaths: string[] };
+  let result: Awaited<ReturnType<typeof exportClaude>>;
 
   try {
     if (agent === 'claude') {
@@ -463,10 +524,11 @@ export async function main(argv?: string[]): Promise<void> {
     console.log(outPath);
   }
 
-  const skipped = 0; // exporter 内でスキップはサイレント処理
+  const total = result.exportedCount + result.skippedCount + result.errorCount;
   console.error(
-    `\n完了: ${result.exportedCount} ファイルを ${outputDir}/${agent}/ に書き出しました（${skipped} 件スキップ）`,
+    `\n完了: ${total} 件処理（出力: ${result.exportedCount} / スキップ: ${result.skippedCount} / エラー: ${result.errorCount}）`,
   );
+  console.error(`出力先: ${outputDir}/${agent}/`);
 }
 
 if (import.meta.main) { await main(); }

--- a/skills/export-chatlog/scripts/exporter/__tests__/unit/export-claude.unit.spec.ts
+++ b/skills/export-chatlog/scripts/exporter/__tests__/unit/export-claude.unit.spec.ts
@@ -146,7 +146,7 @@ describe('exportClaude', () => {
           BASE_CONFIG,
           _makeFlowProviders([
             ['/fake/a.jsonl', () => Promise.resolve(session), () => Promise.resolve('/tmp/out.md')],
-            ['/fake/b.jsonl', () => Promise.resolve(null),    () => Promise.resolve('')],
+            ['/fake/b.jsonl', () => Promise.resolve(null), () => Promise.resolve('')],
             ['/fake/c.jsonl', () => Promise.resolve(session), () => Promise.resolve('/tmp/out.md')],
           ]),
         );
@@ -202,7 +202,7 @@ describe('exportClaude', () => {
           BASE_CONFIG,
           _makeFlowProviders([
             ['/fake/a.jsonl', () => Promise.resolve(session), () => Promise.resolve('/tmp/out.md')],
-            ['/fake/b.jsonl', () => Promise.resolve(null),    () => Promise.resolve('')],
+            ['/fake/b.jsonl', () => Promise.resolve(null), () => Promise.resolve('')],
             ['/fake/c.jsonl', () => Promise.reject(new Error('parse failed')), () => Promise.resolve('')],
           ]),
         );

--- a/skills/export-chatlog/scripts/exporter/__tests__/unit/strip-user-instructions.unit.spec.ts
+++ b/skills/export-chatlog/scripts/exporter/__tests__/unit/strip-user-instructions.unit.spec.ts
@@ -1,0 +1,111 @@
+// src: scripts/exporter/__tests__/unit/strip-user-instructions.unit.spec.ts
+// @(#): _stripUserInstructions 関数のユニットテスト
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+import { _stripUserInstructions } from '../../codex-exporter.ts';
+
+// ─── _stripUserInstructions tests ────────────────────────────────────────────
+
+/**
+ * `_stripUserInstructions` のユニットテストスイート。
+ *
+ * テストケース:
+ * - T-SUI-01: <user_instructions> のみのテキスト → 空文字列を返す
+ * - T-SUI-02: <user_instructions> + 本文テキスト → user_instructions を除いた本文のみ返す
+ * - T-SUI-03: <user_instructions> を含まないテキスト → テキストが変更されない
+ * - T-SUI-04: 複数の <user_instructions> ブロック → 全ブロックが除去される
+ *
+ * @see _stripUserInstructions
+ */
+describe('_stripUserInstructions', () => {
+  // ─── T-SUI-01: <user_instructions> のみのテキスト ─────────────────────────────
+
+  describe('Given: <user_instructions>...</user_instructions> のみを含むテキストを渡す', () => {
+    describe('When: _stripUserInstructions(text) を呼び出す', () => {
+      it('Then: [正常] - 空文字列を返す', () => {
+        const text = '<user_instructions>\nPlease provide all answers in Japanese\n</user_instructions>';
+        const result = _stripUserInstructions(text);
+        assertEquals(result, '');
+      });
+    });
+  });
+
+  // ─── T-SUI-02: <user_instructions> + 本文テキスト ────────────────────────────
+
+  describe('Given: <user_instructions> ブロックと本文テキストを含むテキストを渡す', () => {
+    describe('When: _stripUserInstructions(text) を呼び出す', () => {
+      it('Then: [正常] - user_instructions 部分を除いた本文のみ返す', () => {
+        const text =
+          '<user_instructions>\nPlease provide all answers in Japanese\n</user_instructions>\n\nコードレビューをお願いします';
+        const result = _stripUserInstructions(text);
+        assertEquals(result, 'コードレビューをお願いします');
+      });
+    });
+  });
+
+  // ─── T-SUI-03: <user_instructions> を含まないテキスト ────────────────────────
+
+  describe('Given: <user_instructions> を含まないテキストを渡す', () => {
+    describe('When: _stripUserInstructions(text) を呼び出す', () => {
+      it('Then: [正常] - テキストが変更されず元の値を返す', () => {
+        const text = 'コードレビューをお願いします';
+        const result = _stripUserInstructions(text);
+        assertEquals(result, text);
+      });
+    });
+  });
+
+  // ─── T-SUI-04: 複数の <user_instructions> ブロック ───────────────────────────
+
+  describe('Given: 複数の <user_instructions> ブロックを含むテキストを渡す', () => {
+    describe('When: _stripUserInstructions(text) を呼び出す', () => {
+      it('Then: [正常] - 全ブロックが除去されて本文のみ返す', () => {
+        const text = [
+          '<user_instructions>',
+          'Please provide all answers in Japanese',
+          '</user_instructions>',
+          '',
+          'コードレビューをお願いします',
+          '',
+          '<user_instructions>',
+          'Always use TypeScript',
+          '</user_instructions>',
+        ].join('\n');
+        const result = _stripUserInstructions(text);
+        assertEquals(result, 'コードレビューをお願いします');
+      });
+    });
+  });
+
+  // ─── T-SUI-05: インライン形式（スペース区切り）のみ ──────────────────────────
+
+  describe('Given: インライン形式の <user_instructions> のみを含むテキストを渡す', () => {
+    describe('When: _stripUserInstructions(text) を呼び出す', () => {
+      it('Then: [正常] - 空文字列を返す', () => {
+        const text = '<user_instructions>  Please provide all answers in Japanese  </user_instructions>';
+        const result = _stripUserInstructions(text);
+        assertEquals(result, '');
+      });
+    });
+  });
+
+  // ─── T-SUI-06: インライン形式 + 本文 ─────────────────────────────────────────
+
+  describe('Given: インライン形式の <user_instructions> と本文テキストを含むテキストを渡す', () => {
+    describe('When: _stripUserInstructions(text) を呼び出す', () => {
+      it('Then: [正常] - user_instructions 部分を除いた本文のみ返す', () => {
+        const text =
+          '<user_instructions>  Please provide all answers in Japanese  </user_instructions>\n\nコードレビューをお願いします';
+        const result = _stripUserInstructions(text);
+        assertEquals(result, 'コードレビューをお願いします');
+      });
+    });
+  });
+});

--- a/skills/export-chatlog/scripts/exporter/claude-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/claude-exporter.ts
@@ -11,6 +11,7 @@ import {
   inPeriod,
   isoToDate,
   isSkippable,
+  isSkippableSession,
   parsePeriod,
   walkFiles,
   writeSession,
@@ -179,6 +180,7 @@ export async function parseClaudeSession(
   if (turns.length === 0) { return null; }
 
   const firstUserText = extractClaudeUserText(firstEntry.message?.content);
+  if (isSkippableSession(firstUserText)) { return null; }
   const meta: SessionMeta = {
     sessionId: firstEntry.sessionId ?? 'unknown',
     date: isoToDate(firstEntry.timestamp ?? ''),

--- a/skills/export-chatlog/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/codex-exporter.ts
@@ -11,6 +11,7 @@ import {
   inPeriod,
   isoToDate,
   isSkippable,
+  isSkippableSession,
   parsePeriod,
   walkFiles,
   writeSession,
@@ -20,6 +21,25 @@ import type { ExportConfig } from '../types/export-config.types.ts';
 import type { ExportResult } from '../types/export-result.types.ts';
 import type { PeriodRange } from '../types/filter.types.ts';
 import type { ExportedSession, SessionMeta, Turn } from '../types/session.types.ts';
+
+// ─────────────────────────────────────────────
+// テキスト前処理
+// ─────────────────────────────────────────────
+
+/**
+ * テキストから `<user_instructions>...</user_instructions>` ブロックを全て除去する。
+ *
+ * Codex が自動注入する `<user_instructions>` タグ（ユーザー設定のシステム指示）を
+ * 除去し、除去後のテキストをトリムして返す。
+ * これにより、スキップ判定やスラグ生成が `<user_instructions>` の内容に
+ * 影響されないようにする。
+ *
+ * @param text 処理対象のテキスト
+ * @returns `<user_instructions>` ブロックを除去してトリムしたテキスト
+ */
+export function _stripUserInstructions(text: string): string {
+  return text.replace(/<user_instructions>[\s\S]*?<\/user_instructions>/g, '').trim();
+}
 
 // ─────────────────────────────────────────────
 // Provider 型（テスト用依存性注入）
@@ -99,23 +119,26 @@ export async function parseCodexSession(
     }
     const text = parts.join('\n').trim();
     if (!text) { continue; }
-    if (role === 'user' && isSkippable(text)) { continue; }
+    const cleaned = role === 'user' ? _stripUserInstructions(text) : text;
+    if (!cleaned) { continue; }
+    if (role === 'user' && isSkippable(cleaned)) { continue; }
 
     // user の AGENTS.md/permissions/environment_context は除外
     if (
       role === 'user' && (
-        text.startsWith('# AGENTS.md instructions')
-        || text.startsWith('<permissions instructions>')
-        || text.startsWith('<environment_context>')
+        cleaned.startsWith('# AGENTS.md instructions')
+        || cleaned.startsWith('<permissions instructions>')
+        || cleaned.startsWith('<environment_context>')
       )
     ) { continue; }
 
-    turns.push({ role: role as 'user' | 'assistant', text });
+    turns.push({ role: role as 'user' | 'assistant', text: cleaned });
   }
 
   // 意味あるユーザーターンがなければスキップ
   const firstUserTurn = turns.find((t) => t.role === 'user');
   if (!firstUserTurn) { return null; }
+  if (isSkippableSession(firstUserTurn.text)) { return null; }
 
   const date = isoToDate(sessionTimestamp);
   const meta: SessionMeta = {


### PR DESCRIPTION
## Overview

**Summary**
Fix timezone-aware date handling and add session-level skip/strip logic to the chatlog exporter.

**Background / Motivation**
UTC タイムスタンプを JST(+9) 環境で扱う際に日付がズレる問題があった（例: UTC 大晦日 `2025-12-31T15:00:00Z` が JST では `2026-01-01` になる）。
また、コミットメッセージ生成などの再利用価値の低いサブエージェントセッションが出力に混入しており、Codex の自動挿入する `<user_instructions>`
ブロックがスキップ判定を妨げていた。

## Changes

- `export-chatlog.ts` — ローカル日付基準の期間比較に修正（`_isoToLocalParts` 追加、`isoToDate` / `inPeriod` を更新）、
  スキップ・エラーカウントのログ出力強化
- `claude-exporter.ts` — 先頭ユーザーテキストがスキップキーワードにマッチするセッションを除外する `isSkippableSession()` を組み込み
- `codex-exporter.ts` — `<user_instructions>` ブロックをスキップ判定・保存前に除去する `_stripUserInstructions()` を追加
- `skip-rules.constants.ts` — `SESSION_SKIP_KEYWORDS` にコミットメッセージ生成キーワードを追加、`SESSION_SKIP_KEYWORDS_HEAD_LINES`（10行）を定義
- `session-skip.unit.spec.ts` — `isSkippableSession` のユニットテスト追加
- `strip-user-instructions.unit.spec.ts` — `_stripUserInstructions` のユニットテスト追加
- `SKILL.md` — デフォルト出力ディレクトリを `temp/chatlog/` → `chatlogs/` に変更
- `chatlogs/.gitignore` — エクスポート済みログを Git 管理対象外に設定

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #49

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

**テスト手順**:

- `deno task test:unit` で全ユニットテストが pass することを確認
- `session-skip.unit.spec.ts`: キーワードマッチ・大文字小文字・先頭行制限・YAML値の各ケース
- `strip-user-instructions.unit.spec.ts`: 単独ブロック・複数ブロック・インライン形式・未含有の各ケース
- JST 境界値: `isoToDate("2025-12-31T15:00:00Z")` が `2026-01-01` を返すことを確認
- `dprint check` でフォーマットエラーがないことを確認