### PR TITLE
refactor(scripts): apply naming convention across all chatlog scripts

### DIFF
--- a/.claude/rules/naming-conventions.md
+++ b/.claude/rules/naming-conventions.md
@@ -13,6 +13,70 @@ function _sha256Hex(input: string): Promise<string> { ... }
 function buildTimestamp(): string { ... }
 ```
 
+## モジュールスコープの非 export シンボル
+
+モジュールスコープで `export` しない定数・変数は `_` プレフィックスで始める。
+
+```typescript
+// Good
+const _SYSTEM_PROMPT = `...`;
+const _VALID_MODELS = new Set([...]);
+
+// Bad
+const SYSTEM_PROMPT = `...`;
+const VALID_MODELS = new Set([...]);
+```
+
+## 関数内ローカル変数
+
+関数内の「主要変数」には `_` プレフィックスを付ける。
+
+### 主要変数（`_` を付ける）
+
+以下のいずれかに該当する変数：
+
+- 構築して返す、または次の関数に渡す中間結果（`_lines`, `_results`, `_config`, `_parsed`）
+- 宣言後 2 回以上参照される変数
+- ドメイン概念を表す意味のある名前（`_agentDir`, `_slug`, `_systemPrompt`）
+- AI/CLI 実行の入出力（`_cmd`, `_process`, `_writer`, `_output`, `_raw`）
+
+```typescript
+// Good
+const _lines: string[] = [];
+const _config: ExportConfig = { ...DEFAULT_EXPORT_CONFIG };
+const _slug = textToSlug(session.meta.firstUserText);
+
+// Bad
+const lines: string[] = [];
+const config: ExportConfig = { ...DEFAULT_EXPORT_CONFIG };
+```
+
+### 一時補助変数（`_` を付けない）
+
+以下のいずれかに該当する変数：
+
+- 慣習的な 1 文字変数（`i`, `e`, `m`, `t`, `r`, `p`）
+- `for` ループカウンタ・`for...of` のイテレーション変数（`entry`, `line`, `arg`, `turn`, `segment`）
+- 宣言直後 1〜2 行でのみ使う計算補助値（`start`, `end` 等）
+- コールバック引数（`turns.filter((t) => ...)` の `t`）
+
+注: TypeScript の「未使用引数を示す慣習」としての `_` プレフィックスとは用途が異なる。
+本プロジェクトでは関数パラメータに `_` を付けない。
+
+## クロージャー内の変数・関数
+
+関数内に定義されたクロージャー関数（ネスト関数・アロー関数変数）には `_` プレフィックスを付ける。
+
+```typescript
+// Good
+const _readFile = async (path: string): Promise<string> => { ... };
+async function _worker() { ... }
+
+// Bad
+const readFile = async (path: string): Promise<string> => { ... };
+async function worker() { ... }
+```
+
 ## 関数型エイリアス
 
 コールバック・テスト用インジェクタブル依存として定義する関数型は `Provider` サフィックスで終わらせる（`Fn` は使わない）。

--- a/skills/_scripts/libs/hash.ts
+++ b/skills/_scripts/libs/hash.ts
@@ -27,7 +27,7 @@ export type { GenerateHashOptions, HashProvider } from '../types/common.types.ts
 // ─────────────────────────────────────────────
 
 /** ランダム文字列の生成に使用する文字セット（英小文字+数字）。 */
-const RANDOM_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
+const _RANDOM_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
 // ─────────────────────────────────────────────
 // 内部ユーティリティ
@@ -65,22 +65,22 @@ function _buildRandomString(maxLength: number): string {
     lenOffset = crypto.getRandomValues(new Uint8Array(1))[0];
   } while (lenOffset >= maxUnbiasedLen);
   const len = MIN_RANDOM_LENGTH + (lenOffset % range);
-  const charsetLen = RANDOM_CHARS.length;
+  const charsetLen = _RANDOM_CHARS.length;
   const maxUnbiased = Math.floor(256 / charsetLen) * charsetLen;
-  const out: string[] = [];
+  const _out: string[] = [];
 
-  while (out.length < len) {
-    const remaining = len - out.length;
+  while (_out.length < len) {
+    const remaining = len - _out.length;
     const buf = crypto.getRandomValues(new Uint8Array(remaining));
 
     for (const b of buf) {
       if (b >= maxUnbiased) { continue; }
-      out.push(RANDOM_CHARS[b % charsetLen]);
-      if (out.length === len) { break; }
+      _out.push(_RANDOM_CHARS[b % charsetLen]);
+      if (_out.length === len) { break; }
     }
   }
 
-  return out.join('');
+  return _out.join('');
 }
 
 /**
@@ -107,9 +107,9 @@ async function _sha256Hex(input: string): Promise<string> {
  * @returns シード文字列
  */
 function _buildSeed(filenameBase: string, maxRandomLength: number): string {
-  const timestamp = _buildTimestamp();
-  const random = _buildRandomString(maxRandomLength);
-  return `${filenameBase}-${timestamp}-${random}`;
+  const _timestamp = _buildTimestamp();
+  const _random = _buildRandomString(maxRandomLength);
+  return `${filenameBase}-${_timestamp}-${_random}`;
 }
 
 // ─────────────────────────────────────────────

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -268,14 +268,14 @@ export async function collectDirectMdFiles(dir: string, results: string[]): Prom
 // ─────────────────────────────────────────────
 
 export function buildClassifyPrompt(files: FileMeta[], projects: string[]): string {
-  const projectList = [...projects, FALLBACK_PROJECT].join(', ');
-  const header = `Projects: ${projectList}\n\n`;
+  const _projectList = [...projects, FALLBACK_PROJECT].join(', ');
+  const header = `Projects: ${_projectList}\n\n`;
 
-  const parts = files.map((f, i) => {
+  const _parts = files.map((f, i) => {
     const topicsStr = f.topics.length > 0 ? f.topics.join(', ') : '(none)';
     const tagsStr = f.tags.length > 0 ? f.tags.join(', ') : '(none)';
     const hasMeta = f.title || f.category || f.topics.length > 0 || f.tags.length > 0;
-    const lines = [
+    const _lines = [
       `=== FILE ${i + 1}: ${f.filename} ===`,
       `title: ${f.title || '(no title)'}`,
       `category: ${f.category || '(none)'}`,
@@ -284,20 +284,20 @@ export function buildClassifyPrompt(files: FileMeta[], projects: string[]): stri
     ];
     if (!hasMeta) {
       const snippet = f.fullText.slice(0, 500).trim();
-      lines.push(`body: ${snippet}`);
+      _lines.push(`body: ${snippet}`);
     }
-    return lines.join('\n');
+    return _lines.join('\n');
   });
 
-  return header + parts.join('\n\n');
+  return header + _parts.join('\n\n');
 }
 
 export function buildSystemPrompt(projects: string[]): string {
-  const projectList = [...projects, FALLBACK_PROJECT].join(', ');
+  const _projectList = [...projects, FALLBACK_PROJECT].join(', ');
   return `Output ONLY a JSON array. No markdown, no explanation, no text before or after the array.
 [{"file":"<filename>","project":"<project_name>","confidence":0.0,"reason":"..."},...]
 
-Choose project ONLY from this list: ${projectList}
+Choose project ONLY from this list: ${_projectList}
 If no project matches well, use "${FALLBACK_PROJECT}".
 Base your decision on: title, category, topics, tags.`;
 }
@@ -452,12 +452,12 @@ export async function processChunk(
   }
   if (classifiable.length === 0) { return; }
 
-  const batchPrompt = buildClassifyPrompt(classifiable, projects);
-  const systemPrompt = buildSystemPrompt(projects);
+  const _batchPrompt = buildClassifyPrompt(classifiable, projects);
+  const _systemPrompt = buildSystemPrompt(projects);
 
   let rawResult: string;
   try {
-    rawResult = await runClaude(systemPrompt, batchPrompt);
+    rawResult = await runClaude(_systemPrompt, _batchPrompt);
   } catch (e) {
     logger.warn(`  警告: claude CLI 実行失敗。チャンク内ファイルをすべて ${FALLBACK_PROJECT} 扱い`);
     logger.warn(`  error: ${e}`);

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -71,9 +71,9 @@ export function homeDir(): string {
  * @returns `{ y, m0, d }` ローカル年・月(0始まり)・日。パース失敗時は `null`
  */
 function _isoToLocalParts(iso: string): { y: number; m0: number; d: number } | null {
-  const date = new Date(iso);
-  if (isNaN(date.getTime())) { return null; }
-  return { y: date.getFullYear(), m0: date.getMonth(), d: date.getDate() };
+  const _date = new Date(iso);
+  if (isNaN(_date.getTime())) { return null; }
+  return { y: _date.getFullYear(), m0: _date.getMonth(), d: _date.getDate() };
 }
 
 /**
@@ -331,26 +331,26 @@ export function buildOutputPath(
  * @returns Markdown 形式の文字列
  */
 export function renderMarkdown(meta: SessionMeta, turns: Turn[]): string {
-  const lines: string[] = [];
-  lines.push('---');
-  lines.push(`session_id: ${meta.sessionId}`);
-  lines.push(`date: ${meta.date}`);
-  lines.push(`project: ${meta.project}`);
-  if (meta.slug) { lines.push(`slug: ${meta.slug}`); }
-  lines.push('---');
-  lines.push('');
-  lines.push(`# ${meta.firstUserText.replace(/\n/g, ' ').slice(0, 100)}`);
-  lines.push('');
-  lines.push('## 会話ログ');
-  lines.push('');
+  const _lines: string[] = [];
+  _lines.push('---');
+  _lines.push(`session_id: ${meta.sessionId}`);
+  _lines.push(`date: ${meta.date}`);
+  _lines.push(`project: ${meta.project}`);
+  if (meta.slug) { _lines.push(`slug: ${meta.slug}`); }
+  _lines.push('---');
+  _lines.push('');
+  _lines.push(`# ${meta.firstUserText.replace(/\n/g, ' ').slice(0, 100)}`);
+  _lines.push('');
+  _lines.push('## 会話ログ');
+  _lines.push('');
   for (const turn of turns) {
     const label = turn.role === 'user' ? 'User' : 'Assistant';
-    lines.push(`### ${label}`);
-    lines.push('');
-    lines.push(turn.text.trim().replace(/\n{3,}/g, '\n\n'));
-    lines.push('');
+    _lines.push(`### ${label}`);
+    _lines.push('');
+    _lines.push(turn.text.trim().replace(/\n{3,}/g, '\n\n'));
+    _lines.push('');
   }
-  return lines.join('\n');
+  return _lines.join('\n');
 }
 
 // ─────────────────────────────────────────────
@@ -452,33 +452,33 @@ export async function* walkFiles(dir: string, ext: string): AsyncGenerator<strin
  * @returns 解析済みの `ExportConfig`
  */
 export function parseArgs(args: string[]): ExportConfig {
-  const config: ExportConfig = { ...DEFAULT_EXPORT_CONFIG };
+  const _config: ExportConfig = { ...DEFAULT_EXPORT_CONFIG };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '--output' && i + 1 < args.length) {
-      config.outputDir = args[++i];
+      _config.outputDir = args[++i];
     } else if (arg.startsWith('--output=')) {
-      config.outputDir = arg.slice('--output='.length);
+      _config.outputDir = arg.slice('--output='.length);
     } else if (arg === '--base' && i + 1 < args.length) {
-      config.baseDir = args[++i];
+      _config.baseDir = args[++i];
     } else if (arg.startsWith('--base=')) {
-      config.baseDir = arg.slice('--base='.length);
+      _config.baseDir = arg.slice('--base='.length);
     } else if (arg === '--input' && i + 1 < args.length) {
-      config.inputDir = args[++i];
+      _config.inputDir = args[++i];
     } else if (arg.startsWith('--input=')) {
-      config.inputDir = arg.slice('--input='.length);
+      _config.inputDir = arg.slice('--input='.length);
     } else if (arg.startsWith('-')) {
       console.error(`不明なオプション: ${arg}`);
       Deno.exit(1);
     } else if (KNOWN_AGENTS.includes(arg)) {
-      config.agent = arg;
+      _config.agent = arg;
     } else if (/^\d{4}-\d{2}$/.test(arg) || /^\d{4}$/.test(arg)) {
-      config.period = arg;
+      _config.period = arg;
     } else {
       const normalized = arg.replace(/\\/g, '/');
       if (normalized.includes('/')) {
-        config.inputDir = normalized;
+        _config.inputDir = normalized;
       } else {
         console.error(`不明な引数: ${arg}`);
         Deno.exit(1);
@@ -486,7 +486,7 @@ export function parseArgs(args: string[]): ExportConfig {
     }
   }
 
-  return config;
+  return _config;
 }
 
 // ─────────────────────────────────────────────

--- a/skills/export-chatlog/scripts/exporter/__tests__/unit/strip-user-instructions.unit.spec.ts
+++ b/skills/export-chatlog/scripts/exporter/__tests__/unit/strip-user-instructions.unit.spec.ts
@@ -9,7 +9,7 @@
 import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
-import { _stripUserInstructions } from '../../codex-exporter.ts';
+import { stripUserInstructions } from '../../codex-exporter.ts';
 
 // ─── _stripUserInstructions tests ────────────────────────────────────────────
 
@@ -31,7 +31,7 @@ describe('_stripUserInstructions', () => {
     describe('When: _stripUserInstructions(text) を呼び出す', () => {
       it('Then: [正常] - 空文字列を返す', () => {
         const text = '<user_instructions>\nPlease provide all answers in Japanese\n</user_instructions>';
-        const result = _stripUserInstructions(text);
+        const result = stripUserInstructions(text);
         assertEquals(result, '');
       });
     });
@@ -44,7 +44,7 @@ describe('_stripUserInstructions', () => {
       it('Then: [正常] - user_instructions 部分を除いた本文のみ返す', () => {
         const text =
           '<user_instructions>\nPlease provide all answers in Japanese\n</user_instructions>\n\nコードレビューをお願いします';
-        const result = _stripUserInstructions(text);
+        const result = stripUserInstructions(text);
         assertEquals(result, 'コードレビューをお願いします');
       });
     });
@@ -56,7 +56,7 @@ describe('_stripUserInstructions', () => {
     describe('When: _stripUserInstructions(text) を呼び出す', () => {
       it('Then: [正常] - テキストが変更されず元の値を返す', () => {
         const text = 'コードレビューをお願いします';
-        const result = _stripUserInstructions(text);
+        const result = stripUserInstructions(text);
         assertEquals(result, text);
       });
     });
@@ -78,7 +78,7 @@ describe('_stripUserInstructions', () => {
           'Always use TypeScript',
           '</user_instructions>',
         ].join('\n');
-        const result = _stripUserInstructions(text);
+        const result = stripUserInstructions(text);
         assertEquals(result, 'コードレビューをお願いします');
       });
     });
@@ -90,7 +90,7 @@ describe('_stripUserInstructions', () => {
     describe('When: _stripUserInstructions(text) を呼び出す', () => {
       it('Then: [正常] - 空文字列を返す', () => {
         const text = '<user_instructions>  Please provide all answers in Japanese  </user_instructions>';
-        const result = _stripUserInstructions(text);
+        const result = stripUserInstructions(text);
         assertEquals(result, '');
       });
     });
@@ -103,7 +103,7 @@ describe('_stripUserInstructions', () => {
       it('Then: [正常] - user_instructions 部分を除いた本文のみ返す', () => {
         const text =
           '<user_instructions>  Please provide all answers in Japanese  </user_instructions>\n\nコードレビューをお願いします';
-        const result = _stripUserInstructions(text);
+        const result = stripUserInstructions(text);
         assertEquals(result, 'コードレビューをお願いします');
       });
     });

--- a/skills/export-chatlog/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/codex-exporter.ts
@@ -37,7 +37,7 @@ import type { CodexEntry } from './types/codex-entry.types.ts';
  * @param text 処理対象のテキスト
  * @returns `<user_instructions>` ブロックを除去してトリムしたテキスト
  */
-export function _stripUserInstructions(text: string): string {
+export function stripUserInstructions(text: string): string {
   return text.replace(/<user_instructions>[\s\S]*?<\/user_instructions>/g, '').trim();
 }
 
@@ -119,7 +119,7 @@ export async function parseCodexSession(
     }
     const text = parts.join('\n').trim();
     if (!text) { continue; }
-    const cleaned = role === 'user' ? _stripUserInstructions(text) : text;
+    const cleaned = role === 'user' ? stripUserInstructions(text) : text;
     if (!cleaned) { continue; }
     if (role === 'user' && isSkippable(cleaned)) { continue; }
 

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -24,7 +24,7 @@ export const CONCURRENCY = 4;
 export const DISCARD_THRESHOLD = 0.7;
 export const MAX_BODY_CHARS = 8000;
 
-const SYSTEM_PROMPT = `Output ONLY a JSON array. No markdown, no explanation, no text before or after the array.
+const _SYSTEM_PROMPT = `Output ONLY a JSON array. No markdown, no explanation, no text before or after the array.
 [{"file":"<filename>","decision":"KEEP or DISCARD","confidence":0.0,"reason":"..."},...]
 
 KEEP: design decisions, reusable patterns, new concepts, architecture discussion
@@ -88,7 +88,7 @@ export function parseConversation(body: string): Turn[] {
 // 内容ベース事前フィルタ（obsidian_filter.py 移植）
 // ─────────────────────────────────────────────
 
-const SYSTEM_PREFIXES = [
+const _SYSTEM_PREFIXES = [
   '<system-reminder',
   '<command-name',
   '<command-message',
@@ -98,7 +98,7 @@ const SYSTEM_PREFIXES = [
   '---\n',
 ];
 
-const EXCLUDE_FILENAME_PATTERNS = [
+const _EXCLUDE_FILENAME_PATTERNS = [
   'you-are-a-topic-and-tag-extraction-assistant',
   'say-ok-and-nothing-else',
   'command-message-claude-idd-framework',
@@ -107,12 +107,12 @@ const EXCLUDE_FILENAME_PATTERNS = [
 
 export function isSystemOnlyMessage(text: string): boolean {
   const stripped = text.trim();
-  return SYSTEM_PREFIXES.some((prefix) => stripped.startsWith(prefix));
+  return _SYSTEM_PREFIXES.some((prefix) => stripped.startsWith(prefix));
 }
 
 export function isExcludedByFilename(filename: string): boolean {
   const lower = filename.toLowerCase();
-  return EXCLUDE_FILENAME_PATTERNS.some((pat) => lower.includes(pat));
+  return _EXCLUDE_FILENAME_PATTERNS.some((pat) => lower.includes(pat));
 }
 
 export function isExcludedByContent(
@@ -184,11 +184,11 @@ export async function findMdFiles(
   }
 
   const results: string[] = [];
-  await collectMdFiles(searchDir, results);
+  await _collectMdFiles(searchDir, results);
   return results.sort();
 }
 
-async function collectMdFiles(dir: string, results: string[]): Promise<void> {
+async function _collectMdFiles(dir: string, results: string[]): Promise<void> {
   let entries: Deno.DirEntry[];
   try {
     entries = [];
@@ -202,7 +202,7 @@ async function collectMdFiles(dir: string, results: string[]): Promise<void> {
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const fullPath = `${dir}/${entry.name}`;
     if (entry.isDirectory) {
-      await collectMdFiles(fullPath, results);
+      await _collectMdFiles(fullPath, results);
     } else if (entry.isFile && entry.name.endsWith('.md')) {
       results.push(fullPath);
     }
@@ -358,7 +358,7 @@ export async function withConcurrency<T>(
 
 export async function runClaude(prompt: string): Promise<string> {
   const cmd = new Deno.Command('claude', {
-    args: ['-p', SYSTEM_PROMPT, '--output-format', 'text'],
+    args: ['-p', _SYSTEM_PROMPT, '--output-format', 'text'],
     stdin: 'piped',
     stdout: 'piped',
     stderr: 'null',

--- a/skills/filter-chatlog/scripts/prefilter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/prefilter-chatlog.ts
@@ -93,7 +93,7 @@ const NOISE_USER_EXACT_PATTERNS: { pattern: RegExp; label: string }[] = [
 ];
 
 /** システムタグのみと判断するプレフィックス正規表現 */
-const SYSTEM_TAG_PATTERN =
+const _SYSTEM_TAG_PATTERN =
   /^<(system-reminder|command-name|command-message|local-command-stdout|ide_opened_file|ide_selection)\b/;
 
 /** Assistantの応答が短すぎる場合の閾値（文字数） */
@@ -165,7 +165,7 @@ export function checkUserContent(turns: Turn[]): string | null {
   if (userTurns.length === 0) { return 'Userターンが存在しない'; }
 
   // 全Userターンがシステムタグのみ
-  if (userTurns.every((t) => SYSTEM_TAG_PATTERN.test(t.text))) {
+  if (userTurns.every((t) => _SYSTEM_TAG_PATTERN.test(t.text))) {
     return '全UserターンがシステムTagのみ';
   }
 
@@ -189,7 +189,7 @@ export function checkUserContent(turns: Turn[]): string | null {
     }
 
     // システムタグのみ
-    if (SYSTEM_TAG_PATTERN.test(text)) { return 'UserがシステムTagのみ'; }
+    if (_SYSTEM_TAG_PATTERN.test(text)) { return 'UserがシステムTagのみ'; }
   }
 
   return null;
@@ -257,15 +257,15 @@ export async function findMdFiles(baseDir: string, agent: string, period?: strin
     } catch {
       targetDir = flat;
     }
-    await collectMdFiles(targetDir, results);
+    await _collectMdFiles(targetDir, results);
   } else {
-    await collectMdFiles(agentDir, results);
+    await _collectMdFiles(agentDir, results);
   }
 
   return results.sort();
 }
 
-async function collectMdFiles(dir: string, results: string[]): Promise<void> {
+async function _collectMdFiles(dir: string, results: string[]): Promise<void> {
   let entries: Deno.DirEntry[];
   try {
     entries = [];
@@ -279,7 +279,7 @@ async function collectMdFiles(dir: string, results: string[]): Promise<void> {
   for (const e of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const fullPath = `${dir}/${e.name}`;
     if (e.isDirectory) {
-      await collectMdFiles(fullPath, results);
+      await _collectMdFiles(fullPath, results);
     } else if (e.isFile && e.name.endsWith('.md')) {
       results.push(fullPath);
     }

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -43,16 +43,16 @@ export type ResolveResult =
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /** Default maximum number of concurrent tasks for {@link parseArgs}. */
-const DEFAULT_CONCURRENCY = 4;
+const _DEFAULT_CONCURRENCY = 4;
 
 /** Maximum number of segments returned by {@link segmentChatlog}. */
-const MAX_SEGMENTS = 10;
+const _MAX_SEGMENTS = 10;
 
 /** Markdown heading that marks the start of the body section in a segment file. */
 export const START_BODY_HEADING = '## Excerpt';
 
 /** Model IDs and aliases accepted by the Claude Code CLI. */
-const VALID_MODELS = new Set([
+const _VALID_MODELS = new Set([
   'claude-opus-4-6',
   'claude-sonnet-4-6',
   'claude-haiku-4-5-20251001',
@@ -310,8 +310,8 @@ export function attachFrontmatter(
  * @throws Propagates spawn errors (e.g., command not found) naturally
  */
 export async function runAI(model: string, systemPrompt: string, userPrompt: string): Promise<string> {
-  if (!VALID_MODELS.has(model)) {
-    throw new Error(`Unknown model: "${model}". Valid models: ${[...VALID_MODELS].join(', ')}`);
+  if (!_VALID_MODELS.has(model)) {
+    throw new Error(`Unknown model: "${model}". Valid models: ${[..._VALID_MODELS].join(', ')}`);
   }
   const cmd = new Deno.Command('claude', {
     args: [
@@ -379,7 +379,7 @@ export async function segmentChatlog(filePath: string, content: string): Promise
   }
 
   const segments = parsed as Segment[];
-  return segments.slice(0, MAX_SEGMENTS);
+  return segments.slice(0, _MAX_SEGMENTS);
 }
 
 // ─── File Operations ──────────────────────────────────────────────────────────
@@ -612,7 +612,7 @@ export function resolveOutputDir(inputDir: string, outputBase: string, project: 
  * @param p - The path string to normalize
  * @returns The normalized path string with `/` as separator
  */
-function normalizePath(p: string): string {
+function _normalizePath(p: string): string {
   return p.replaceAll('\\', '/');
 }
 
@@ -637,13 +637,13 @@ function normalizePath(p: string): string {
  * @returns Parsed options as a {@link ParsedArgs} object
  */
 export function parseArgs(argv: string[]): ParsedArgs {
-  const result: ParsedArgs = { concurrency: DEFAULT_CONCURRENCY, dryRun: false };
+  const result: ParsedArgs = { concurrency: _DEFAULT_CONCURRENCY, dryRun: false };
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     switch (arg) {
       case '--dir':
-        result.dir = normalizePath(argv[++i]);
+        result.dir = _normalizePath(argv[++i]);
         break;
       case '--agent':
         result.agent = argv[++i];
@@ -661,7 +661,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
         result.output = argv[++i];
         break;
       default: {
-        const normalized = normalizePath(arg);
+        const normalized = _normalizePath(arg);
         if (!normalized.startsWith('--') && normalized.includes('/')) {
           // Positional path argument: already normalized, assign to dir
           result.dir = normalized;
@@ -691,10 +691,10 @@ export async function withConcurrency<T>(
   concurrency: number,
 ): Promise<T[]> {
   const results: T[] = new Array(tasks.length);
-  let nextIndex = 0;
+  let _nextIndex = 0;
 
   async function runNext(): Promise<void> {
-    const index = nextIndex++;
+    const index = _nextIndex++;
     if (index >= tasks.length) {
       return;
     }
@@ -714,7 +714,7 @@ export async function withConcurrency<T>(
 // ─── Main Orchestration ───────────────────────────────────────────────────────
 
 /** Default output directory for normalized segment files. */
-const DEFAULT_OUTPUT_DIR = 'temp/normalize_logs';
+const _DEFAULT_OUTPUT_DIR = 'temp/normalize_logs';
 
 /**
  * Orchestrates the full normalize-chatlog pipeline.
@@ -737,7 +737,7 @@ export async function main(argv?: string[], hashFn?: HashProvider): Promise<void
     Deno.exit(1);
   }
   const inputDir = resolved.dir;
-  const outputBase = args.output ?? DEFAULT_OUTPUT_DIR;
+  const outputBase = args.output ?? _DEFAULT_OUTPUT_DIR;
 
   const mdFiles = findMdFiles(inputDir);
   const stats: Stats = { success: 0, skip: 0, fail: 0 };

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -172,11 +172,11 @@ export async function loadDics(dicsDir: string): Promise<Dics> {
       });
   };
 
-  const category = Object.keys(parseYamlDic(categoryRaw)).join(',');
-  const tags = Object.keys(parseYamlDic(tagsRaw)).join(',');
+  const _category = Object.keys(parseYamlDic(categoryRaw)).join(',');
+  const _tags = Object.keys(parseYamlDic(tagsRaw)).join(',');
 
   const categoryRulesObj = parseYamlDic(categoryRulesRaw);
-  const categoryPrompts = new Map<string, string>(
+  const _categoryPrompts = new Map<string, string>(
     Object.entries(categoryRulesObj)
       .filter(([, v]) => typeof v === 'string')
       .map(([k, v]) => [k, (v as string).trim()]),
@@ -201,11 +201,11 @@ export async function loadDics(dicsDir: string): Promise<Dics> {
   ]);
 
   return {
-    category,
-    tags,
+    category: _category,
+    tags: _tags,
     typeEntries: extractEntries(typesRaw),
     topicEntries: extractEntries(topicsRaw),
-    categoryPrompts,
+    categoryPrompts: _categoryPrompts,
     prompts,
   };
 }
@@ -264,28 +264,28 @@ export function parseFrontmatter(text: string): { meta: Record<string, string>; 
     return { meta: {}, body: lines.join('\n') };
   }
 
-  const meta: Record<string, string> = {};
-  let bodyStart = lines.length;
+  const _meta: Record<string, string> = {};
+  let _bodyStart = lines.length;
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i];
     if (/^---/.test(line)) {
-      bodyStart = i + 1;
+      _bodyStart = i + 1;
       break;
     }
 
     const idx = line.indexOf(': ');
     if (idx !== -1 && !line.startsWith(' ') && /^\w/.test(line)) {
-      meta[line.slice(0, idx).trim()] = line.slice(idx + 2).trim();
+      _meta[line.slice(0, idx).trim()] = line.slice(idx + 2).trim();
     } else if (line.trim() === '' || line.startsWith(' ') || line.startsWith('\t')) {
       // YAML継続値・空行はスキップ
     } else {
-      bodyStart = i;
+      _bodyStart = i;
       break;
     }
   }
 
-  return { meta, body: lines.slice(bodyStart).join('\n') };
+  return { meta: _meta, body: lines.slice(_bodyStart).join('\n') };
 }
 
 // ─────────────────────────────────────────────
@@ -294,11 +294,11 @@ export function parseFrontmatter(text: string): { meta: Record<string, string>; 
 
 export async function findMdFiles(dir: string): Promise<string[]> {
   const results: string[] = [];
-  await collectMdFiles(dir, results);
+  await _collectMdFiles(dir, results);
   return results.sort();
 }
 
-async function collectMdFiles(dir: string, results: string[]): Promise<void> {
+async function _collectMdFiles(dir: string, results: string[]): Promise<void> {
   let entries: Deno.DirEntry[];
   try {
     entries = [];
@@ -309,7 +309,7 @@ async function collectMdFiles(dir: string, results: string[]): Promise<void> {
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const fullPath = `${dir}/${entry.name}`;
     if (entry.isDirectory) {
-      await collectMdFiles(fullPath, results);
+      await _collectMdFiles(fullPath, results);
     } else if (entry.isFile && entry.name.endsWith('.md')) {
       results.push(fullPath);
     }
@@ -510,9 +510,9 @@ export async function reviewFrontmatter(
     };
   }
 
-  const cleaned = raw.split('\n').filter((l) => !l.startsWith('```')).join('\n').trim();
+  const _cleaned = raw.split('\n').filter((l) => !l.startsWith('```')).join('\n').trim();
 
-  const validityMatch = cleaned.match(/^validity:\s*(pass|fail)/m);
+  const validityMatch = _cleaned.match(/^validity:\s*(pass|fail)/m);
   const validity = (validityMatch?.[1] ?? 'pass') as 'pass' | 'fail';
 
   if (validity === 'pass') {
@@ -526,18 +526,18 @@ export async function reviewFrontmatter(
     };
   }
 
-  const errorsMatch = cleaned.match(/^errors:\s*\n((?: {2}- .+\n?)*)/m);
+  const errorsMatch = _cleaned.match(/^errors:\s*\n((?: {2}- .+\n?)*)/m);
   const errors = errorsMatch
     ? errorsMatch[1].split('\n').map((l) => l.replace(/^ {2}- /, '').trim()).filter(Boolean)
     : [];
 
-  const typeMatch = cleaned.match(/^ {2}type:\s*(\S+)/m);
+  const typeMatch = _cleaned.match(/^ {2}type:\s*(\S+)/m);
   const correctedType = typeMatch?.[1]?.trim() ?? '';
 
-  const categoryMatch = cleaned.match(/^ {2}category:\s*(\S+)/m);
+  const categoryMatch = _cleaned.match(/^ {2}category:\s*(\S+)/m);
   const correctedCategory = categoryMatch?.[1]?.trim() ?? '';
 
-  const correctedYaml = cleaned
+  const correctedYaml = _cleaned
     .replace(/^[\s\S]*?(^ {2}title:)/m, '$1')
     .split('\n')
     .map((l) => l.replace(/^ {2}/, ''))


### PR DESCRIPTION
## Overview

**Summary**
Apply `_` prefix naming convention to internal symbols across all chatlog scripts

**Background / Motivation**
`.claude/rules/naming-conventions.md` の命名規則 (非 export モジュールスコープ定数・関数内主要変数・クロージャー関数への `_` プレフィックス付与) を既存スクリプトへ一貫して適用する。
また、誤って `_` プレフィックスが付いていた export 関数 `_stripUserInstructions` を正しい名前 `stripUserInstructions` に修正する。

## Changes

- `.claude/rules/naming-conventions.md` — モジュールスコープ非 export シンボル・関数内主要変数・クロージャーへの命名規則を追加
- `skills/_scripts/libs/hash.ts` — `_RANDOM_CHARS`、`_out`、`_timestamp`、`_random` にリネーム
- `skills/classify-chatlog/scripts/classify-chatlog.ts` — `_projectList`、`_parts`、`_lines`、`_batchPrompt`、
  `_systemPrompt` にリネーム
- `skills/export-chatlog/scripts/export-chatlog.ts` — `_date`、`_lines`、`_config` にリネーム
- `skills/export-chatlog/scripts/exporter/codex-exporter.ts` — `_stripUserInstructions` → `stripUserInstructions` に修正
  (export 関数からの誤 prefix 除去)
- `skills/filter-chatlog/scripts/filter-chatlog.ts` — `_SYSTEM_PROMPT`、`_SYSTEM_PREFIXES`、`_EXCLUDE_FILENAME_PATTERNS`、
  `_collectMdFiles` にリネーム
- `skills/filter-chatlog/scripts/prefilter-chatlog.ts` — `_SYSTEM_TAG_PATTERN`、`_collectMdFiles` にリネーム
- `skills/normalize-chatlog/scripts/normalize-chatlog.ts` — `_DEFAULT_CONCURRENCY` ほかモジュール定数・`_normalizePath`・
  `_nextIndex` にリネーム
- `skills/set-frontmatter/scripts/set-frontmatter.ts` — `_category`、`_tags`、`_categoryPrompts`、`_meta`、`_bodyStart`、
  `_collectMdFiles` にリネーム
- `skills/export-chatlog/__tests__/unit/strip-user-instructions.unit.spec.ts` — `stripUserInstructions` のインポート・呼び出しを更新 (6箇所)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

このリファクタリングは Issue #48 の命名規則統一作業の一環。対象は既存スクリプトの内部変数・関数名のみで、ロジックの変更は一切含まない。
`stripUserInstructions` の rename のみ export シンボル名の変更だが、呼び出し箇所 (テスト含む) は本 PR で対応済み。
