### PR TITLE
refactor(runai-common): extract shared runAI utility and unify error handling

### DIFF
--- a/skills/_scripts/classes/ChatlogError.class.ts
+++ b/skills/_scripts/classes/ChatlogError.class.ts
@@ -1,0 +1,12 @@
+import { ERROR_KIND_LABELS } from '../constants/chatlog-error.constants.ts';
+import type { ErrorKind } from '../types/chatlog-error.types.ts';
+
+export class ChatlogError extends Error {
+  readonly kind: ErrorKind;
+
+  constructor(kind: ErrorKind, detail: string) {
+    super(`${ERROR_KIND_LABELS[kind]}: ${detail}`);
+    this.name = 'ChatlogError';
+    this.kind = kind;
+  }
+}

--- a/skills/_scripts/libs/backup.ts
+++ b/skills/_scripts/libs/backup.ts
@@ -12,7 +12,7 @@
  * リネームする。outputPath が存在しない場合は何もしない。
  */
 
-import { ChatlogError } from '../types/chatlog-error.types.ts';
+import { ChatlogError } from '../classes/ChatlogError.class.ts';
 import type { ListDirProvider } from '../types/common.types.ts';
 
 // ─────────────────────────────────────────────

--- a/skills/_scripts/libs/run-ai.ts
+++ b/skills/_scripts/libs/run-ai.ts
@@ -6,8 +6,8 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { ChatlogError } from '../classes/ChatlogError.class.ts';
 import { DEFAULT_AI_MODEL, DEFAULT_TIMEOUT_MS } from '../constants/common.constants.ts';
-import { ChatlogError } from '../types/chatlog-error.types.ts';
 
 /** Model IDs and aliases accepted by the Claude Code CLI. */
 const _VALID_MODELS = new Set([
@@ -35,7 +35,10 @@ export async function runAI(
 ): Promise<string> {
   const _options = { model: DEFAULT_AI_MODEL, timeoutMs: DEFAULT_TIMEOUT_MS, ...options };
   if (!_VALID_MODELS.has(_options.model)) {
-    throw new ChatlogError('UnknownModel', `"${_options.model}" is not valid. Valid models: ${[..._VALID_MODELS].join(', ')}`);
+    throw new ChatlogError(
+      'UnknownModel',
+      `"${_options.model}" is not valid. Valid models: ${[..._VALID_MODELS].join(', ')}`,
+    );
   }
   const _controller = new AbortController();
   const _timer = _options.timeoutMs !== 0
@@ -77,6 +80,6 @@ export async function runAI(
     }
     throw e;
   } finally {
-    if (_timer !== undefined) clearTimeout(_timer);
+    if (_timer !== undefined) { clearTimeout(_timer); }
   }
 }

--- a/skills/_scripts/types/chatlog-error.types.ts
+++ b/skills/_scripts/types/chatlog-error.types.ts
@@ -1,13 +1,3 @@
 import { ERROR_KIND_LABELS } from '../constants/chatlog-error.constants.ts';
 
 export type ErrorKind = keyof typeof ERROR_KIND_LABELS;
-
-export class ChatlogError extends Error {
-  readonly kind: ErrorKind;
-
-  constructor(kind: ErrorKind, detail: string) {
-    super(`${ERROR_KIND_LABELS[kind]}: ${detail}`);
-    this.name = 'ChatlogError';
-    this.kind = kind;
-  }
-}

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -14,10 +14,15 @@
  *     [agent] [YYYY-MM] [--dry-run] --input DIR --dics DIR
  */
 
+// -- external --
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
+import { isKnownAgent } from '../../_scripts/constants/agents.constants.ts';
+import { DEFAULT_CHUNK_SIZE, DEFAULT_CONCURRENCY } from '../../_scripts/constants/concurrency.constants.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
+
+// -- internal --
 import { FALLBACK_PROJECT, MIN_CLASSIFIABLE_LENGTH } from './constants/classify.constants.ts';
 import type { ClassifyConfig, ClassifyResult, FileMeta, FrontmatterData, Stats } from './types/classify.types.ts';
-
 
 // ─────────────────────────────────────────────
 // 辞書読み込み

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -18,10 +18,12 @@
  *   codex   — ~/.codex/sessions/YYYY/MM/DD/ 以下のJSONL
  */
 
+// -- external --
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { isKnownAgent } from '../../_scripts/constants/agents.constants.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
-import { ChatlogError } from '../../_scripts/types/chatlog-error.types.ts';
-import { KNOWN_AGENTS } from './constants/agents.constants.ts';
+
+// -- internal --
 import { DEFAULT_EXPORT_CONFIG } from './constants/defaults.constants.ts';
 import {
   SESSION_SKIP_KEYWORDS,

--- a/skills/export-chatlog/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/chatgpt-exporter.ts
@@ -6,7 +6,10 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { ChatlogError } from '../../../_scripts/types/chatlog-error.types.ts';
+// -- external --
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+
+// -- internal --
 import {
   inPeriod,
   isoToDate,

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -17,8 +17,9 @@
 // 定数
 // ─────────────────────────────────────────────
 
+// -- external --
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
-import { ChatlogError } from '../../_scripts/types/chatlog-error.types.ts';
 
 export const CHUNK_SIZE = 10;
 export const CONCURRENCY = 4;

--- a/skills/normalize-chatlog/SKILL.md
+++ b/skills/normalize-chatlog/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: normalize-chatlog
+description: >
+  チャットログMarkdownをAI（Claude CLI）でトピック別セグメントに分割し、
+  フロントマター付きMarkdownとして出力する。
+  /normalize-chatlog で呼び出す。
+  入力ファイルのフロントマターを引き継ぎつつ、title/log_id/summaryをAIが生成する。
+argument-hint: "<agent> <YYYY-MM> | <path> [--output <dir>] [--concurrency <n>] [--model <model>] [--dry-run]"
+allowed-tools: Bash, Glob
+---
+
+# normalize-chatlog スキル
+
+チャットログMarkdownをAI（Claude CLI）でトピック別セグメントに分割して正規化する。
+各セグメントはフロントマター付きMarkdownとして出力され、既存ファイルはアトミックに上書き（`.old-NN.md` バックアップ）される。
+
+## 前提条件
+
+- `claude` コマンドがPATHに存在すること（Claude Code CLIインストール済み）
+- `deno` コマンドが利用可能であること（TypeScript実行用）
+
+## 引数の処理
+
+`$ARGUMENTS` を解析し、以下のルールでスクリプト引数に変換する。
+
+スクリプトは位置引数として `agent` や `YYYY-MM` を直接受け付けない。
+SKILL.md 側でフラグ（`--agent`, `--year-month`）に変換してから渡す。
+
+引数の判定ルール:
+
+- `YYYY-MM` パターン（`^[0-9]{4}-[0-9]{2}$`）→ YEAR_MONTH
+- `/` または `\` を含む文字列 → PATH（位置引数として渡す）
+- `--output <dir>` → OUTPUT_DIR（`--output` フラグとしてそのまま転送）
+- `--concurrency <n>` → 並列実行数（`--concurrency` フラグとしてそのまま転送、デフォルト: 4）
+- `--model <model>` → AI モデル名（`--model` フラグとしてそのまま転送）
+- 上記以外の文字列 → AGENT
+
+引数パターンと変換ルール:
+
+- 引数なし → **エラー**。`agent + YYYY-MM` または `path` のいずれかが必須。使い方を表示して終了する。
+- `YYYY-MM` のみ → `--agent claude --year-month YYYY-MM`
+- `agent` のみ → `--agent <agent> --year-month` が揃っていないためエラー。YYYY-MM も指定するよう案内する。
+- `agent YYYY-MM` → `--agent <agent> --year-month YYYY-MM`
+- `/path/to/dir` → `/path/to/dir`（位置引数のまま渡す）
+- `--output <dir>` → `--output <dir>` としてスクリプトに転送
+- `--dry-run` フラグ → そのままスクリプトに転送
+
+## ステップ1: スクリプトパスの解決
+
+Glob ツールで `**/normalize-chatlog/SKILL.md` を検索し、そのディレクトリを `SKILL_DIR` として確定する。
+
+```bash
+SKILL_DIR   = <SKILL.md が存在するディレクトリの絶対パス>
+SCRIPT_PATH = $SKILL_DIR/scripts/normalize-chatlog.ts
+```
+
+## ステップ2: スクリプト実行
+
+解決した `SCRIPT_PATH` を使い、Bash で実行する:
+
+```bash
+deno run --allow-read --allow-write --allow-env --allow-run "$SCRIPT_PATH" {変換後の引数}
+```
+
+### 引数からオプションを組み立てるルール
+
+- 引数なし → エラー出力して終了（`agent + YYYY-MM` または `path` が必須）
+- `agent` のみ → エラー出力して終了（YYYY-MM が不足）
+- `2026-03` のみ → `deno run ... "$SCRIPT_PATH" --agent claude --year-month 2026-03`
+- `claude 2026-03` → `deno run ... "$SCRIPT_PATH" --agent claude --year-month 2026-03`
+- `/path/to/chatlogs` → `deno run ... "$SCRIPT_PATH" /path/to/chatlogs`
+- `--output <dir>` を含む → `--output <dir>` をスクリプトに転送
+- `--concurrency <n>` を含む → `--concurrency <n>` をスクリプトに転送
+- `--model <model>` を含む → `--model <model>` をスクリプトに転送
+- `--dry-run` を含む → `--dry-run` を末尾に追加
+
+スクリプトは以下の処理を行う:
+
+1. 入力ディレクトリ配下の `.md` ファイルを再帰的に収集
+2. Claude CLI で各 chatlog をトピック別セグメントに分割（最大10セグメント）
+3. 各セグメントをフロントマター付きMarkdownとして出力
+4. 出力ファイル名形式: `<baseName>-<XX>-<hash7>.md`
+5. 既存ファイルがある場合は `.old-NN.md` にバックアップ後、アトミック上書き（tmp-then-rename）
+
+## ステップ3: 結果通知
+
+スクリプト完了後、`stderr` のサマリー行を読んでユーザーに結果を通知する。
+
+通知形式:
+
+- 生成したセグメントファイル数（success）と出力先ディレクトリ
+- `fail > 0` の場合は失敗件数を警告として強調表示
+- dry-run モードの場合はその旨を明示する
+
+## 出力ディレクトリ構造
+
+入力が `temp/chatlog/<agent>/<year>/<yearMonth>` 形式の場合:
+
+```bash
+temp/normalize_logs/
+  └── <agent>/
+       └── <year>/
+            └── <yearMonth>/
+                 └── <project>/
+                      └── <baseName>-<XX>-<hash7>.md
+```
+
+入力が任意パスの場合:
+
+```bash
+temp/normalize_logs/
+  └── <project>/
+       └── <baseName>-<XX>-<hash7>.md
+```
+
+`project` はソースファイルのフロントマターから引き継ぐ。未定義の場合は `misc/` に出力される。
+
+## 関連スキル
+
+- `/export-chatlog` — ChatLog のエクスポート（normalize-chatlog の前工程）
+- `/filter-chatlog` — 低価値ChatLogのフィルタリング
+- `/classify-chatlog` — プロジェクト別サブディレクトリへの分類
+- `/set-frontmatter` — フロントマター付加

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -7,8 +7,9 @@
 // https://opensource.org/licenses/MIT
 // normalize_chatlog.ts — Utilities for normalizing chatlog processing
 
+// -- external --
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
-import { ChatlogError } from '../../_scripts/types/chatlog-error.types.ts';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -23,10 +23,10 @@
 
 // cspell:words dics
 
-// import libraries
+// -- external --
 import { parse as parseYaml } from '@std/yaml';
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
-import { ChatlogError } from '../../_scripts/types/chatlog-error.types.ts';
 
 // ─────────────────────────────────────────────
 // 定数


### PR DESCRIPTION
## Overview

**Summary**
Extract shared `runAI` utility to `_scripts/libs/` and unify error label prefixes across all skills.

**Background / Motivation**
`normalize-chatlog` スキルが独自に保持していた `runAI` 実装とハッシュ生成を、`skills/_scripts/libs/` 配下の共通ライブラリとして分離・整備した。
合わせて `ChatlogError` クラスを `types/` から専用の `classes/` モジュールへ抽出し、型定義と実装クラスの責務を分離した。
共通化により、将来の新スキルが同じ Claude CLI 呼び出しロジックを再実装するリスクを排除する。
また、全スキルのエラーメッセージにラベルプレフィックス（`CLI Error:`, `Invalid Period:`, `Timed Out:` 等）を統一し、ログからのエラー種別判別を容易にする。

## Changes

- `skills/_scripts/classes/ChatlogError.class.ts` — `ChatlogError` クラスを `types/` から `classes/` 配下へ新規分離
- `skills/_scripts/types/chatlog-error.types.ts` — `ChatlogError` クラス定義を削除し `ErrorKind` 型のみ残す
- `skills/_scripts/libs/run-ai.ts` — Claude CLI を呼び出す共通 `runAI` ユーティリティを新規追加。モデル検証・タイムアウト制御・標準化エラーラベルを実装
- `skills/_scripts/libs/backup.ts` — バックアップ上限超過エラーに `Too Many Backups:` ラベルを追加。`ChatlogError` import パスを classes モジュールへ更新
- `skills/normalize-chatlog/scripts/normalize-chatlog.ts` — ローカル `runAI` と `hash` 実装を共通 `libs` へ移行。エラーラベル統一 (`Timed Out:`,
  `Too Many Backups:`)
- `skills/classify-chatlog/scripts/classify-chatlog.ts` — `runClaude` エラーに `CLI Error:` プレフィックスを追加。
  `ChatlogError` import を classes モジュールへ更新
- `skills/export-chatlog/scripts/export-chatlog.ts` — `Invalid Period:` ラベルを追加。import を整理し未使用 `KNOWN_AGENTS` import を削除
- `skills/export-chatlog/scripts/exporter/chatgpt-exporter.ts` — `Missing Arg:` ラベルを追加。`ChatlogError` import を classes モジュールへ更新
- `skills/filter-chatlog/scripts/filter-chatlog.ts` — `runClaude` エラーに `CLI Error:` プレフィックスを追加。import を再編
- `skills/set-frontmatter/scripts/set-frontmatter.ts` — `runClaude` エラーに `CLI Error:` プレフィックスを追加。import を再編
- `skills/normalize-chatlog/SKILL.md` — `normalize-chatlog` スキルの SKILL.md を新規追加

---

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Closes #64

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint fmt --check`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

`ChatlogError` の import パスが変更されています。
`types/chatlog-error.types.ts` からの import は引き続き動作しますが、新規コードは `classes/ChatlogError.class.ts` から import してください。

```typescript
// Before
import { ChatlogError } from "../../_scripts/types/chatlog-error.types.ts";

// After
import { ChatlogError } from "../../_scripts/classes/ChatlogError.class.ts";
```

`runAI` を新規スキルで使用する場合は `skills/_scripts/libs/run-ai.ts` から import してください。
