### PR TITLE
test(helpers/find-fixture-dirs): add findFixtureDirs helper with tests

### DIFF
--- a/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
+++ b/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
@@ -306,6 +306,28 @@ describe('Given: findFixtureDirs', () => {
     });
   });
 
+  /**
+   * isFixtureDir が true を返したディレクトリの内部は走査しない仕様（再帰打ち切り）。
+   * fixture のネストは想定しない。
+   */
+  describe('When: isFixtureDir が true を返したディレクトリの内部にサブディレクトリがある', () => {
+    it('Then: [仕様] - 内部のサブディレクトリは収集されない', async () => {
+      // arrange
+      const _parent = 'edge-nested-parent';
+      const _child = `${_parent}/child`;
+      await Deno.mkdir(`${_tempDir}/${_child}`, { recursive: true });
+      const _isFixtureDir: IsFixtureDirProvider = (dir) =>
+        Promise.resolve(normalizePath(dir).endsWith(_parent) || normalizePath(dir).endsWith('child'));
+
+      // act
+      const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
+
+      // assert: _parent は収集されるが child は収集されない
+      assertEquals(_result.includes(_parent), true);
+      assertEquals(_result.includes(_child), false);
+    });
+  });
+
   /** rootDir が存在しないパスを指す場合（エッジケース） */
   describe('When: rootDir が存在しないディレクトリを指す', () => {
     it('Then: [エッジケース] - エラーを投げず空配列を返す', async () => {

--- a/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
+++ b/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
@@ -12,21 +12,10 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // -- test target --
-<<<<<<< HEAD
 import { defaultIsFixtureDir, findFixtureDirs } from '../find-fixture-dirs.ts';
 // -- utils --
-||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
-import { findFixtureDirs } from '../find-fixture-dirs.ts';
-import type { IsFixtureDirProvider } from '../find-fixture-dirs.ts';
-=======
->>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
 import { normalizePath } from '../../../libs/file-io/path-utils.ts';
-<<<<<<< HEAD
 // -- types --
-||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
-=======
-import { defaultIsFixtureDir, findFixtureDirs } from '../find-fixture-dirs.ts';
->>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
 import type { IsFixtureDirProvider } from '../find-fixture-dirs.ts';
 
 // ─────────────────────────────────────────────
@@ -87,16 +76,10 @@ describe('Given: defaultIsFixtureDir', () => {
   });
 });
 
-const FILTER_FIXTURES_ROOT = new URL(
-  '../../../../filter-chatlog/scripts/__tests__/fixtures/fixtures-data',
-  import.meta.url,
-).pathname.replace(/^\/([A-Z]:)/, '$1');
-
 // ─────────────────────────────────────────────
 // findFixtureDirs — ユニットテスト
 // ─────────────────────────────────────────────
 
-<<<<<<< HEAD
 /** findFixtureDirs: isFixtureDir を省略してデフォルト動作を確認するテスト */
 describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
   let _tempDir: string;
@@ -133,9 +116,6 @@ describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
 });
 
 /** findFixtureDirs: カスタム isFixtureDir を DI して動作を検証するテスト */
-||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
-=======
-// ─────────────────────────────────────────────
 // defaultIsFixtureDir — ユニットテスト
 // ─────────────────────────────────────────────
 
@@ -192,13 +172,29 @@ describe('Given: defaultIsFixtureDir', () => {
 // ─────────────────────────────────────────────
 
 describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
+  let _tempDir: string;
+
+  beforeEach(async () => {
+    _tempDir = await Deno.makeTempDir({ prefix: 'find-fixture-dirs-' });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(_tempDir, { recursive: true });
+  });
+
   describe('When: isFixtureDir 引数を省略して呼び出す', () => {
     it('Then: [正常] - input.md を持つディレクトリのみ収集される', async () => {
       // arrange
+      await Deno.mkdir(`${_tempDir}/edge-01-minimal`);
+      await Deno.writeTextFile(`${_tempDir}/edge-01-minimal/input.md`, '');
+      await Deno.mkdir(`${_tempDir}/normal-01-basic-keep`);
+      await Deno.writeTextFile(`${_tempDir}/normal-01-basic-keep/input.md`, '');
+      await Deno.mkdir(`${_tempDir}/normal-02-basic-discard`);
+      await Deno.writeTextFile(`${_tempDir}/normal-02-basic-discard/input.md`, '');
       const _expected = ['edge-01-minimal', 'normal-01-basic-keep', 'normal-02-basic-discard'];
 
       // act
-      const _result = await findFixtureDirs(FILTER_FIXTURES_ROOT);
+      const _result = await findFixtureDirs(_tempDir);
 
       // assert
       assertEquals(_result, _expected);
@@ -206,7 +202,6 @@ describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
   });
 });
 
->>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
 describe('Given: findFixtureDirs', () => {
   let _tempDir: string;
 
@@ -241,14 +236,10 @@ describe('Given: findFixtureDirs', () => {
     it('Then: [正常] - 多階層の相対パスが正しく収集される', async () => {
       // arrange
       const _target = 'edge/whitespace/crlf-input';
-<<<<<<< HEAD
       await Deno.mkdir(`${_tempDir}/${_target}`, { recursive: true });
-||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
-      const _isFixtureDir: IsFixtureDirProvider = (dir) =>
-        Promise.resolve(normalizePath(dir).endsWith('crlf-input'));
-=======
->>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
+
       const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(normalizePath(dir).endsWith('crlf-input'));
+      await Deno.mkdir(`${_tempDir}/${_target}`, { recursive: true });
 
       // act
       const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
@@ -263,14 +254,8 @@ describe('Given: findFixtureDirs', () => {
     it('Then: [正常] - false を返すディレクトリは除外される', async () => {
       // arrange
       const _excluded = 're-normal-02-array-fields';
-<<<<<<< HEAD
       await Deno.mkdir(`${_tempDir}/re-normal-01-basic-entry`);
       await Deno.mkdir(`${_tempDir}/${_excluded}`);
-||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
-      const _isFixtureDir: IsFixtureDirProvider = (dir) =>
-        Promise.resolve(!normalizePath(dir).endsWith(_excluded));
-=======
->>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
       const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(!normalizePath(dir).endsWith(_excluded));
 
       // act

--- a/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
+++ b/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
@@ -12,10 +12,21 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // -- test target --
+<<<<<<< HEAD
 import { defaultIsFixtureDir, findFixtureDirs } from '../find-fixture-dirs.ts';
 // -- utils --
+||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
+import { findFixtureDirs } from '../find-fixture-dirs.ts';
+import type { IsFixtureDirProvider } from '../find-fixture-dirs.ts';
+=======
+>>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
 import { normalizePath } from '../../../libs/file-io/path-utils.ts';
+<<<<<<< HEAD
 // -- types --
+||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
+=======
+import { defaultIsFixtureDir, findFixtureDirs } from '../find-fixture-dirs.ts';
+>>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
 import type { IsFixtureDirProvider } from '../find-fixture-dirs.ts';
 
 // ─────────────────────────────────────────────
@@ -76,10 +87,16 @@ describe('Given: defaultIsFixtureDir', () => {
   });
 });
 
+const FILTER_FIXTURES_ROOT = new URL(
+  '../../../../filter-chatlog/scripts/__tests__/fixtures/fixtures-data',
+  import.meta.url,
+).pathname.replace(/^\/([A-Z]:)/, '$1');
+
 // ─────────────────────────────────────────────
 // findFixtureDirs — ユニットテスト
 // ─────────────────────────────────────────────
 
+<<<<<<< HEAD
 /** findFixtureDirs: isFixtureDir を省略してデフォルト動作を確認するテスト */
 describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
   let _tempDir: string;
@@ -116,6 +133,80 @@ describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
 });
 
 /** findFixtureDirs: カスタム isFixtureDir を DI して動作を検証するテスト */
+||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
+=======
+// ─────────────────────────────────────────────
+// defaultIsFixtureDir — ユニットテスト
+// ─────────────────────────────────────────────
+
+describe('Given: defaultIsFixtureDir', () => {
+  let _tempDir: string;
+
+  beforeEach(async () => {
+    _tempDir = await Deno.makeTempDir({ prefix: 'find-fixture-dirs-' });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(_tempDir, { recursive: true });
+  });
+
+  describe('When: input.md があるディレクトリを渡す', () => {
+    it('Then: [正常] - true を返す', async () => {
+      // arrange
+      await Deno.writeTextFile(`${_tempDir}/input.md`, '');
+
+      // act
+      const _result = await defaultIsFixtureDir(_tempDir);
+
+      // assert
+      assertEquals(_result, true);
+    });
+  });
+
+  describe('When: input.md がないディレクトリを渡す', () => {
+    it('Then: [正常] - false を返す', async () => {
+      // act
+      const _result = await defaultIsFixtureDir(_tempDir);
+
+      // assert
+      assertEquals(_result, false);
+    });
+  });
+
+  describe('When: 存在しないディレクトリを渡す', () => {
+    it('Then: [エッジケース] - 例外をスローせず false を返す', async () => {
+      // arrange
+      const _dir = `${_tempDir}/__nonexistent__`;
+
+      // act
+      const _result = await defaultIsFixtureDir(_dir);
+
+      // assert
+      assertEquals(_result, false);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// findFixtureDirs — ユニットテスト
+// ─────────────────────────────────────────────
+
+describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
+  describe('When: isFixtureDir 引数を省略して呼び出す', () => {
+    it('Then: [正常] - input.md を持つディレクトリのみ収集される', async () => {
+      // arrange
+      const _expected = ['edge-01-minimal', 'normal-01-basic-keep', 'normal-02-basic-discard'];
+
+      // act
+      const _result = await findFixtureDirs(FILTER_FIXTURES_ROOT);
+
+      // assert
+      assertEquals(_result, _expected);
+    });
+  });
+});
+
+>>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
 describe('Given: findFixtureDirs', () => {
   let _tempDir: string;
 
@@ -150,7 +241,13 @@ describe('Given: findFixtureDirs', () => {
     it('Then: [正常] - 多階層の相対パスが正しく収集される', async () => {
       // arrange
       const _target = 'edge/whitespace/crlf-input';
+<<<<<<< HEAD
       await Deno.mkdir(`${_tempDir}/${_target}`, { recursive: true });
+||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
+      const _isFixtureDir: IsFixtureDirProvider = (dir) =>
+        Promise.resolve(normalizePath(dir).endsWith('crlf-input'));
+=======
+>>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
       const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(normalizePath(dir).endsWith('crlf-input'));
 
       // act
@@ -166,8 +263,14 @@ describe('Given: findFixtureDirs', () => {
     it('Then: [正常] - false を返すディレクトリは除外される', async () => {
       // arrange
       const _excluded = 're-normal-02-array-fields';
+<<<<<<< HEAD
       await Deno.mkdir(`${_tempDir}/re-normal-01-basic-entry`);
       await Deno.mkdir(`${_tempDir}/${_excluded}`);
+||||||| parent of d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
+      const _isFixtureDir: IsFixtureDirProvider = (dir) =>
+        Promise.resolve(!normalizePath(dir).endsWith(_excluded));
+=======
+>>>>>>> d9bf5f4d (test(helpers/find-fixture-dirs): add defaultIsFixtureDir tests)
       const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(!normalizePath(dir).endsWith(_excluded));
 
       // act

--- a/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
+++ b/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
@@ -1,0 +1,235 @@
+// src: skills/_scripts/__tests__/helpers/find-fixture-dirs.unit.spec.ts
+// @(#): findFixtureDirs ユニットテスト
+//       isFixtureDirProvider を DI して実ファイルシステムに依存しないテストを実施する
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// -- test target --
+import { defaultIsFixtureDir, findFixtureDirs } from '../find-fixture-dirs.ts';
+// -- utils --
+import { normalizePath } from '../../../libs/file-io/path-utils.ts';
+// -- types --
+import type { IsFixtureDirProvider } from '../find-fixture-dirs.ts';
+
+// ─────────────────────────────────────────────
+// defaultIsFixtureDir — ユニットテスト
+// ─────────────────────────────────────────────
+
+/** defaultIsFixtureDir: input.md の有無でフィクスチャディレクトリを判定する関数のテスト */
+describe('Given: defaultIsFixtureDir', () => {
+  let _tempDir: string;
+
+  /** 共通前処理: 一時ディレクトリを作成 */
+  beforeEach(async () => {
+    _tempDir = await Deno.makeTempDir({ prefix: 'find-fixture-dirs-' });
+  });
+
+  /** 共通後処理: 一時ディレクトリを削除 */
+  afterEach(async () => {
+    await Deno.remove(_tempDir, { recursive: true });
+  });
+
+  /** input.md が存在するディレクトリを渡した場合 */
+  describe('When: input.md があるディレクトリを渡す', () => {
+    it('Then: [正常] - true を返す', async () => {
+      // arrange
+      await Deno.writeTextFile(`${_tempDir}/input.md`, '');
+
+      // act
+      const _result = await defaultIsFixtureDir(_tempDir);
+
+      // assert
+      assertEquals(_result, true);
+    });
+  });
+
+  /** input.md が存在しないディレクトリを渡した場合 */
+  describe('When: input.md がないディレクトリを渡す', () => {
+    it('Then: [正常] - false を返す', async () => {
+      // act
+      const _result = await defaultIsFixtureDir(_tempDir);
+
+      // assert
+      assertEquals(_result, false);
+    });
+  });
+
+  /** 存在しないディレクトリパスを渡した場合（エッジケース） */
+  describe('When: 存在しないディレクトリを渡す', () => {
+    it('Then: [エッジケース] - 例外をスローせず false を返す', async () => {
+      // arrange
+      const _dir = `${_tempDir}/__nonexistent__`;
+
+      // act
+      const _result = await defaultIsFixtureDir(_dir);
+
+      // assert
+      assertEquals(_result, false);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// findFixtureDirs — ユニットテスト
+// ─────────────────────────────────────────────
+
+/** findFixtureDirs: isFixtureDir を省略してデフォルト動作を確認するテスト */
+describe('Given: findFixtureDirs (デフォルト isFixtureDir)', () => {
+  let _tempDir: string;
+
+  /** 共通前処理: 一時ディレクトリを作成 */
+  beforeEach(async () => {
+    _tempDir = await Deno.makeTempDir({ prefix: 'find-fixture-dirs-' });
+  });
+
+  /** 共通後処理: 一時ディレクトリを削除 */
+  afterEach(async () => {
+    await Deno.remove(_tempDir, { recursive: true });
+  });
+
+  /** isFixtureDir を省略（デフォルト使用）して呼び出した場合 */
+  describe('When: isFixtureDir 引数を省略して呼び出す', () => {
+    it('Then: [正常] - input.md を持つディレクトリのみ収集される', async () => {
+      // arrange
+      await Deno.mkdir(`${_tempDir}/edge-01-minimal`);
+      await Deno.writeTextFile(`${_tempDir}/edge-01-minimal/input.md`, '');
+      await Deno.mkdir(`${_tempDir}/normal-01-basic-keep`);
+      await Deno.writeTextFile(`${_tempDir}/normal-01-basic-keep/input.md`, '');
+      await Deno.mkdir(`${_tempDir}/normal-02-basic-discard`);
+      await Deno.writeTextFile(`${_tempDir}/normal-02-basic-discard/input.md`, '');
+      const _expected = ['edge-01-minimal', 'normal-01-basic-keep', 'normal-02-basic-discard'];
+
+      // act
+      const _result = await findFixtureDirs(_tempDir);
+
+      // assert
+      assertEquals(_result, _expected);
+    });
+  });
+});
+
+/** findFixtureDirs: カスタム isFixtureDir を DI して動作を検証するテスト */
+describe('Given: findFixtureDirs', () => {
+  let _tempDir: string;
+
+  /** 共通前処理: 一時ディレクトリを作成 */
+  beforeEach(async () => {
+    _tempDir = await Deno.makeTempDir({ prefix: 'find-fixture-dirs-' });
+  });
+
+  /** 共通後処理: 一時ディレクトリを削除 */
+  afterEach(async () => {
+    await Deno.remove(_tempDir, { recursive: true });
+  });
+
+  /** isFixtureDir が特定ディレクトリに対して true を返す場合 */
+  describe('When: isFixtureDir が特定ディレクトリで true を返す', () => {
+    it('Then: [正常] - そのディレクトリの相対パスが結果に含まれる', async () => {
+      // arrange
+      const _target = 're-normal-01-basic-entry';
+      await Deno.mkdir(`${_tempDir}/${_target}`);
+      const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(normalizePath(dir).endsWith(_target));
+
+      // act
+      const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
+
+      // assert
+      assertEquals(_result.includes(_target), true);
+    });
+  });
+
+  /** isFixtureDir が多階層パス（サブディレクトリ）のディレクトリで true を返す場合 */
+  describe('When: isFixtureDir が多階層パスのディレクトリで true を返す', () => {
+    it('Then: [正常] - 多階層の相対パスが正しく収集される', async () => {
+      // arrange
+      const _target = 'edge/whitespace/crlf-input';
+      await Deno.mkdir(`${_tempDir}/${_target}`, { recursive: true });
+      const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(normalizePath(dir).endsWith('crlf-input'));
+
+      // act
+      const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
+
+      // assert
+      assertEquals(_result.includes(_target), true);
+    });
+  });
+
+  /** isFixtureDir が false を返すディレクトリが混在する場合 */
+  describe('When: isFixtureDir が false を返すディレクトリがある', () => {
+    it('Then: [正常] - false を返すディレクトリは除外される', async () => {
+      // arrange
+      const _excluded = 're-normal-02-array-fields';
+      await Deno.mkdir(`${_tempDir}/re-normal-01-basic-entry`);
+      await Deno.mkdir(`${_tempDir}/${_excluded}`);
+      const _isFixtureDir: IsFixtureDirProvider = (dir) => Promise.resolve(!normalizePath(dir).endsWith(_excluded));
+
+      // act
+      const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
+
+      // assert
+      assertEquals(_result.includes(_excluded), false);
+    });
+  });
+
+  /** isFixtureDir が全ディレクトリで false を返す場合 */
+  describe('When: isFixtureDir が全ディレクトリで false を返す', () => {
+    it('Then: [正常] - 空配列が返る', async () => {
+      // arrange
+      await Deno.mkdir(`${_tempDir}/some-subdir`);
+      const _isFixtureDir: IsFixtureDirProvider = () => Promise.resolve(false);
+
+      // act
+      const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
+
+      // assert
+      assertEquals(_result, []);
+    });
+  });
+
+  /** isFixtureDir が複数ディレクトリで true を返す場合（ソート確認） */
+  describe('When: isFixtureDir が複数のディレクトリで true を返す', () => {
+    it('Then: [正常] - 結果が辞書順ソートされている', async () => {
+      // arrange
+      await Deno.mkdir(`${_tempDir}/re-normal-01-basic-entry`);
+      await Deno.mkdir(`${_tempDir}/re-normal-02-array-fields`);
+      await Deno.mkdir(`${_tempDir}/re-normal-03-multiline-content`);
+      const _isFixtureDir: IsFixtureDirProvider = (dir) => {
+        const _normalized = normalizePath(dir);
+        return Promise.resolve(
+          _normalized.endsWith('re-normal-01-basic-entry')
+            || _normalized.endsWith('re-normal-03-multiline-content')
+            || _normalized.endsWith('re-normal-02-array-fields'),
+        );
+      };
+
+      // act
+      const _result = await findFixtureDirs(_tempDir, _isFixtureDir);
+
+      // assert
+      const _sorted = [..._result].sort();
+      assertEquals(_result, _sorted);
+    });
+  });
+
+  /** rootDir が存在しないパスを指す場合（エッジケース） */
+  describe('When: rootDir が存在しないディレクトリを指す', () => {
+    it('Then: [エッジケース] - エラーを投げず空配列を返す', async () => {
+      // arrange
+      const _nonExistent = `${_tempDir}/__nonexistent__`;
+      const _isFixtureDir: IsFixtureDirProvider = () => Promise.resolve(true);
+
+      // act
+      const _result = await findFixtureDirs(_nonExistent, _isFixtureDir);
+
+      // assert
+      assertEquals(_result, []);
+    });
+  });
+});

--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -37,6 +37,9 @@ export const defaultIsFixtureDir = async (dir: string): Promise<boolean> => {
 /**
  * rootDir 以下を再帰的に走査し、isFixtureDir が true を返したディレクトリの
  * rootDir からのスラッシュ区切り相対パスを辞書順ソートして返す。
+ *
+ * isFixtureDir が true を返したディレクトリはそこで走査を打ち切る（内部を再帰しない）。
+ * fixture ディレクトリのネストは想定しない仕様。
  */
 export const findFixtureDirs = async (
   rootDir: string,

--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -22,21 +22,32 @@ export type IsFixtureDirProvider = (dir: string) => Promise<boolean>;
 // ─────────────────────────────────────────────
 
 /**
+ * dir 直下に `input.md` が存在すれば true を返す。
+ * ファイルが存在しない場合や stat に失敗した場合は false を返す。
+ */
+export const defaultIsFixtureDir = async (dir: string): Promise<boolean> => {
+  try {
+    await Deno.stat(`${dir}/input.md`);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * rootDir 以下を再帰的に走査し、isFixtureDir が true を返したディレクトリの
  * rootDir からのスラッシュ区切り相対パスを辞書順ソートして返す。
  */
 export const findFixtureDirs = async (
   rootDir: string,
-  isFixtureDir: IsFixtureDirProvider,
+  isFixtureDir: IsFixtureDirProvider = defaultIsFixtureDir,
 ): Promise<string[]> => {
   const _rootNorm = normalizePath(rootDir);
 
   const _walk = async (dir: string): Promise<string[]> => {
     const subs = await findDirectories(dir);
     const nested = await Promise.all(
-      subs.map(async (sub) =>
-        (await isFixtureDir(sub)) ? [sub] : _walk(sub)
-      ),
+      subs.map(async (sub) => (await isFixtureDir(sub)) ? [sub] : _walk(sub)),
     );
     return nested.flat();
   };

--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -1,0 +1,46 @@
+// src: skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+// @(#): findFixtureDirs — fixture ディレクトリ再帰収集ヘルパー
+//       isFixtureDirProvider を DI で注入し、テスト可能な設計にする
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { findDirectories } from '../../libs/file-io/find-entries.ts';
+import { normalizePath } from '../../libs/file-io/path-utils.ts';
+
+// ─────────────────────────────────────────────
+// 型定義
+// ─────────────────────────────────────────────
+
+/** 指定ディレクトリが有効な fixture dir かを判定する関数の型。 */
+export type IsFixtureDirProvider = (dir: string) => Promise<boolean>;
+
+// ─────────────────────────────────────────────
+// 実装
+// ─────────────────────────────────────────────
+
+/**
+ * rootDir 以下を再帰的に走査し、isFixtureDir が true を返したディレクトリの
+ * rootDir からのスラッシュ区切り相対パスを辞書順ソートして返す。
+ */
+export const findFixtureDirs = async (
+  rootDir: string,
+  isFixtureDir: IsFixtureDirProvider,
+): Promise<string[]> => {
+  const _rootNorm = normalizePath(rootDir);
+
+  const _walk = async (dir: string): Promise<string[]> => {
+    const subs = await findDirectories(dir);
+    const nested = await Promise.all(
+      subs.map(async (sub) =>
+        (await isFixtureDir(sub)) ? [sub] : _walk(sub)
+      ),
+    );
+    return nested.flat();
+  };
+
+  const _abs = await _walk(_rootNorm);
+  return _abs.map((p) => p.slice(_rootNorm.length + 1)).sort();
+};


### PR DESCRIPTION
# test(helpers/find-fixture-dirs): add findFixtureDirs helper with tests

## Overview

**Summary**
Add `findFixtureDirs` helper and `defaultIsFixtureDir` with unit tests using temp directories.

**Background / Motivation**
テストヘルパーとして `findFixtureDirs` 関数が必要になった。指定ルートを再帰走査して fixture ディレクトリを収集する機能を、DI パターンを用いてテスタブルに実装する。
テストはリポジトリ内 fixture への依存を排除し、`Deno.makeTempDir` による一時ディレクトリで独立して動作する設計とした。

## Changes

- `skills/_scripts/__tests__/helpers/find-fixture-dirs.ts`
  - `IsFixtureDirProvider` 型定義を追加
  - `defaultIsFixtureDir` 実装（`input.md` 存在確認、例外時は `false` を返す）
  - `findFixtureDirs` 実装（DI ベース再帰走査、POSIX パス正規化、辞書順ソート）
  - fixture ディレクトリ内部を再帰しない仕様（ネスト fixture 非対応）

- `skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts`
  - `defaultIsFixtureDir` のユニットテスト（`input.md` あり / なし / 存在しないディレクトリ）
  - `findFixtureDirs` のユニットテスト（デフォルト動作 / カスタム DI / ソート / ネスト打ち切り / 存在しない rootDir）
  - `beforeEach` / `afterEach` で一時ディレクトリのライフサイクル管理
  - import 文をセクション分類・JSDoc コメントを追加

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [x] Other

## Related Issues

該当する Issue なし。

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

特記事項なし。
