### PR TITLE
refactor(scripts): unify exit handling across all chatlog scripts

### DIFF
--- a/skills/_scripts/constants/chatlog-error.constants.ts
+++ b/skills/_scripts/constants/chatlog-error.constants.ts
@@ -5,5 +5,7 @@ export const ERROR_KIND_LABELS = {
   TooManyBackups: 'Too Many Backups',
   InvalidPeriod: 'Invalid Period',
   MissingArg: 'Missing Arg',
-  ForbiddenOutput: 'R-010',
+  ForbiddenOutput: 'Forbidden Output',
+  InvalidArgs: 'Invalid Args',
+  InputNotFound: 'Input Not Found',
 } as const;

--- a/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
@@ -249,35 +249,3 @@ describe('main - 対象ファイルなし', () => {
     });
   });
 });
-
-// ─── T-CL-E2E-05: 存在しない inputDir → Deno.exit(1) ────────────────────────
-
-describe('main - 存在しない inputDir', () => {
-  describe('Given: 存在しない inputDir を指定', () => {
-    describe('When: main([...args, "--input", "/nonexistent"]) を呼び出す', () => {
-      describe('Then: T-CL-E2E-05 - Deno.exit(1) が最初に呼ばれる', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        let errStub: Stub;
-
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-          errStub = stub(console, 'error', () => {});
-        });
-
-        afterEach(() => {
-          exitStub.restore();
-          errStub.restore();
-        });
-
-        it('T-CL-E2E-05-01: 最初の Deno.exit 呼び出しが exit(1) である', async () => {
-          await main(['claude', '--input', '/nonexistent/path/does/not/exist', '--dics', '/tmp']);
-
-          // Deno.exit スタブは exit を止めないため複数回呼ばれる可能性あり
-          // 最初の呼び出しが exit(1) であることを確認する
-          assertEquals(exitStub.calls.length >= 1, true);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
-      });
-    });
-  });
-});

--- a/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.main.system.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.main.system.spec.ts
@@ -1,0 +1,36 @@
+// src: scripts/__tests__/system/classify-chatlog.main.system.spec.ts
+// @(#): classify-chatlog main() のシステムテスト（実プロセス起動による終了コード検証）
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+const SCRIPT_PATH = new URL('../../classify-chatlog.ts', import.meta.url).pathname;
+
+async function runClassify(args: string[]): Promise<number> {
+  const _cmd = new Deno.Command(Deno.execPath(), {
+    args: ['run', '--allow-read', '--allow-write', '--allow-run', SCRIPT_PATH, ...args],
+    stdout: 'null',
+    stderr: 'null',
+  });
+  const { code } = await _cmd.output();
+  return code;
+}
+
+// ─── T-CL-SYS-01: エラー時に exit(1) で終了する ──────────────────────────────
+
+describe('main - エラー終了コード', () => {
+  describe('Given: 不正なオプションを指定', () => {
+    describe('When: classify-chatlog をサブプロセスで実行する', () => {
+      describe('Then: T-CL-SYS-01 - プロセスが終了コード 1 で終了する', () => {
+        it('T-CL-SYS-01-01: 終了コードが 1 である', async () => {
+          const code = await runClassify(['--unknown-option']);
+          assertEquals(code, 1);
+        });
+      });
+    });
+  });
+});

--- a/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
@@ -1,18 +1,21 @@
 // src: scripts/__tests__/unit/classify-chatlog.parseArgs.unit.spec.ts
 // @(#): parseArgs のユニットテスト
 //       CLI 引数解析: デフォルト値・各オプション・エラー終了
-//
+
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 
-import { assertEquals } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+// -- BDD modules --
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
+// -- modules for test --
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 // test target
 import { parseArgs } from '../../classify-chatlog.ts';
+
+type ClassifyConfig = ReturnType<typeof parseArgs>;
 
 // ─── デフォルト値の確認 ───────────────────────────────────────────────────────
 
@@ -20,119 +23,40 @@ describe('parseArgs', () => {
   describe('Given: 引数なしの空配列', () => {
     describe('When: parseArgs([]) を呼び出す', () => {
       describe('Then: T-CL-PA-01 - デフォルト値が適用される', () => {
-        it('T-CL-PA-01-01: agent が "chatgpt" になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.agent, 'chatgpt');
-        });
-
-        it('T-CL-PA-01-02: dryRun が false になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.dryRun, false);
-        });
-
-        it('T-CL-PA-01-03: inputDir が "./temp/chatlog" になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.inputDir, './temp/chatlog');
-        });
-
-        it('T-CL-PA-01-04: dicsDir が "./assets/dics" になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.dicsDir, './assets/dics');
-        });
-
-        it('T-CL-PA-01-05: period が undefined になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.period, undefined);
-        });
+        const _defaultCases: { id: string; field: keyof ClassifyConfig; expected: unknown }[] = [
+          { id: 'T-CL-PA-01-01', field: 'agent', expected: 'chatgpt' },
+          { id: 'T-CL-PA-01-02', field: 'dryRun', expected: false },
+          { id: 'T-CL-PA-01-03', field: 'inputDir', expected: './temp/chatlog' },
+          { id: 'T-CL-PA-01-04', field: 'dicsDir', expected: './assets/dics' },
+          { id: 'T-CL-PA-01-05', field: 'period', expected: undefined },
+        ];
+        for (const { id, field, expected } of _defaultCases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs([])[field], expected);
+          });
+        }
       });
     });
   });
 
-  // ─── agent 引数の解析 ─────────────────────────────────────────────────────
+  // ─── 単一オプションの解析 ─────────────────────────────────────────────────
 
-  describe('Given: ["claude"] を渡す', () => {
-    describe('When: parseArgs(["claude"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-02 - agent=claude', () => {
-        it('T-CL-PA-02-01: agent が "claude" になる', () => {
-          const result = parseArgs(['claude']);
-
-          assertEquals(result.agent, 'claude');
-        });
-      });
-    });
-  });
-
-  // ─── period の解析 ────────────────────────────────────────────────────────
-
-  describe('Given: ["2026-03"] を渡す', () => {
-    describe('When: parseArgs(["2026-03"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-03 - period=2026-03', () => {
-        it('T-CL-PA-03-01: period が "2026-03" になる', () => {
-          const result = parseArgs(['2026-03']);
-
-          assertEquals(result.period, '2026-03');
-        });
-      });
-    });
-  });
-
-  // ─── --dry-run フラグの解析 ───────────────────────────────────────────────
-
-  describe('Given: ["--dry-run"] を渡す', () => {
-    describe('When: parseArgs(["--dry-run"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-04 - dryRun=true', () => {
-        it('T-CL-PA-04-01: dryRun が true になる', () => {
-          const result = parseArgs(['--dry-run']);
-
-          assertEquals(result.dryRun, true);
-        });
-      });
-    });
-  });
-
-  // ─── --input オプション（スペース区切り）の解析 ───────────────────────────
-
-  describe('Given: ["--input", "/path/to/input"] を渡す', () => {
-    describe('When: parseArgs(["--input", "/path/to/input"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-05 - inputDir=/path/to/input', () => {
-        it('T-CL-PA-05-01: inputDir が "/path/to/input" になる', () => {
-          const result = parseArgs(['--input', '/path/to/input']);
-
-          assertEquals(result.inputDir, '/path/to/input');
-        });
-      });
-    });
-  });
-
-  // ─── --input=value 形式の解析 ─────────────────────────────────────────────
-
-  describe('Given: ["--input=/path/to/input"] を渡す', () => {
-    describe('When: parseArgs(["--input=/path/to/input"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-06 - --input=value 形式のパース', () => {
-        it('T-CL-PA-06-01: inputDir が "/path/to/input" になる', () => {
-          const result = parseArgs(['--input=/path/to/input']);
-
-          assertEquals(result.inputDir, '/path/to/input');
-        });
-      });
-    });
-  });
-
-  // ─── --dics オプションの解析 ──────────────────────────────────────────────
-
-  describe('Given: ["--dics", "/path/to/dics"] を渡す', () => {
-    describe('When: parseArgs(["--dics", "/path/to/dics"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-07 - dicsDir=/path/to/dics', () => {
-        it('T-CL-PA-07-01: dicsDir が "/path/to/dics" になる', () => {
-          const result = parseArgs(['--dics', '/path/to/dics']);
-
-          assertEquals(result.dicsDir, '/path/to/dics');
-        });
+  describe('Given: 単一オプション', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: 対応フィールドに値が設定される', () => {
+        const _cases: { id: string; args: string[]; field: keyof ClassifyConfig; expected: unknown }[] = [
+          { id: 'T-CL-PA-02-01', args: ['claude'], field: 'agent', expected: 'claude' },
+          { id: 'T-CL-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
+          { id: 'T-CL-PA-04-01', args: ['--dry-run'], field: 'dryRun', expected: true },
+          { id: 'T-CL-PA-05-01', args: ['--input', '/path/to/input'], field: 'inputDir', expected: '/path/to/input' },
+          { id: 'T-CL-PA-06-01', args: ['--input=/path/to/input'], field: 'inputDir', expected: '/path/to/input' },
+          { id: 'T-CL-PA-07-01', args: ['--dics', '/path/to/dics'], field: 'dicsDir', expected: '/path/to/dics' },
+        ];
+        for (const { id, args, field, expected } of _cases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs(args)[field], expected);
+          });
+        }
       });
     });
   });
@@ -163,48 +87,24 @@ describe('parseArgs', () => {
     });
   });
 
-  // ─── 未知のオプションで Deno.exit(1) が呼ばれる ──────────────────────────
+  // ─── 異常系: ChatlogError がスローされる ──────────────────────────────────
 
-  describe('Given: 未知のオプション ["--unknown"]', () => {
-    describe('When: parseArgs(["--unknown"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-09 - 未知オプション → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-CL-PA-09-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          parseArgs(['--unknown']);
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
-      });
-    });
-  });
-
-  // ─── 未知の位置引数で Deno.exit(1) が呼ばれる ────────────────────────────
-
-  describe('Given: 未知の位置引数 ["invalid-arg"]', () => {
-    describe('When: parseArgs(["invalid-arg"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-10 - 未知の位置引数 → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-CL-PA-10-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          parseArgs(['invalid-arg']);
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
+  describe('Given: 不正な引数', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
+        const _errorCases: { id: string; args: string[]; label: string }[] = [
+          { id: 'T-CL-PA-09-01', args: ['--unknown'], label: '未知オプション' },
+          { id: 'T-CL-PA-10-01', args: ['invalid-arg'], label: '未知の位置引数' },
+        ];
+        for (const { id, args, label } of _errorCases) {
+          it(`${id}: ${label} → ChatlogError(InvalidArgs) がスローされる`, () => {
+            assertThrows(
+              () => parseArgs(args),
+              ChatlogError,
+              'Invalid Args',
+            );
+          });
+        }
       });
     });
   });

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -34,7 +34,7 @@ export async function loadProjects(dicsDir: string): Promise<string[]> {
   try {
     text = await Deno.readTextFile(dicPath);
   } catch {
-    logger.warn(`警告: projects.dic が見つかりません: ${dicPath}`);
+    logger.warn(`projects.dic が見つかりません: ${dicPath}`);
     return [];
   }
   return text
@@ -496,15 +496,13 @@ export function parseArgs(args: string[]): ClassifyConfig {
     } else if (arg.startsWith('--dics=')) {
       dicsDir = arg.slice('--dics='.length);
     } else if (arg.startsWith('-')) {
-      console.error(`不明なオプション: ${arg}`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
     } else if (/^\d{4}-\d{2}$/.test(arg)) {
       period = arg;
     } else if (isKnownAgent(arg)) {
       agent = arg;
     } else {
-      console.error(`不明な引数: ${arg}`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不明な引数: ${arg}`);
     }
   }
 
@@ -516,78 +514,85 @@ export function parseArgs(args: string[]): ClassifyConfig {
 // ─────────────────────────────────────────────
 
 export async function main(argv?: string[]): Promise<void> {
-  const _config = parseArgs(argv ?? Deno.args);
-
-  // 入力ディレクトリ確認
-  const agentDir = `${_config.inputDir}/${_config.agent}`;
   try {
-    const stat = await Deno.stat(agentDir);
-    if (!stat.isDirectory) {
-      logger.error(`エラー: 入力ディレクトリが見つかりません: ${agentDir}`);
+    const _config = parseArgs(argv ?? Deno.args);
+
+    // 入力ディレクトリ確認
+    const agentDir = `${_config.inputDir}/${_config.agent}`;
+    try {
+      const stat = await Deno.stat(agentDir);
+      if (!stat.isDirectory) {
+        throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
+      }
+    } catch (e) {
+      if (e instanceof ChatlogError) { throw e; }
+      throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
+    }
+
+    // プロジェクト辞書読み込み
+    const projects = await loadProjects(_config.dicsDir);
+    if (projects.length === 0) {
+      logger.warn('警告: projects.dic にプロジェクトが定義されていません。すべて misc に分類されます。');
+    }
+
+    logger.info(`対象 agent: ${_config.agent}`);
+    if (_config.period) { logger.info(`対象期間: ${_config.period}`); }
+    if (_config.dryRun) { logger.info('dry-run モード: ファイルは移動しません'); }
+    logger.info(`プロジェクト候補: ${projects.join(', ')}`);
+
+    // ファイル列挙
+    const allFiles = await findMdFilesFlat(_config.inputDir, _config.agent, _config.period);
+    if (allFiles.length === 0) {
+      logger.info('対象ファイルなし');
+      logger.info('完了: moved=0 skipped=0 error=0');
+      return;
+    }
+
+    // メタデータ読み込みとスキップ判定
+    const targetMetas: FileMeta[] = [];
+    const stats: Stats = { moved: 0, skipped: 0, error: 0 };
+
+    for (const filePath of allFiles) {
+      const meta = await loadFileMeta(filePath);
+      if (!meta) {
+        stats.error++;
+        continue;
+      }
+      if (meta.existingProject) {
+        logger.info(`  skipped (既にプロジェクト設定済み: ${meta.existingProject}): ${meta.filename}`);
+        stats.skipped++;
+        continue;
+      }
+      targetMetas.push(meta);
+    }
+
+    logger.info(`\n対象ファイル数: ${targetMetas.length} (スキップ: ${stats.skipped})`);
+
+    if (targetMetas.length === 0) {
+      logger.info(`\n完了: moved=${stats.moved} skipped=${stats.skipped} error=${stats.error}`);
+      return;
+    }
+
+    // チャンク分割して並列処理
+    const tasks: (() => Promise<void>)[] = [];
+    for (let i = 0; i < targetMetas.length; i += DEFAULT_CHUNK_SIZE) {
+      const chunk = targetMetas.slice(i, i + DEFAULT_CHUNK_SIZE);
+      tasks.push(() => processChunk(chunk, projects, _config.dryRun, stats));
+    }
+    await withConcurrency(tasks, DEFAULT_CONCURRENCY);
+
+    // サマリー
+    const drySuffix = _config.dryRun ? ' (dry-run)' : '';
+    logger.info(
+      `\n完了${drySuffix}: moved=${stats.moved} skipped=${stats.skipped} error=${stats.error}`,
+    );
+  } catch (e) {
+    if (e instanceof ChatlogError) {
+      logger.error(e.message);
       Deno.exit(1);
     }
-  } catch {
-    logger.error(`エラー: 入力ディレクトリが見つかりません: ${agentDir}`);
-    Deno.exit(1);
+    throw e;
   }
-
-  // プロジェクト辞書読み込み
-  const projects = await loadProjects(_config.dicsDir);
-  if (projects.length === 0) {
-    logger.warn('警告: projects.dic にプロジェクトが定義されていません。すべて misc に分類されます。');
-  }
-
-  logger.info(`対象 agent: ${_config.agent}`);
-  if (_config.period) { logger.info(`対象期間: ${_config.period}`); }
-  if (_config.dryRun) { logger.info('dry-run モード: ファイルは移動しません'); }
-  logger.info(`プロジェクト候補: ${projects.join(', ')}`);
-
-  // ファイル列挙
-  const allFiles = await findMdFilesFlat(_config.inputDir, _config.agent, _config.period);
-  if (allFiles.length === 0) {
-    logger.info('対象ファイルなし');
-    logger.info('完了: moved=0 skipped=0 error=0');
-    Deno.exit(0);
-  }
-
-  // メタデータ読み込みとスキップ判定
-  const targetMetas: FileMeta[] = [];
-  const stats: Stats = { moved: 0, skipped: 0, error: 0 };
-
-  for (const filePath of allFiles) {
-    const meta = await loadFileMeta(filePath);
-    if (!meta) {
-      stats.error++;
-      continue;
-    }
-    if (meta.existingProject) {
-      logger.info(`  skipped (既にプロジェクト設定済み: ${meta.existingProject}): ${meta.filename}`);
-      stats.skipped++;
-      continue;
-    }
-    targetMetas.push(meta);
-  }
-
-  logger.info(`\n対象ファイル数: ${targetMetas.length} (スキップ: ${stats.skipped})`);
-
-  if (targetMetas.length === 0) {
-    logger.info(`\n完了: moved=${stats.moved} skipped=${stats.skipped} error=${stats.error}`);
-    Deno.exit(0);
-  }
-
-  // チャンク分割して並列処理
-  const tasks: (() => Promise<void>)[] = [];
-  for (let i = 0; i < targetMetas.length; i += DEFAULT_CHUNK_SIZE) {
-    const chunk = targetMetas.slice(i, i + DEFAULT_CHUNK_SIZE);
-    tasks.push(() => processChunk(chunk, projects, _config.dryRun, stats));
-  }
-  await withConcurrency(tasks, DEFAULT_CONCURRENCY);
-
-  // サマリー
-  const drySuffix = _config.dryRun ? ' (dry-run)' : '';
-  logger.info(
-    `\n完了${drySuffix}: moved=${stats.moved} skipped=${stats.skipped} error=${stats.error}`,
-  );
 }
 
 if (import.meta.main) { await main(); }

--- a/skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -6,281 +6,157 @@
 //
 // This software is released under the MIT License.
 
-import { assertEquals } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import {
   DEFAULT_EXPORT_CONFIG,
 } from '../../../../export-chatlog/scripts/constants/defaults.constants.ts';
 import { parseArgs } from '../../../../export-chatlog/scripts/export-chatlog.ts';
 
-// ─── parseArgs tests ──────────────────────────────────────────────────────────
+type ExportConfig = ReturnType<typeof parseArgs>;
 
-/**
- * `parseArgs` のユニットテストスイート。
- *
- * CLI 引数配列を解析して ExportConfig を生成する関数の動作を検証する。
- * テスト対象ケース:
- * - デフォルト値（引数なし）
- * - agent 指定（"codex"）
- * - 期間指定（YYYY-MM・YYYY）
- * - --output / --output= オプション
- * - --base / --base= オプション
- * - --output と --base の併用
- * - 全フィールド同時指定
- * - 未知のオプション・位置引数での Deno.exit(1) 呼び出し
- *
- * 異常系テストでは `stub(Deno, 'exit')` でプロセス終了をモックして検証する。
- *
- * @see parseArgs
- * @see DEFAULT_EXPORT_CONFIG
- */
 describe('parseArgs', () => {
+  // ─── T-EC-PA-01: デフォルト値 ────────────────────────────────────────────────
+
   describe('Given: 空の引数配列 []', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs([]);
-    });
-
-    it('T-EC-PA-01-01: agent が DEFAULT_EXPORT_CONFIG.agent（デフォルト）', () => {
-      assertEquals(result.agent, DEFAULT_EXPORT_CONFIG.agent);
-    });
-
-    it('T-EC-PA-01-02: outputDir が DEFAULT_EXPORT_CONFIG.outputDir（デフォルト）', () => {
-      assertEquals(result.outputDir, DEFAULT_EXPORT_CONFIG.outputDir);
-    });
-
-    it('T-EC-PA-01-03: period が undefined', () => {
-      assertEquals(result.period, undefined);
-    });
-
-    it('T-EC-PA-01-05: baseDir が undefined', () => {
-      assertEquals(result.baseDir, undefined);
+    describe('When: parseArgs([]) を呼び出す', () => {
+      describe('Then: T-EC-PA-01 - デフォルト値が適用される', () => {
+        const _defaultCases: { id: string; field: keyof ExportConfig; expected: unknown }[] = [
+          { id: 'T-EC-PA-01-01', field: 'agent', expected: DEFAULT_EXPORT_CONFIG.agent },
+          { id: 'T-EC-PA-01-02', field: 'outputDir', expected: DEFAULT_EXPORT_CONFIG.outputDir },
+          { id: 'T-EC-PA-01-03', field: 'period', expected: undefined },
+          { id: 'T-EC-PA-01-05', field: 'baseDir', expected: undefined },
+        ];
+        for (const { id, field, expected } of _defaultCases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs([])[field], expected);
+          });
+        }
+      });
     });
   });
 
-  /** 正常系: agent 指定 */
-  describe('Given: ["codex"]', () => {
-    it('T-EC-PA-02-01: agent が "codex"', () => {
-      const result = parseArgs(['codex']);
-      assertEquals(result.agent, 'codex');
+  // ─── T-EC-PA-02〜15: 単一オプション ──────────────────────────────────────────
+
+  describe('Given: 単一オプション', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: 対応フィールドに値が設定される', () => {
+        const _cases: { id: string; args: string[]; field: keyof ExportConfig; expected: unknown }[] = [
+          { id: 'T-EC-PA-02-01', args: ['codex'], field: 'agent', expected: 'codex' },
+          { id: 'T-EC-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
+          { id: 'T-EC-PA-03-02', args: ['2026'], field: 'period', expected: '2026' },
+          { id: 'T-EC-PA-04-01', args: ['--output', '/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
+          { id: 'T-EC-PA-04-02', args: ['--output=/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
+          { id: 'T-EC-PA-08-01', args: ['--base', '/data/logs'], field: 'baseDir', expected: '/data/logs' },
+          { id: 'T-EC-PA-08-02', args: ['--base=/data/logs'], field: 'baseDir', expected: '/data/logs' },
+          {
+            id: 'T-EC-PA-11-01',
+            args: ['--output', '/chatlog/claude'],
+            field: 'outputDir',
+            expected: '/chatlog/claude',
+          },
+          {
+            id: 'T-EC-PA-12-01',
+            args: ['--input', '/data/chatgpt-export'],
+            field: 'inputDir',
+            expected: '/data/chatgpt-export',
+          },
+          {
+            id: 'T-EC-PA-12-02',
+            args: ['--input=/data/chatgpt-export'],
+            field: 'inputDir',
+            expected: '/data/chatgpt-export',
+          },
+          { id: 'T-EC-PA-13-01', args: ['chatgpt'], field: 'agent', expected: 'chatgpt' },
+          { id: 'T-EC-PA-15-01', args: ['chatgpt', '/path/to/export'], field: 'inputDir', expected: '/path/to/export' },
+          {
+            id: 'T-EC-PA-15-04',
+            args: ['chatgpt', 'C:\\Users\\foo\\export'],
+            field: 'inputDir',
+            expected: 'C:/Users/foo/export',
+          },
+        ];
+        for (const { id, args, field, expected } of _cases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs(args)[field], expected);
+          });
+        }
+      });
     });
   });
 
-  /** 正常系: 期間指定（YYYY-MM）*/
-  describe('Given: ["2026-03"]', () => {
-    it('T-EC-PA-03-01: period が "2026-03"', () => {
-      const result = parseArgs(['2026-03']);
-      assertEquals(result.period, '2026-03');
-    });
-  });
+  // ─── 複数フィールド組み合わせ ─────────────────────────────────────────────────
 
-  /** 正常系: 期間指定（YYYY）*/
-  describe('Given: ["2026"]', () => {
-    it('T-EC-PA-03-02: period が "2026"', () => {
-      const result = parseArgs(['2026']);
-      assertEquals(result.period, '2026');
-    });
-  });
-
-  /** 正常系: --output オプション */
-  describe('Given: ["--output", "/tmp/out"]', () => {
-    it('T-EC-PA-04-01: outputDir が "/tmp/out"', () => {
-      const result = parseArgs(['--output', '/tmp/out']);
-      assertEquals(result.outputDir, '/tmp/out');
-    });
-  });
-
-  /** 正常系: --output= 形式 */
-  describe('Given: ["--output=/tmp/out"]', () => {
-    it('T-EC-PA-04-02: outputDir が "/tmp/out"', () => {
-      const result = parseArgs(['--output=/tmp/out']);
-      assertEquals(result.outputDir, '/tmp/out');
-    });
-  });
-
-  /** 正常系: --base オプション */
-  describe('Given: ["--base", "/data/logs"]', () => {
-    it('T-EC-PA-08-01: baseDir が "/data/logs"', () => {
-      const result = parseArgs(['--base', '/data/logs']);
-      assertEquals(result.baseDir, '/data/logs');
-    });
-  });
-
-  /** 正常系: --base= 形式 */
-  describe('Given: ["--base=/data/logs"]', () => {
-    it('T-EC-PA-08-02: baseDir が "/data/logs"', () => {
-      const result = parseArgs(['--base=/data/logs']);
-      assertEquals(result.baseDir, '/data/logs');
-    });
-  });
-
-  /** 正常系: --output と --base の併用 */
   describe('Given: ["--base", "/data", "--output", "/data/claude"]', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs(['--base', '/data', '--output', '/data/claude']);
-    });
-
-    it('T-EC-PA-09-01: baseDir が "/data"', () => {
+    it('T-EC-PA-09: baseDir と outputDir が同時に設定される', () => {
+      const result = parseArgs(['--base', '/data', '--output', '/data/claude']);
       assertEquals(result.baseDir, '/data');
-    });
-
-    it('T-EC-PA-09-02: outputDir が "/data/claude"', () => {
       assertEquals(result.outputDir, '/data/claude');
     });
   });
 
-  /** 異常系: 未知のオプション */
-  describe('Given: ["--unknown"]', () => {
-    let exitStub: Stub<typeof Deno, [code?: number], never>;
-
-    beforeEach(() => {
-      exitStub = stub(Deno, 'exit');
-    });
-
-    afterEach(() => {
-      exitStub.restore();
-    });
-
-    it('T-EC-PA-06-01: Deno.exit(1) が呼ばれる', () => {
-      parseArgs(['--unknown']);
-      assertEquals(exitStub.calls.length, 1);
-      assertEquals(exitStub.calls[0].args[0], 1);
-    });
-
-    it('T-EC-PA-06-02: 未知の位置引数で Deno.exit(1) が呼ばれる', () => {
-      parseArgs(['my-project']);
-      assertEquals(exitStub.calls.length, 1);
-      assertEquals(exitStub.calls[0].args[0], 1);
-    });
-  });
-
-  /** 正常系: 全フィールドを同時指定 */
   describe('Given: ["claude", "2026-03", "--output", "/out"]', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs(['claude', '2026-03', '--output', '/out']);
-    });
-
-    it('T-EC-PA-07-01: agent が "claude"', () => {
+    it('T-EC-PA-07: agent・period・outputDir が同時に設定される', () => {
+      const result = parseArgs(['claude', '2026-03', '--output', '/out']);
       assertEquals(result.agent, 'claude');
-    });
-
-    it('T-EC-PA-07-02: period が "2026-03"', () => {
       assertEquals(result.period, '2026-03');
-    });
-
-    it('T-EC-PA-07-04: outputDir が "/out"', () => {
       assertEquals(result.outputDir, '/out');
     });
   });
 
-  /** 正常系: --base と agent の組み合わせ */
   describe('Given: ["claude", "--base", "/data/logs"]', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs(['claude', '--base', '/data/logs']);
-    });
-
-    it('T-EC-PA-10-01: agent が "claude"', () => {
+    it('T-EC-PA-10: agent と baseDir が同時に設定される', () => {
+      const result = parseArgs(['claude', '--base', '/data/logs']);
       assertEquals(result.agent, 'claude');
-    });
-
-    it('T-EC-PA-10-02: baseDir が "/data/logs"', () => {
       assertEquals(result.baseDir, '/data/logs');
     });
   });
 
-  /** 正常系: /chatlog/<agent> スタイルの --output パス */
-  describe('Given: ["--output", "/chatlog/claude"]', () => {
-    it('T-EC-PA-11-01: outputDir が "/chatlog/claude"', () => {
-      const result = parseArgs(['--output', '/chatlog/claude']);
-      assertEquals(result.outputDir, '/chatlog/claude');
-    });
-  });
-
-  /** 正常系: --input オプション */
-  describe('Given: ["--input", "/data/chatgpt-export"]', () => {
-    it('T-EC-PA-12-01: inputDir が "/data/chatgpt-export"', () => {
-      const result = parseArgs(['--input', '/data/chatgpt-export']);
-      assertEquals(result.inputDir, '/data/chatgpt-export');
-    });
-  });
-
-  /** 正常系: --input= 形式 */
-  describe('Given: ["--input=/data/chatgpt-export"]', () => {
-    it('T-EC-PA-12-02: inputDir が "/data/chatgpt-export"', () => {
-      const result = parseArgs(['--input=/data/chatgpt-export']);
-      assertEquals(result.inputDir, '/data/chatgpt-export');
-    });
-  });
-
-  /** 正常系: chatgpt agent 指定 */
-  describe('Given: ["chatgpt"]', () => {
-    it('T-EC-PA-13-01: agent が "chatgpt"', () => {
-      const result = parseArgs(['chatgpt']);
-      assertEquals(result.agent, 'chatgpt');
-    });
-  });
-
-  /** 正常系: chatgpt + 位置引数パス */
-  describe('Given: ["chatgpt", "/path/to/export"]', () => {
-    it('T-EC-PA-15-01: inputDir が "/path/to/export"', () => {
-      const result = parseArgs(['chatgpt', '/path/to/export']);
-      assertEquals(result.inputDir, '/path/to/export');
-    });
-  });
-
-  /** 正常系: chatgpt + 期間 + 位置引数パス */
-  describe('Given: ["chatgpt", "2026-03", "/path/to/export"]', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs(['chatgpt', '2026-03', '/path/to/export']);
-    });
-
-    it('T-EC-PA-15-02: period が "2026-03"、inputDir が "/path/to/export"', () => {
-      assertEquals(result.period, '2026-03');
-      assertEquals(result.inputDir, '/path/to/export');
-    });
-  });
-
-  /** 正常系: chatgpt + Windows パス（バックスラッシュ正規化） */
-  describe('Given: ["chatgpt", "C:\\\\Users\\\\foo\\\\export"]', () => {
-    it('T-EC-PA-15-04: inputDir が "C:/Users/foo/export"（\\ → / 正規化済み）', () => {
-      const result = parseArgs(['chatgpt', 'C:\\Users\\foo\\export']);
-      assertEquals(result.inputDir, 'C:/Users/foo/export');
-    });
-  });
-
-  /** 正常系: chatgpt + 位置引数パス + 期間（順番逆） */
-  describe('Given: ["chatgpt", "/path/to/export", "2026-03"]', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs(['chatgpt', '/path/to/export', '2026-03']);
-    });
-
-    it('T-EC-PA-15-03: period が "2026-03"、inputDir が "/path/to/export"', () => {
-      assertEquals(result.period, '2026-03');
-      assertEquals(result.inputDir, '/path/to/export');
-    });
-  });
-
-  /** 正常系: chatgpt + --input の組み合わせ */
   describe('Given: ["chatgpt", "--input", "/data/export"]', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs(['chatgpt', '--input', '/data/export']);
-    });
-
-    it('T-EC-PA-14-01: agent が "chatgpt"', () => {
+    it('T-EC-PA-14: agent と inputDir が同時に設定される', () => {
+      const result = parseArgs(['chatgpt', '--input', '/data/export']);
       assertEquals(result.agent, 'chatgpt');
-    });
-
-    it('T-EC-PA-14-02: inputDir が "/data/export"', () => {
       assertEquals(result.inputDir, '/data/export');
+    });
+  });
+
+  describe('Given: ["chatgpt", "2026-03", "/path/to/export"]', () => {
+    it('T-EC-PA-15-02: period と inputDir が同時に設定される', () => {
+      const result = parseArgs(['chatgpt', '2026-03', '/path/to/export']);
+      assertEquals(result.period, '2026-03');
+      assertEquals(result.inputDir, '/path/to/export');
+    });
+  });
+
+  describe('Given: ["chatgpt", "/path/to/export", "2026-03"]（順番逆）', () => {
+    it('T-EC-PA-15-03: 順番が逆でも period と inputDir が正しく設定される', () => {
+      const result = parseArgs(['chatgpt', '/path/to/export', '2026-03']);
+      assertEquals(result.period, '2026-03');
+      assertEquals(result.inputDir, '/path/to/export');
+    });
+  });
+
+  // ─── 異常系: ChatlogError がスローされる ──────────────────────────────────────
+
+  describe('Given: 不正な引数', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
+        const _errorCases: { id: string; args: string[]; label: string }[] = [
+          { id: 'T-EC-PA-06-01', args: ['--unknown'], label: '未知オプション' },
+          { id: 'T-EC-PA-06-02', args: ['my-project'], label: '未知の位置引数' },
+        ];
+        for (const { id, args, label } of _errorCases) {
+          it(`${id}: ${label} → ChatlogError(InvalidArgs) がスローされる`, () => {
+            assertThrows(
+              () => parseArgs(args),
+              ChatlogError,
+              'Invalid Args',
+            );
+          });
+        }
+      });
     });
   });
 });

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -473,8 +473,7 @@ export function parseArgs(args: string[]): ExportConfig {
     } else if (arg.startsWith('--input=')) {
       _config.inputDir = arg.slice('--input='.length);
     } else if (arg.startsWith('-')) {
-      console.error(`不明なオプション: ${arg}`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
     } else if (isKnownAgent(arg)) {
       _config.agent = arg;
     } else if (/^\d{4}-\d{2}$/.test(arg) || /^\d{4}$/.test(arg)) {
@@ -484,8 +483,7 @@ export function parseArgs(args: string[]): ExportConfig {
       if (normalized.includes('/')) {
         _config.inputDir = normalized;
       } else {
-        console.error(`不明な引数: ${arg}`);
-        Deno.exit(1);
+        throw new ChatlogError('InvalidArgs', `不明な引数: ${arg}`);
       }
     }
   }
@@ -516,43 +514,47 @@ export function parseArgs(args: string[]): ExportConfig {
  * @param argv CLI 引数の配列。省略時は `Deno.args` を使用
  */
 export async function main(argv?: string[]): Promise<void> {
-  const config = parseArgs(argv ?? Deno.args);
-  const { agent, period, outputDir } = config;
-
-  logger.info(`対象 agent: ${agent}`);
-  if (period) { logger.info(`対象期間: ${period}`); }
-
-  let result: Awaited<ReturnType<typeof exportClaude>>;
-
   try {
+    const config = parseArgs(argv ?? Deno.args);
+    const { agent, period, outputDir } = config;
+
+    logger.info(`対象 agent: ${agent}`);
+    if (period) { logger.info(`対象期間: ${period}`); }
+
+    let result: Awaited<ReturnType<typeof exportClaude>>;
+
     if (agent === 'claude') {
       result = await exportClaude(config);
     } else if (agent === 'codex') {
       result = await exportCodex(config);
     } else if (agent === 'chatgpt') {
       if (!config.inputDir && !config.baseDir) {
-        logger.error('chatgpt エージェントには入力ディレクトリを指定してください（位置引数または --input）');
-        Deno.exit(1);
+        throw new ChatlogError(
+          'InvalidArgs',
+          'chatgpt エージェントには入力ディレクトリを指定してください（位置引数または --input）',
+        );
       }
       result = await exportChatGPT(config);
     } else {
-      logger.error(`未対応のエージェント: ${agent}`);
+      throw new ChatlogError('InvalidArgs', `未対応のエージェント: ${agent}`);
+    }
+
+    for (const outPath of result.outputPaths) {
+      logger.log(outPath);
+    }
+
+    const total = result.exportedCount + result.skippedCount + result.errorCount;
+    logger.info(
+      `\n完了: ${total} 件処理（出力: ${result.exportedCount} / スキップ: ${result.skippedCount} / エラー: ${result.errorCount}）`,
+    );
+    logger.info(`出力先: ${outputDir}/${agent}/`);
+  } catch (e) {
+    if (e instanceof ChatlogError) {
+      logger.error(e.message);
       Deno.exit(1);
     }
-  } catch (e) {
-    logger.error(`エラー: ${e}`);
-    Deno.exit(1);
+    throw e;
   }
-
-  for (const outPath of result.outputPaths) {
-    logger.log(outPath);
-  }
-
-  const total = result.exportedCount + result.skippedCount + result.errorCount;
-  logger.info(
-    `\n完了: ${total} 件処理（出力: ${result.exportedCount} / スキップ: ${result.skippedCount} / エラー: ${result.errorCount}）`,
-  );
-  logger.info(`出力先: ${outputDir}/${agent}/`);
 }
 
 if (import.meta.main) { await main(); }

--- a/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
@@ -7,12 +7,11 @@
 //
 // This software is released under the MIT License.
 
-import { assertEquals, assertNotEquals, assertStringIncludes } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+import { assertEquals, assertNotEquals, assertStringIncludes, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
 // test target
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import {
   extractBodyText,
   isExcludedByContent,
@@ -22,6 +21,8 @@ import {
   parseFrontmatter,
   parseJsonArray,
 } from '../../filter-chatlog.ts';
+
+type Args = ReturnType<typeof parseArgs>;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // parseArgs
@@ -33,125 +34,41 @@ describe('parseArgs', () => {
   describe('Given: 引数なしの空配列', () => {
     describe('When: parseArgs([]) を呼び出す', () => {
       describe('Then: T-FL-PA-01 - デフォルト値が適用される', () => {
-        it('T-FL-PA-01-01: agent が "claude" になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.agent, 'claude');
-        });
-
-        it('T-FL-PA-01-02: dryRun が false になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.dryRun, false);
-        });
-
-        it('T-FL-PA-01-03: inputDir が "./temp/chatlog" になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.inputDir, './temp/chatlog');
-        });
-
-        it('T-FL-PA-01-04: period が undefined になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.period, undefined);
-        });
-
-        it('T-FL-PA-01-05: project が undefined になる', () => {
-          const result = parseArgs([]);
-
-          assertEquals(result.project, undefined);
-        });
+        const _defaultCases: { id: string; field: keyof Args; expected: unknown }[] = [
+          { id: 'T-FL-PA-01-01', field: 'agent', expected: 'claude' },
+          { id: 'T-FL-PA-01-02', field: 'dryRun', expected: false },
+          { id: 'T-FL-PA-01-03', field: 'inputDir', expected: './temp/chatlog' },
+          { id: 'T-FL-PA-01-04', field: 'period', expected: undefined },
+          { id: 'T-FL-PA-01-05', field: 'project', expected: undefined },
+        ];
+        for (const { id, field, expected } of _defaultCases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs([])[field], expected);
+          });
+        }
       });
     });
   });
 
-  // ─── T-FL-PA-02: agent 引数 ──────────────────────────────────────────────────
+  // ─── T-FL-PA-02〜07: 単一オプション ──────────────────────────────────────────
 
-  describe('Given: ["chatgpt"] を渡す', () => {
-    describe('When: parseArgs(["chatgpt"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-02 - agent=chatgpt', () => {
-        it('T-FL-PA-02-01: agent が "chatgpt" になる', () => {
-          const result = parseArgs(['chatgpt']);
-
-          assertEquals(result.agent, 'chatgpt');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-03: period の解析 ───────────────────────────────────────────────
-
-  describe('Given: ["2026-03"] を渡す', () => {
-    describe('When: parseArgs(["2026-03"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-03 - period=2026-03', () => {
-        it('T-FL-PA-03-01: period が "2026-03" になる', () => {
-          const result = parseArgs(['2026-03']);
-
-          assertEquals(result.period, '2026-03');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-04: project の解析 ──────────────────────────────────────────────
-
-  describe('Given: ["2026-03", "my-project"] を渡す', () => {
-    describe('When: parseArgs(["2026-03", "my-project"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-04 - project=my-project', () => {
-        it('T-FL-PA-04-01: project が "my-project" になる', () => {
-          const result = parseArgs(['2026-03', 'my-project']);
-
-          assertEquals(result.project, 'my-project');
-        });
-
-        it('T-FL-PA-04-02: period が "2026-03" になる', () => {
-          const result = parseArgs(['2026-03', 'my-project']);
-
-          assertEquals(result.period, '2026-03');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-05: --dry-run フラグ ────────────────────────────────────────────
-
-  describe('Given: ["--dry-run"] を渡す', () => {
-    describe('When: parseArgs(["--dry-run"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-05 - dryRun=true', () => {
-        it('T-FL-PA-05-01: dryRun が true になる', () => {
-          const result = parseArgs(['--dry-run']);
-
-          assertEquals(result.dryRun, true);
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-06: --input <path> オプション ───────────────────────────────────
-
-  describe('Given: ["--input", "/path/to/input"] を渡す', () => {
-    describe('When: parseArgs(["--input", "/path/to/input"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-06 - inputDir=/path/to/input', () => {
-        it('T-FL-PA-06-01: inputDir が "/path/to/input" になる', () => {
-          const result = parseArgs(['--input', '/path/to/input']);
-
-          assertEquals(result.inputDir, '/path/to/input');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-07: --input=value 形式 ──────────────────────────────────────────
-
-  describe('Given: ["--input=/path/to/input"] を渡す', () => {
-    describe('When: parseArgs(["--input=/path/to/input"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-07 - --input=value 形式のパース', () => {
-        it('T-FL-PA-07-01: inputDir が "/path/to/input" になる', () => {
-          const result = parseArgs(['--input=/path/to/input']);
-
-          assertEquals(result.inputDir, '/path/to/input');
-        });
+  describe('Given: 単一オプション', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: 対応フィールドに値が設定される', () => {
+        const _cases: { id: string; args: string[]; field: keyof Args; expected: unknown }[] = [
+          { id: 'T-FL-PA-02-01', args: ['chatgpt'], field: 'agent', expected: 'chatgpt' },
+          { id: 'T-FL-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
+          { id: 'T-FL-PA-04-01', args: ['2026-03', 'my-project'], field: 'project', expected: 'my-project' },
+          { id: 'T-FL-PA-04-02', args: ['2026-03', 'my-project'], field: 'period', expected: '2026-03' },
+          { id: 'T-FL-PA-05-01', args: ['--dry-run'], field: 'dryRun', expected: true },
+          { id: 'T-FL-PA-06-01', args: ['--input', '/path/to/input'], field: 'inputDir', expected: '/path/to/input' },
+          { id: 'T-FL-PA-07-01', args: ['--input=/path/to/input'], field: 'inputDir', expected: '/path/to/input' },
+        ];
+        for (const { id, args, field, expected } of _cases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs(args)[field], expected);
+          });
+        }
       });
     });
   });
@@ -159,41 +76,25 @@ describe('parseArgs', () => {
   // ─── T-FL-PA-08: 複数オプション組み合わせ ────────────────────────────────────
 
   describe('Given: claude 2026-03 my-proj --dry-run --input ./in を渡す', () => {
-    describe('When: parseArgs(args) を呼び出す', () => {
-      describe('Then: T-FL-PA-08 - 複数オプション組み合わせ', () => {
-        it('T-FL-PA-08-01: 全フィールドが正しく解析される', () => {
-          const result = parseArgs(['claude', '2026-03', 'my-proj', '--dry-run', '--input', './in']);
-
-          assertEquals(result.agent, 'claude');
-          assertEquals(result.period, '2026-03');
-          assertEquals(result.project, 'my-proj');
-          assertEquals(result.dryRun, true);
-          assertEquals(result.inputDir, './in');
-        });
-      });
+    it('T-FL-PA-08-01: 全フィールドが正しく解析される', () => {
+      const result = parseArgs(['claude', '2026-03', 'my-proj', '--dry-run', '--input', './in']);
+      assertEquals(result.agent, 'claude');
+      assertEquals(result.period, '2026-03');
+      assertEquals(result.project, 'my-proj');
+      assertEquals(result.dryRun, true);
+      assertEquals(result.inputDir, './in');
     });
   });
 
-  // ─── T-FL-PA-09: 未知オプションで Deno.exit(1) が呼ばれる ───────────────────
+  // ─── T-FL-PA-09: 異常系 ───────────────────────────────────────────────────────
 
-  describe('Given: 未知のオプション ["--unknown"]', () => {
-    describe('When: parseArgs(["--unknown"]) を呼び出す', () => {
-      describe('Then: T-FL-PA-09 - 未知オプション → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-FL-PA-09-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          parseArgs(['--unknown']);
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
-      });
+  describe('Given: 不正な引数', () => {
+    it('T-FL-PA-09-01: 未知オプション → ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => parseArgs(['--unknown']),
+        ChatlogError,
+        'Invalid Args',
+      );
     });
   });
 });

--- a/skills/filter-chatlog/scripts/__tests__/unit/prefilter-chatlog.unit.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/unit/prefilter-chatlog.unit.spec.ts
@@ -7,12 +7,11 @@
 //
 // This software is released under the MIT License.
 
-import { assertEquals, assertNotEquals } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+import { assertEquals, assertNotEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
 // test target
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import {
   checkAssistantContent,
   checkFilename,
@@ -959,24 +958,17 @@ describe('parseArgs (prefilter)', () => {
     });
   });
 
-  // ─── T-PF-PA-11: 未知オプション → Deno.exit(1) ──────────────────────────────
+  // ─── T-PF-PA-11: 未知オプション → ChatlogError(InvalidArgs) ──────────────────────────────
 
   describe('Given: 未知のオプション ["--unknown"]', () => {
     describe('When: parseArgs(["--unknown"]) を呼び出す', () => {
-      describe('Then: T-PF-PA-11 - Deno.exit(1) が呼ばれる', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-PF-PA-11-01: Deno.exit(1) がちょうど 1 回呼ばれる', () => {
-          parseArgs(['--unknown']);
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
+      describe('Then: T-PF-PA-11 - ChatlogError(InvalidArgs) がスローされる', () => {
+        it('T-PF-PA-11-01: ChatlogError(InvalidArgs) がスローされる', () => {
+          assertThrows(
+            () => parseArgs(['--unknown']),
+            ChatlogError,
+            'Invalid Args',
+          );
         });
       });
     });

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -485,8 +485,7 @@ export function parseArgs(args: string[]): Args {
     } else if (arg.startsWith('--input=')) {
       inputDir = arg.slice('--input='.length);
     } else if (arg.startsWith('-')) {
-      console.error(`不明なオプション: ${arg}`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
     } else if (/^\d{4}-\d{2}$/.test(arg)) {
       period = arg;
     } else if (period) {
@@ -504,54 +503,61 @@ export function parseArgs(args: string[]): Args {
 // ─────────────────────────────────────────────
 
 export async function main(args?: string[]): Promise<void> {
-  const { agent, period, project, dryRun, inputDir } = parseArgs(args ?? Deno.args);
-  const agentDir = `${inputDir}/${agent}`;
-
-  // 入力ディレクトリ確認
   try {
-    const stat = await Deno.stat(agentDir);
-    if (!stat.isDirectory) {
-      logger.error(`エラー: 入力ディレクトリが見つかりません: ${agentDir}`);
+    const { agent, period, project, dryRun, inputDir } = parseArgs(args ?? Deno.args);
+    const agentDir = `${inputDir}/${agent}`;
+
+    // 入力ディレクトリ確認
+    try {
+      const stat = await Deno.stat(agentDir);
+      if (!stat.isDirectory) {
+        throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
+      }
+    } catch (e) {
+      if (e instanceof ChatlogError) { throw e; }
+      throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
+    }
+
+    logger.info(`対象 agent: ${agent}`);
+
+    // ファイル列挙
+    const allFiles = await findMdFiles(agentDir, period, project);
+
+    // 事前フィルタ
+    const targetFiles = await prefilterFiles(allFiles);
+
+    const total = targetFiles.length;
+    if (total === 0) {
+      logger.info('対象ファイルなし');
+      logger.info('完了: kept=0 discarded=0 skipped=0 error=0');
+      return;
+    }
+
+    logger.info(`判定対象ファイル数: ${total}`);
+    if (dryRun) { logger.info('dry-run モード: ファイルは削除しません'); }
+
+    // チャンク分割して並列処理
+    const stats: Stats = { kept: 0, discarded: 0, skipped: 0, error: 0 };
+
+    const tasks: (() => Promise<void>)[] = [];
+    for (let i = 0; i < targetFiles.length; i += CHUNK_SIZE) {
+      const chunk = targetFiles.slice(i, i + CHUNK_SIZE);
+      tasks.push(() => processChunk(chunk, dryRun, stats));
+    }
+    await withConcurrency(tasks, CONCURRENCY);
+
+    // サマリー
+    const drySuffix = dryRun ? ' (dry-run)' : '';
+    logger.info(
+      `\n完了${drySuffix}: kept=${stats.kept} discarded=${stats.discarded} skipped=${stats.skipped} error=${stats.error}`,
+    );
+  } catch (e) {
+    if (e instanceof ChatlogError) {
+      logger.error(e.message);
       Deno.exit(1);
     }
-  } catch {
-    logger.error(`エラー: 入力ディレクトリが見つかりません: ${agentDir}`);
-    Deno.exit(1);
+    throw e;
   }
-
-  logger.info(`対象 agent: ${agent}`);
-
-  // ファイル列挙
-  const allFiles = await findMdFiles(agentDir, period, project);
-
-  // 事前フィルタ
-  const targetFiles = await prefilterFiles(allFiles);
-
-  const total = targetFiles.length;
-  if (total === 0) {
-    logger.info('対象ファイルなし');
-    logger.info('完了: kept=0 discarded=0 skipped=0 error=0');
-    Deno.exit(0);
-  }
-
-  logger.info(`判定対象ファイル数: ${total}`);
-  if (dryRun) { logger.info('dry-run モード: ファイルは削除しません'); }
-
-  // チャンク分割して並列処理
-  const stats: Stats = { kept: 0, discarded: 0, skipped: 0, error: 0 };
-
-  const tasks: (() => Promise<void>)[] = [];
-  for (let i = 0; i < targetFiles.length; i += CHUNK_SIZE) {
-    const chunk = targetFiles.slice(i, i + CHUNK_SIZE);
-    tasks.push(() => processChunk(chunk, dryRun, stats));
-  }
-  await withConcurrency(tasks, CONCURRENCY);
-
-  // サマリー
-  const drySuffix = dryRun ? ' (dry-run)' : '';
-  logger.info(
-    `\n完了${drySuffix}: kept=${stats.kept} discarded=${stats.discarded} skipped=${stats.skipped} error=${stats.error}`,
-  );
 }
 
 if (import.meta.main) {

--- a/skills/filter-chatlog/scripts/prefilter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/prefilter-chatlog.ts
@@ -29,6 +29,7 @@
  *   deno run --allow-read --allow-write scripts/prefilter_chatlog.ts --input ./temp/chatlog
  */
 
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
 
 // ─────────────────────────────────────────────
@@ -316,8 +317,7 @@ export function parseArgs(args: string[]): Args {
     } else if (arg.startsWith('--input=')) {
       inputDir = arg.slice('--input='.length);
     } else if (arg.startsWith('-')) {
-      console.error(`不明なオプション: ${arg}`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
     } else if (/^\d{4}-\d{2}$/.test(arg)) {
       period = arg;
     } else {
@@ -333,61 +333,69 @@ export function parseArgs(args: string[]): Args {
 // ─────────────────────────────────────────────
 
 export async function main(args: string[] = Deno.args): Promise<void> {
-  const { agent, period, inputDir, dryRun, report } = parseArgs(args);
-
   try {
-    const stat = await Deno.stat(inputDir);
-    if (!stat.isDirectory) { throw new Error(); }
-  } catch {
-    logger.error(`エラー: 入力ディレクトリが見つかりません: ${inputDir}`);
-    Deno.exit(1);
-  }
+    const { agent, period, inputDir, dryRun, report } = parseArgs(args);
 
-  const files = await findMdFiles(inputDir, agent, period);
-  logger.info(`対象ファイル数: ${files.length}`);
-  if (dryRun) {
-    logger.info(`${report ? 'report' : 'dry-run'} モード: ファイルは削除しません`);
-  }
-
-  const counts = { noise: 0, keep: 0, error: 0 };
-
-  for (const filePath of files) {
-    const filename = filePath.replace(/\\/g, '/').split('/').pop()!;
-
-    let text: string;
     try {
-      text = await Deno.readTextFile(filePath);
+      const stat = await Deno.stat(inputDir);
+      if (!stat.isDirectory) { throw new Error(); }
     } catch (e) {
-      logger.error(`  error (${filename}): ${e}`);
-      counts.error++;
-      continue;
+      if (e instanceof ChatlogError) { throw e; }
+      throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${inputDir}`);
     }
 
-    const { isNoise, reason } = classifyFile(filename, text);
+    const files = await findMdFiles(inputDir, agent, period);
+    logger.info(`対象ファイル数: ${files.length}`);
+    if (dryRun) {
+      logger.info(`${report ? 'report' : 'dry-run'} モード: ファイルは削除しません`);
+    }
 
-    if (isNoise) {
-      counts.noise++;
-      if (report) {
-        logger.log(`NOISE\t${reason}\t${filePath}`);
-      } else if (dryRun) {
-        logger.log(filePath);
-      } else {
-        try {
-          await Deno.remove(filePath);
-          logger.info(`deleted: ${filePath}`);
-        } catch (e) {
-          logger.error(`  削除失敗: ${filename}: ${e}`);
-          counts.error++;
-          counts.noise--;
-        }
+    const counts = { noise: 0, keep: 0, error: 0 };
+
+    for (const filePath of files) {
+      const filename = filePath.replace(/\\/g, '/').split('/').pop()!;
+
+      let text: string;
+      try {
+        text = await Deno.readTextFile(filePath);
+      } catch (e) {
+        logger.error(`  error (${filename}): ${e}`);
+        counts.error++;
+        continue;
       }
-    } else {
-      counts.keep++;
-    }
-  }
 
-  const suffix = dryRun ? ` (${report ? 'report' : 'dry-run'})` : '';
-  logger.info(`\n完了${suffix}: noise=${counts.noise} keep=${counts.keep} error=${counts.error}`);
+      const { isNoise, reason } = classifyFile(filename, text);
+
+      if (isNoise) {
+        counts.noise++;
+        if (report) {
+          logger.log(`NOISE\t${reason}\t${filePath}`);
+        } else if (dryRun) {
+          logger.log(filePath);
+        } else {
+          try {
+            await Deno.remove(filePath);
+            logger.info(`deleted: ${filePath}`);
+          } catch (e) {
+            logger.error(`  削除失敗: ${filename}: ${e}`);
+            counts.error++;
+            counts.noise--;
+          }
+        }
+      } else {
+        counts.keep++;
+      }
+    }
+
+    const suffix = dryRun ? ` (${report ? 'report' : 'dry-run'})` : '';
+    logger.info(`\n完了${suffix}: noise=${counts.noise} keep=${counts.keep} error=${counts.error}`);
+  } catch (e) {
+    if (e instanceof ChatlogError) {
+      logger.error(e.message);
+      Deno.exit(1);
+    }
+    throw e;
+  }
 }
 
 if (import.meta.main) {

--- a/skills/normalize-chatlog/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
@@ -302,7 +302,7 @@ describe('writeOutput', () => {
                 await writeOutput(inputPath, 'overwrite', false, stats);
               },
               Error,
-              'R-010',
+              'Forbidden Output',
             );
           });
         });

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.cli-args.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.cli-args.unit.spec.ts
@@ -6,39 +6,61 @@
 //
 // This software is released under the MIT License.
 
-// Deno Test module
-import { assertEquals } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
 // test target
-import {
-  parseArgs,
-} from '../../normalize-chatlog.ts';
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
+import { parseArgs } from '../../normalize-chatlog.ts';
 
-// ─── parseArgs tests ──────────────────────────────────────────────────────────
+type ParsedArgs = ReturnType<typeof parseArgs>;
 
-/**
- * parseArgs のユニットテスト。
- * CLI 引数配列を解析して { dir, agent, yearMonth, dryRun, concurrency, output } を返す関数の
- * 正常系・デフォルト値・エラー終了・パス正規化を検証する。
- */
 describe('parseArgs', () => {
-  /** 正常系: --dir オプションを正しくパースする */
-  describe('Given: --dir オプションを含む引数配列', () => {
-    it('T-08-01-01: args.dir が "/some/path" になる', () => {
-      const result = parseArgs(['--dir', '/some/path']);
+  // ─── T-08-01: デフォルト値 ────────────────────────────────────────────────────
 
-      assertEquals(result.dir, '/some/path');
+  describe('Given: オプションなしの空配列', () => {
+    describe('When: parseArgs([]) を呼び出す', () => {
+      describe('Then: T-08-02 - デフォルト値が適用される', () => {
+        const _defaultCases: { id: string; field: keyof ParsedArgs; expected: unknown }[] = [
+          { id: 'T-08-02-01', field: 'concurrency', expected: 4 },
+          { id: 'T-08-02-02', field: 'dryRun', expected: false },
+        ];
+        for (const { id, field, expected } of _defaultCases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs([])[field], expected);
+          });
+        }
+      });
     });
   });
 
-  /** 正常系: 複数オプションが混在しても全フィールドを正しく解析する */
-  describe('Given: --agent・--year-month・--dry-run・--concurrency・--output を含む引数配列', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs([
+  // ─── T-08-01: 単一・複数オプション ───────────────────────────────────────────
+
+  describe('Given: 各種オプション', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: 対応フィールドに値が設定される', () => {
+        const _cases: { id: string; args: string[]; field: keyof ParsedArgs; expected: unknown }[] = [
+          { id: 'T-08-01-01', args: ['--dir', '/some/path'], field: 'dir', expected: '/some/path' },
+          { id: 'T-08-01-02a', args: ['--agent', 'claude'], field: 'agent', expected: 'claude' },
+          { id: 'T-08-01-02b', args: ['--year-month', '2026-03'], field: 'yearMonth', expected: '2026-03' },
+          { id: 'T-08-01-02c', args: ['--dry-run'], field: 'dryRun', expected: true },
+          { id: 'T-08-01-02d', args: ['--concurrency', '8'], field: 'concurrency', expected: 8 },
+          { id: 'T-08-01-02e', args: ['--output', './out'], field: 'output', expected: './out' },
+        ];
+        for (const { id, args, field, expected } of _cases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs(args)[field], expected);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-08-01: 複数オプション組み合わせ ───────────────────────────────────────
+
+  describe('Given: 全オプションを組み合わせた引数', () => {
+    it('T-08-01-02: 全フィールドが正しく解析される', () => {
+      const result = parseArgs([
         '--agent',
         'claude',
         '--year-month',
@@ -49,81 +71,50 @@ describe('parseArgs', () => {
         '--output',
         './out',
       ]);
-    });
-
-    it('T-08-01-02a: args.agent が "claude" になる', () => {
       assertEquals(result.agent, 'claude');
-    });
-
-    it('T-08-01-02b: args.yearMonth が "2026-03" になる', () => {
       assertEquals(result.yearMonth, '2026-03');
-    });
-
-    it('T-08-01-02c: args.dryRun が true になる', () => {
       assertEquals(result.dryRun, true);
-    });
-
-    it('T-08-01-02d: args.concurrency が 8 になる', () => {
       assertEquals(result.concurrency, 8);
-    });
-
-    it('T-08-01-02e: args.output が "./out" になる', () => {
       assertEquals(result.output, './out');
     });
   });
 
-  /** 正常系: 省略時はデフォルト値 (concurrency=4, dryRun=false) が適用される */
-  describe('Given: --concurrency・--dry-run を含まない引数配列', () => {
-    let result: ReturnType<typeof parseArgs>;
-    beforeEach(() => {
-      result = parseArgs([]);
-    });
+  // ─── T-08-04: パス正規化と自動 --dir 判定 ────────────────────────────────────
 
-    it('T-08-02-01: args.concurrency が 4 になる', () => {
-      assertEquals(result.concurrency, 4);
-    });
-
-    it('T-08-02-02: args.dryRun が false になる', () => {
-      assertEquals(result.dryRun, false);
-    });
-  });
-
-  /** 異常系: 未知のオプションは Deno.exit(1) を呼び出してエラー終了する */
-  describe('Given: 未知のオプションを含む引数配列', () => {
-    let exitStub: Stub<typeof Deno, [code?: number], never>;
-    beforeEach(() => {
-      exitStub = stub(Deno, 'exit');
-    });
-    afterEach(() => {
-      exitStub.restore();
-    });
-
-    it('T-08-03-01: Deno.exit(1) が呼ばれる', () => {
-      parseArgs(['--unknown']);
-
-      assertEquals(exitStub.calls.length, 1);
-      assertEquals(exitStub.calls[0].args[0], 1);
+  describe('Given: パス引数', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-08-04 - dir フィールドにスラッシュ正規化されたパスが設定される', () => {
+        const _pathCases: { id: string; args: string[]; expected: string }[] = [
+          { id: 'T-08-04-01', args: ['--dir', 'temp\\chatlog\\claude'], expected: 'temp/chatlog/claude' },
+          {
+            id: 'T-08-04-02',
+            args: ['temp/chatlog/claude/2026/2026-03'],
+            expected: 'temp/chatlog/claude/2026/2026-03',
+          },
+          {
+            id: 'T-08-04-03',
+            args: ['temp\\chatlog\\claude\\2026\\2026-03'],
+            expected: 'temp/chatlog/claude/2026/2026-03',
+          },
+        ];
+        for (const { id, args, expected } of _pathCases) {
+          it(`${id}: dir が "${expected}" になる`, () => {
+            assertEquals(parseArgs(args).dir, expected);
+          });
+        }
+      });
     });
   });
 
-  /** 正常系: パス正規化と自動 --dir 判定 */
-  describe('Given: パス区切り文字の正規化または自動 --dir 判定が必要な引数配列', () => {
-    it('T-08-04-01: --dir 値のバックスラッシュがスラッシュに正規化される', () => {
-      const result = parseArgs(['--dir', 'temp\\chatlog\\claude']);
+  // ─── 異常系: ChatlogError がスローされる ──────────────────────────────────────
 
-      assertEquals(result.dir, 'temp/chatlog/claude');
-    });
-
-    it('T-08-04-02: / を含む位置引数が args.dir に設定される', () => {
-      const result = parseArgs(['temp/chatlog/claude/2026/2026-03']);
-
-      assertEquals(result.dir, 'temp/chatlog/claude/2026/2026-03');
-    });
-
-    it('T-08-04-03: \\ を含む位置引数がスラッシュ正規化されて args.dir に設定される', () => {
-      const result = parseArgs(['temp\\chatlog\\claude\\2026\\2026-03']);
-
-      assertEquals(result.dir, 'temp/chatlog/claude/2026/2026-03');
+  describe('Given: 未知のオプション', () => {
+    it('T-08-03-01: ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => parseArgs(['--unknown']),
+        ChatlogError,
+        'Invalid Args',
+      );
     });
   });
 });

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
@@ -270,7 +270,7 @@ describe('writeOutput', () => {
       await assertRejects(
         () => writeOutput(outputPath, 'content', false, stats),
         Error,
-        'R-010',
+        'Forbidden Output',
       );
     });
   });

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -670,8 +670,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
           // Positional path argument: already normalized, assign to dir
           result.dir = normalized;
         } else {
-          console.error(`Error: unknown option: ${arg}`);
-          Deno.exit(1);
+          throw new ChatlogError('InvalidArgs', `unknown option: ${arg}`);
         }
       }
     }
@@ -730,52 +729,58 @@ const _DEFAULT_OUTPUT_DIR = 'temp/normalize_logs';
  * @param hashFn - Optional hash generator for output file names (injectable for testing)
  */
 export async function main(argv?: string[], hashFn?: HashProvider): Promise<void> {
-  const args = parseArgs(argv ?? Deno.args);
-  const resolved = resolveInputDir(args);
-  if (!resolved.ok) {
-    logger.error(`Error: ${resolved.error}`);
-    Deno.exit(1);
-  }
-  if (!validateInputDir(resolved.dir)) {
-    logger.error(`Error: directory not found: ${resolved.dir}`);
-    Deno.exit(1);
-  }
-  const inputDir = resolved.dir;
-  const outputBase = args.output ?? _DEFAULT_OUTPUT_DIR;
-
-  const mdFiles = findMdFiles(inputDir);
-  const stats: Stats = { success: 0, skip: 0, fail: 0 };
-
-  const tasks = mdFiles.map((filePath) => async () => {
-    const content = await Deno.readTextFile(filePath);
-    const { meta: sourceMeta } = parseFrontmatter(content);
-
-    const segments = await segmentChatlog(filePath, content);
-    if (segments === null) {
-      stats.fail++;
-      return;
+  try {
+    const args = parseArgs(argv ?? Deno.args);
+    const resolved = resolveInputDir(args);
+    if (!resolved.ok) {
+      throw new ChatlogError('InputNotFound', resolved.error);
     }
-
-    const outputDir = resolveOutputDir(inputDir, outputBase, sourceMeta['project']);
-    await Deno.mkdir(outputDir, { recursive: true });
-
-    for (let i = 0; i < segments.length; i++) {
-      const segment = segments[i];
-      const outputFileName = await generateOutputFileName(filePath, i, hashFn);
-      const segmentContent = generateSegmentFile(segment);
-      const fullContent = attachFrontmatter(segmentContent, sourceMeta, {
-        title: segment.title,
-        log_id: outputFileName.replace(/\.md$/, ''),
-        summary: segment.summary,
-      });
-      const outputPath = `${outputDir}/${outputFileName}`;
-      await writeOutput(outputPath, fullContent, args.dryRun, stats);
+    if (!validateInputDir(resolved.dir)) {
+      throw new ChatlogError('InputNotFound', `directory not found: ${resolved.dir}`);
     }
-  });
+    const inputDir = resolved.dir;
+    const outputBase = args.output ?? _DEFAULT_OUTPUT_DIR;
 
-  await withConcurrency(tasks, args.concurrency);
+    const mdFiles = findMdFiles(inputDir);
+    const stats: Stats = { success: 0, skip: 0, fail: 0 };
 
-  reportResults(stats);
+    const tasks = mdFiles.map((filePath) => async () => {
+      const content = await Deno.readTextFile(filePath);
+      const { meta: sourceMeta } = parseFrontmatter(content);
+
+      const segments = await segmentChatlog(filePath, content);
+      if (segments === null) {
+        stats.fail++;
+        return;
+      }
+
+      const outputDir = resolveOutputDir(inputDir, outputBase, sourceMeta['project']);
+      await Deno.mkdir(outputDir, { recursive: true });
+
+      for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i];
+        const outputFileName = await generateOutputFileName(filePath, i, hashFn);
+        const segmentContent = generateSegmentFile(segment);
+        const fullContent = attachFrontmatter(segmentContent, sourceMeta, {
+          title: segment.title,
+          log_id: outputFileName.replace(/\.md$/, ''),
+          summary: segment.summary,
+        });
+        const outputPath = `${outputDir}/${outputFileName}`;
+        await writeOutput(outputPath, fullContent, args.dryRun, stats);
+      }
+    });
+
+    await withConcurrency(tasks, args.concurrency);
+
+    reportResults(stats);
+  } catch (e) {
+    if (e instanceof ChatlogError) {
+      logger.error(e.message);
+      Deno.exit(1);
+    }
+    throw e;
+  }
 }
 
 if (import.meta.main) {

--- a/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.parse-args.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.parse-args.unit.spec.ts
@@ -6,219 +6,96 @@
 //
 // This software is released under the MIT License.
 
-import { assertEquals } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
 // test target
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_CONCURRENCY, parseArgs } from '../../set-frontmatter.ts';
 
-// ─── デフォルト値の確認 ───────────────────────────────────────────────────────
+type Args = ReturnType<typeof parseArgs>;
 
 describe('parseArgs', () => {
+  // ─── T-SF-PA-01: デフォルト値 ────────────────────────────────────────────────
+
   describe('Given: 最小引数 ["/path/to/dir"]', () => {
     describe('When: parseArgs(["/path/to/dir"]) を呼び出す', () => {
       describe('Then: T-SF-PA-01 - デフォルト値が適用される', () => {
-        it('T-SF-PA-01-01: targetDir が "/path/to/dir" になる', () => {
-          const result = parseArgs(['/path/to/dir']);
-
-          assertEquals(result.targetDir, '/path/to/dir');
-        });
-
-        it('T-SF-PA-01-02: dicsDir が "./assets/dics" になる', () => {
-          const result = parseArgs(['/path/to/dir']);
-
-          assertEquals(result.dicsDir, './assets/dics');
-        });
-
-        it('T-SF-PA-01-03: dryRun が false になる', () => {
-          const result = parseArgs(['/path/to/dir']);
-
-          assertEquals(result.dryRun, false);
-        });
-
-        it('T-SF-PA-01-04: review が true になる', () => {
-          const result = parseArgs(['/path/to/dir']);
-
-          assertEquals(result.review, true);
-        });
-
-        it('T-SF-PA-01-05: concurrency が DEFAULT_CONCURRENCY になる', () => {
-          const result = parseArgs(['/path/to/dir']);
-
-          assertEquals(result.concurrency, DEFAULT_CONCURRENCY);
-        });
+        const _defaultCases: { id: string; field: keyof Args; expected: unknown }[] = [
+          { id: 'T-SF-PA-01-01', field: 'targetDir', expected: '/path/to/dir' },
+          { id: 'T-SF-PA-01-02', field: 'dicsDir', expected: './assets/dics' },
+          { id: 'T-SF-PA-01-03', field: 'dryRun', expected: false },
+          { id: 'T-SF-PA-01-04', field: 'review', expected: true },
+          { id: 'T-SF-PA-01-05', field: 'concurrency', expected: DEFAULT_CONCURRENCY },
+        ];
+        for (const { id, field, expected } of _defaultCases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs(['/path/to/dir'])[field], expected);
+          });
+        }
       });
     });
   });
 
-  // ─── --dry-run フラグの解析 ───────────────────────────────────────────────
+  // ─── T-SF-PA-02〜08: 単一オプション ──────────────────────────────────────────
 
-  describe('Given: ["/path", "--dry-run"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-02 - dryRun=true', () => {
-        it('T-SF-PA-02-01: dryRun が true になる', () => {
-          const result = parseArgs(['/path', '--dry-run']);
-
-          assertEquals(result.dryRun, true);
-        });
+  describe('Given: 単一オプション', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: 対応フィールドに値が設定される', () => {
+        const _cases: { id: string; args: string[]; field: keyof Args; expected: unknown }[] = [
+          { id: 'T-SF-PA-02-01', args: ['/path', '--dry-run'], field: 'dryRun', expected: true },
+          { id: 'T-SF-PA-03-01', args: ['/path', '--no-review'], field: 'review', expected: false },
+          { id: 'T-SF-PA-04-01', args: ['/path', '--dics', '/dics'], field: 'dicsDir', expected: '/dics' },
+          { id: 'T-SF-PA-05-01', args: ['/path', '--dics=/dics'], field: 'dicsDir', expected: '/dics' },
+          { id: 'T-SF-PA-06-01', args: ['/path', '--concurrency', '8'], field: 'concurrency', expected: 8 },
+          { id: 'T-SF-PA-07-01', args: ['/path', '--concurrency=8'], field: 'concurrency', expected: 8 },
+          {
+            id: 'T-SF-PA-08-01',
+            args: ['/path', '--concurrency=invalid'],
+            field: 'concurrency',
+            expected: DEFAULT_CONCURRENCY,
+          },
+        ];
+        for (const { id, args, field, expected } of _cases) {
+          it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs(args)[field], expected);
+          });
+        }
       });
     });
   });
 
-  // ─── --no-review フラグの解析 ─────────────────────────────────────────────
-
-  describe('Given: ["/path", "--no-review"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-03 - review=false', () => {
-        it('T-SF-PA-03-01: review が false になる', () => {
-          const result = parseArgs(['/path', '--no-review']);
-
-          assertEquals(result.review, false);
-        });
-      });
-    });
-  });
-
-  // ─── --dics オプション（スペース区切り）の解析 ───────────────────────────
-
-  describe('Given: ["/path", "--dics", "/dics"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-04 - dicsDir=/dics', () => {
-        it('T-SF-PA-04-01: dicsDir が "/dics" になる', () => {
-          const result = parseArgs(['/path', '--dics', '/dics']);
-
-          assertEquals(result.dicsDir, '/dics');
-        });
-      });
-    });
-  });
-
-  // ─── --dics=value 形式の解析 ─────────────────────────────────────────────
-
-  describe('Given: ["/path", "--dics=/dics"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-05 - --dics=value 形式のパース', () => {
-        it('T-SF-PA-05-01: dicsDir が "/dics" になる', () => {
-          const result = parseArgs(['/path', '--dics=/dics']);
-
-          assertEquals(result.dicsDir, '/dics');
-        });
-      });
-    });
-  });
-
-  // ─── --concurrency オプション（スペース区切り）の解析 ────────────────────
-
-  describe('Given: ["/path", "--concurrency", "8"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-06 - concurrency=8', () => {
-        it('T-SF-PA-06-01: concurrency が 8 になる', () => {
-          const result = parseArgs(['/path', '--concurrency', '8']);
-
-          assertEquals(result.concurrency, 8);
-        });
-      });
-    });
-  });
-
-  // ─── --concurrency=value 形式の解析 ──────────────────────────────────────
-
-  describe('Given: ["/path", "--concurrency=8"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-07 - --concurrency=value 形式のパース', () => {
-        it('T-SF-PA-07-01: concurrency が 8 になる', () => {
-          const result = parseArgs(['/path', '--concurrency=8']);
-
-          assertEquals(result.concurrency, 8);
-        });
-      });
-    });
-  });
-
-  // ─── --concurrency に無効値を渡した場合のフォールバック ──────────────────
-
-  describe('Given: ["/path", "--concurrency=invalid"] を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-08 - 無効値 → デフォルトにフォールバック', () => {
-        it('T-SF-PA-08-01: concurrency が DEFAULT_CONCURRENCY になる', () => {
-          const result = parseArgs(['/path', '--concurrency=invalid']);
-
-          assertEquals(result.concurrency, DEFAULT_CONCURRENCY);
-        });
-      });
-    });
-  });
-
-  // ─── 複数オプションの組み合わせ ──────────────────────────────────────────
+  // ─── T-SF-PA-09: 複数オプション組み合わせ ────────────────────────────────────
 
   describe('Given: 全オプションを組み合わせた引数', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-09 - 複数オプション組み合わせ', () => {
-        it('T-SF-PA-09-01: 全フィールドが正しく解析される', () => {
-          const result = parseArgs([
-            '/path/to/dir',
-            '--dry-run',
-            '--no-review',
-            '--dics',
-            '/dics',
-            '--concurrency',
-            '2',
-          ]);
-
-          assertEquals(result.targetDir, '/path/to/dir');
-          assertEquals(result.dryRun, true);
-          assertEquals(result.review, false);
-          assertEquals(result.dicsDir, '/dics');
-          assertEquals(result.concurrency, 2);
-        });
-      });
+    it('T-SF-PA-09-01: 全フィールドが正しく解析される', () => {
+      const result = parseArgs(['/path/to/dir', '--dry-run', '--no-review', '--dics', '/dics', '--concurrency', '2']);
+      assertEquals(result.targetDir, '/path/to/dir');
+      assertEquals(result.dryRun, true);
+      assertEquals(result.review, false);
+      assertEquals(result.dicsDir, '/dics');
+      assertEquals(result.concurrency, 2);
     });
   });
 
-  // ─── targetDir なし（空配列）で Deno.exit(1) が呼ばれる ──────────────────
+  // ─── 異常系: ChatlogError がスローされる ──────────────────────────────────────
 
-  describe('Given: 空配列 []', () => {
-    describe('When: parseArgs([]) を呼び出す', () => {
-      describe('Then: T-SF-PA-10 - targetDir なし → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-SF-PA-10-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          parseArgs([]);
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
-      });
-    });
-  });
-
-  // ─── 未知のオプションで Deno.exit(1) が呼ばれる ──────────────────────────
-
-  describe('Given: 未知のオプション ["/path", "--unknown"]', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-SF-PA-11 - 未知オプション → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-SF-PA-11-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          parseArgs(['/path', '--unknown']);
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
+  describe('Given: 不正な引数', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
+        const _errorCases: { id: string; args: string[]; label: string }[] = [
+          { id: 'T-SF-PA-10-01', args: [], label: 'targetDir なし（空配列）' },
+          { id: 'T-SF-PA-11-01', args: ['/path', '--unknown'], label: '未知オプション' },
+        ];
+        for (const { id, args, label } of _errorCases) {
+          it(`${id}: ${label} → ChatlogError(InvalidArgs) がスローされる`, () => {
+            assertThrows(
+              () => parseArgs(args),
+              ChatlogError,
+              'Invalid Args',
+            );
+          });
+        }
       });
     });
   });

--- a/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.render-prompt.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.render-prompt.unit.spec.ts
@@ -6,12 +6,11 @@
 //
 // This software is released under the MIT License.
 
-import { assertEquals } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import type { Stub } from '@std/testing/mock';
-import { stub } from '@std/testing/mock';
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
 
 // test target
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import { renderPrompt } from '../../set-frontmatter.ts';
 
 // ─── 基本的な変数置換 ─────────────────────────────────────────────────────────
@@ -71,47 +70,33 @@ describe('renderPrompt', () => {
     });
   });
 
-  // ─── 不正な変数名（大文字含む）で exit(1) ────────────────────────────────
+  // ─── 不正な変数名（大文字含む）で ChatlogError がスローされる ────────────────────────────────
 
   describe('Given: テンプレート "${BadName}" と変数 { BadName: "val" }', () => {
     describe('When: renderPrompt を呼び出す', () => {
-      describe('Then: T-SF-RP-05 - 大文字含む変数名 → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-SF-RP-05-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          renderPrompt('${BadName}', { BadName: 'val' });
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
+      describe('Then: T-SF-RP-05 - 大文字含む変数名 → ChatlogError(InvalidArgs)', () => {
+        it('T-SF-RP-05-01: ChatlogError(InvalidArgs) がスローされる', () => {
+          assertThrows(
+            () => renderPrompt('${BadName}', { BadName: 'val' }),
+            ChatlogError,
+            'Invalid Args',
+          );
         });
       });
     });
   });
 
-  // ─── 未定義変数で exit(1) ────────────────────────────────────────────────
+  // ─── 未定義変数で ChatlogError がスローされる ────────────────────────────────────────────────
 
   describe('Given: テンプレート "${missing}" と空の変数マップ {}', () => {
     describe('When: renderPrompt を呼び出す', () => {
-      describe('Then: T-SF-RP-06 - 未定義変数 → Deno.exit(1)', () => {
-        let exitStub: Stub<typeof Deno, [code?: number], never>;
-        beforeEach(() => {
-          exitStub = stub(Deno, 'exit');
-        });
-        afterEach(() => {
-          exitStub.restore();
-        });
-
-        it('T-SF-RP-06-01: Deno.exit(1) がちょうど1回呼ばれる', () => {
-          renderPrompt('${missing}', {});
-
-          assertEquals(exitStub.calls.length, 1);
-          assertEquals(exitStub.calls[0].args[0], 1);
+      describe('Then: T-SF-RP-06 - 未定義変数 → ChatlogError(InvalidArgs)', () => {
+        it('T-SF-RP-06-01: ChatlogError(InvalidArgs) がスローされる', () => {
+          assertThrows(
+            () => renderPrompt('${missing}', {}),
+            ChatlogError,
+            'Invalid Args',
+          );
         });
       });
     });

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -118,7 +118,7 @@ export async function loadDics(dicsDir: string): Promise<Dics> {
     try {
       return await Deno.readTextFile(path);
     } catch {
-      logger.warn(`警告: 辞書ファイルが見つかりません: ${path}`);
+      logger.warn(`辞書ファイルが見つかりません: ${path}`);
       return '';
     }
   };
@@ -189,7 +189,7 @@ export async function loadDics(dicsDir: string): Promise<Dics> {
     const system = typeof obj['system'] === 'string' ? (obj['system'] as string).trim() : '';
     const user = typeof obj['user'] === 'string' ? (obj['user'] as string).trim() : '';
     if (!system || !user) {
-      logger.warn(`警告: プロンプトテンプレート "${name}" に system/user キーがありません`);
+      logger.warn(`プロンプトテンプレート "${name}" に system/user キーがありません`);
     }
     return { system, user };
   };
@@ -222,12 +222,10 @@ export async function loadDics(dicsDir: string): Promise<Dics> {
 export function renderPrompt(template: string, vars: Record<string, string>): string {
   return template.replace(/\$\{([^}]+)\}/g, (_match, name: string) => {
     if (!/^[a-z_]+$/.test(name)) {
-      console.error(`エラー: 不正な変数名 "${name}" — 英小文字と "_" のみ使用可能`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不正な変数名 "${name}" — 英小文字と "_" のみ使用可能`);
     }
     if (!(name in vars)) {
-      console.error(`エラー: 未定義の変数 "${name}"`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `未定義の変数 "${name}"`);
     }
     return vars[name];
   });
@@ -629,13 +627,14 @@ export function parseArgs(args: string[]): Args {
     } else if (!arg.startsWith('-')) {
       targetDir = arg;
     } else {
-      console.error(`不明なオプション: ${arg}`);
-      Deno.exit(1);
+      throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
     }
   }
   if (!targetDir) {
-    console.error('Usage: set_frontmatter.ts <target_dir> [--dry-run] [--no-review] [--concurrency N] [--dics DIR]');
-    Deno.exit(1);
+    throw new ChatlogError(
+      'InvalidArgs',
+      'Usage: set_frontmatter.ts <target_dir> [--dry-run] [--no-review] [--concurrency N] [--dics DIR]',
+    );
   }
   return { targetDir, dicsDir, dryRun, review, concurrency };
 }
@@ -645,119 +644,127 @@ export function parseArgs(args: string[]): Args {
 // ─────────────────────────────────────────────
 
 export async function main(args: string[]): Promise<void> {
-  const { targetDir, dicsDir, dryRun, review, concurrency } = parseArgs(args);
-
   try {
-    const stat = await Deno.stat(targetDir);
-    if (!stat.isDirectory) { throw new Error(); }
-  } catch {
-    logger.error(`エラー: ディレクトリが見つかりません: ${targetDir}`);
-    Deno.exit(1);
-  }
+    const { targetDir, dicsDir, dryRun, review, concurrency } = parseArgs(args);
 
-  const dics = await loadDics(dicsDir);
-  logger.info(
-    `辞書読み込み完了: category=${dics.category.split(',').length}件 `
-      + `topics=${dics.topicEntries.length}件 tags=${dics.tags.split(',').length}件 `
-      + `types=${dics.typeEntries.length}件`,
-  );
+    try {
+      const stat = await Deno.stat(targetDir);
+      if (!stat.isDirectory) { throw new Error(); }
+    } catch (e) {
+      if (e instanceof ChatlogError) { throw e; }
+      throw new ChatlogError('InputNotFound', `ディレクトリが見つかりません: ${targetDir}`);
+    }
 
-  const allFiles = await findMdFiles(targetDir);
-  logger.info(`対象ファイル数: ${allFiles.length}`);
-  if (dryRun) { logger.info('dry-run モード: ファイルは更新しません'); }
-  if (!review) { logger.info('--no-review モード: Phase 3.5 をスキップします'); }
-  if (allFiles.length === 0) {
-    logger.info('対象ファイルなし');
-    Deno.exit(0);
-  }
+    const dics = await loadDics(dicsDir);
+    logger.info(
+      `辞書読み込み完了: category=${dics.category.split(',').length}件 `
+        + `topics=${dics.topicEntries.length}件 tags=${dics.tags.split(',').length}件 `
+        + `types=${dics.typeEntries.length}件`,
+    );
 
-  // Phase 1: メタ読み込み
-  const fileMetaList: FileMeta[] = [];
-  const stats: Stats = { total: allFiles.length, success: 0, fail: 0, skip: 0 };
-  for (const filePath of allFiles) {
-    const fm = await loadFileMeta(filePath);
-    if (!fm) {
-      logger.info(`  skip: ${filePath.split(/[/\\]/).pop()}`);
-      stats.skip++;
-    } else { fileMetaList.push(fm); }
-  }
-  logger.info(`メタ読み込み: ${fileMetaList.length}件（スキップ: ${stats.skip}件）`);
+    const allFiles = await findMdFiles(targetDir);
+    logger.info(`対象ファイル数: ${allFiles.length}`);
+    if (dryRun) { logger.info('dry-run モード: ファイルは更新しません'); }
+    if (!review) { logger.info('--no-review モード: Phase 3.5 をスキップします'); }
+    if (allFiles.length === 0) {
+      logger.info('対象ファイルなし');
+      return;
+    }
 
-  // Phase 2: type判定（並列）
-  logger.info(`\nPhase 2: type判定開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
-  const typeResults = await withConcurrency(fileMetaList.map((fm) => () => judgeType(fm, dics)), concurrency);
-  const typeMap = new Map(typeResults.map((r) => [r.file, r]));
-  for (const r of typeResults) { logger.info(`  type [${r.type}]: ${r.file.split(/[/\\]/).pop()}`); }
+    // Phase 1: メタ読み込み
+    const fileMetaList: FileMeta[] = [];
+    const stats: Stats = { total: allFiles.length, success: 0, fail: 0, skip: 0 };
+    for (const filePath of allFiles) {
+      const fm = await loadFileMeta(filePath);
+      if (!fm) {
+        logger.info(`  skip: ${filePath.split(/[/\\]/).pop()}`);
+        stats.skip++;
+      } else { fileMetaList.push(fm); }
+    }
+    logger.info(`メタ読み込み: ${fileMetaList.length}件（スキップ: ${stats.skip}件）`);
 
-  // Phase 3a: category判定（並列）
-  logger.info(`\nPhase 3a: category判定開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
-  const categoryResults = await withConcurrency(
-    fileMetaList.map((fm) => async () => {
-      const type = typeMap.get(fm.file)?.type ?? 'research';
-      const category = await judgeCategory(fm, type, dics);
-      logger.info(`  category [${category}]: ${fm.file.split(/[/\\]/).pop()}`);
-      return { file: fm.file, type, category };
-    }),
-    concurrency,
-  );
-  const categoryMap = new Map(categoryResults.map((r) => [r.file, r]));
+    // Phase 2: type判定（並列）
+    logger.info(`\nPhase 2: type判定開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+    const typeResults = await withConcurrency(fileMetaList.map((fm) => () => judgeType(fm, dics)), concurrency);
+    const typeMap = new Map(typeResults.map((r) => [r.file, r]));
+    for (const r of typeResults) { logger.info(`  type [${r.type}]: ${r.file.split(/[/\\]/).pop()}`); }
 
-  // Phase 3b: フロントマター生成（並列）
-  logger.info(`\nPhase 3b: フロントマター生成開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
-  const fmResults = await withConcurrency(
-    fileMetaList.map((fm) => () => {
-      const cr = categoryMap.get(fm.file);
-      const type = cr?.type ?? 'research';
-      const category = cr?.category ?? 'development';
-      return generateFrontmatter(fm, type, category, dics);
-    }),
-    concurrency,
-  );
-  const fmResultMap = new Map(fmResults.map((r) => [r.file, r]));
-  for (const r of fmResults) { logger.info(`  generated: ${r.file.split(/[/\\]/).pop()}`); }
-
-  // Phase 3.5: レビュー（並列）
-  if (review) {
-    logger.info(`\nPhase 3.5: フロントマターレビュー開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
-    const reviewResults = await withConcurrency(
-      fmResults.filter((r) => r.yaml).map((r) => () => reviewFrontmatter(r, dics)),
+    // Phase 3a: category判定（並列）
+    logger.info(`\nPhase 3a: category判定開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+    const categoryResults = await withConcurrency(
+      fileMetaList.map((fm) => async () => {
+        const type = typeMap.get(fm.file)?.type ?? 'research';
+        const category = await judgeCategory(fm, type, dics);
+        logger.info(`  category [${category}]: ${fm.file.split(/[/\\]/).pop()}`);
+        return { file: fm.file, type, category };
+      }),
       concurrency,
     );
-    for (const r of reviewResults) {
-      if (r.validity === 'fail') {
-        logger.warn(`  review FAIL: ${r.file.split(/[/\\]/).pop()} — ${r.errors.join('; ')}`);
-        const fm = fmResultMap.get(r.file);
-        if (fm) {
-          fmResultMap.set(r.file, {
-            ...fm,
-            type: r.correctedType || fm.type,
-            category: r.correctedCategory || fm.category,
-            yaml: r.correctedYaml || fm.yaml,
-          });
+    const categoryMap = new Map(categoryResults.map((r) => [r.file, r]));
+
+    // Phase 3b: フロントマター生成（並列）
+    logger.info(`\nPhase 3b: フロントマター生成開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+    const fmResults = await withConcurrency(
+      fileMetaList.map((fm) => () => {
+        const cr = categoryMap.get(fm.file);
+        const type = cr?.type ?? 'research';
+        const category = cr?.category ?? 'development';
+        return generateFrontmatter(fm, type, category, dics);
+      }),
+      concurrency,
+    );
+    const fmResultMap = new Map(fmResults.map((r) => [r.file, r]));
+    for (const r of fmResults) { logger.info(`  generated: ${r.file.split(/[/\\]/).pop()}`); }
+
+    // Phase 3.5: レビュー（並列）
+    if (review) {
+      logger.info(`\nPhase 3.5: フロントマターレビュー開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+      const reviewResults = await withConcurrency(
+        fmResults.filter((r) => r.yaml).map((r) => () => reviewFrontmatter(r, dics)),
+        concurrency,
+      );
+      for (const r of reviewResults) {
+        if (r.validity === 'fail') {
+          logger.warn(`  review FAIL: ${r.file.split(/[/\\]/).pop()} — ${r.errors.join('; ')}`);
+          const fm = fmResultMap.get(r.file);
+          if (fm) {
+            fmResultMap.set(r.file, {
+              ...fm,
+              type: r.correctedType || fm.type,
+              category: r.correctedCategory || fm.category,
+              yaml: r.correctedYaml || fm.yaml,
+            });
+          }
+        } else {
+          logger.info(`  review OK: ${r.file.split(/[/\\]/).pop()}`);
         }
-      } else {
-        logger.info(`  review OK: ${r.file.split(/[/\\]/).pop()}`);
       }
+    } else {
+      logger.info(`\nPhase 3.5: スキップ (--no-review)`);
     }
-  } else {
-    logger.info(`\nPhase 3.5: スキップ (--no-review)`);
-  }
 
-  // Phase 4: 書き込み
-  logger.info(`\nPhase 4: Markdownへ書き込み`);
-  for (const fm of fileMetaList) {
-    const result = fmResultMap.get(fm.file);
-    if (!result) {
-      stats.fail++;
-      continue;
+    // Phase 4: 書き込み
+    logger.info(`\nPhase 4: Markdownへ書き込み`);
+    for (const fm of fileMetaList) {
+      const result = fmResultMap.get(fm.file);
+      if (!result) {
+        stats.fail++;
+        continue;
+      }
+      await writeFrontmatter(fm, result, dryRun, stats);
     }
-    await writeFrontmatter(fm, result, dryRun, stats);
-  }
 
-  const drySuffix = dryRun ? ' (dry-run)' : '';
-  logger.info(
-    `\n完了${drySuffix}: total=${stats.total} success=${stats.success} fail=${stats.fail} skip=${stats.skip}`,
-  );
+    const drySuffix = dryRun ? ' (dry-run)' : '';
+    logger.info(
+      `\n完了${drySuffix}: total=${stats.total} success=${stats.success} fail=${stats.fail} skip=${stats.skip}`,
+    );
+  } catch (e) {
+    if (e instanceof ChatlogError) {
+      logger.error(e.message);
+      Deno.exit(1);
+    }
+    throw e;
+  }
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Overview

**Summary**
Unify error exit handling across all chatlog scripts by replacing direct `Deno.exit()` calls with `ChatlogError` throws.

**Background / Motivation**
各スクリプトで `console.error + Deno.exit(1)` が散在しており、unit テストでプロセス終了の副作用が発生していた。
`ChatlogError` をスローする統一パターンに置き換えることで、エラー処理の一貫性とテスト容易性を向上させる。
また `chatlog-error.constants.ts` に `InvalidArgs` / `InputNotFound` ラベルを追加し、`ForbiddenOutput` のラベルも修正した。

## Changes

- `skills/_scripts/constants/chatlog-error.constants.ts` — `InvalidArgs`, `InputNotFound` ラベル追加、`ForbiddenOutput` ラベル修正
- `skills/classify-chatlog/scripts/classify-chatlog.ts` — exit 処理統一化
- `skills/export-chatlog/scripts/export-chatlog.ts` — exit 処理統一化
- `skills/filter-chatlog/scripts/filter-chatlog.ts` — exit 処理統一化
- `skills/filter-chatlog/scripts/prefilter-chatlog.ts` — exit 処理統一化
- `skills/normalize-chatlog/scripts/normalize-chatlog.ts` — exit 処理統一化
- `skills/set-frontmatter/scripts/set-frontmatter.ts` — exit 処理統一化
- テスト 11件: `Deno.exit` stub → `assertThrows(ChatlogError)` に移行

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

- 各スクリプトで重複していた `Deno.exit` 直接呼び出しのパターンを排除し、エラー処理を `ChatlogError` による例外モデルに一本化
- unit テストでのプロセス終了副作用が排除され、`assertThrows` による純粋なエラー検証が可能になった
- system test (`classify-chatlog.main.system.spec.ts`) はサブプロセス起動による終了コード検証を担当し、unit テストとの役割分担を明確化
