### PR TITLE
refactor(frontmatter): 5 モジュール横断の frontmatter 統一リファクタリング

### DIFF
--- a/skills/_scripts/libs/__tests__/text/unit/frontmatter-utils.unit.spec.ts
+++ b/skills/_scripts/libs/__tests__/text/unit/frontmatter-utils.unit.spec.ts
@@ -64,7 +64,7 @@ describe('parseFrontmatter', () => {
         it('T-LIB-FM-04: body の正確性', () => {
           const text = '---\ntitle: Hello\n---\nThis is the body.\nSecond line.';
           const result = parseFrontmatter(text);
-          assertEquals(result.body, 'This is the body.\nSecond line.');
+          assertEquals(result.content, 'This is the body.\nSecond line.');
         });
       });
     });
@@ -77,7 +77,7 @@ describe('parseFrontmatter', () => {
           const text = 'This is plain text without frontmatter.';
           const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
           assertEquals(result.frontmatterEnd, 0);
         });
       });
@@ -91,7 +91,7 @@ describe('parseFrontmatter', () => {
           const text = '---\ntitle: Hello\nno closing separator';
           const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
           assertEquals(result.frontmatterEnd, 0);
         });
       });
@@ -118,7 +118,7 @@ describe('parseFrontmatter', () => {
           const text = '---\n---\nafter body';
           const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, 'after body');
+          assertEquals(result.content, 'after body');
         });
       });
     });
@@ -131,7 +131,7 @@ describe('parseFrontmatter', () => {
           const text = '---\n: invalid: yaml: {\n---\nbody';
           const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
           assertEquals(result.frontmatterEnd, 0);
         });
       });
@@ -156,7 +156,7 @@ describe('parseFrontmatter', () => {
         it('T-LIB-FM-11: 空文字列入力', () => {
           const result = parseFrontmatter('');
           assertEquals(result.meta, {});
-          assertEquals(result.body, '');
+          assertEquals(result.content, '');
           assertEquals(result.frontmatterEnd, 0);
         });
       });
@@ -170,7 +170,7 @@ describe('parseFrontmatter', () => {
           const text = '---\n';
           const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
           assertEquals(result.frontmatterEnd, 0);
         });
       });
@@ -184,7 +184,7 @@ describe('parseFrontmatter', () => {
           const text = '---\ntitle: Hello\n---';
           const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
           assertEquals(result.frontmatterEnd, 0);
         });
       });
@@ -198,7 +198,7 @@ describe('parseFrontmatter', () => {
           const text = '---\ntitle: Hello\n---\n';
           const result = parseFrontmatter(text);
           assertEquals(result.meta['title'], 'Hello');
-          assertEquals(result.body, '');
+          assertEquals(result.content, '');
           assertEquals(result.frontmatterEnd, text.length);
         });
       });
@@ -214,7 +214,7 @@ describe('parseFrontmatter', () => {
           const text = '---\r\ntitle: Hi\r\n---\r\nbody text';
           const result = parseFrontmatter(text);
           assertEquals(result.meta['title'], 'Hi');
-          assertEquals(result.body, 'body text');
+          assertEquals(result.content, 'body text');
           assertEquals(result.frontmatterEnd, 18);
         });
       });
@@ -228,7 +228,7 @@ describe('parseFrontmatter', () => {
           const text = '---\nsummary: "foo --- bar"\n---\nbody';
           const result = parseFrontmatter(text);
           assertEquals(result.meta['summary'], 'foo --- bar');
-          assertEquals(result.body, 'body');
+          assertEquals(result.content, 'body');
         });
       });
     });
@@ -284,7 +284,7 @@ describe('parseFrontmatterEntries', () => {
           const text = 'plain text without frontmatter';
           const result = parseFrontmatterEntries(text);
           assertEquals(result.meta, {});
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
         });
       });
     });
@@ -296,7 +296,37 @@ describe('parseFrontmatterEntries', () => {
         it('T-LIB-FSM-05: body の正確性', () => {
           const text = '---\ntitle: Hello\n---\n# 本文\n内容';
           const result = parseFrontmatterEntries(text);
-          assertEquals(result.body, '# 本文\n内容');
+          assertEquals(result.content, '# 本文\n内容');
+        });
+      });
+    });
+  });
+
+  describe('Given: 配列フィールドを含む frontmatter', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
+      describe('Then: T-LIB-FSM-06 - 配列フィールドが string[] として返る', () => {
+        it('T-LIB-FSM-06-01: 複数要素配列が順序保持で string[] に変換される', () => {
+          const text = '---\ntags:\n  - foo\n  - bar\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['tags'], ['foo', 'bar']);
+        });
+
+        it('T-LIB-FSM-06-02: 単一要素配列が string[] に変換される', () => {
+          const text = '---\ntags:\n  - foo\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['tags'], ['foo']);
+        });
+
+        it('T-LIB-FSM-06-03: 空配列が [] として返る', () => {
+          const text = '---\ntags: []\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['tags'], []);
+        });
+
+        it('T-LIB-FSM-06-04: null 混入配列の null 要素が空文字列に変換される', () => {
+          const text = '---\ntags:\n  - foo\n  - ~\n  - bar\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['tags'], ['foo', '', 'bar']);
         });
       });
     });

--- a/skills/_scripts/libs/__tests__/text/unit/frontmatter-utils.unit.spec.ts
+++ b/skills/_scripts/libs/__tests__/text/unit/frontmatter-utils.unit.spec.ts
@@ -11,19 +11,19 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // -- test target --
-import { extractFrontmatter } from '../../../text/frontmatter-utils.ts';
+import { parseFrontmatter, parseFrontmatterEntries } from '../../../text/frontmatter-utils.ts';
 
 // ─────────────────────────────────────────────
-// extractFrontmatter
+// parseFrontmatter
 // ─────────────────────────────────────────────
 
-describe('extractFrontmatter', () => {
+describe('parseFrontmatter', () => {
   describe('Given: title と category を含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-01 - title, category が正しく取得できる', () => {
         it('T-LIB-FM-01: 基本フィールド（string）のパース', () => {
           const text = '---\ntitle: Hello\ncategory: dev\n---\nbody text';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['title'], 'Hello');
           assertEquals(result.meta['category'], 'dev');
         });
@@ -32,11 +32,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: topics に配列を含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-02 - topics が配列として取得できる', () => {
         it('T-LIB-FM-02: 配列フィールドのパース', () => {
           const text = '---\ntopics:\n  - alpha\n  - beta\n---\nbody';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['topics'], ['alpha', 'beta']);
         });
       });
@@ -44,13 +44,13 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: frontmatter と本文を含むテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-03 - frontmatterEnd が本文開始位置と一致する', () => {
         it('T-LIB-FM-03: frontmatterEnd の正確性', () => {
           // "---\ntitle: Hi\n" = 14 chars (index 0-13)
           // "\n---\n" starts at index 13, length 5 → frontmatterEnd = 13 + 5 = 18
           const text = '---\ntitle: Hi\n---\nbody text';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           // frontmatterEnd should point to the start of "body text" = index 18
           assertEquals(result.frontmatterEnd, 18);
         });
@@ -59,11 +59,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: frontmatter と複数行の本文を含むテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-04 - body が frontmatter 以降の本文と一致する', () => {
         it('T-LIB-FM-04: body の正確性', () => {
           const text = '---\ntitle: Hello\n---\nThis is the body.\nSecond line.';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.body, 'This is the body.\nSecond line.');
         });
       });
@@ -71,11 +71,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: ---\\n で始まらないプレーンテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-05 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
         it('T-LIB-FM-05: frontmatter なし（---\\n で始まらない）', () => {
           const text = 'This is plain text without frontmatter.';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
           assertEquals(result.body, text);
           assertEquals(result.frontmatterEnd, 0);
@@ -85,11 +85,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 開き --- はあるが閉じ --- がないテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-06 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
         it('T-LIB-FM-06: 閉じ --- なし', () => {
           const text = '---\ntitle: Hello\nno closing separator';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
           assertEquals(result.body, text);
           assertEquals(result.frontmatterEnd, 0);
@@ -99,11 +99,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: CRLF 改行を含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-07 - CRLF でも正しくパースされる', () => {
         it('T-LIB-FM-07: CRLF 改行の正規化', () => {
           const text = '---\r\ntitle: Hello\r\ncategory: dev\r\n---\r\nbody text';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['title'], 'Hello');
           assertEquals(result.meta['category'], 'dev');
         });
@@ -112,11 +112,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 空の frontmatter ブロック（---\\n---\\n の形式）', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-08 - meta:{}, body が後続テキストになる', () => {
         it('T-LIB-FM-08: 空の frontmatter ブロック', () => {
           const text = '---\n---\nafter body';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
           assertEquals(result.body, 'after body');
         });
@@ -125,11 +125,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 不正な YAML を含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-09 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
         it('T-LIB-FM-09: YAML パース失敗（不正な YAML）', () => {
           const text = '---\n: invalid: yaml: {\n---\nbody';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
           assertEquals(result.body, text);
           assertEquals(result.frontmatterEnd, 0);
@@ -139,11 +139,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 数値フィールドを含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-10 - count が number として取得できる', () => {
         it('T-LIB-FM-10: 数値フィールド', () => {
           const text = '---\ncount: 42\n---\nbody';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['count'], 42);
         });
       });
@@ -151,10 +151,10 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 空文字列', () => {
-    describe('When: extractFrontmatter("") を呼び出す', () => {
+    describe('When: parseFrontmatter("") を呼び出す', () => {
       describe('Then: T-LIB-FM-11 - meta:{}, body="", frontmatterEnd=0 が返る', () => {
         it('T-LIB-FM-11: 空文字列入力', () => {
-          const result = extractFrontmatter('');
+          const result = parseFrontmatter('');
           assertEquals(result.meta, {});
           assertEquals(result.body, '');
           assertEquals(result.frontmatterEnd, 0);
@@ -164,11 +164,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 開き --- のみで本文も閉じ --- もないテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-12 - meta:{}, body=text, frontmatterEnd=0 が返る', () => {
         it('T-LIB-FM-12: 開き --- のみ（EOF）', () => {
           const text = '---\n';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
           assertEquals(result.body, text);
           assertEquals(result.frontmatterEnd, 0);
@@ -178,11 +178,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: 閉じ区切りが \\n--- で終わり末尾改行なしのテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-13 - \\n---\\n にマッチしないため失敗パス', () => {
         it('T-LIB-FM-13: 末尾改行なしの閉じ ---', () => {
           const text = '---\ntitle: Hello\n---';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta, {});
           assertEquals(result.body, text);
           assertEquals(result.frontmatterEnd, 0);
@@ -192,11 +192,11 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: frontmatter のみで本文が空のテキスト', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-14 - body が空文字列で frontmatterEnd が正しい', () => {
         it('T-LIB-FM-14: frontmatter 後の本文が空', () => {
           const text = '---\ntitle: Hello\n---\n';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['title'], 'Hello');
           assertEquals(result.body, '');
           assertEquals(result.frontmatterEnd, text.length);
@@ -206,13 +206,13 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: CRLF 改行を含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-15 - body と frontmatterEnd も正しく取得できる', () => {
         it('T-LIB-FM-15: CRLF 正規化後の body と frontmatterEnd', () => {
           // CRLF を LF に正規化してから処理するため、frontmatterEnd は正規化後の位置
           // "---\ntitle: Hi\n---\n" = 18 chars → frontmatterEnd=18, body=""
           const text = '---\r\ntitle: Hi\r\n---\r\nbody text';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['title'], 'Hi');
           assertEquals(result.body, 'body text');
           assertEquals(result.frontmatterEnd, 18);
@@ -222,13 +222,81 @@ describe('extractFrontmatter', () => {
   });
 
   describe('Given: YAML 値の中に --- を含む frontmatter ブロック', () => {
-    describe('When: extractFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatter(text) を呼び出す', () => {
       describe('Then: T-LIB-FM-16 - 値内の --- を区切りと誤認しない', () => {
         it('T-LIB-FM-16: YAML 値内に --- を含む（quoted string）', () => {
           const text = '---\nsummary: "foo --- bar"\n---\nbody';
-          const result = extractFrontmatter(text);
+          const result = parseFrontmatter(text);
           assertEquals(result.meta['summary'], 'foo --- bar');
           assertEquals(result.body, 'body');
+        });
+      });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// parseFrontmatterEntries
+// ─────────────────────────────────────────────
+
+describe('parseFrontmatterEntries', () => {
+  describe('Given: 基本的な文字列フィールドを持つ frontmatter', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
+      describe('Then: T-LIB-FSM-01 - 文字列フィールドが正しく取得できる', () => {
+        it('T-LIB-FSM-01: 基本文字列フィールドのパース', () => {
+          const text = '---\ntitle: Hello\nproject: my-proj\n---\nbody text';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['title'], 'Hello');
+          assertEquals(result.meta['project'], 'my-proj');
+        });
+      });
+    });
+  });
+
+  describe('Given: date フィールドを含む frontmatter', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
+      describe('Then: T-LIB-FSM-02 - date が YYYY-MM-DD 文字列として返る', () => {
+        it('T-LIB-FSM-02: Date オブジェクトが YYYY-MM-DD 文字列に変換される', () => {
+          const text = '---\ndate: 2026-03-15\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['date'], '2026-03-15');
+        });
+      });
+    });
+  });
+
+  describe('Given: 数値フィールドを含む frontmatter', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
+      describe('Then: T-LIB-FSM-03 - 数値が文字列として返る', () => {
+        it('T-LIB-FSM-03: 数値フィールドが文字列に変換される', () => {
+          const text = '---\ncount: 42\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['count'], '42');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter のないプレーンテキスト', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
+      describe('Then: T-LIB-FSM-04 - meta={}, body=元テキスト が返る', () => {
+        it('T-LIB-FSM-04: frontmatter なし', () => {
+          const text = 'plain text without frontmatter';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta, {});
+          assertEquals(result.body, text);
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter と本文を含むテキスト', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
+      describe('Then: T-LIB-FSM-05 - body が frontmatter 後のテキストと一致する', () => {
+        it('T-LIB-FSM-05: body の正確性', () => {
+          const text = '---\ntitle: Hello\n---\n# 本文\n内容';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.body, '# 本文\n内容');
         });
       });
     });

--- a/skills/_scripts/libs/text/frontmatter-utils.ts
+++ b/skills/_scripts/libs/text/frontmatter-utils.ts
@@ -6,21 +6,24 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// YAML テキストをパースする (@std/yaml)
 import { parse as parseYaml } from '@std/yaml';
 
-export type FrontmatterResult = {
-  meta: Record<string, unknown>;
-  body: string;
-  frontmatterEnd: number;
-};
+// unknown → string 変換ユーティリティ
+import { toStringWithNull } from './coerce-utils.ts';
 
-type BlockResult = {
+import type { FrontmatterEntries, FrontmatterResult } from '../../types/frontmatter.types.ts';
+
+/** frontmatter ブロック抽出の中間結果（内部使用）。 */
+type _BlockResult = {
+  /** フロントマター区切り内の YAML テキスト。 */
   yamlText: string;
+  /** フロントマター終端のバイトオフセット。 */
   frontmatterEnd: number;
 };
 
 /** 正規化済みテキストから frontmatter ブロックを抽出する。見つからない場合は null を返す。 */
-const _extractBlock = (normalized: string): BlockResult | null => {
+const _extractBlock = (normalized: string): _BlockResult | null => {
   const _lines = normalized.split('\n');
   if (_lines[0] !== '---') { return null; }
 
@@ -35,10 +38,26 @@ const _extractBlock = (normalized: string): BlockResult | null => {
   };
 };
 
+/** unknown 値を文字列に変換する。Date は YYYY-MM-DD 形式。 */
+const _unknownToString = (v: unknown): string => {
+  if (v instanceof Date) {
+    return v.toISOString().slice(0, 10);
+  }
+  return toStringWithNull(v);
+};
+
+/** unknown 値を string または string[] に変換する。配列要素は各要素を string 化。 */
+const _unknownToStringOrArray = (v: unknown): string | string[] => {
+  if (Array.isArray(v)) {
+    return v.map((item) => _unknownToString(item));
+  }
+  return _unknownToString(v);
+};
+
 /** Markdown テキストから frontmatter を抽出してパースする。 */
-export const extractFrontmatter = (text: string): FrontmatterResult => {
+export const parseFrontmatter = (text: string): FrontmatterResult => {
   const _normalized = text.replace(/\r\n/g, '\n');
-  const _failure: FrontmatterResult = { meta: {}, body: text, frontmatterEnd: 0 };
+  const _failure: FrontmatterResult = { meta: {}, content: text, frontmatterEnd: 0 };
 
   const _block = _extractBlock(_normalized);
   if (_block === null) { return _failure; }
@@ -56,7 +75,17 @@ export const extractFrontmatter = (text: string): FrontmatterResult => {
 
   return {
     meta: _meta,
-    body: _normalized.slice(_block.frontmatterEnd),
+    content: _normalized.slice(_block.frontmatterEnd),
     frontmatterEnd: _block.frontmatterEnd,
   };
+};
+
+/** Markdown テキストから frontmatter を抽出し、文字列または文字列配列に変換して返す。 */
+export const parseFrontmatterEntries = (text: string): FrontmatterEntries => {
+  const { meta, content } = parseFrontmatter(text);
+  const _typedMeta: Record<string, string | string[]> = {};
+  for (const key of Object.keys(meta)) {
+    _typedMeta[key] = _unknownToStringOrArray(meta[key]);
+  }
+  return { meta: _typedMeta, content };
 };

--- a/skills/_scripts/types/frontmatter.types.ts
+++ b/skills/_scripts/types/frontmatter.types.ts
@@ -1,0 +1,29 @@
+// src: skills/_scripts/types/frontmatter.types.ts
+// @(#): Frontmatter 関連型定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─────────────────────────────────────────────
+// frontmatter 抽出結果系
+// ─────────────────────────────────────────────
+
+/** frontmatter 抽出結果。meta は YAML パース済みオブジェクト。 */
+export type FrontmatterResult = {
+  /** YAML パース済みのフロントマターフィールド。 */
+  meta: Record<string, unknown>;
+  /** フロントマターを除いた本文。 */
+  content: string;
+  /** フロントマター終端のバイトオフセット。 */
+  frontmatterEnd: number;
+};
+
+/** frontmatter フィールドを文字列または文字列配列に変換した抽出結果。 */
+export type FrontmatterEntries = {
+  /** 変換されたフロントマターフィールド。配列値は string[] で保持される。 */
+  meta: Record<string, string | string[]>;
+  /** フロントマターを除いた本文。 */
+  content: string;
+};

--- a/skills/classify-chatlog/scripts/__tests__/fixtures/classify-chatlog.fixtures.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/fixtures/classify-chatlog.fixtures.spec.ts
@@ -17,7 +17,7 @@ import { processChunk } from '../../classify-chatlog.ts';
 // constants
 import { DEFAULT_AI_MODEL } from '../../../../_scripts/constants/defaults.constants.ts';
 // types
-import type { FileMeta, Stats } from '../../types/classify.types.ts';
+import type { ClassifyFileMeta, ClassifyStats } from '../../types/classify.types.ts';
 
 // helpers
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -90,7 +90,7 @@ for (const _relPath of _fixtureDirs) {
   describe(`processChunk — classify-chatlog/${_relPath}`, () => {
     describe(`Given: ${_relPath}/input.md と projects.dic`, () => {
       let _tempDir: string;
-      let _stats: Stats;
+      let _stats: ClassifyStats;
       let _inputContent: string;
       let _loggerStub: LoggerStub;
 
@@ -113,7 +113,7 @@ for (const _relPath of _fixtureDirs) {
         it(
           `SF-CL-${_relPath}-project: 分類結果が known_projects に含まれる`,
           async () => {
-            const _fileMeta: FileMeta = {
+            const _fileMeta: ClassifyFileMeta = {
               filePath: `${_tempDir}/input.md`,
               filename: 'input.md',
               existingProject: '',

--- a/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.process-chunk.functional.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.process-chunk.functional.spec.ts
@@ -16,7 +16,7 @@ import { processChunk } from '../../classify-chatlog.ts';
 import { DEFAULT_AI_MODEL } from '../../../../_scripts/constants/defaults.constants.ts';
 import { FALLBACK_PROJECT } from '../../constants/classify.constants.ts';
 // types
-import type { FileMeta, Stats } from '../../types/classify.types.ts';
+import type { ClassifyFileMeta, ClassifyStats } from '../../types/classify.types.ts';
 
 // helpers
 import {
@@ -30,7 +30,7 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 
 // ─── テスト用ヘルパー ──────────────────────────────────────────────────────────
 
-function _makeFileMeta(filename: string, overrides: Partial<FileMeta> = {}): FileMeta {
+function _makeClassifyFileMeta(filename: string, overrides: Partial<ClassifyFileMeta> = {}): ClassifyFileMeta {
   return {
     filePath: `/tmp/input/${filename}`,
     filename,
@@ -44,7 +44,7 @@ function _makeFileMeta(filename: string, overrides: Partial<FileMeta> = {}): Fil
   };
 }
 
-function _makeStats(): Stats {
+function _makeStats(): ClassifyStats {
   return { moved: 0, skipped: 0, error: 0 };
 }
 
@@ -75,7 +75,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-01-01: stats.moved が 1 になる', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1', 'app2'], true, stats, model);
@@ -84,7 +84,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-01-02: stats.error が 0 のまま', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1', 'app2'], true, stats, model);
@@ -93,7 +93,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-01-03: classify ログが infoLogs に記録される', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1', 'app2'], true, stats, model);
@@ -106,7 +106,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-01-04: [dry-run] ログが infoLogs に記録される', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1', 'app2'], true, stats, model);
@@ -142,7 +142,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-02-01: stats.moved が ファイル数（2）になる', async () => {
-          const metas = [_makeFileMeta('a.md'), _makeFileMeta('b.md')];
+          const metas = [_makeClassifyFileMeta('a.md'), _makeClassifyFileMeta('b.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -151,7 +151,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-02-02: stats.error が 0 のまま（fallback 処理成功）', async () => {
-          const metas = [_makeFileMeta('a.md'), _makeFileMeta('b.md')];
+          const metas = [_makeClassifyFileMeta('a.md'), _makeClassifyFileMeta('b.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -160,7 +160,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-02-03: warn ログが warnLogs に記録される', async () => {
-          const metas = [_makeFileMeta('a.md'), _makeFileMeta('b.md')];
+          const metas = [_makeClassifyFileMeta('a.md'), _makeClassifyFileMeta('b.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -198,7 +198,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-03-01: stats.moved が 1 になる', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -207,7 +207,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-03-02: stats.error が 0 のまま', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -216,7 +216,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-03-03: warn ログが warnLogs に記録される', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -258,7 +258,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-04-01: stats.moved が 1 になる（FALLBACK_PROJECT で移動）', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);
@@ -267,7 +267,7 @@ describe('processChunk', () => {
         });
 
         it('T-CL-PC-04-02: [dry-run] ログが infoLogs に記録される', async () => {
-          const metas = [_makeFileMeta('a.md')];
+          const metas = [_makeClassifyFileMeta('a.md')];
           const stats = _makeStats();
 
           await processChunk(metas, ['app1'], true, stats, model);

--- a/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.file-ops.integration.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.file-ops.integration.spec.ts
@@ -1,5 +1,5 @@
 // src: scripts/__tests__/integration/classify-chatlog.fileOps.integration.spec.ts
-// @(#): loadProjects / loadFileMeta の統合テスト（実ファイルシステム使用）
+// @(#): loadProjects / loadClassifyFileMeta の統合テスト（実ファイルシステム使用）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -9,7 +9,7 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // test target
-import { loadFileMeta, loadProjects } from '../../classify-chatlog.ts';
+import { loadClassifyFileMeta, loadProjects } from '../../classify-chatlog.ts';
 
 // ─── フィクスチャパス ──────────────────────────────────────────────────────────
 
@@ -70,9 +70,9 @@ describe('loadProjects', () => {
   });
 });
 
-// ─── loadFileMeta ─────────────────────────────────────────────────────────────
+// ─── loadClassifyFileMeta ─────────────────────────────────────────────────────────────
 
-describe('loadFileMeta', () => {
+describe('loadClassifyFileMeta', () => {
   let tempDir: string;
 
   beforeEach(async () => {
@@ -86,7 +86,7 @@ describe('loadFileMeta', () => {
   // ─── T-CL-LFM-01: frontmatter 付き md の全フィールド確認 ─────────────────
 
   describe('Given: frontmatter 付き .md ファイル（project なし）', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadClassifyFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-CL-LFM-01 - 全フィールドが正しく設定される', () => {
         it('T-CL-LFM-01-01: filename が正しく設定される', async () => {
           const filePath = `${tempDir}/test.md`;
@@ -95,7 +95,7 @@ describe('loadFileMeta', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadFileMeta(filePath);
+          const meta = await loadClassifyFileMeta(filePath);
 
           assertEquals(meta?.filename, 'test.md');
         });
@@ -107,7 +107,7 @@ describe('loadFileMeta', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadFileMeta(filePath);
+          const meta = await loadClassifyFileMeta(filePath);
 
           assertEquals(meta?.title, 'テストタイトル');
         });
@@ -119,7 +119,7 @@ describe('loadFileMeta', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadFileMeta(filePath);
+          const meta = await loadClassifyFileMeta(filePath);
 
           assertEquals(meta?.category, 'development');
         });
@@ -129,7 +129,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, content);
 
-          const meta = await loadFileMeta(filePath);
+          const meta = await loadClassifyFileMeta(filePath);
 
           assertEquals(meta?.fullText, content);
         });
@@ -140,10 +140,10 @@ describe('loadFileMeta', () => {
   // ─── T-CL-LFM-02: 存在しないファイル → null ──────────────────────────────
 
   describe('Given: 存在しないファイルパス', () => {
-    describe('When: loadFileMeta("/nonexistent/file.md") を呼び出す', () => {
+    describe('When: loadClassifyFileMeta("/nonexistent/file.md") を呼び出す', () => {
       describe('Then: T-CL-LFM-02 - null が返される', () => {
         it('T-CL-LFM-02-01: null が返される（例外なし）', async () => {
-          const meta = await loadFileMeta('/nonexistent/file.md');
+          const meta = await loadClassifyFileMeta('/nonexistent/file.md');
 
           assertEquals(meta, null);
         });
@@ -154,13 +154,13 @@ describe('loadFileMeta', () => {
   // ─── T-CL-LFM-03: project なし → existingProject = "" ────────────────────
 
   describe('Given: project フィールドのない frontmatter の .md ファイル', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadClassifyFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-CL-LFM-03 - existingProject が空文字列（分類対象）', () => {
         it('T-CL-LFM-03-01: existingProject が "" である', async () => {
           const filePath = `${tempDir}/no-project.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n本文');
 
-          const meta = await loadFileMeta(filePath);
+          const meta = await loadClassifyFileMeta(filePath);
 
           assertEquals(meta?.existingProject, '');
         });
@@ -171,7 +171,7 @@ describe('loadFileMeta', () => {
   // ─── T-CL-LFM-04: project 設定済み → existingProject = "my-app" ──────────
 
   describe('Given: project: my-app を含む frontmatter の .md ファイル', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadClassifyFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-CL-LFM-04 - existingProject が "my-app"（スキップ対象）', () => {
         it('T-CL-LFM-04-01: existingProject が "my-app" である', async () => {
           const filePath = `${tempDir}/with-project.md`;
@@ -180,7 +180,7 @@ describe('loadFileMeta', () => {
             '---\ntitle: テスト\nproject: my-app\n---\n本文',
           );
 
-          const meta = await loadFileMeta(filePath);
+          const meta = await loadClassifyFileMeta(filePath);
 
           assertEquals(meta?.existingProject, 'my-app');
         });

--- a/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.build-prompt.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.build-prompt.unit.spec.ts
@@ -14,11 +14,11 @@ import {
   buildSystemPrompt,
 } from '../../classify-chatlog.ts';
 import { FALLBACK_PROJECT } from '../../constants/classify.constants.ts';
-import type { FileMeta } from '../../types/classify.types.ts';
+import type { ClassifyFileMeta } from '../../types/classify.types.ts';
 
-// ─── テスト用 FileMeta ヘルパー ───────────────────────────────────────────────
+// ─── テスト用 ClassifyFileMeta ヘルパー ───────────────────────────────────────────────
 
-function makeFileMeta(overrides: Partial<FileMeta> = {}): FileMeta {
+function makeClassifyFileMeta(overrides: Partial<ClassifyFileMeta> = {}): ClassifyFileMeta {
   return {
     filePath: 'test/path/file.md',
     filename: 'file.md',
@@ -35,13 +35,13 @@ function makeFileMeta(overrides: Partial<FileMeta> = {}): FileMeta {
 // ─── buildClassifyPrompt ──────────────────────────────────────────────────────
 
 describe('buildClassifyPrompt', () => {
-  describe('Given: 2件の FileMeta と ["app1", "app2"] のプロジェクトリスト', () => {
+  describe('Given: 2件の ClassifyFileMeta と ["app1", "app2"] のプロジェクトリスト', () => {
     describe('When: buildClassifyPrompt(files, projects) を呼び出す', () => {
       describe('Then: T-CL-BCP-01 - 複数ファイルのプロンプト生成', () => {
         it('T-CL-BCP-01-01: "Projects: app1, app2, misc" ヘッダーが含まれる', () => {
           const files = [
-            makeFileMeta({ filename: 'a.md' }),
-            makeFileMeta({ filename: 'b.md' }),
+            makeClassifyFileMeta({ filename: 'a.md' }),
+            makeClassifyFileMeta({ filename: 'b.md' }),
           ];
 
           const result = buildClassifyPrompt(files, ['app1', 'app2']);
@@ -51,8 +51,8 @@ describe('buildClassifyPrompt', () => {
 
         it('T-CL-BCP-01-02: FILE 1 のセクションが含まれる', () => {
           const files = [
-            makeFileMeta({ filename: 'a.md' }),
-            makeFileMeta({ filename: 'b.md' }),
+            makeClassifyFileMeta({ filename: 'a.md' }),
+            makeClassifyFileMeta({ filename: 'b.md' }),
           ];
 
           const result = buildClassifyPrompt(files, ['app1', 'app2']);
@@ -62,8 +62,8 @@ describe('buildClassifyPrompt', () => {
 
         it('T-CL-BCP-01-03: FILE 2 のセクションが含まれる', () => {
           const files = [
-            makeFileMeta({ filename: 'a.md' }),
-            makeFileMeta({ filename: 'b.md' }),
+            makeClassifyFileMeta({ filename: 'a.md' }),
+            makeClassifyFileMeta({ filename: 'b.md' }),
           ];
 
           const result = buildClassifyPrompt(files, ['app1', 'app2']);
@@ -74,11 +74,11 @@ describe('buildClassifyPrompt', () => {
     });
   });
 
-  describe('Given: topics/tags が空の FileMeta', () => {
+  describe('Given: topics/tags が空の ClassifyFileMeta', () => {
     describe('When: buildClassifyPrompt([fileMeta], projects) を呼び出す', () => {
       describe('Then: T-CL-BCP-02 - topics/tags が空のとき (none) が出力される', () => {
         it('T-CL-BCP-02-01: topics として "(none)" が含まれる', () => {
-          const files = [makeFileMeta({ topics: [], tags: [] })];
+          const files = [makeClassifyFileMeta({ topics: [], tags: [] })];
 
           const result = buildClassifyPrompt(files, ['app1']);
 
@@ -86,7 +86,7 @@ describe('buildClassifyPrompt', () => {
         });
 
         it('T-CL-BCP-02-02: tags として "(none)" が含まれる', () => {
-          const files = [makeFileMeta({ topics: [], tags: [] })];
+          const files = [makeClassifyFileMeta({ topics: [], tags: [] })];
 
           const result = buildClassifyPrompt(files, ['app1']);
 
@@ -96,12 +96,12 @@ describe('buildClassifyPrompt', () => {
     });
   });
 
-  describe('Given: フロントマターなし（title/category/topics/tags が空）の FileMeta', () => {
+  describe('Given: フロントマターなし（title/category/topics/tags が空）の ClassifyFileMeta', () => {
     describe('When: buildClassifyPrompt([fileMeta], projects) を呼び出す', () => {
       describe('Then: T-CL-BCP-04 - 本文スニペットが追加される', () => {
         it('T-CL-BCP-04-01: "body:" フィールドが含まれる', () => {
           const files = [
-            makeFileMeta({
+            makeClassifyFileMeta({
               title: '',
               category: '',
               topics: [],
@@ -118,7 +118,7 @@ describe('buildClassifyPrompt', () => {
         it('T-CL-BCP-04-02: 本文が 500 文字以内にトリムされて含まれる', () => {
           const longBody = 'a'.repeat(600);
           const files = [
-            makeFileMeta({
+            makeClassifyFileMeta({
               title: '',
               category: '',
               topics: [],
@@ -135,12 +135,12 @@ describe('buildClassifyPrompt', () => {
     });
   });
 
-  describe('Given: フロントマターあり（title が存在する）の FileMeta', () => {
+  describe('Given: フロントマターあり（title が存在する）の ClassifyFileMeta', () => {
     describe('When: buildClassifyPrompt([fileMeta], projects) を呼び出す', () => {
       describe('Then: T-CL-BCP-05 - 本文スニペットは追加されない', () => {
         it('T-CL-BCP-05-01: "body:" フィールドが含まれない', () => {
           const files = [
-            makeFileMeta({
+            makeClassifyFileMeta({
               title: 'テストタイトル',
               category: '',
               topics: [],
@@ -161,11 +161,11 @@ describe('buildClassifyPrompt', () => {
     });
   });
 
-  describe('Given: topics/tags が存在する FileMeta', () => {
+  describe('Given: topics/tags が存在する ClassifyFileMeta', () => {
     describe('When: buildClassifyPrompt([fileMeta], projects) を呼び出す', () => {
       describe('Then: T-CL-BCP-03 - topics/tags がカンマ区切りで出力される', () => {
         it('T-CL-BCP-03-01: topics がカンマ区切りで含まれる', () => {
-          const files = [makeFileMeta({ topics: ['API', '設計'], tags: ['ts'] })];
+          const files = [makeClassifyFileMeta({ topics: ['API', '設計'], tags: ['ts'] })];
 
           const result = buildClassifyPrompt(files, ['app1']);
 
@@ -173,7 +173,7 @@ describe('buildClassifyPrompt', () => {
         });
 
         it('T-CL-BCP-03-02: tags がカンマ区切りで含まれる', () => {
-          const files = [makeFileMeta({ topics: ['API'], tags: ['ts', 'deno'] })];
+          const files = [makeClassifyFileMeta({ topics: ['API'], tags: ['ts', 'deno'] })];
 
           const result = buildClassifyPrompt(files, ['app1']);
 

--- a/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-frontmatter.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-frontmatter.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/__tests__/unit/classify-chatlog.parseFrontmatter.unit.spec.ts
 // @(#): parseFrontmatter のユニットテスト (classify-chatlog 専用)
-//       topics/tags リスト対応・frontmatterEnd インデックス付き
+//       topics/tags リスト対応
 //       ※ normalize-chatlog.ts の parseFrontmatter とは戻り値型が異なる
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -126,22 +126,6 @@ describe('parseFrontmatter', () => {
     });
   });
 
-  // ─── frontmatterEnd の正確性 ──────────────────────────────────────────────
-
-  describe('Given: フロントマターブロックを含むテキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
-      describe('Then: T-CL-PF-06 - frontmatterEnd の正確性', () => {
-        it('T-CL-PF-06-01: frontmatterEnd が本文開始位置を指す', () => {
-          const text = '---\ntitle: test\n---\nHello World';
-
-          const result = parseFrontmatter(text);
-
-          assertEquals(text.slice(result.frontmatterEnd), 'Hello World');
-        });
-      });
-    });
-  });
-
   // ─── frontmatter なし ─────────────────────────────────────────────────────
 
   describe('Given: --- で始まらない Markdown テキスト', () => {
@@ -155,15 +139,7 @@ describe('parseFrontmatter', () => {
           assertEquals(result.title, '');
         });
 
-        it('T-CL-PF-07-02: frontmatterEnd が 0 である', () => {
-          const text = '# タイトル\n本文';
-
-          const result = parseFrontmatter(text);
-
-          assertEquals(result.frontmatterEnd, 0);
-        });
-
-        it('T-CL-PF-07-03: topics が空配列である', () => {
+        it('T-CL-PF-07-02: topics が空配列である', () => {
           const text = '# タイトル\n本文';
 
           const result = parseFrontmatter(text);
@@ -185,14 +161,6 @@ describe('parseFrontmatter', () => {
           const result = parseFrontmatter(text);
 
           assertEquals(result.title, '');
-        });
-
-        it('T-CL-PF-08-02: frontmatterEnd が 0 である', () => {
-          const text = '---\ntitle: foo\n';
-
-          const result = parseFrontmatter(text);
-
-          assertEquals(result.frontmatterEnd, 0);
         });
       });
     });

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -23,7 +23,7 @@ import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
 import { toStringArrayWithNull, toStringWithNull } from '../../_scripts/libs/text/coerce-utils.ts';
-import { extractFrontmatter } from '../../_scripts/libs/text/frontmatter-utils.ts';
+import { parseFrontmatter as _parseFrontmatter } from '../../_scripts/libs/text/frontmatter-utils.ts';
 import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';
 import { normalizeLine } from '../../_scripts/libs/text/line-utils.ts';
 // instances
@@ -41,11 +41,11 @@ import {
 } from './constants/classify.constants.ts';
 import type {
   ClassifyConfig,
+  ClassifyFileMeta,
   ClassifyResult,
-  FileMeta,
+  ClassifyStats,
   FrontmatterData,
   ParsedConfig,
-  Stats,
 } from './types/classify.types.ts';
 
 // ─────────────────────────────────────────────
@@ -72,7 +72,7 @@ export const loadProjects = async (dicsDir: string): Promise<string[]> => {
 // ─────────────────────────────────────────────
 
 export const parseFrontmatter = (text: string): FrontmatterData => {
-  const { meta, frontmatterEnd } = extractFrontmatter(text);
+  const { meta, frontmatterEnd } = _parseFrontmatter(text);
 
   return {
     project: toStringWithNull(meta['project']),
@@ -116,7 +116,7 @@ export const insertProjectField = (text: string, project: string): string => {
 // ファイルメタデータ読み込み
 // ─────────────────────────────────────────────
 
-export const loadFileMeta = async (filePath: string): Promise<FileMeta | null> => {
+export const loadClassifyFileMeta = async (filePath: string): Promise<ClassifyFileMeta | null> => {
   let text: string;
   try {
     text = await readTextFile(filePath);
@@ -143,7 +143,7 @@ export const loadFileMeta = async (filePath: string): Promise<FileMeta | null> =
 // バッチプロンプト構築
 // ─────────────────────────────────────────────
 
-export const buildClassifyPrompt = (files: FileMeta[], projects: string[]): string => {
+export const buildClassifyPrompt = (files: ClassifyFileMeta[], projects: string[]): string => {
   const _projectList = [...projects, FALLBACK_PROJECT].join(', ');
   const header = `Projects: ${_projectList}\n\n`;
 
@@ -184,10 +184,10 @@ Base your decision on: title, category, topics, tags.`;
 // ─────────────────────────────────────────────
 
 export const classifyFile = async (
-  fileMeta: FileMeta,
+  fileMeta: ClassifyFileMeta,
   project: string,
   dryRun: boolean,
-  stats: Stats,
+  stats: ClassifyStats,
 ): Promise<void> => {
   const srcPath = fileMeta.filePath;
   const srcDir = getDirectory(srcPath);
@@ -221,14 +221,14 @@ export const classifyFile = async (
 // ─────────────────────────────────────────────
 
 export const processChunk = async (
-  chunkMetas: FileMeta[],
+  chunkMetas: ClassifyFileMeta[],
   projects: string[],
   dryRun: boolean,
-  stats: Stats,
+  stats: ClassifyStats,
   model: string,
 ): Promise<void> => {
   // フロントマターなし かつ 本文が短すぎるファイルは Claude に渡さず misc に直接分類
-  const classifiable: FileMeta[] = [];
+  const classifiable: ClassifyFileMeta[] = [];
   for (const f of chunkMetas) {
     const hasMeta = f.title || f.category || f.topics.length > 0 || f.tags.length > 0;
     if (!hasMeta && f.fullText.trim().length < MIN_CLASSIFIABLE_LENGTH) {
@@ -343,11 +343,11 @@ export const main = async (argv?: string[]): Promise<void> => {
     }
 
     // メタデータ読み込みとスキップ判定
-    const targetMetas: FileMeta[] = [];
-    const stats: Stats = { moved: 0, skipped: 0, error: 0 };
+    const targetMetas: ClassifyFileMeta[] = [];
+    const stats: ClassifyStats = { moved: 0, skipped: 0, error: 0 };
 
     for (const filePath of allFiles) {
-      const meta = await loadFileMeta(filePath);
+      const meta = await loadClassifyFileMeta(filePath);
       if (!meta) {
         stats.error++;
         continue;

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -72,7 +72,7 @@ export const loadProjects = async (dicsDir: string): Promise<string[]> => {
 // ─────────────────────────────────────────────
 
 export const parseFrontmatter = (text: string): FrontmatterData => {
-  const { meta, frontmatterEnd } = _parseFrontmatter(text);
+  const { meta } = _parseFrontmatter(text);
 
   return {
     project: toStringWithNull(meta['project']),
@@ -80,7 +80,6 @@ export const parseFrontmatter = (text: string): FrontmatterData => {
     category: toStringWithNull(meta['category']),
     topics: toStringArrayWithNull(meta['topics']),
     tags: toStringArrayWithNull(meta['tags']),
-    frontmatterEnd,
   };
 };
 
@@ -232,9 +231,8 @@ export const processChunk = async (
   for (const f of chunkMetas) {
     const hasMeta = f.title || f.category || f.topics.length > 0 || f.tags.length > 0;
     if (!hasMeta && f.fullText.trim().length < MIN_CLASSIFIABLE_LENGTH) {
-      logger.warn(
-        `[skip-ai: too-short] classify: ${f.filename} → ${FALLBACK_PROJECT} (本文が短すぎるため AI をスキップ)`,
-      );
+      logger.warn(`[skip-ai: too-short] ${f.filename} (content is too short.`);
+      logger.info(`  classify: ${f.filename} → fallback:${FALLBACK_PROJECT}`);
       await classifyFile(f, FALLBACK_PROJECT, dryRun, stats);
     } else {
       classifiable.push(f);

--- a/skills/classify-chatlog/scripts/types/classify.types.ts
+++ b/skills/classify-chatlog/scripts/types/classify.types.ts
@@ -27,7 +27,7 @@ export interface ClassifyResult {
 // ─────────────────────────────────────────────
 
 /** 分類処理に使用する1ファイルのメタデータ。`loadFileMeta` が返す。 */
-export interface FileMeta {
+export interface ClassifyFileMeta {
   /** ファイルの絶対パス。 */
   filePath: string;
   /** ファイル名（パスなし）。 */
@@ -51,7 +51,7 @@ export interface FileMeta {
 // ─────────────────────────────────────────────
 
 /** 処理全体の集計カウンター。`main` 関数が完了時に出力する。 */
-export interface Stats {
+export interface ClassifyStats {
   /** 移動（または dry-run での移動予定）件数。 */
   moved: number;
   /** 既にプロジェクト設定済みでスキップした件数。 */

--- a/skills/classify-chatlog/scripts/types/classify.types.ts
+++ b/skills/classify-chatlog/scripts/types/classify.types.ts
@@ -99,6 +99,4 @@ export interface FrontmatterData {
   topics: string[];
   /** フロントマターの `tags` リスト。 */
   tags: string[];
-  /** フロントマター終端の文字インデックス（本文先頭位置）。 */
-  frontmatterEnd: number;
 }

--- a/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/__tests__/unit/filter-chatlog.unit.spec.ts
 // @(#): filter-chatlog.ts のユニットテスト
-//       parseArgs / parseFrontmatter / parseConversation / parseJsonArray /
+//       parseArgs / parseFrontmatterEntries / parseConversation / parseJsonArray /
 //       extractBodyText / isExcludedByFilename / isExcludedByContent
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -12,6 +12,7 @@ import { describe, it } from '@std/testing/bdd';
 
 // test target
 import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
+import { parseFrontmatterEntries } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
 import { parseJsonArray } from '../../../../_scripts/libs/text/json-utils.ts';
 import { parseConversation } from '../../../../_scripts/libs/text/markdown-utils.ts';
 import {
@@ -20,7 +21,6 @@ import {
   isExcludedByContent,
   isExcludedByFilename,
   parseArgs,
-  parseFrontmatter,
 } from '../../filter-chatlog.ts';
 
 type Args = ReturnType<typeof parseArgs>;
@@ -101,25 +101,25 @@ describe('parseArgs', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// parseFrontmatter
+// parseFrontmatterEntries
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('parseFrontmatter', () => {
+describe('parseFrontmatterEntries', () => {
   // ─── T-FL-PF-01: frontmatter あり → body 分離 ─────────────────────────────────
 
   describe('Given: frontmatter 付きのテキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
       describe('Then: T-FL-PF-01 - body が frontmatter 以降になる', () => {
         it('T-FL-PF-01-01: body が frontmatter の後の部分になる', () => {
           const text = '---\ntitle: テスト\n---\n本文です\n';
-          const { body } = parseFrontmatter(text);
+          const { content } = parseFrontmatterEntries(text);
 
-          assertEquals(body, '本文です\n');
+          assertEquals(content, '本文です\n');
         });
 
         it('T-FL-PF-01-02: meta が空オブジェクトを返す', () => {
           const text = '---\ntitle: テスト\n---\n本文';
-          const { meta } = parseFrontmatter(text);
+          const { meta } = parseFrontmatterEntries(text);
 
           assertEquals(typeof meta, 'object');
         });
@@ -130,13 +130,13 @@ describe('parseFrontmatter', () => {
   // ─── T-FL-PF-02: frontmatter なし → body=全文 ──────────────────────────────
 
   describe('Given: frontmatter なしのテキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
       describe('Then: T-FL-PF-02 - body が全文になる', () => {
         it('T-FL-PF-02-01: body が入力テキスト全体になる', () => {
           const text = '本文のみです\n追加テキスト';
-          const { body } = parseFrontmatter(text);
+          const { content } = parseFrontmatterEntries(text);
 
-          assertEquals(body, text);
+          assertEquals(content, text);
         });
       });
     });
@@ -145,13 +145,13 @@ describe('parseFrontmatter', () => {
   // ─── T-FL-PF-03: 閉じ区切りなし → body=全文 ────────────────────────────────
 
   describe('Given: 開始区切りはあるが閉じ区切りがないテキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
       describe('Then: T-FL-PF-03 - 閉じ区切りなし → body=全文', () => {
         it('T-FL-PF-03-01: body が入力テキスト全体になる', () => {
           const text = '---\ntitle: テスト\n本文（閉じ区切りなし）';
-          const { body } = parseFrontmatter(text);
+          const { content } = parseFrontmatterEntries(text);
 
-          assertEquals(body, text);
+          assertEquals(content, text);
         });
       });
     });
@@ -160,13 +160,13 @@ describe('parseFrontmatter', () => {
   // ─── T-FL-PF-04: frontmatter のみ（body 空） ────────────────────────────────
 
   describe('Given: frontmatter のみで本文がないテキスト', () => {
-    describe('When: parseFrontmatter(text) を呼び出す', () => {
+    describe('When: parseFrontmatterEntries(text) を呼び出す', () => {
       describe('Then: T-FL-PF-04 - body が空文字列になる', () => {
         it('T-FL-PF-04-01: body が空文字列になる', () => {
           const text = '---\ntitle: テスト\n---\n';
-          const { body } = parseFrontmatter(text);
+          const { content } = parseFrontmatterEntries(text);
 
-          assertEquals(body, '');
+          assertEquals(content, '');
         });
       });
     });

--- a/skills/filter-chatlog/scripts/__tests__/unit/prefilter-chatlog.unit.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/unit/prefilter-chatlog.unit.spec.ts
@@ -35,9 +35,9 @@ describe('loadFrontmatter', () => {
         const text = '---\ntitle: テスト\nauthor: bob\n---\n本文\n';
 
         it('T-PF-LF-01-01: body が "本文\\n" になる', () => {
-          const { body } = loadFrontmatter(text);
+          const { content } = loadFrontmatter(text);
 
-          assertEquals(body, '本文\n');
+          assertEquals(content, '本文\n');
         });
 
         it('T-PF-LF-01-02: meta.title が "テスト" になる', () => {
@@ -63,9 +63,9 @@ describe('loadFrontmatter', () => {
         const text = '本文のみ\n追加行';
 
         it('T-PF-LF-02-01: body が入力テキスト全体と等しい', () => {
-          const { body } = loadFrontmatter(text);
+          const { content } = loadFrontmatter(text);
 
-          assertEquals(body, text);
+          assertEquals(content, text);
         });
 
         it('T-PF-LF-02-02: meta が空オブジェクトになる', () => {
@@ -85,9 +85,9 @@ describe('loadFrontmatter', () => {
         const text = '---\ntitle: テスト\n本文（閉じ区切りなし）';
 
         it('T-PF-LF-03-01: body が入力テキスト全体と等しい', () => {
-          const { body } = loadFrontmatter(text);
+          const { content } = loadFrontmatter(text);
 
-          assertEquals(body, text);
+          assertEquals(content, text);
         });
 
         it('T-PF-LF-03-02: meta が空オブジェクトになる', () => {
@@ -107,9 +107,9 @@ describe('loadFrontmatter', () => {
         const text = '---\ntitle: テスト\n---\n';
 
         it('T-PF-LF-04-01: body が空文字列になる', () => {
-          const { body } = loadFrontmatter(text);
+          const { content } = loadFrontmatter(text);
 
-          assertEquals(body, '');
+          assertEquals(content, '');
         });
 
         it('T-PF-LF-04-02: meta.title が "テスト" になる', () => {
@@ -179,9 +179,9 @@ describe('loadFrontmatter', () => {
         });
 
         it('T-PF-LF-07-02: body が "本文\\n" になる（CRLF が LF に変換される）', () => {
-          const { body } = loadFrontmatter(text);
+          const { content } = loadFrontmatter(text);
 
-          assertEquals(body, '本文\n');
+          assertEquals(content, '本文\n');
         });
       });
     });

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -22,6 +22,7 @@ import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
+import { parseFrontmatterEntries } from '../../_scripts/libs/text/frontmatter-utils.ts';
 import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';
 import { parseConversation } from '../../_scripts/libs/text/markdown-utils.ts';
 
@@ -46,22 +47,6 @@ export interface ClaudeResult {
   confidence: number;
   reason: string;
 }
-
-// ─────────────────────────────────────────────
-// Frontmatter パース
-// ─────────────────────────────────────────────
-
-export const parseFrontmatter = (text: string): { meta: Record<string, unknown>; body: string } => {
-  if (!text.startsWith('---\n')) {
-    return { meta: {}, body: text };
-  }
-  const end = text.indexOf('\n---\n', 4);
-  if (end === -1) {
-    return { meta: {}, body: text };
-  }
-  const body = text.slice(end + 5);
-  return { meta: {}, body };
-};
 
 // ─────────────────────────────────────────────
 // 内容ベース事前フィルタ（obsidian_filter.py 移植）
@@ -197,20 +182,20 @@ export const prefilterFiles = async (files: string[]): Promise<string[]> => {
       continue;
     }
 
-    const { body } = parseFrontmatter(text);
-    if (!body.trim()) {
+    const { content } = parseFrontmatterEntries(text);
+    if (!content.trim()) {
       skipped++;
       continue;
     }
 
-    const { excluded, reason } = isExcludedByContent(body);
+    const { excluded, reason } = isExcludedByContent(content);
     if (excluded) {
       logger.info(`  skipped (${reason}): ${filename}`);
       skipped++;
       continue;
     }
 
-    const bodyText = extractBodyText(body);
+    const bodyText = extractBodyText(content);
     if (!bodyText.trim()) {
       skipped++;
       continue;
@@ -239,8 +224,8 @@ export const buildBatchPrompt = async (files: string[]): Promise<string> => {
     } catch {
       text = '';
     }
-    const { body } = parseFrontmatter(text);
-    const bodyText = extractBodyText(body, MAX_BODY_CHARS);
+    const { content } = parseFrontmatterEntries(text);
+    const bodyText = extractBodyText(content, MAX_BODY_CHARS);
 
     parts.push(`=== FILE ${i + 1}: ${filename} ===\n${bodyText}`);
   }

--- a/skills/filter-chatlog/scripts/prefilter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/prefilter-chatlog.ts
@@ -107,15 +107,15 @@ export const MIN_ASSISTANT_CHARS = 100;
 // Frontmatter パーサー
 // ─────────────────────────────────────────────
 
-export const loadFrontmatter = (text: string): { meta: Record<string, string>; body: string } => {
+export const loadFrontmatter = (text: string): { meta: Record<string, string>; content: string } => {
   const normalized = text.replace(/\r\n/g, '\n');
-  if (!normalized.startsWith('---\n')) { return { meta: {}, body: normalized }; }
+  if (!normalized.startsWith('---\n')) { return { meta: {}, content: normalized }; }
 
   const end = normalized.indexOf('\n---\n', 4);
-  if (end === -1) { return { meta: {}, body: normalized }; }
+  if (end === -1) { return { meta: {}, content: normalized }; }
 
   const fmText = normalized.slice(4, end);
-  const body = normalized.slice(end + 5);
+  const content = normalized.slice(end + 5);
 
   const meta: Record<string, string> = {};
   for (const line of fmText.split('\n')) {
@@ -124,7 +124,7 @@ export const loadFrontmatter = (text: string): { meta: Record<string, string>; b
       meta[line.slice(0, idx).trim()] = line.slice(idx + 2).trim();
     }
   }
-  return { meta, body };
+  return { meta, content };
 };
 
 // ─────────────────────────────────────────────
@@ -196,11 +196,11 @@ export const classifyFile = (filename: string, text: string): { isNoise: boolean
   const filenameReason = checkFilename(filename);
   if (filenameReason) { return { isNoise: true, reason: filenameReason }; }
 
-  // 2. frontmatter + body 読み込み
-  const { body } = loadFrontmatter(text);
+  // 2. frontmatter + content 読み込み
+  const { content } = loadFrontmatter(text);
 
   // 3. 会話ターン解析
-  const turns = parseConversation(body);
+  const turns = parseConversation(content);
 
   // 4. User本文チェック
   const userReason = checkUserContent(turns);

--- a/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
@@ -51,7 +51,7 @@ async function _loadOutputSegment(filePath: string): Promise<Segment> {
   return {
     title: _extractFrontmatterField(content, 'title'),
     summary: _extractFrontmatterField(content, 'summary'),
-    body: '',
+    content: '',
   };
 }
 
@@ -62,7 +62,7 @@ async function _loadOutputSegment(filePath: string): Promise<Segment> {
  */
 function _buildOutput(
   segment: Segment,
-  sourceMeta: Record<string, string>,
+  sourceMeta: Record<string, string | string[]>,
 ): string {
   const segmentContent = generateSegmentFile(segment);
   return attachFrontmatter(segmentContent, sourceMeta, {
@@ -128,7 +128,7 @@ for (const _dirName of _fixtureDirs) {
       let _segments: Segment[];
       let _expectedSegments: Segment[];
       let _fixtureContents: string[];
-      let _sourceMeta: Record<string, string>;
+      let _sourceMeta: Record<string, string | string[]>;
       let _mockHandle: ReturnType<typeof installCommandMock>;
 
       beforeEach(async () => {

--- a/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
@@ -19,10 +19,10 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
 // test target
+import { parseFrontmatterEntries as parseFrontmatter } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
 import {
   attachFrontmatter,
   generateSegmentFile,
-  parseFrontmatter,
   segmentChatlog,
 } from '../../normalize-chatlog.ts';
 import type { Segment } from '../../normalize-chatlog.ts';

--- a/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-markdown.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-markdown.spec.ts
@@ -48,7 +48,7 @@ async function _loadOutputSegment(filePath: string): Promise<Segment> {
   return {
     title: '',
     summary: '',
-    body: idx === -1 ? '' : content.slice(idx + marker.length).replace(/^\n+/, ''),
+    content: idx === -1 ? '' : content.slice(idx + marker.length).replace(/^\n+/, ''),
   };
 }
 

--- a/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-segments.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-segments.spec.ts
@@ -76,7 +76,7 @@ function _buildMock(output: FixtureOutput): DenoCommandLike {
   const _mockSegments = Array.from({ length: output.count }, () => ({
     title: '',
     summary: '',
-    body: '',
+    content: '',
   }));
   return makeSuccessMock(new TextEncoder().encode(JSON.stringify(_mockSegments)));
 }

--- a/skills/normalize-chatlog/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
@@ -54,8 +54,8 @@ describe('segmentChatlog', () => {
 
         it('T-09-01-01: {title, summary, body}[] の2件以上の配列を返す', async () => {
           const segments = [
-            { title: 'Topic A', summary: 'Summary A', body: 'Body A' },
-            { title: 'Topic B', summary: 'Summary B', body: 'Body B' },
+            { title: 'Topic A', summary: 'Summary A', content: 'Body A' },
+            { title: 'Topic B', summary: 'Summary B', content: 'Body B' },
           ];
           const mock = makeSuccessMock(new TextEncoder().encode(JSON.stringify(segments)));
           (Deno as unknown as Record<string, unknown>).Command = mock;
@@ -66,14 +66,14 @@ describe('segmentChatlog', () => {
           assertEquals((result as unknown[]).length >= 2, true);
           assertEquals((result as { title: string }[])[0].title, 'Topic A');
           assertEquals((result as { summary: string }[])[0].summary, 'Summary A');
-          assertEquals((result as { body: string }[])[0].body, 'Body A');
+          assertEquals((result as { content: string }[])[0].content, 'Body A');
         });
 
         it('T-09-01-02: 1呼び出しにつき runAI をちょうど1回だけ呼び出す', async () => {
           const counter = { calls: 0 };
           const segments = [
-            { title: 'Topic A', summary: 'Summary A', body: 'Body A' },
-            { title: 'Topic B', summary: 'Summary B', body: 'Body B' },
+            { title: 'Topic A', summary: 'Summary A', content: 'Body A' },
+            { title: 'Topic B', summary: 'Summary B', content: 'Body B' },
           ];
           const mock = makeCountingMock(JSON.stringify(segments), counter);
           (Deno as unknown as Record<string, unknown>).Command = mock;
@@ -142,7 +142,7 @@ describe('segmentChatlog', () => {
           const segments = Array.from({ length: 15 }, (_, i) => ({
             title: `Topic ${i + 1}`,
             summary: `Summary ${i + 1}`,
-            body: `Body ${i + 1}`,
+            content: `Body ${i + 1}`,
           }));
           const mock = makeSuccessMock(new TextEncoder().encode(JSON.stringify(segments)));
           (Deno as unknown as Record<string, unknown>).Command = mock;

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-gen.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-gen.unit.spec.ts
@@ -206,7 +206,7 @@ describe('generateSegmentFile', () => {
   /** 正常系: summary フィールドが `## Summary` セクションとして出力される */
   describe('Given: { title: "Fix CI pipeline", summary: "Fix CI pipeline", body: "..." } を持つセグメント', () => {
     it('T-11-01-01: 返却文字列に `## Summary\\nFix CI pipeline` が含まれる', () => {
-      const seg = { title: 'Fix CI pipeline', summary: 'Fix CI pipeline', body: '### User\nHow do I fix CI?' };
+      const seg = { title: 'Fix CI pipeline', summary: 'Fix CI pipeline', content: '### User\nHow do I fix CI?' };
 
       const result = generateSegmentFile(seg);
 
@@ -217,7 +217,7 @@ describe('generateSegmentFile', () => {
   /** 正常系: body フィールドが START_BODY_HEADING セクションとして出力される */
   describe('Given: { title: "Debug session", summary: "Debug session", body: "..." } を持つセグメント', () => {
     it('T-11-01-02: 返却文字列に START_BODY_HEADING + "\\n### User\\nHow do I..." が含まれる', () => {
-      const seg = { title: 'Debug session', summary: 'Debug session', body: '### User\nHow do I...' };
+      const seg = { title: 'Debug session', summary: 'Debug session', content: '### User\nHow do I...' };
 
       const result = generateSegmentFile(seg);
 
@@ -228,7 +228,7 @@ describe('generateSegmentFile', () => {
   /** エッジケース: 全フィールドが空でも `## Summary` と START_BODY_HEADING 見出しを含む文字列を返す */
   describe('Given: { title: "", summary: "", body: "" } を持つセグメント', () => {
     it('T-11-02-01: 返却文字列に `## Summary` と START_BODY_HEADING の両セクション見出しが含まれる', () => {
-      const seg = { title: '', summary: '', body: '' };
+      const seg = { title: '', summary: '', content: '' };
 
       const result = generateSegmentFile(seg);
 

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
@@ -140,8 +140,8 @@ describe('segmentChatlog', () => {
     it('T-SC-01-01: AI が有効な JSON 配列を返すとき Segment 配列を返す', async () => {
       // arrange
       const segments = [
-        { title: 'Topic 1', summary: 'Summary 1', body: 'Body 1' },
-        { title: 'Topic 2', summary: 'Summary 2', body: 'Body 2' },
+        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' },
+        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2' },
       ];
       const stdout = new TextEncoder().encode(JSON.stringify(segments));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
@@ -187,7 +187,7 @@ describe('segmentChatlog', () => {
       const segments = Array.from({ length: 12 }, (_, i) => ({
         title: `Topic ${i + 1}`,
         summary: `Summary ${i + 1}`,
-        body: `Body ${i + 1}`,
+        content: `Body ${i + 1}`,
       }));
       const stdout = new TextEncoder().encode(JSON.stringify(segments));
       mockHandle = installCommandMock(makeSuccessMock(stdout));

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.string-utils.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.string-utils.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/__tests__/unit/normalize-chatlog.string-utils.unit.spec.ts
 // @(#): 文字列処理関数のユニットテスト
-//       対象: cleanYaml, parseFrontmatter, extractBaseName, parseJsonArray
+//       対象: cleanYaml, parseFrontmatterEntries, extractBaseName, parseJsonArray
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -11,12 +11,10 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // test target
+import { parseFrontmatterEntries } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
 import { parseJsonArray } from '../../../../_scripts/libs/text/json-utils.ts';
 import { cleanYaml } from '../../../../_scripts/libs/text/markdown-utils.ts';
-import {
-  extractBaseName,
-  parseFrontmatter,
-} from '../../normalize-chatlog.ts';
+import { extractBaseName } from '../../normalize-chatlog.ts';
 
 // ─── cleanYaml tests ──────────────────────────────────────────────────────────
 
@@ -85,61 +83,61 @@ describe('cleanYaml', () => {
   });
 });
 
-// ─── parseFrontmatter tests ───────────────────────────────────────────────────
+// ─── parseFrontmatterEntries tests ───────────────────────────────────────
 
 /**
- * parseFrontmatter のユニットテスト。
+ * parseFrontmatterEntries のユニットテスト。
  * Markdown テキストの先頭にある `---` 区切りのフロントマターを解析し、
- * meta オブジェクトと fullBody 文字列に分解する関数の正常系・異常系を検証する。
+ * meta オブジェクトと body 文字列に分解する関数の正常系・異常系を検証する。
  */
-describe('parseFrontmatter', () => {
-  /** 正常系: `---` で囲まれたフロントマターを meta と fullBody に分解する */
+describe('parseFrontmatterEntries', () => {
+  /** 正常系: `---` で囲まれたフロントマターを meta と body に分解する */
   describe('Given: フロントマターブロックを含む Markdown テキスト', () => {
     it('meta に project と date フィールドが含まれる', () => {
       const text = '---\nproject: ci-platform\ndate: 2026-03-01\n---\n# Body';
 
-      const { meta } = parseFrontmatter(text);
+      const { meta } = parseFrontmatterEntries(text);
 
       assertEquals(meta, { project: 'ci-platform', date: '2026-03-01' });
     });
 
-    it('fullBody に閉じ --- 以降のテキストが含まれる', () => {
+    it('body に閉じ --- 以降のテキストが含まれる', () => {
       const text = '---\nproject: ci-platform\ndate: 2026-03-01\n---\n# Body';
 
-      const { fullBody } = parseFrontmatter(text);
+      const { content } = parseFrontmatterEntries(text);
 
-      assertEquals(fullBody, '\n# Body');
+      assertEquals(content, '# Body');
     });
   });
 
-  /** 正常系: フロントマターなしの場合は meta を空にして fullBody を元テキスト全体とする */
+  /** 正常系: フロントマターなしの場合は meta を空にして body を元テキスト全体とする */
   describe('Given: --- で始まらない Markdown テキスト', () => {
     it('meta が空のレコードである', () => {
       const text = '# No Frontmatter\n\nSome content.';
 
-      const { meta } = parseFrontmatter(text);
+      const { meta } = parseFrontmatterEntries(text);
 
       assertEquals(meta, {});
     });
 
-    it('fullBody が元のテキスト全体と等しい', () => {
+    it('body が元のテキスト全体と等しい', () => {
       const text = '# No Frontmatter\n\nSome content.';
 
-      const { fullBody } = parseFrontmatter(text);
+      const { content } = parseFrontmatterEntries(text);
 
-      assertEquals(fullBody, text);
+      assertEquals(content, text);
     });
   });
 
   /** 異常系: 開き `---` はあるが閉じ `---` がない不正なフロントマターは無視する */
   describe('Given: --- で始まるが閉じ --- がない Markdown テキスト', () => {
-    it('meta が空で fullBody が元のテキスト全体を含む', () => {
+    it('meta が空で body が元のテキスト全体を含む', () => {
       const text = '---\nproject: ci-platform\n';
 
-      const { meta, fullBody } = parseFrontmatter(text);
+      const { meta, content } = parseFrontmatterEntries(text);
 
       assertEquals(meta, {});
-      assertEquals(fullBody, text);
+      assertEquals(content, text);
     });
   });
 });
@@ -206,7 +204,7 @@ describe('parseJsonArray', () => {
   /** 正常系: `[` 始まりの JSON 配列を直接パースして返す */
   describe('Given: `[` で始まる有効な JSON 配列文字列', () => {
     it('T-10-01-01: 1 オブジェクトを含む配列が返される', () => {
-      const rawDirect = '[{"title":"T1","summary":"S1","body":"B1"}]';
+      const rawDirect = '[{"title":"T1","summary":"S1","content":"B1"}]';
 
       const result = parseJsonArray(rawDirect);
 

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -15,6 +15,7 @@ import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
+import { parseFrontmatterEntries } from '../../_scripts/libs/text/frontmatter-utils.ts';
 import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';
 import { normalizeLine } from '../../_scripts/libs/text/line-utils.ts';
 
@@ -34,7 +35,7 @@ export type ParsedArgs = {
 export type Segment = {
   title: string;
   summary: string;
-  body: string;
+  content: string;
 };
 
 /** Counters for {@link writeOutput} results across a batch run. */
@@ -59,44 +60,6 @@ const _MAX_SEGMENTS = 10;
 
 /** Markdown heading that marks the start of the body section in a segment file. */
 export const START_BODY_HEADING = '## Excerpt';
-
-/**
- * Parses a YAML frontmatter block from a Markdown text string.
- *
- * @param text - The full Markdown text, optionally starting with a `---` frontmatter block
- * @returns An object with `meta` (key-value pairs from frontmatter) and `fullBody` (text after frontmatter)
- */
-export const parseFrontmatter = (text: string): { meta: Record<string, string>; fullBody: string } => {
-  const DELIMITER = '---';
-
-  // Must start with `---\n` (or `---` at start); otherwise no frontmatter
-  if (!text.startsWith(DELIMITER + '\n')) {
-    return { meta: {}, fullBody: text };
-  }
-
-  // Find the closing `---` delimiter (after the opening line)
-  const afterOpen = text.indexOf('\n') + 1; // position after first `---\n`
-  const closeIndex = text.indexOf('\n' + DELIMITER, afterOpen);
-
-  // No closing delimiter found — treat as invalid frontmatter
-  if (closeIndex === -1) {
-    return { meta: {}, fullBody: text };
-  }
-
-  const frontmatterBlock = text.slice(afterOpen, closeIndex);
-  const fullBody = text.slice(closeIndex + 1 + DELIMITER.length);
-
-  const meta: Record<string, string> = {};
-  for (const line of frontmatterBlock.split('\n')) {
-    const colonPos = line.indexOf(':');
-    if (colonPos === -1) { continue; }
-    const key = line.slice(0, colonPos).trim();
-    const value = line.slice(colonPos + 1).trim();
-    if (key) { meta[key] = value; }
-  }
-
-  return { meta, fullBody };
-};
 
 // ─── ID Generation ────────────────────────────────────────────────────────────
 
@@ -191,7 +154,7 @@ export const generateOutputFileName = async (
  * @returns Markdown string containing the Summary and Excerpt sections
  */
 export const generateSegmentFile = (segment: Segment): string => {
-  return `## Summary\n\n${segment.summary}\n\n${START_BODY_HEADING}\n\n${segment.body}`;
+  return `## Summary\n\n${segment.summary}\n\n${START_BODY_HEADING}\n\n${segment.content}`;
 };
 
 /**
@@ -208,12 +171,17 @@ export const generateSegmentFile = (segment: Segment): string => {
  */
 export const attachFrontmatter = (
   content: string,
-  sourceMeta: Record<string, string>,
+  sourceMeta: Record<string, string | string[]>,
   segmentMeta: { title: string; log_id: string; summary: string },
 ): string => {
   const fields: string[] = [];
   for (const [key, value] of Object.entries(sourceMeta)) {
-    fields.push(`${key}: ${value}`);
+    if (Array.isArray(value)) {
+      fields.push(`${key}:`);
+      value.forEach((v) => fields.push(`  - ${v}`));
+    } else {
+      fields.push(`${key}: ${value}`);
+    }
   }
   fields.push(`title: ${segmentMeta.title}`);
   fields.push(`log_id: ${segmentMeta.log_id}`);
@@ -283,8 +251,8 @@ export const runAI = async (model: string, systemPrompt: string, userPrompt: str
 export const segmentChatlog = async (filePath: string, content: string): Promise<Segment[] | null> => {
   const systemPrompt = 'You are a chatlog analyst. Split the given chatlog into topic-based segments. '
     + 'Return ONLY a JSON array where each element has exactly three string fields: '
-    + '"title" (short topic title), "summary" (one-sentence summary), and "body" (relevant text). '
-    + 'For "body": copy the relevant conversation verbatim — do NOT rewrite, paraphrase, or reformat. '
+    + '"title" (short topic title), "summary" (one-sentence summary), and "content" (relevant text). '
+    + 'For "content": copy the relevant conversation verbatim — do NOT rewrite, paraphrase, or reformat. '
     + 'Preserve all original line breaks, blank lines, code blocks, and list formatting exactly as they appear. '
     + 'Preserve ### User and ### Assistant headings to distinguish speakers. '
     + 'Do not include any explanation or markdown fences — respond with the JSON array only.';
@@ -529,7 +497,7 @@ export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void
 
     await runConcurrent(mdFiles, async (filePath) => {
       const content = await Deno.readTextFile(filePath);
-      const { meta: sourceMeta } = parseFrontmatter(content);
+      const { meta: sourceMeta } = parseFrontmatterEntries(content);
 
       const segments = await segmentChatlog(filePath, content);
       if (segments === null) {
@@ -537,7 +505,8 @@ export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void
         return;
       }
 
-      const outputDir = resolveOutputDir(inputDir, outputBase, sourceMeta['project']);
+      const _project = typeof sourceMeta['project'] === 'string' ? sourceMeta['project'] : undefined;
+      const outputDir = resolveOutputDir(inputDir, outputBase, _project);
       await Deno.mkdir(outputDir, { recursive: true });
 
       for (let i = 0; i < segments.length; i++) {

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
@@ -22,7 +22,7 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 
 // test target
-import type { Dics, FileMeta } from '../../set-frontmatter.ts';
+import type { Dics, FrontmatterFileMeta } from '../../set-frontmatter.ts';
 import { generateFrontmatter, judgeCategory, judgeType, loadDics } from '../../set-frontmatter.ts';
 
 const _enc = new TextEncoder();
@@ -98,8 +98,8 @@ async function _collectFixtureDirs(rootDir: string): Promise<string[]> {
   return dirs.sort();
 }
 
-/** FileMeta を input.md から構築する */
-async function _makeFileMeta(filePath: string): Promise<FileMeta> {
+/** FrontmatterFileMeta を input.md から構築する */
+async function _makeFrontmatterFileMeta(filePath: string): Promise<FrontmatterFileMeta> {
   const text = await Deno.readTextFile(filePath);
 
   // 簡易フロントマター解析
@@ -174,7 +174,7 @@ for (const _relPath of _fixtureDirs) {
   describe(`set-frontmatter — ${_relPath}`, () => {
     describe(`Given: ${_relPath}/input.md と辞書ファイル`, () => {
       let _tempDir: string;
-      let _fileMeta: FileMeta;
+      let _fileMeta: FrontmatterFileMeta;
       let _loggerStub: LoggerStub;
       let _commandHandle: CommandMockHandle | null = null;
 
@@ -182,7 +182,7 @@ for (const _relPath of _fixtureDirs) {
         _tempDir = await Deno.makeTempDir();
         const _tempPath = `${_tempDir}/input.md`;
         await Deno.copyFile(_inputPath, _tempPath);
-        _fileMeta = await _makeFileMeta(_tempPath);
+        _fileMeta = await _makeFrontmatterFileMeta(_tempPath);
         _loggerStub = makeLoggerStub();
 
         if (_isFallbackCase) {

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
@@ -125,7 +125,7 @@ async function _makeFrontmatterFileMeta(filePath: string): Promise<FrontmatterFi
     date: meta['date'] ?? '',
     project: meta['project'] ?? '',
     slug: meta['slug'] ?? '',
-    body: fullBody.slice(0, 4000),
+    content: fullBody.slice(0, 4000),
     fullBody,
   };
 }

--- a/skills/set-frontmatter/scripts/__tests__/functional/load-frontmatter-file-meta.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/load-frontmatter-file-meta.functional.spec.ts
@@ -1,5 +1,5 @@
-// src: scripts/__tests__/functional/set-frontmatter.load-file-meta.functional.spec.ts
-// @(#): loadFileMeta の機能テスト
+// src: scripts/__tests__/functional/load-frontmatter-file-meta.functional.spec.ts
+// @(#): loadFrontmatterFileMeta の機能テスト
 //       実ファイルを使ったメタデータ読み込みの検証
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -10,7 +10,7 @@ import { assertEquals, assertNotEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // test target
-import { loadFileMeta, MAX_BODY_CHARS } from '../../set-frontmatter.ts';
+import { loadFrontmatterFileMeta, MAX_BODY_CHARS } from '../../set-frontmatter.ts';
 
 // ─── テスト共通セットアップ ───────────────────────────────────────────────────
 
@@ -26,9 +26,9 @@ afterEach(async () => {
 
 // ─── フロントマターありのファイル ────────────────────────────────────────────
 
-describe('loadFileMeta', () => {
+describe('loadFrontmatterFileMeta', () => {
   describe('Given: フロントマターありの .md ファイル', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadFrontmatterFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-SF-LFM-01 - フロントマターフィールドが正しく読み込まれる', () => {
         const content = [
           '---',
@@ -46,7 +46,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, content);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertNotEquals(result, null);
           assertEquals(result!.sessionId, 'sess-001');
@@ -56,7 +56,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, content);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result!.date, '2026-03-15');
         });
@@ -65,7 +65,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, content);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result!.project, 'my-project');
         });
@@ -74,7 +74,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, content);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result!.slug, 'test-slug');
         });
@@ -83,7 +83,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, content);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result!.body.includes('# テスト'), true);
         });
@@ -94,14 +94,14 @@ describe('loadFileMeta', () => {
   // ─── 本文が MAX_BODY_CHARS を超える場合 ──────────────────────────────────
 
   describe('Given: 本文が MAX_BODY_CHARS を超えるファイル', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadFrontmatterFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-SF-LFM-02 - body が制限され fullBody は全文', () => {
         it('T-SF-LFM-02-01: body が MAX_BODY_CHARS 以下になる', async () => {
           const filePath = `${tempDir}/long.md`;
           const longBody = '# タイトル\n' + 'x'.repeat(MAX_BODY_CHARS + 100);
           await Deno.writeTextFile(filePath, longBody);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertNotEquals(result, null);
           assertEquals(result!.body.length <= MAX_BODY_CHARS, true);
@@ -112,7 +112,7 @@ describe('loadFileMeta', () => {
           const longBody = '# タイトル\n' + 'x'.repeat(MAX_BODY_CHARS + 100);
           await Deno.writeTextFile(filePath, longBody);
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result!.fullBody.length > MAX_BODY_CHARS, true);
         });
@@ -123,13 +123,13 @@ describe('loadFileMeta', () => {
   // ─── ヘッダー行なし → null ───────────────────────────────────────────────
 
   describe('Given: "#" ヘッダー行のないファイル', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadFrontmatterFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-SF-LFM-03 - null が返る', () => {
         it('T-SF-LFM-03-01: null が返る', async () => {
           const filePath = `${tempDir}/noheader.md`;
           await Deno.writeTextFile(filePath, 'ヘッダーなしの本文テキスト');
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result, null);
         });
@@ -140,10 +140,10 @@ describe('loadFileMeta', () => {
   // ─── 存在しないファイル → null ───────────────────────────────────────────
 
   describe('Given: 存在しないファイルパス', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadFrontmatterFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-SF-LFM-04 - null が返る（例外なし）', () => {
         it('T-SF-LFM-04-01: null が返る', async () => {
-          const result = await loadFileMeta(`${tempDir}/nonexistent.md`);
+          const result = await loadFrontmatterFileMeta(`${tempDir}/nonexistent.md`);
 
           assertEquals(result, null);
         });
@@ -154,13 +154,13 @@ describe('loadFileMeta', () => {
   // ─── フロントマターなし（ヘッダーのみ）→ meta フィールドが空文字 ─────────
 
   describe('Given: フロントマターのない .md ファイル（ヘッダーのみ）', () => {
-    describe('When: loadFileMeta(filePath) を呼び出す', () => {
+    describe('When: loadFrontmatterFileMeta(filePath) を呼び出す', () => {
       describe('Then: T-SF-LFM-05 - meta フィールドが空文字になる', () => {
         it('T-SF-LFM-05-01: sessionId が空文字になる', async () => {
           const filePath = `${tempDir}/nofm.md`;
           await Deno.writeTextFile(filePath, '# タイトル\n本文');
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertNotEquals(result, null);
           assertEquals(result!.sessionId, '');
@@ -170,7 +170,7 @@ describe('loadFileMeta', () => {
           const filePath = `${tempDir}/nofm.md`;
           await Deno.writeTextFile(filePath, '# タイトル\n本文');
 
-          const result = await loadFileMeta(filePath);
+          const result = await loadFrontmatterFileMeta(filePath);
 
           assertEquals(result!.date, '');
         });

--- a/skills/set-frontmatter/scripts/__tests__/functional/load-frontmatter-file-meta.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/load-frontmatter-file-meta.functional.spec.ts
@@ -85,7 +85,7 @@ describe('loadFrontmatterFileMeta', () => {
 
           const result = await loadFrontmatterFileMeta(filePath);
 
-          assertEquals(result!.body.includes('# テスト'), true);
+          assertEquals(result!.content.includes('# テスト'), true);
         });
       });
     });
@@ -104,7 +104,7 @@ describe('loadFrontmatterFileMeta', () => {
           const result = await loadFrontmatterFileMeta(filePath);
 
           assertNotEquals(result, null);
-          assertEquals(result!.body.length <= MAX_BODY_CHARS, true);
+          assertEquals(result!.content.length <= MAX_BODY_CHARS, true);
         });
 
         it('T-SF-LFM-02-02: fullBody が MAX_BODY_CHARS を超える', async () => {

--- a/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
@@ -28,7 +28,7 @@ function _makeFrontmatterFileMeta(filePath: string): FrontmatterFileMeta {
     date: '2026-03-15',
     project: 'my-project',
     slug: 'test-slug',
-    body: '# テスト\n本文テキスト',
+    content: '# テスト\n本文テキスト',
     fullBody: '# テスト\n本文テキスト',
   };
 }

--- a/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
@@ -12,7 +12,7 @@ import type { Stub } from '@std/testing/mock';
 import { stub } from '@std/testing/mock';
 
 // test target
-import type { FileMeta, FrontmatterResult, Stats } from '../../set-frontmatter.ts';
+import type { FrontmatterFileMeta, FrontmatterResult, Stats } from '../../set-frontmatter.ts';
 import { writeFrontmatter } from '../../set-frontmatter.ts';
 
 // ─── テスト共通セットアップ ───────────────────────────────────────────────────
@@ -21,7 +21,7 @@ let tempDir: string;
 let errStub: Stub<Console>;
 let logStub: Stub<Console>;
 
-function _makeFileMeta(filePath: string): FileMeta {
+function _makeFrontmatterFileMeta(filePath: string): FrontmatterFileMeta {
   return {
     file: filePath,
     sessionId: 'sess-001',
@@ -67,7 +67,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-01-01: ファイルが更新される', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -80,7 +80,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-01-02: stats.success が 1 になる', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -92,7 +92,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-01-03: ファイルに "type: research" が含まれる', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -105,7 +105,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-01-04: ファイルに "category: development" が含まれる', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -118,7 +118,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-01-05: fullBody が末尾に保持される', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -140,7 +140,7 @@ describe('writeFrontmatter', () => {
           const filePath = `${tempDir}/test.md`;
           const originalContent = '# テスト\n本文';
           await Deno.writeTextFile(filePath, originalContent);
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -153,7 +153,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-02-02: stats.success が 1 になる', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 
@@ -173,7 +173,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-03-01: stats.fail が 1 になる', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath, '');
           const stats = _makeStats();
 
@@ -186,7 +186,7 @@ describe('writeFrontmatter', () => {
           const filePath = `${tempDir}/test.md`;
           const originalContent = '# テスト\n本文';
           await Deno.writeTextFile(filePath, originalContent);
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath, '');
           const stats = _makeStats();
 
@@ -207,7 +207,7 @@ describe('writeFrontmatter', () => {
         it('T-SF-WF-04-01: .tmp ファイルが残らない', async () => {
           const filePath = `${tempDir}/test.md`;
           await Deno.writeTextFile(filePath, '# テスト\n本文');
-          const fm = _makeFileMeta(filePath);
+          const fm = _makeFrontmatterFileMeta(filePath);
           const result = _makeResult(filePath);
           const stats = _makeStats();
 

--- a/skills/set-frontmatter/scripts/__tests__/integration/set-frontmatter.judge-pipeline.integration.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/integration/set-frontmatter.judge-pipeline.integration.spec.ts
@@ -37,7 +37,7 @@ function _makeFrontmatterFileMeta(): FrontmatterFileMeta {
     date: '2026-03-15',
     project: 'my-project',
     slug: 'test-slug',
-    body: '# テスト\n本文テキスト',
+    content: '# テスト\n本文テキスト',
     fullBody: '# テスト\n本文テキスト',
   };
 }

--- a/skills/set-frontmatter/scripts/__tests__/integration/set-frontmatter.judge-pipeline.integration.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/integration/set-frontmatter.judge-pipeline.integration.spec.ts
@@ -23,14 +23,14 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
 // test target
-import type { Dics, FileMeta, FrontmatterResult } from '../../set-frontmatter.ts';
+import type { Dics, FrontmatterFileMeta, FrontmatterResult } from '../../set-frontmatter.ts';
 import { generateFrontmatter, judgeCategory, judgeType, reviewFrontmatter } from '../../set-frontmatter.ts';
 
 const _enc = new TextEncoder();
 
 // ─── テスト用ヘルパー ─────────────────────────────────────────────────────────
 
-function _makeFileMeta(): FileMeta {
+function _makeFrontmatterFileMeta(): FrontmatterFileMeta {
   return {
     file: '/tmp/test.md',
     sessionId: 'sess-001',
@@ -93,7 +93,7 @@ describe('judgeType', () => {
         });
 
         it('T-SF-JP-01-01: type が "research" になる', async () => {
-          const result = await judgeType(_makeFileMeta(), _makeDics());
+          const result = await judgeType(_makeFrontmatterFileMeta(), _makeDics());
 
           assertEquals(result.type, 'research');
         });
@@ -109,7 +109,7 @@ describe('judgeType', () => {
         });
 
         it('T-SF-JP-02-01: type が "research" になる（フォールバック）', async () => {
-          const result = await judgeType(_makeFileMeta(), _makeDics());
+          const result = await judgeType(_makeFrontmatterFileMeta(), _makeDics());
 
           assertEquals(result.type, 'research');
         });
@@ -125,7 +125,7 @@ describe('judgeType', () => {
         });
 
         it('T-SF-JP-03-01: type が "research" になる（例外なし）', async () => {
-          const result = await judgeType(_makeFileMeta(), _makeDics());
+          const result = await judgeType(_makeFrontmatterFileMeta(), _makeDics());
 
           assertEquals(result.type, 'research');
         });
@@ -145,7 +145,7 @@ describe('judgeCategory', () => {
         });
 
         it('T-SF-JP-04-01: "development" が返る', async () => {
-          const result = await judgeCategory(_makeFileMeta(), 'research', _makeDics());
+          const result = await judgeCategory(_makeFrontmatterFileMeta(), 'research', _makeDics());
 
           assertEquals(result, 'development');
         });
@@ -161,7 +161,7 @@ describe('judgeCategory', () => {
         });
 
         it('T-SF-JP-05-01: "development" が返る（フォールバック）', async () => {
-          const result = await judgeCategory(_makeFileMeta(), 'research', _makeDics());
+          const result = await judgeCategory(_makeFrontmatterFileMeta(), 'research', _makeDics());
 
           assertEquals(result, 'development');
         });
@@ -177,7 +177,7 @@ describe('judgeCategory', () => {
         });
 
         it('T-SF-JP-06-01: "development" が返る（例外なし）', async () => {
-          const result = await judgeCategory(_makeFileMeta(), 'research', _makeDics());
+          const result = await judgeCategory(_makeFrontmatterFileMeta(), 'research', _makeDics());
 
           assertEquals(result, 'development');
         });
@@ -199,19 +199,34 @@ describe('generateFrontmatter', () => {
         });
 
         it('T-SF-JP-07-01: yaml が設定される', async () => {
-          const result = await generateFrontmatter(_makeFileMeta(), 'research', 'development', _makeDics());
+          const result = await generateFrontmatter(
+            _makeFrontmatterFileMeta(),
+            'research',
+            'development',
+            _makeDics(),
+          );
 
           assertEquals(result.yaml.length > 0, true);
         });
 
         it('T-SF-JP-07-02: type が "research" になる', async () => {
-          const result = await generateFrontmatter(_makeFileMeta(), 'research', 'development', _makeDics());
+          const result = await generateFrontmatter(
+            _makeFrontmatterFileMeta(),
+            'research',
+            'development',
+            _makeDics(),
+          );
 
           assertEquals(result.type, 'research');
         });
 
         it('T-SF-JP-07-03: category が "development" になる', async () => {
-          const result = await generateFrontmatter(_makeFileMeta(), 'research', 'development', _makeDics());
+          const result = await generateFrontmatter(
+            _makeFrontmatterFileMeta(),
+            'research',
+            'development',
+            _makeDics(),
+          );
 
           assertEquals(result.category, 'development');
         });
@@ -229,7 +244,12 @@ describe('generateFrontmatter', () => {
         });
 
         it('T-SF-JP-08-01: yaml に ``` が含まれない', async () => {
-          const result = await generateFrontmatter(_makeFileMeta(), 'research', 'development', _makeDics());
+          const result = await generateFrontmatter(
+            _makeFrontmatterFileMeta(),
+            'research',
+            'development',
+            _makeDics(),
+          );
 
           assertEquals(result.yaml.includes('```'), false);
         });
@@ -245,7 +265,12 @@ describe('generateFrontmatter', () => {
         });
 
         it('T-SF-JP-09-01: yaml が空文字になる', async () => {
-          const result = await generateFrontmatter(_makeFileMeta(), 'research', 'development', _makeDics());
+          const result = await generateFrontmatter(
+            _makeFrontmatterFileMeta(),
+            'research',
+            'development',
+            _makeDics(),
+          );
 
           assertEquals(result.yaml, '');
         });

--- a/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.parse-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.parse-frontmatter.unit.spec.ts
@@ -29,7 +29,7 @@ describe('parseFrontmatterEntries', () => {
         it('T-SF-PF-01-02: body が元テキスト全体になる', () => {
           const result = parseFrontmatterEntries(text);
 
-          assertEquals(result.body, text);
+          assertEquals(result.content, text);
         });
       });
     });
@@ -51,7 +51,7 @@ describe('parseFrontmatterEntries', () => {
         it('T-SF-PF-02-02: body が "本文" になる', () => {
           const result = parseFrontmatterEntries(text);
 
-          assertEquals(result.body, '本文');
+          assertEquals(result.content, '本文');
         });
       });
     });
@@ -117,7 +117,7 @@ describe('parseFrontmatterEntries', () => {
         it('T-SF-PF-04-02: body が "本文" になる', () => {
           const result = parseFrontmatterEntries(text);
 
-          assertEquals(result.body, '本文');
+          assertEquals(result.content, '本文');
         });
       });
     });
@@ -139,7 +139,7 @@ describe('parseFrontmatterEntries', () => {
         it('T-SF-PF-05-02: body が "本文" になる', () => {
           const result = parseFrontmatterEntries(text);
 
-          assertEquals(result.body, '本文');
+          assertEquals(result.content, '本文');
         });
       });
     });
@@ -168,7 +168,7 @@ describe('parseFrontmatterEntries', () => {
         it('T-SF-PF-06-02: body が "本文" になる', () => {
           const result = parseFrontmatterEntries(text);
 
-          assertEquals(result.body, '本文');
+          assertEquals(result.content, '本文');
         });
       });
     });

--- a/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.parse-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/set-frontmatter.parse-frontmatter.unit.spec.ts
@@ -1,5 +1,5 @@
 // src: scripts/__tests__/unit/set-frontmatter.parse-frontmatter.unit.spec.ts
-// @(#): parseFrontmatter のユニットテスト
+// @(#): parseFrontmatterEntries のユニットテスト
 //       Markdownテキストからフロントマターを抽出する関数の検証
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -10,24 +10,24 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // test target
-import { parseFrontmatter } from '../../set-frontmatter.ts';
+import { parseFrontmatterEntries } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
 
 // ─── フロントマターなしのテキスト ─────────────────────────────────────────────
 
-describe('parseFrontmatter', () => {
+describe('parseFrontmatterEntries', () => {
   describe('Given: フロントマターのないテキスト "# タイトル\\n本文"', () => {
     describe('When: parseFrontmatter を呼び出す', () => {
       describe('Then: T-SF-PF-01 - meta={}、body=元テキスト', () => {
         const text = '# タイトル\n本文';
 
         it('T-SF-PF-01-01: meta が空オブジェクトになる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta, {});
         });
 
         it('T-SF-PF-01-02: body が元テキスト全体になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.body, text);
         });
@@ -43,13 +43,13 @@ describe('parseFrontmatter', () => {
         const text = '---\nkey: val\n---\n本文';
 
         it('T-SF-PF-02-01: meta.key が "val" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta['key'], 'val');
         });
 
         it('T-SF-PF-02-02: body が "本文" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.body, '本文');
         });
@@ -75,25 +75,25 @@ describe('parseFrontmatter', () => {
         ].join('\n');
 
         it('T-SF-PF-03-01: session_id が "sess-001" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta['session_id'], 'sess-001');
         });
 
         it('T-SF-PF-03-02: date が "2026-03-15" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta['date'], '2026-03-15');
         });
 
         it('T-SF-PF-03-03: project が "my-project" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta['project'], 'my-project');
         });
 
         it('T-SF-PF-03-04: slug が "test-slug" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta['slug'], 'test-slug');
         });
@@ -109,13 +109,13 @@ describe('parseFrontmatter', () => {
         const text = '---\r\nkey: val\r\n---\r\n本文';
 
         it('T-SF-PF-04-01: meta.key が "val" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta['key'], 'val');
         });
 
         it('T-SF-PF-04-02: body が "本文" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.body, '本文');
         });
@@ -131,13 +131,13 @@ describe('parseFrontmatter', () => {
         const text = '---\n---\n本文';
 
         it('T-SF-PF-05-01: meta が空オブジェクトになる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.meta, {});
         });
 
         it('T-SF-PF-05-02: body が "本文" になる', () => {
-          const result = parseFrontmatter(text);
+          const result = parseFrontmatterEntries(text);
 
           assertEquals(result.body, '本文');
         });
@@ -145,29 +145,30 @@ describe('parseFrontmatter', () => {
     });
   });
 
-  // ─── インデント継続値（YAML multiline）のスキップ ─────────────────────────
+  // ─── YAML block scalar（正当な multiline）のパース ────────────────────────
 
-  describe('Given: インデントされた継続値を含むフロントマター', () => {
-    describe('When: parseFrontmatter を呼び出す', () => {
-      describe('Then: T-SF-PF-06 - インデント行はスキップされる', () => {
+  describe('Given: YAML block scalar (|) を含むフロントマター', () => {
+    describe('When: parseFrontmatterEntries を呼び出す', () => {
+      describe('Then: T-SF-PF-06 - summary が複数行文字列として取得できる', () => {
         const text = [
           '---',
-          'key: val',
-          '  continued: line',
+          'summary: |',
+          '  line1',
+          '  line2',
           '---',
           '本文',
         ].join('\n');
 
-        it('T-SF-PF-06-01: key が "val" になる（インデント行は無視）', () => {
-          const result = parseFrontmatter(text);
+        it('T-SF-PF-06-01: summary が "line1\\nline2\\n" になる', () => {
+          const result = parseFrontmatterEntries(text);
 
-          assertEquals(result.meta['key'], 'val');
+          assertEquals(result.meta['summary'], 'line1\nline2\n');
         });
 
-        it('T-SF-PF-06-02: "continued" キーは meta に含まれない', () => {
-          const result = parseFrontmatter(text);
+        it('T-SF-PF-06-02: body が "本文" になる', () => {
+          const result = parseFrontmatterEntries(text);
 
-          assertEquals('continued' in result.meta, false);
+          assertEquals(result.body, '本文');
         });
       });
     });

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -30,7 +30,7 @@ import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
 import { toStringArrayWithNull } from '../../_scripts/libs/text/coerce-utils.ts';
-import { normalizeLine } from '../../_scripts/libs/text/line-utils.ts';
+import { parseFrontmatterEntries } from '../../_scripts/libs/text/frontmatter-utils.ts';
 import { cleanYaml } from '../../_scripts/libs/text/markdown-utils.ts';
 
 // ─────────────────────────────────────────────
@@ -46,7 +46,7 @@ export const MAX_BODY_CHARS = 4000;
 
 export type LogType = string;
 
-export interface FileMeta {
+export interface FrontmatterFileMeta {
   file: string; // フルパス
   sessionId: string;
   date: string;
@@ -257,45 +257,10 @@ export const formatEntryShort = (e: DicEntry): string => {
 };
 
 // ─────────────────────────────────────────────
-// Frontmatter パーサー
-// ─────────────────────────────────────────────
-
-export const parseFrontmatter = (text: string): { meta: Record<string, string>; body: string } => {
-  const lines = normalizeLine(text).split('\n');
-
-  if (lines[0] !== '---') {
-    return { meta: {}, body: lines.join('\n') };
-  }
-
-  const _meta: Record<string, string> = {};
-  let _bodyStart = lines.length;
-
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^---/.test(line)) {
-      _bodyStart = i + 1;
-      break;
-    }
-
-    const idx = line.indexOf(': ');
-    if (idx !== -1 && !line.startsWith(' ') && /^\w/.test(line)) {
-      _meta[line.slice(0, idx).trim()] = line.slice(idx + 2).trim();
-    } else if (line.trim() === '' || line.startsWith(' ') || line.startsWith('\t')) {
-      // YAML継続値・空行はスキップ
-    } else {
-      _bodyStart = i;
-      break;
-    }
-  }
-
-  return { meta: _meta, body: lines.slice(_bodyStart).join('\n') };
-};
-
-// ─────────────────────────────────────────────
 // ファイルメタ読み込み
 // ─────────────────────────────────────────────
 
-export const loadFileMeta = async (filePath: string): Promise<FileMeta | null> => {
+export const loadFrontmatterFileMeta = async (filePath: string): Promise<FrontmatterFileMeta | null> => {
   let text: string;
   try {
     text = await Deno.readTextFile(filePath);
@@ -303,7 +268,7 @@ export const loadFileMeta = async (filePath: string): Promise<FileMeta | null> =
     return null;
   }
 
-  const { meta } = parseFrontmatter(text);
+  const { meta } = parseFrontmatterEntries(text);
 
   const rawLines = text.replace(/\r\n/g, '\n').split('\n');
   const headerIdx = rawLines.findIndex((l) => /^#/.test(l));
@@ -317,10 +282,10 @@ export const loadFileMeta = async (filePath: string): Promise<FileMeta | null> =
 
   return {
     file: filePath,
-    sessionId: meta['session_id'] ?? '',
-    date: meta['date'] ?? '',
-    project: meta['project'] ?? '',
-    slug: meta['slug'] ?? '',
+    sessionId: typeof meta['session_id'] === 'string' ? meta['session_id'] : '',
+    date: typeof meta['date'] === 'string' ? meta['date'] : '',
+    project: typeof meta['project'] === 'string' ? meta['project'] : '',
+    slug: typeof meta['slug'] === 'string' ? meta['slug'] : '',
     body: fullBody.slice(0, MAX_BODY_CHARS),
     fullBody,
   };
@@ -350,7 +315,7 @@ export const runClaude = async (systemPrompt: string, userPrompt: string): Promi
 // Phase 2: type判定（並列）
 // ─────────────────────────────────────────────
 
-export const judgeType = async (fm: FileMeta, dics: Dics): Promise<TypeResult> => {
+export const judgeType = async (fm: FrontmatterFileMeta, dics: Dics): Promise<TypeResult> => {
   const tmpl = dics.prompts.get('type') ?? { system: '', user: '' };
   const typeList = dics.typeEntries.map(formatEntryWithRules).join('\n');
   const system = renderPrompt(tmpl.system, {});
@@ -370,7 +335,7 @@ export const judgeType = async (fm: FileMeta, dics: Dics): Promise<TypeResult> =
 // Phase 3a: category判定（並列）
 // ─────────────────────────────────────────────
 
-export const judgeCategory = async (fm: FileMeta, type: LogType, dics: Dics): Promise<string> => {
+export const judgeCategory = async (fm: FrontmatterFileMeta, type: LogType, dics: Dics): Promise<string> => {
   const tmpl = dics.prompts.get('category') ?? { system: '', user: '' };
   const focusGuide = dics.categoryPrompts.get(type) ?? '';
   const system = renderPrompt(tmpl.system, {});
@@ -395,7 +360,7 @@ export const judgeCategory = async (fm: FileMeta, type: LogType, dics: Dics): Pr
 // ─────────────────────────────────────────────
 
 export const generateFrontmatter = async (
-  fm: FileMeta,
+  fm: FrontmatterFileMeta,
   type: LogType,
   category: string,
   dics: Dics,
@@ -496,7 +461,7 @@ export const reviewFrontmatter = async (
 // ─────────────────────────────────────────────
 
 export const writeFrontmatter = async (
-  fm: FileMeta,
+  fm: FrontmatterFileMeta,
   result: FrontmatterResult,
   dryRun: boolean,
   stats: Stats,
@@ -617,10 +582,10 @@ export const main = async (args: string[]): Promise<void> => {
     }
 
     // Phase 1: メタ読み込み
-    const fileMetaList: FileMeta[] = [];
+    const fileMetaList: FrontmatterFileMeta[] = [];
     const stats: Stats = { total: allFiles.length, success: 0, fail: 0, skip: 0 };
     for (const filePath of allFiles) {
-      const fm = await loadFileMeta(filePath);
+      const fm = await loadFrontmatterFileMeta(filePath);
       if (!fm) {
         logger.info(`  skip: ${filePath.split(/[/\\]/).pop()}`);
         stats.skip++;

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -52,7 +52,7 @@ export interface FrontmatterFileMeta {
   date: string;
   project: string;
   slug: string;
-  body: string; // 本文（4000文字制限）
+  content: string; // 本文（4000文字制限）
   fullBody: string; // 本文（無制限、書き込み用）
 }
 
@@ -286,7 +286,7 @@ export const loadFrontmatterFileMeta = async (filePath: string): Promise<Frontma
     date: typeof meta['date'] === 'string' ? meta['date'] : '',
     project: typeof meta['project'] === 'string' ? meta['project'] : '',
     slug: typeof meta['slug'] === 'string' ? meta['slug'] : '',
-    body: fullBody.slice(0, MAX_BODY_CHARS),
+    content: fullBody.slice(0, MAX_BODY_CHARS),
     fullBody,
   };
 };
@@ -319,7 +319,7 @@ export const judgeType = async (fm: FrontmatterFileMeta, dics: Dics): Promise<Ty
   const tmpl = dics.prompts.get('type') ?? { system: '', user: '' };
   const typeList = dics.typeEntries.map(formatEntryWithRules).join('\n');
   const system = renderPrompt(tmpl.system, {});
-  const user = renderPrompt(tmpl.user, { type_list: typeList, body: fm.body });
+  const user = renderPrompt(tmpl.user, { type_list: typeList, body: fm.content });
   let raw: string;
   try {
     raw = await runClaude(system, user);
@@ -342,7 +342,7 @@ export const judgeCategory = async (fm: FrontmatterFileMeta, type: LogType, dics
   const user = renderPrompt(tmpl.user, {
     category_list: dics.category,
     focus_guide: focusGuide,
-    body: fm.body,
+    body: fm.content,
   });
   let raw: string;
   try {
@@ -373,7 +373,7 @@ export const generateFrontmatter = async (
     log_category: category,
     topic_list: topicList,
     tags_list: dics.tags,
-    body: fm.body,
+    body: fm.content,
   });
   let raw: string;
   try {


### PR DESCRIPTION
## Overview

**Summary**
5 モジュール横断で frontmatter パーサーを共通化し、型名の衝突解消・フィールド名統一を行う。

**Background / Motivation**
各モジュール（`filter-chatlog`, `normalize-chatlog`, `set-frontmatter`, `classify-chatlog`）がそれぞれ独自の frontmatter パーサーを持っており、重複実装が存在していた。加えて以下の問題があった。

- YAML 配列値（`tags: [a, b]` 等）を `string` として読み込んでしまい、正しい型で扱えなかった
- `classify-chatlog` の `FileMeta` 型が `_scripts/types/frontmatter.types.ts` の `FileMeta` と名前衝突していた
- `body` と `content` フィールドが混在しており、一貫性がなかった

## Changes

- `skills/_scripts/libs/text/frontmatter-utils.ts` に共通パーサー `parseFrontmatterEntries` を追加（YAML 配列値対応）
- `skills/_scripts/types/frontmatter.types.ts` を新規作成し、共通型定義（`FileMeta`, `FrontmatterFileMeta`）を集約
- `filter-chatlog`, `normalize-chatlog`, `set-frontmatter`, `classify-chatlog` の独自パーサーを削除し、共通パーサーへ移行
- `classify-chatlog` の型名を `ClassifyFileMeta` / `ClassifyStats` にリネームして名前衝突を解消
- 全モジュールで `body` フィールドを `content` にリネーム
- `classify-chatlog` の `frontmatterEnd` フィールドを削除（未使用）
- 上記変更に対応するテストフィクスチャ・テストコードを更新

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

影響モジュール一覧:

| パス                                             | 種別 | 内容                             |
| ------------------------------------------------ | ---- | -------------------------------- |
| `skills/_scripts/types/frontmatter.types.ts`     | 新規 | 共通型定義                       |
| `skills/_scripts/libs/text/frontmatter-utils.ts` | 変更 | 共通パーサー追加                 |
| `skills/classify-chatlog/scripts/`               | 変更 | 型リネーム・共通パーサー移行     |
| `skills/filter-chatlog/scripts/`                 | 変更 | 共通パーサー移行・`body→content` |
| `skills/normalize-chatlog/scripts/`              | 変更 | 共通パーサー移行・配列 meta 対応 |
| `skills/set-frontmatter/scripts/`                | 変更 | 共通パーサー移行・型リネーム     |
| `skills/*/\_\_tests\_\_/`                        | 変更 | 上記変更に対応したテスト更新     |

型リネーム対応表:

| 変更前           | 変更後                   | モジュール         |
| ---------------- | ------------------------ | ------------------ |
| `FileMeta`       | `ClassifyFileMeta`       | `classify-chatlog` |
| `Stats`          | `ClassifyStats`          | `classify-chatlog` |
| `loadFileMeta()` | `loadClassifyFileMeta()` | `classify-chatlog` |

> 注意:
> `prefilter-chatlog.ts` は独自の軽量パーサーを保持しています（設計上の意図的な残存）。スキルの外部インターフェース
> （シェルスクリプト経由の入出力）への変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
