### PR TITLE
refactor(libs): add shared utils and refactor scripts to use them

### DIFF
--- a/skills/_scripts/libs/__tests__/unit/frontmatter-utils.unit.spec.ts
+++ b/skills/_scripts/libs/__tests__/unit/frontmatter-utils.unit.spec.ts
@@ -1,0 +1,236 @@
+// src: skills/_scripts/libs/__tests__/unit/frontmatter-utils.unit.spec.ts
+// @(#): frontmatter-utils ユニットテスト
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// -- test target --
+import { extractFrontmatter } from '../../frontmatter-utils.ts';
+
+// ─────────────────────────────────────────────
+// extractFrontmatter
+// ─────────────────────────────────────────────
+
+describe('extractFrontmatter', () => {
+  describe('Given: title と category を含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-01 - title, category が正しく取得できる', () => {
+        it('T-LIB-FM-01: 基本フィールド（string）のパース', () => {
+          const text = '---\ntitle: Hello\ncategory: dev\n---\nbody text';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['title'], 'Hello');
+          assertEquals(result.meta['category'], 'dev');
+        });
+      });
+    });
+  });
+
+  describe('Given: topics に配列を含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-02 - topics が配列として取得できる', () => {
+        it('T-LIB-FM-02: 配列フィールドのパース', () => {
+          const text = '---\ntopics:\n  - alpha\n  - beta\n---\nbody';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['topics'], ['alpha', 'beta']);
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter と本文を含むテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-03 - frontmatterEnd が本文開始位置と一致する', () => {
+        it('T-LIB-FM-03: frontmatterEnd の正確性', () => {
+          // "---\ntitle: Hi\n" = 14 chars (index 0-13)
+          // "\n---\n" starts at index 13, length 5 → frontmatterEnd = 13 + 5 = 18
+          const text = '---\ntitle: Hi\n---\nbody text';
+          const result = extractFrontmatter(text);
+          // frontmatterEnd should point to the start of "body text" = index 18
+          assertEquals(result.frontmatterEnd, 18);
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter と複数行の本文を含むテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-04 - body が frontmatter 以降の本文と一致する', () => {
+        it('T-LIB-FM-04: body の正確性', () => {
+          const text = '---\ntitle: Hello\n---\nThis is the body.\nSecond line.';
+          const result = extractFrontmatter(text);
+          assertEquals(result.body, 'This is the body.\nSecond line.');
+        });
+      });
+    });
+  });
+
+  describe('Given: ---\\n で始まらないプレーンテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-05 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
+        it('T-LIB-FM-05: frontmatter なし（---\\n で始まらない）', () => {
+          const text = 'This is plain text without frontmatter.';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, text);
+          assertEquals(result.frontmatterEnd, 0);
+        });
+      });
+    });
+  });
+
+  describe('Given: 開き --- はあるが閉じ --- がないテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-06 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
+        it('T-LIB-FM-06: 閉じ --- なし', () => {
+          const text = '---\ntitle: Hello\nno closing separator';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, text);
+          assertEquals(result.frontmatterEnd, 0);
+        });
+      });
+    });
+  });
+
+  describe('Given: CRLF 改行を含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-07 - CRLF でも正しくパースされる', () => {
+        it('T-LIB-FM-07: CRLF 改行の正規化', () => {
+          const text = '---\r\ntitle: Hello\r\ncategory: dev\r\n---\r\nbody text';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['title'], 'Hello');
+          assertEquals(result.meta['category'], 'dev');
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の frontmatter ブロック（---\\n---\\n の形式）', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-08 - meta:{}, body が後続テキストになる', () => {
+        it('T-LIB-FM-08: 空の frontmatter ブロック', () => {
+          const text = '---\n---\nafter body';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, 'after body');
+        });
+      });
+    });
+  });
+
+  describe('Given: 不正な YAML を含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-09 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
+        it('T-LIB-FM-09: YAML パース失敗（不正な YAML）', () => {
+          const text = '---\n: invalid: yaml: {\n---\nbody';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, text);
+          assertEquals(result.frontmatterEnd, 0);
+        });
+      });
+    });
+  });
+
+  describe('Given: 数値フィールドを含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-10 - count が number として取得できる', () => {
+        it('T-LIB-FM-10: 数値フィールド', () => {
+          const text = '---\ncount: 42\n---\nbody';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['count'], 42);
+        });
+      });
+    });
+  });
+
+  describe('Given: 空文字列', () => {
+    describe('When: extractFrontmatter("") を呼び出す', () => {
+      describe('Then: T-LIB-FM-11 - meta:{}, body="", frontmatterEnd=0 が返る', () => {
+        it('T-LIB-FM-11: 空文字列入力', () => {
+          const result = extractFrontmatter('');
+          assertEquals(result.meta, {});
+          assertEquals(result.body, '');
+          assertEquals(result.frontmatterEnd, 0);
+        });
+      });
+    });
+  });
+
+  describe('Given: 開き --- のみで本文も閉じ --- もないテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-12 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
+        it('T-LIB-FM-12: 開き --- のみ（EOF）', () => {
+          const text = '---\n';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, text);
+          assertEquals(result.frontmatterEnd, 0);
+        });
+      });
+    });
+  });
+
+  describe('Given: 閉じ区切りが \\n--- で終わり末尾改行なしのテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-13 - \\n---\\n にマッチしないため失敗パス', () => {
+        it('T-LIB-FM-13: 末尾改行なしの閉じ ---', () => {
+          const text = '---\ntitle: Hello\n---';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, text);
+          assertEquals(result.frontmatterEnd, 0);
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter のみで本文が空のテキスト', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-14 - body が空文字列で frontmatterEnd が正しい', () => {
+        it('T-LIB-FM-14: frontmatter 後の本文が空', () => {
+          const text = '---\ntitle: Hello\n---\n';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['title'], 'Hello');
+          assertEquals(result.body, '');
+          assertEquals(result.frontmatterEnd, text.length);
+        });
+      });
+    });
+  });
+
+  describe('Given: CRLF 改行を含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-15 - body と frontmatterEnd も正しく取得できる', () => {
+        it('T-LIB-FM-15: CRLF 正規化後の body と frontmatterEnd', () => {
+          // CRLF を LF に正規化してから処理するため、frontmatterEnd は正規化後の位置
+          // "---\ntitle: Hi\n---\n" = 18 chars → frontmatterEnd=18, body=""
+          const text = '---\r\ntitle: Hi\r\n---\r\nbody text';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['title'], 'Hi');
+          assertEquals(result.body, 'body text');
+          assertEquals(result.frontmatterEnd, 18);
+        });
+      });
+    });
+  });
+
+  describe('Given: YAML 値の中に --- を含む frontmatter ブロック', () => {
+    describe('When: extractFrontmatter(text) を呼び出す', () => {
+      describe('Then: T-LIB-FM-16 - 値内の --- を区切りと誤認しない', () => {
+        it('T-LIB-FM-16: YAML 値内に --- を含む（quoted string）', () => {
+          const text = '---\nsummary: "foo --- bar"\n---\nbody';
+          const result = extractFrontmatter(text);
+          assertEquals(result.meta['summary'], 'foo --- bar');
+          assertEquals(result.body, 'body');
+        });
+      });
+    });
+  });
+});

--- a/skills/_scripts/libs/__tests__/unit/text-utils.unit.spec.ts
+++ b/skills/_scripts/libs/__tests__/unit/text-utils.unit.spec.ts
@@ -1,0 +1,186 @@
+// src: skills/_scripts/libs/__tests__/unit/text-utils.unit.spec.ts
+// @(#): text-utils ユニットテスト
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// -- test target --
+import { toStringArrayWithNull, toStringWithNull } from '../../../libs/text-utils.ts';
+
+// ─────────────────────────────────────────────
+// toStringWithNull
+// ─────────────────────────────────────────────
+
+describe('toStringWithNull', () => {
+  describe('Given: null', () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-01 - "" が返る', () => {
+        it('T-LIB-TU-01: null は空文字列を返す', () => {
+          assertEquals(toStringWithNull(null), '');
+        });
+      });
+    });
+  });
+
+  describe('Given: undefined', () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-02 - "" が返る', () => {
+        it('T-LIB-TU-02: undefined は空文字列を返す', () => {
+          assertEquals(toStringWithNull(undefined), '');
+        });
+      });
+    });
+  });
+
+  describe("Given: 文字列 'hello'", () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-03 - 'hello' が返る", () => {
+        it('T-LIB-TU-03: 文字列はそのまま返す', () => {
+          assertEquals(toStringWithNull('hello'), 'hello');
+        });
+      });
+    });
+  });
+
+  describe("Given: 空文字列 ''", () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-04 - '' が返る", () => {
+        it('T-LIB-TU-04: 空文字列はそのまま返す', () => {
+          assertEquals(toStringWithNull(''), '');
+        });
+      });
+    });
+  });
+
+  describe('Given: 数値 42', () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-05 - '42' が返る", () => {
+        it('T-LIB-TU-05: 数値は文字列に変換して返す', () => {
+          assertEquals(toStringWithNull(42), '42');
+        });
+      });
+    });
+  });
+
+  describe('Given: 数値 0', () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-06 - '0' が返る", () => {
+        it("T-LIB-TU-06: 数値 0 は '0' を返す（null 扱いにならない）", () => {
+          assertEquals(toStringWithNull(0), '0');
+        });
+      });
+    });
+  });
+
+  describe('Given: オブジェクト { a: 1 }', () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-07 - '[object Object]' が返る", () => {
+        it('T-LIB-TU-07: オブジェクトは String() 変換結果を返す', () => {
+          assertEquals(toStringWithNull({ a: 1 }), '[object Object]');
+        });
+      });
+    });
+  });
+
+  describe('Given: 真偽値 true', () => {
+    describe('When: toStringWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-08 - 'true' が返る", () => {
+        it("T-LIB-TU-08: true は 'true' を返す", () => {
+          assertEquals(toStringWithNull(true), 'true');
+        });
+      });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// toStringArrayWithNull
+// ─────────────────────────────────────────────
+
+describe('toStringArrayWithNull', () => {
+  describe("Given: 文字列配列 ['a', 'b']", () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-09 - ['a', 'b'] が返る", () => {
+        it('T-LIB-TU-09: 文字列配列はそのまま返す', () => {
+          assertEquals(toStringArrayWithNull(['a', 'b']), ['a', 'b']);
+        });
+      });
+    });
+  });
+
+  describe("Given: 数値混在配列 [1, 'two', 3]", () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe("Then: T-LIB-TU-10 - ['1', 'two', '3'] が返る", () => {
+        it('T-LIB-TU-10: 数値混在配列は全要素を文字列に変換して返す', () => {
+          assertEquals(toStringArrayWithNull([1, 'two', 3]), ['1', 'two', '3']);
+        });
+      });
+    });
+  });
+
+  describe('Given: 空配列 []', () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-11 - [] が返る', () => {
+        it('T-LIB-TU-11: 空配列はそのまま空配列を返す', () => {
+          assertEquals(toStringArrayWithNull([]), []);
+        });
+      });
+    });
+  });
+
+  describe('Given: null', () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-12 - [] が返る', () => {
+        it('T-LIB-TU-12: null は空配列を返す', () => {
+          assertEquals(toStringArrayWithNull(null), []);
+        });
+      });
+    });
+  });
+
+  describe('Given: undefined', () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-13 - [] が返る', () => {
+        it('T-LIB-TU-13: undefined は空配列を返す', () => {
+          assertEquals(toStringArrayWithNull(undefined), []);
+        });
+      });
+    });
+  });
+
+  describe("Given: 文字列 'hello'（配列でない）", () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-14 - [] が返る', () => {
+        it('T-LIB-TU-14: 文字列は配列でないため空配列を返す', () => {
+          assertEquals(toStringArrayWithNull('hello'), []);
+        });
+      });
+    });
+  });
+
+  describe('Given: 数値 42（配列でない）', () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-15 - [] が返る', () => {
+        it('T-LIB-TU-15: 数値は配列でないため空配列を返す', () => {
+          assertEquals(toStringArrayWithNull(42), []);
+        });
+      });
+    });
+  });
+
+  describe('Given: オブジェクト { a: 1 }（配列でない）', () => {
+    describe('When: toStringArrayWithNull を実行する', () => {
+      describe('Then: T-LIB-TU-16 - [] が返る', () => {
+        it('T-LIB-TU-16: オブジェクトは配列でないため空配列を返す', () => {
+          assertEquals(toStringArrayWithNull({ a: 1 }), []);
+        });
+      });
+    });
+  });
+});

--- a/skills/_scripts/libs/__tests__/unit/utils.unit.spec.ts
+++ b/skills/_scripts/libs/__tests__/unit/utils.unit.spec.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // -- BDD modules --
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // -- test target --
@@ -17,6 +17,7 @@ import {
   homeDir,
   normalizeLine,
   normalizePath,
+  readTextFile,
   textToSlug,
 } from '../../../libs/utils.ts';
 
@@ -385,6 +386,62 @@ describe('textToSlug', () => {
       describe('Then: T-LIB-U-10-08 - 第 1 段落のみが使われる', () => {
         it('T-LIB-U-10-08: 2 段落目以降は無視されスラッグが返る', () => {
           assertEquals(textToSlug('first paragraph\n\nsecond paragraph'), 'first-paragraph');
+        });
+      });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// readTextFile
+// ─────────────────────────────────────────────
+
+describe('readTextFile', () => {
+  describe('Given: LF 改行のテキストファイルが存在する', () => {
+    describe('When: readTextFile を実行する', () => {
+      describe('Then: T-LIB-U-RF-01 - LF 正規化した文字列が返る', () => {
+        it('T-LIB-U-RF-01: 存在するファイルを読み込み LF 正規化した文字列を返す', async () => {
+          const _tmpPath = await Deno.makeTempFile({ prefix: 'utils-test-rf01-' });
+          try {
+            const _content = 'line1\nline2\nline3';
+            await Deno.writeTextFile(_tmpPath, _content);
+            const _result = await readTextFile(_tmpPath);
+            assertEquals(_result, _content);
+          } finally {
+            await Deno.remove(_tmpPath);
+          }
+        });
+      });
+    });
+  });
+
+  describe('Given: CRLF 改行のテキストファイルが存在する', () => {
+    describe('When: readTextFile を実行する', () => {
+      describe('Then: T-LIB-U-RF-02 - CRLF が LF に正規化された文字列が返る', () => {
+        it('T-LIB-U-RF-02: CRLF ファイルを読み込むと LF に正規化される', async () => {
+          const _tmpPath = await Deno.makeTempFile({ prefix: 'utils-test-rf02-' });
+          try {
+            await Deno.writeTextFile(_tmpPath, 'line1\r\nline2\r\nline3');
+            const _result = await readTextFile(_tmpPath);
+            assertEquals(_result, 'line1\nline2\nline3');
+          } finally {
+            await Deno.remove(_tmpPath);
+          }
+        });
+      });
+    });
+  });
+
+  describe('Given: 存在しないファイルパスを渡す', () => {
+    describe('When: readTextFile を実行する', () => {
+      describe('Then: T-LIB-U-RF-03 - Deno.errors.NotFound がスローされる', () => {
+        it('T-LIB-U-RF-03: 存在しないファイルパスを渡すと Deno.errors.NotFound がスローされる', async () => {
+          const _tmpPath = await Deno.makeTempFile({ prefix: 'utils-test-rf03-' });
+          await Deno.remove(_tmpPath);
+          await assertRejects(
+            () => readTextFile(_tmpPath),
+            Deno.errors.NotFound,
+          );
         });
       });
     });

--- a/skills/_scripts/libs/frontmatter-utils.ts
+++ b/skills/_scripts/libs/frontmatter-utils.ts
@@ -1,0 +1,62 @@
+// src: skills/_scripts/libs/frontmatter-utils.ts
+// @(#): Frontmatter パースユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { parse as parseYaml } from '@std/yaml';
+
+export type FrontmatterResult = {
+  meta: Record<string, unknown>;
+  body: string;
+  frontmatterEnd: number;
+};
+
+type BlockResult = {
+  yamlText: string;
+  frontmatterEnd: number;
+};
+
+/** 正規化済みテキストから frontmatter ブロックを抽出する。見つからない場合は null を返す。 */
+const _extractBlock = (normalized: string): BlockResult | null => {
+  const _lines = normalized.split('\n');
+  if (_lines[0] !== '---') { return null; }
+
+  const _closeIdx = _lines.indexOf('---', 1);
+  // 閉じ --- の後に必ず改行が必要（末尾が --- で終わる場合は不正）
+  if (_closeIdx === -1 || _closeIdx === _lines.length - 1) { return null; }
+
+  const _yamlLines = _lines.slice(1, _closeIdx);
+  return {
+    yamlText: _yamlLines.join('\n'),
+    frontmatterEnd: ['---', ..._yamlLines, '---', ''].join('\n').length,
+  };
+};
+
+/** Markdown テキストから frontmatter を抽出してパースする。 */
+export const extractFrontmatter = (text: string): FrontmatterResult => {
+  const _normalized = text.replace(/\r\n/g, '\n');
+  const _failure: FrontmatterResult = { meta: {}, body: text, frontmatterEnd: 0 };
+
+  const _block = _extractBlock(_normalized);
+  if (_block === null) { return _failure; }
+
+  let _parsed: unknown;
+  try {
+    _parsed = parseYaml(_block.yamlText);
+  } catch {
+    return _failure;
+  }
+
+  const _meta = (_parsed !== null && _parsed !== undefined && typeof _parsed === 'object' && !Array.isArray(_parsed))
+    ? (_parsed as Record<string, unknown>)
+    : {};
+
+  return {
+    meta: _meta,
+    body: _normalized.slice(_block.frontmatterEnd),
+    frontmatterEnd: _block.frontmatterEnd,
+  };
+};

--- a/skills/_scripts/libs/text-utils.ts
+++ b/skills/_scripts/libs/text-utils.ts
@@ -1,0 +1,11 @@
+// src: skills/_scripts/libs/text-utils.ts
+// @(#): テキスト処理ユーティリティ（null/undefined を空文字列にフォールバックする型変換）
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+export const toStringWithNull = (v: unknown): string => v == null ? '' : typeof v === 'string' ? v : String(v);
+
+export const toStringArrayWithNull = (v: unknown): string[] => Array.isArray(v) ? v.map(String) : [];

--- a/skills/_scripts/libs/utils.ts
+++ b/skills/_scripts/libs/utils.ts
@@ -37,6 +37,11 @@ export const getFileName = (path: string): string => {
   return normalizePath(path).split('/').pop() ?? '';
 };
 
+/** ファイルを読み込み、行末文字を LF に正規化して返す。 */
+export const readTextFile = async (path: string): Promise<string> => {
+  return normalizeLine(await Deno.readTextFile(path));
+};
+
 /**
  * テキストからファイル名用の URL セーフなスラッグ文字列を生成する。
  * 英小文字・数字・ハイフンのみからなる 3〜50 文字のスラッグ、または `fallback` を返す。

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -17,11 +17,13 @@
 // -- external --
 import { runChunked } from '../../_scripts/libs/concurrency.ts';
 import { findEntries } from '../../_scripts/libs/find-entries.ts';
+import { extractFrontmatter } from '../../_scripts/libs/frontmatter-utils.ts';
 import { parseJsonArray } from '../../_scripts/libs/json-utils.ts';
 import { isValidModel } from '../../_scripts/libs/model-utils.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/parse-args.ts';
 import { runAI } from '../../_scripts/libs/run-ai.ts';
-import { getDirectory, normalizeLine, normalizePath } from '../../_scripts/libs/utils.ts';
+import { toStringArrayWithNull, toStringWithNull } from '../../_scripts/libs/text-utils.ts';
+import { getDirectory, normalizeLine, normalizePath, readTextFile } from '../../_scripts/libs/utils.ts';
 // instances
 import { logger } from '../../_scripts/libs/logger.ts';
 // constants
@@ -52,7 +54,7 @@ export const loadProjects = async (dicsDir: string): Promise<string[]> => {
   const dicPath = `${dicsDir}/projects.dic`;
   let text: string;
   try {
-    text = await Deno.readTextFile(dicPath);
+    text = await readTextFile(dicPath);
   } catch {
     logger.warn(`projects.dic が見つかりません: ${dicPath}`);
     return [];
@@ -68,52 +70,16 @@ export const loadProjects = async (dicsDir: string): Promise<string[]> => {
 // ─────────────────────────────────────────────
 
 export const parseFrontmatter = (text: string): FrontmatterData => {
-  const empty: FrontmatterData = {
-    project: '',
-    title: '',
-    category: '',
-    topics: [],
-    tags: [],
-    frontmatterEnd: 0,
+  const { meta, frontmatterEnd } = extractFrontmatter(text);
+
+  return {
+    project: toStringWithNull(meta['project']),
+    title: toStringWithNull(meta['title']),
+    category: toStringWithNull(meta['category']),
+    topics: toStringArrayWithNull(meta['topics']),
+    tags: toStringArrayWithNull(meta['tags']),
+    frontmatterEnd,
   };
-
-  const normalized = text.replace(/\r\n/g, '\n');
-  if (!normalized.startsWith('---\n')) { return empty; }
-
-  const end = normalized.indexOf('\n---\n', 4);
-  if (end === -1) { return empty; }
-
-  const fmText = normalized.slice(4, end);
-  const frontmatterEnd = end + 5; // '\n---\n' の後
-
-  const lines = fmText.split('\n');
-  const result: FrontmatterData = { project: '', title: '', category: '', topics: [], tags: [], frontmatterEnd };
-
-  let currentList: string[] | null = null;
-
-  for (const line of lines) {
-    const listMatch = line.match(/^\s{2}- (.+)$/);
-    if (listMatch && currentList) {
-      currentList.push(listMatch[1].trim());
-      continue;
-    }
-
-    currentList = null;
-
-    if (line.startsWith('title:')) {
-      result.title = line.slice('title:'.length).trim();
-    } else if (line.startsWith('category:')) {
-      result.category = line.slice('category:'.length).trim();
-    } else if (line.startsWith('project:')) {
-      result.project = line.slice('project:'.length).trim();
-    } else if (line === 'topics:') {
-      currentList = result.topics;
-    } else if (line === 'tags:') {
-      currentList = result.tags;
-    }
-  }
-
-  return result;
 };
 
 // ─────────────────────────────────────────────
@@ -121,29 +87,27 @@ export const parseFrontmatter = (text: string): FrontmatterData => {
 // ─────────────────────────────────────────────
 
 export const insertProjectField = (text: string, project: string): string => {
-  const normalized = text.replace(/\r\n/g, '\n');
-  if (!normalized.startsWith('---\n')) { return text; }
+  const _normalized = text.replace(/\r\n/g, '\n');
+  const _lines = _normalized.split('\n');
+  if (_lines[0] !== '---') { return text; }
 
-  const end = normalized.indexOf('\n---\n', 4);
-  if (end === -1) { return text; }
+  const _closeIdx = _lines.indexOf('---', 1);
+  if (_closeIdx === -1) { return text; }
 
-  const fmText = normalized.slice(4, end);
-  const lines = fmText.split('\n');
-
-  const newLines: string[] = [];
-  let inserted = false;
-  for (const line of lines) {
-    newLines.push(line);
-    if (!inserted && line.startsWith('date:')) {
-      newLines.push(`project: ${project}`);
-      inserted = true;
+  const _fmLines = _lines.slice(1, _closeIdx);
+  const _newFmLines: string[] = [];
+  let _inserted = false;
+  for (const line of _fmLines) {
+    _newFmLines.push(line);
+    if (!_inserted && line.startsWith('date:')) {
+      _newFmLines.push(`project: ${project}`);
+      _inserted = true;
     }
   }
-  if (!inserted) {
-    newLines.unshift(`project: ${project}`);
-  }
+  if (!_inserted) { _newFmLines.unshift(`project: ${project}`); }
 
-  return `---\n${newLines.join('\n')}\n---\n${normalized.slice(end + 5)}`;
+  const _bodyLines = _lines.slice(_closeIdx + 1);
+  return ['---', ..._newFmLines, '---', ..._bodyLines].join('\n');
 };
 
 // ─────────────────────────────────────────────
@@ -153,7 +117,7 @@ export const insertProjectField = (text: string, project: string): string => {
 export const loadFileMeta = async (filePath: string): Promise<FileMeta | null> => {
   let text: string;
   try {
-    text = await Deno.readTextFile(filePath);
+    text = await readTextFile(filePath);
   } catch {
     return null;
   }

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -30,6 +30,7 @@ import { runConcurrent } from '../../_scripts/libs/concurrency.ts';
 import { findFiles } from '../../_scripts/libs/find-files.ts';
 import { logger } from '../../_scripts/libs/logger.ts';
 import { cleanYaml } from '../../_scripts/libs/markdown-utils.ts';
+import { toStringArrayWithNull } from '../../_scripts/libs/text-utils.ts';
 import { normalizeLine } from '../../_scripts/libs/utils.ts';
 
 // ─────────────────────────────────────────────
@@ -164,14 +165,13 @@ export const loadDics = async (dicsDir: string): Promise<Dics> => {
       .map(([k, v]) => {
         const entry = v as Record<string, unknown>;
         const rulesRaw = entry['rules'] as Record<string, unknown> | undefined;
-        const toStrArray = (val: unknown): string[] => Array.isArray(val) ? val.map(String) : [];
         return {
           key: k,
           def: (entry['def'] as string | undefined)?.trim() ?? '',
           desc: (entry['desc'] as string | undefined)?.trim() ?? '',
           rules: {
-            when: toStrArray(rulesRaw?.['when']),
-            not: toStrArray(rulesRaw?.['not']),
+            when: toStringArrayWithNull(rulesRaw?.['when']),
+            not: toStringArrayWithNull(rulesRaw?.['not']),
           },
         };
       });


### PR DESCRIPTION
## Overview

**Summary**
Add shared utility helpers for frontmatter parsing, null-safe string conversion, and file reading;
migrate classify and set-frontmatter scripts to use them.

**Background / Motivation**
`classify-chatlog` と `set-frontmatter` の各スクリプトで、YAML frontmatter パースや文字列変換のロジックがそれぞれ独立して実装されており、重複・不整合が生じていた。
共通ユーティリティを `skills/_scripts/libs/` に集約することで、重複コードを排除し、一貫した実装を実現する。

## Changes

- `skills/_scripts/libs/frontmatter-utils.ts` — `extractFrontmatter` 関数を新規追加（YAML frontmatter の抽出・パース、
  CRLF 正規化、フォールバック処理）
- `skills/_scripts/libs/text-utils.ts` — null-safe 文字列変換ヘルパー `toStringWithNull` / `toStringArrayWithNull` を新規追加
- `skills/_scripts/libs/utils.ts` — LF 正規化付きファイル読み込み `readTextFile` ヘルパーを追加
- `skills/classify-chatlog/scripts/classify-chatlog.ts` — `parseFrontmatter` を
  `extractFrontmatter` ベースに整理、共通 `readTextFile` に統一
- `skills/set-frontmatter/scripts/set-frontmatter.ts` — ローカルヘルパー `toStrArray` を削除し、共通 `toStringArrayWithNull` に置き換え
- `skills/_scripts/libs/__tests__/unit/` — 各ユーティリティの BDD ユニットテストを追加（`frontmatter-utils`, `text-utils`, `utils`）

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

なし。
