### PR TITLE
refactor(classes): add ChatlogEntry and ChatlogFrontmatter with fixture tests

### DIFF
--- a/skills/_scripts/classes/ChatlogEntry.class.ts
+++ b/skills/_scripts/classes/ChatlogEntry.class.ts
@@ -1,0 +1,55 @@
+// src: skills/_scripts/classes/ChatlogEntry.class.ts
+// @(#): Chatlog エントリクラス
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { FRONTMATTER_DELIMITER } from '../constants/common.constants.ts';
+import { normalizeLine } from '../libs/text/line-utils.ts';
+import { ChatlogError } from './ChatlogError.class.ts';
+import { ChatlogFrontmatter } from './ChatlogFrontmatter.class.ts';
+
+export class ChatlogEntry {
+  readonly frontmatter: ChatlogFrontmatter;
+  readonly frontmatterText: string;
+  readonly content: string;
+
+  constructor(text: string) {
+    const { frontmatter, content } = this._divideEntry(text);
+    this.frontmatter = new ChatlogFrontmatter(frontmatter);
+    this.frontmatterText = frontmatter;
+    this.content = content;
+  }
+
+  private _normalizeContent(content: string): string {
+    const _stripped = content.replace(/^\n+/, '').replace(/\n+$/, '');
+    return _stripped === '' ? '' : _stripped + '\n';
+  }
+
+  private _divideEntry(text: string): { frontmatter: string; content: string } {
+    const _lines = normalizeLine(text).split('\n');
+
+    if (_lines[0] !== FRONTMATTER_DELIMITER) {
+      return { frontmatter: '', content: this._normalizeContent(_lines.join('\n')) };
+    }
+    const _closeIdx = _lines.indexOf(FRONTMATTER_DELIMITER, 1);
+    if (_closeIdx === -1) {
+      throw new ChatlogError('InvalidFormat', 'frontmatter block is not closed');
+    }
+    if (_closeIdx === _lines.length - 1) {
+      return { frontmatter: '', content: this._normalizeContent(_lines.join('\n')) };
+    }
+
+    return {
+      frontmatter: _lines.slice(0, _closeIdx + 1).join('\n') + '\n',
+      content: this._normalizeContent(_lines.slice(_closeIdx + 1).join('\n')),
+    };
+  }
+
+  renderEntry(fieldOrder?: string[]): string {
+    const _fm = this.frontmatter.toFrontmatter(fieldOrder);
+    return this.content === '' ? _fm : `${_fm}\n${this.content}`;
+  }
+}

--- a/skills/_scripts/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_scripts/classes/ChatlogFrontmatter.class.ts
@@ -1,0 +1,112 @@
+// src: skills/_scripts/classes/ChatlogFrontmatter.class.ts
+// @(#): Chatlog フロントマタークラス
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { parse as parseYaml } from '@std/yaml';
+import { FRONTMATTER_DELIMITER } from '../constants/common.constants.ts';
+import { escapeString, toStringWithNull } from '../libs/text/string-utils.ts';
+import { ChatlogError } from './ChatlogError.class.ts';
+
+const _DEFAULT_FIELD_ORDER: string[] = [
+  'title',
+  'date',
+  'session_id',
+  'project',
+  'slug',
+  'type',
+  'category',
+  'summary',
+  'topics',
+  'tags',
+];
+
+export class ChatlogFrontmatter {
+  private _entries: Record<string, string | string[]>;
+
+  constructor(input: string | Record<string, string | string[]>) {
+    if (typeof input !== 'string') {
+      this._entries = { ...input };
+      return;
+    }
+    const _lines = input.split('\n');
+    if (_lines[0] !== FRONTMATTER_DELIMITER) {
+      this._entries = {};
+      return;
+    }
+    const _closeIdx = _lines.indexOf(FRONTMATTER_DELIMITER, 1);
+    if (_closeIdx === -1) {
+      this._entries = {};
+      return;
+    }
+    let _parsed: unknown;
+    try {
+      _parsed = parseYaml(_lines.slice(1, _closeIdx).join('\n'));
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new ChatlogError('InvalidYaml', detail);
+    }
+    if (_parsed === null || _parsed === undefined || typeof _parsed !== 'object' || Array.isArray(_parsed)) {
+      this._entries = {};
+      return;
+    }
+    this._entries = this._toEntries(_parsed as Record<string, unknown>);
+  }
+
+  private _toStringOrArray(v: unknown): string | string[] {
+    if (Array.isArray(v)) {
+      return v.map((item) => item instanceof Date ? item.toISOString().slice(0, 10) : toStringWithNull(item));
+    }
+    if (v instanceof Date) { return v.toISOString().slice(0, 10); }
+    return toStringWithNull(v);
+  }
+
+  private _toEntries(parsed: Record<string, unknown>): Record<string, string | string[]> {
+    const _result: Record<string, string | string[]> = {};
+    for (const key of Object.keys(parsed)) {
+      _result[key] = this._toStringOrArray(parsed[key]);
+    }
+    return _result;
+  }
+
+  get(key: string): string | string[] | undefined {
+    return this._entries[key];
+  }
+
+  set(key: string, value: string | string[]): void {
+    this._entries[key] = value;
+  }
+
+  remove(key: string): void {
+    delete this._entries[key];
+  }
+
+  toFrontmatter(fieldOrder: string[] = _DEFAULT_FIELD_ORDER): string {
+    const _lines: string[] = [FRONTMATTER_DELIMITER];
+    const _seen = new Set<string>();
+    for (const field of fieldOrder) {
+      if (_seen.has(field)) { continue; }
+      _seen.add(field);
+      const value = this._entries[field];
+      if (value === undefined) { continue; }
+      if (typeof value === 'string') {
+        if (value === '') { continue; }
+        _lines.push(`${field}: "${escapeString(value)}"`);
+      } else {
+        if (value.length === 0) { continue; }
+        _lines.push(`${field}:`);
+        for (const item of value) {
+          _lines.push(`  - "${escapeString(item)}"`);
+        }
+      }
+    }
+    if (_lines.length === 1) {
+      _lines.push('');
+    }
+    _lines.push(FRONTMATTER_DELIMITER);
+    return _lines.join('\n') + '\n';
+  }
+}

--- a/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
@@ -1,0 +1,83 @@
+// src: skills/_scripts/classes/__tests__/fixtures/divide-content.fixtures.spec.ts
+// @(#): ChatlogEntry.frontmatterText / content fixtures テスト
+//       fixtures-data/divide-content/ 下の各ディレクトリをスキャンし
+//       input.md を処理し、expected.yaml の期待値と照合する
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+import { parse as parseYaml } from '@std/yaml';
+
+// -- error class --
+import { ChatlogError } from '../../ChatlogError.class.ts';
+
+// -- helpers --
+import { findFixtureDirs, type IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+
+// -- test target --
+import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
+
+// ─────────────────────────────────────────────
+// divideContent — ファイルベース fixtures
+// ─────────────────────────────────────────────
+
+type _FixtureExpected =
+  | { frontmatterText: string; content: string; error?: never }
+  | { error: string; frontmatterText?: never; content?: never };
+
+const FIXTURES_DIR = new URL('./fixtures-data/divide-entry', import.meta.url)
+  .pathname
+  .replace(/^\/([A-Z]:)/, '$1');
+
+const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
+  try {
+    await Deno.stat(`${dir}/input.md`);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+async function _loadFixture(
+  dir: string,
+): Promise<{ input: string; expected: _FixtureExpected }> {
+  const input = await Deno.readTextFile(`${dir}/input.md`);
+  const expectedRaw = await Deno.readTextFile(`${dir}/expected.yaml`);
+  const expected = parseYaml(expectedRaw) as _FixtureExpected;
+  return { input, expected };
+}
+
+const _fixtureDirs = await findFixtureDirs(FIXTURES_DIR, _isFixtureDir);
+const _fixtures = await Promise.all(
+  _fixtureDirs.map(async (relPath) => ({ relPath, ...await _loadFixture(`${FIXTURES_DIR}/${relPath}`) })),
+);
+
+describe('divideContent', () => {
+  describe('Given: fixtures-data/divide-content/ 下の各 fixture ディレクトリ', () => {
+    describe('When: new ChatlogEntry(input) でインスタンスを生成する', () => {
+      describe('Then: frontmatterText と content が期待値と一致する', () => {
+        for (const { relPath: _relPath, input, expected } of _fixtures) {
+          const _testId = _relPath.replace(/\//g, '-');
+          it(`DC-CE-${_testId}: frontmatterText と content が期待値と一致する`, () => {
+            if (expected.error) {
+              const err = assertThrows(
+                () => new ChatlogEntry(input),
+                ChatlogError,
+              );
+              assertEquals(err.kind, expected.error);
+            } else {
+              const entry = new ChatlogEntry(input);
+              assertEquals(entry.frontmatterText, expected.frontmatterText);
+              assertEquals(entry.content, expected.content);
+            }
+          });
+        }
+      });
+    });
+  });
+});

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-multiple-leading-blank-lines/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-multiple-leading-blank-lines/expected.yaml
@@ -1,0 +1,5 @@
+frontmatterText: |
+  ---
+  title: Multiple Leading Blank Lines
+  ---
+content: "body\n"

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-multiple-leading-blank-lines/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-multiple-leading-blank-lines/input.md
@@ -1,0 +1,5 @@
+---
+title: Multiple Leading Blank Lines
+---
+
+body

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-trailing-blank-lines/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-trailing-blank-lines/expected.yaml
@@ -1,0 +1,5 @@
+frontmatterText: |
+  ---
+  title: Trailing Blank Lines
+  ---
+content: "body\n"

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-trailing-blank-lines/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/blank-lines/edge-trailing-blank-lines/input.md
@@ -1,0 +1,5 @@
+---
+title: Trailing Blank Lines
+---
+
+body

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/line-ending/edge-no-trailing-newline/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/line-ending/edge-no-trailing-newline/expected.yaml
@@ -1,0 +1,5 @@
+frontmatterText: |
+  ---
+  title: No Trailing Newline
+  ---
+content: "body\n"

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/line-ending/edge-no-trailing-newline/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/line-ending/edge-no-trailing-newline/input.md
@@ -1,0 +1,5 @@
+---
+title: No Trailing Newline
+---
+
+body

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/no-frontmatter/edge-empty-input/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/no-frontmatter/edge-empty-input/expected.yaml
@@ -1,0 +1,2 @@
+frontmatterText: ""
+content: ""

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/no-frontmatter/edge-no-frontmatter/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/no-frontmatter/edge-no-frontmatter/expected.yaml
@@ -1,0 +1,3 @@
+frontmatterText: ""
+content: |
+  plain text without frontmatter

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/no-frontmatter/edge-no-frontmatter/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/no-frontmatter/edge-no-frontmatter/input.md
@@ -1,0 +1,1 @@
+plain text without frontmatter

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-closing-lastline/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-closing-lastline/expected.yaml
@@ -1,0 +1,5 @@
+frontmatterText: |
+  ---
+  title: Only Frontmatter
+  ---
+content: ""

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-closing-lastline/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-closing-lastline/input.md
@@ -1,0 +1,3 @@
+---
+title: Only Frontmatter
+---

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-only-newlines/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-only-newlines/expected.yaml
@@ -1,0 +1,5 @@
+frontmatterText: |
+  ---
+  title: Only Newlines Content
+  ---
+content: ""

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-only-newlines/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/edge/separator/edge-only-newlines/input.md
@@ -1,0 +1,3 @@
+---
+title: Only Newlines Content
+---

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/error/separator/error-no-closing-separator/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/error/separator/error-no-closing-separator/expected.yaml
@@ -1,0 +1,1 @@
+error: InvalidFormat

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/error/separator/error-no-closing-separator/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/error/separator/error-no-closing-separator/input.md
@@ -1,0 +1,4 @@
+---
+
+title: Hello
+no closing separator

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-basic/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-basic/expected.yaml
@@ -1,0 +1,6 @@
+frontmatterText: |
+  ---
+  title: Hello World
+  category: dev
+  ---
+content: "This is a basic entry body.\n"

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-basic/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-basic/input.md
@@ -1,0 +1,6 @@
+---
+title: Hello World
+category: dev
+---
+
+This is a basic entry body.

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-internal-blank-lines/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-internal-blank-lines/expected.yaml
@@ -1,0 +1,5 @@
+frontmatterText: |
+  ---
+  title: Internal Blank Lines
+  ---
+content: "line1\n\nline2\n"

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-internal-blank-lines/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-internal-blank-lines/input.md
@@ -1,0 +1,7 @@
+---
+title: Internal Blank Lines
+---
+
+line1
+
+line2

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-multiline-frontmatter/expected.yaml
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-multiline-frontmatter/expected.yaml
@@ -1,0 +1,8 @@
+frontmatterText: |
+  ---
+  title: Multi
+  tags:
+    - foo
+    - bar
+  ---
+content: "body text\n"

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-multiline-frontmatter/input.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/divide-entry/normal/basic/normal-multiline-frontmatter/input.md
@@ -1,0 +1,8 @@
+---
+title: Multi
+tags:
+  - foo
+  - bar
+---
+
+body text

--- a/skills/_scripts/classes/__tests__/unit/ChatlogEntry.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogEntry.unit.spec.ts
@@ -1,0 +1,301 @@
+// src: skills/_scripts/classes/__tests__/unit/ChatlogEntry.unit.spec.ts
+// @(#): ChatlogEntry ユニットテスト
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals, assertThrows } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+// -- error class --
+import { ChatlogError } from '../../ChatlogError.class.ts';
+// -- test target --
+import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
+
+// ─────────────────────────────────────────────
+// ChatlogEntry
+// ─────────────────────────────────────────────
+
+describe('ChatlogEntry', () => {
+  describe('Given: title と category を含む frontmatter + body の Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-01 - frontmatter.get("title") が正しい値を返す', () => {
+        it('T-CLS-CE-01: frontmatter フィールドのパース', () => {
+          const text = '---\ntitle: Hello\ncategory: dev\n---\nbody text\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('title'), 'Hello');
+          assertEquals(entry.frontmatter.get('category'), 'dev');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter + body の Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-02 - content が本文のみ（frontmatter を除く）', () => {
+        it('T-CLS-CE-02: content に本文のみが格納される', () => {
+          const text = '---\ntitle: Hello\n---\nbody text\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.content, 'body text\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter なしのプレーンテキスト', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-03 - frontmatter は空、content は末尾 \\n 付きテキスト全体', () => {
+        it('T-CLS-CE-03: frontmatter なし入力', () => {
+          const text = 'plain text without frontmatter';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('title'), undefined);
+          assertEquals(entry.content, 'plain text without frontmatter\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: 空文字列', () => {
+    describe('When: new ChatlogEntry("") を呼び出す', () => {
+      describe('Then: T-CLS-CE-04 - frontmatter は空、content は空文字列', () => {
+        it('T-CLS-CE-04: 空文字列入力', () => {
+          const entry = new ChatlogEntry('');
+          assertEquals(entry.frontmatter.get('title'), undefined);
+          assertEquals(entry.content, '');
+        });
+      });
+    });
+  });
+
+  describe('Given: CRLF 改行を含む frontmatter + body の Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-05 - content が正しく取り出される', () => {
+        it('T-CLS-CE-05: CRLF 改行の正規化', () => {
+          const text = '---\r\ntitle: Hello\r\n---\r\nbody text\r\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('title'), 'Hello');
+          assertEquals(entry.content, 'body text\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter + body の Markdown', () => {
+    describe('When: renderEntry() を引数なしで呼び出す', () => {
+      describe('Then: T-CLS-CE-06 - フロントマター + 空行 + 本文の形式で出力される', () => {
+        it('T-CLS-CE-06: renderEntry() の基本出力形式', () => {
+          const text = '---\ntitle: Hello\n---\nbody text\n';
+          const entry = new ChatlogEntry(text);
+          const result = entry.renderEntry(['title']);
+          assertEquals(result, '---\ntitle: "Hello"\n---\n\nbody text\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter のみで body が空の Markdown', () => {
+    describe('When: renderEntry() を呼び出す', () => {
+      describe('Then: T-CLS-CE-07 - フロントマター + 空行で終わる出力', () => {
+        it('T-CLS-CE-07: body が空の場合の renderEntry() 出力', () => {
+          const text = '---\ntitle: Hello\n---\n';
+          const entry = new ChatlogEntry(text);
+          const result = entry.renderEntry(['title']);
+          assertEquals(result, '---\ntitle: "Hello"\n---\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: ChatlogEntry 構築後に frontmatter.set() で値を変更', () => {
+    describe('When: renderEntry() を呼び出す', () => {
+      describe('Then: T-CLS-CE-08 - 変更後の title が出力に反映される', () => {
+        it('T-CLS-CE-08: frontmatter 変更が renderEntry() に反映される', () => {
+          const text = '---\ntitle: Old\n---\nbody\n';
+          const entry = new ChatlogEntry(text);
+          entry.frontmatter.set('title', 'New');
+          const result = entry.renderEntry(['title']);
+          assertEquals(result, '---\ntitle: "New"\n---\n\nbody\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter + body の Markdown', () => {
+    describe('When: renderEntry(["title"]) と fieldOrder を指定して呼び出す', () => {
+      describe('Then: T-CLS-CE-09 - fieldOrder が toFrontmatter に渡され指定フィールドのみ出力', () => {
+        it('T-CLS-CE-09: fieldOrder 指定が renderEntry() に反映される', () => {
+          const text = '---\ntitle: Hello\ncategory: dev\n---\nbody\n';
+          const entry = new ChatlogEntry(text);
+          const result = entry.renderEntry(['title']);
+          assertEquals(result, '---\ntitle: "Hello"\n---\n\nbody\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: tags に配列を含む frontmatter + body の Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-10 - tags が string[] として取得できる', () => {
+        it('T-CLS-CE-10: 配列フィールドのパース', () => {
+          const text = '---\ntags:\n  - foo\n  - bar\n---\nbody';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('tags'), ['foo', 'bar']);
+        });
+      });
+    });
+  });
+
+  describe('Given: count に数値を含む frontmatter + body の Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-11 - count が文字列 "42" として取得できる', () => {
+        it('T-CLS-CE-11: 数値フィールドが文字列に変換される', () => {
+          const text = '---\ncount: 42\n---\nbody';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('count'), '42');
+        });
+      });
+    });
+  });
+
+  describe('Given: date フィールドを含む frontmatter + body の Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-12 - date が YYYY-MM-DD 文字列として取得できる', () => {
+        it('T-CLS-CE-12: Date フィールドが YYYY-MM-DD 文字列に変換される', () => {
+          const text = '---\ndate: 2026-03-15\n---\nbody';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('date'), '2026-03-15');
+        });
+      });
+    });
+  });
+
+  describe('Given: 閉じ --- なしの不完全な frontmatter ブロック', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-13 - InvalidFormat を throw する', () => {
+        it('T-CLS-CE-13: 閉じ --- なし入力では InvalidFormat を throw する', () => {
+          const text = '---\ntitle: Hello\nno closing separator';
+          const err = assertThrows(
+            () => new ChatlogEntry(text),
+            ChatlogError,
+          );
+          assertEquals(err.kind, 'InvalidFormat');
+        });
+      });
+    });
+  });
+
+  describe('Given: 不正な YAML を含む frontmatter ブロック', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-14 - InvalidYaml を throw する', () => {
+        it('T-CLS-CE-14: YAML パース失敗時は InvalidYaml を throw する', () => {
+          const text = '---\n: invalid: yaml: {\n---\nbody';
+          const err = assertThrows(
+            () => new ChatlogEntry(text),
+            ChatlogError,
+          );
+          assertEquals(err.kind, 'InvalidYaml');
+        });
+      });
+    });
+  });
+
+  describe('Given: tags に null 混入配列（~ を含む）を含む frontmatter ブロック', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-15 - null 要素が空文字列に変換される', () => {
+        it('T-CLS-CE-15: null 混入配列の null 要素が空文字列に変換される', () => {
+          const text = '---\ntags:\n  - foo\n  - ~\n  - bar\n---\nbody';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.frontmatter.get('tags'), ['foo', '', 'bar']);
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter の直後に複数の空行が続く Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-16 - content の先頭の複数改行が全て削除される', () => {
+        it('T-CLS-CE-16: 先頭複数改行の削除', () => {
+          const text = '---\ntitle: T\n---\n\n\nbody\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.content, 'body\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter 後の本文末尾に複数の空行が続く Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-17 - content の末尾の複数改行が単一 \\n に正規化される', () => {
+        it('T-CLS-CE-17: 末尾複数改行の正規化', () => {
+          const text = '---\ntitle: T\n---\nbody\n\n\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.content, 'body\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter 後の本文が改行のみの Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-18 - content が空文字列になる', () => {
+        it('T-CLS-CE-18: 改行のみの本文は空文字列に正規化される', () => {
+          const text = '---\ntitle: T\n---\n\n\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.content, '');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter 後の本文中に空行を含む Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-19 - content の本文中の空行は保持される', () => {
+        it('T-CLS-CE-19: 本文中空行の保持', () => {
+          const text = '---\ntitle: T\n---\nline1\n\nline2\n';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.content, 'line1\n\nline2\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter 後の本文が末尾改行なしの Markdown', () => {
+    describe('When: new ChatlogEntry(text) を呼び出す', () => {
+      describe('Then: T-CLS-CE-20 - content の末尾に \\n が付与される', () => {
+        it('T-CLS-CE-20: 末尾改行なし入力への \\n 付与', () => {
+          const text = '---\ntitle: T\n---\nbody';
+          const entry = new ChatlogEntry(text);
+          assertEquals(entry.content, 'body\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter の直後に複数の空行が続く Markdown', () => {
+    describe('When: renderEntry() を呼び出す', () => {
+      describe('Then: T-CLS-CE-21 - 出力は先頭空行 1 つ + 本文の標準形になる', () => {
+        it('T-CLS-CE-21: 先頭複数改行入力でも renderEntry() の出力は標準形', () => {
+          const text = '---\ntitle: T\n---\n\n\n\nbody\n';
+          const entry = new ChatlogEntry(text);
+          const result = entry.renderEntry(['title']);
+          assertEquals(result, '---\ntitle: "T"\n---\n\nbody\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: frontmatter 後の本文末尾に複数の空行が続く Markdown', () => {
+    describe('When: renderEntry() を呼び出す', () => {
+      describe('Then: T-CLS-CE-22 - 出力の本文末尾は単一 \\n のみになる', () => {
+        it('T-CLS-CE-22: 末尾余剰改行入力でも renderEntry() の末尾は単一 \\n', () => {
+          const text = '---\ntitle: T\n---\nbody\n\n\n';
+          const entry = new ChatlogEntry(text);
+          const result = entry.renderEntry(['title']);
+          assertEquals(result, '---\ntitle: "T"\n---\n\nbody\n');
+        });
+      });
+    });
+  });
+});

--- a/skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
@@ -1,0 +1,200 @@
+// src: skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
+// @(#): ChatlogFrontmatter ユニットテスト
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+// -- test target --
+import { ChatlogFrontmatter } from '../../ChatlogFrontmatter.class.ts';
+
+// ─────────────────────────────────────────────
+// ChatlogFrontmatter
+// ─────────────────────────────────────────────
+
+describe('ChatlogFrontmatter', () => {
+  describe('Given: title を含む frontmatter ブロック', () => {
+    describe('When: get("title") を呼び出す', () => {
+      describe('Then: T-CLS-CF-11 - title の文字列値が返る', () => {
+        it('T-CLS-CF-11: [正常] - 存在するキーの文字列値を返す', () => {
+          const fm = new ChatlogFrontmatter({ title: 'Hello' });
+          assertEquals(fm.get('title'), 'Hello');
+        });
+      });
+    });
+  });
+
+  describe('Given: tags に配列を含む frontmatter ブロック', () => {
+    describe('When: get("tags") を呼び出す', () => {
+      describe('Then: T-CLS-CF-12 - tags の配列値が返る', () => {
+        it('T-CLS-CF-12: [正常] - 存在するキーの配列値を返す', () => {
+          const fm = new ChatlogFrontmatter({ tags: ['foo', 'bar'] });
+          assertEquals(fm.get('tags'), ['foo', 'bar']);
+        });
+      });
+    });
+  });
+
+  describe('Given: title のみを含む frontmatter ブロック', () => {
+    describe('When: get("missing") を呼び出す', () => {
+      describe('Then: T-CLS-CF-13 - undefined が返る', () => {
+        it('T-CLS-CF-13: [正常] - 存在しないキーは undefined を返す', () => {
+          const fm = new ChatlogFrontmatter({ title: 'Hello' });
+          assertEquals(fm.get('missing'), undefined);
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の ChatlogFrontmatter', () => {
+    describe('When: set("title", "Hello") を呼び出す', () => {
+      describe('Then: T-CLS-CF-14 - title が "Hello" になる', () => {
+        it('T-CLS-CF-14: [正常] - 新規キーに文字列をセットできる', () => {
+          const fm = new ChatlogFrontmatter({});
+          fm.set('title', 'Hello');
+          assertEquals(fm.get('title'), 'Hello');
+        });
+      });
+    });
+  });
+
+  describe('Given: title: "Old" を含む frontmatter ブロック', () => {
+    describe('When: set("title", "New") を呼び出す', () => {
+      describe('Then: T-CLS-CF-15 - title が "New" に上書きされる', () => {
+        it('T-CLS-CF-15: [正常] - 既存キーを上書きできる', () => {
+          const fm = new ChatlogFrontmatter({ title: 'Old' });
+          fm.set('title', 'New');
+          assertEquals(fm.get('title'), 'New');
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の ChatlogFrontmatter', () => {
+    describe('When: set("tags", ["foo", "bar"]) を呼び出す', () => {
+      describe('Then: T-CLS-CF-16 - tags が ["foo", "bar"] になる', () => {
+        it('T-CLS-CF-16: [正常] - 新規キーに配列をセットできる', () => {
+          const fm = new ChatlogFrontmatter({});
+          fm.set('tags', ['foo', 'bar']);
+          assertEquals(fm.get('tags'), ['foo', 'bar']);
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の ChatlogFrontmatter', () => {
+    describe('When: set("title", "") を呼び出す', () => {
+      describe('Then: T-CLS-CF-17 - title が空文字列になる（有効な値）', () => {
+        it('T-CLS-CF-17: [エッジケース] - 空文字列をセットできる', () => {
+          const fm = new ChatlogFrontmatter({});
+          fm.set('title', '');
+          assertEquals(fm.get('title'), '');
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の ChatlogFrontmatter', () => {
+    describe('When: set("tags", []) を呼び出す', () => {
+      describe('Then: T-CLS-CF-18 - tags が空配列になる（有効な値）', () => {
+        it('T-CLS-CF-18: [エッジケース] - 空配列をセットできる', () => {
+          const fm = new ChatlogFrontmatter({});
+          fm.set('tags', []);
+          assertEquals(fm.get('tags'), []);
+        });
+      });
+    });
+  });
+
+  describe('Given: title を含む frontmatter ブロック', () => {
+    describe('When: remove("title") を呼び出す', () => {
+      describe('Then: T-CLS-CF-19 - title が削除され undefined になる', () => {
+        it('T-CLS-CF-19: [正常] - 存在するキーを削除できる', () => {
+          const fm = new ChatlogFrontmatter({ title: 'Hello' });
+          fm.remove('title');
+          assertEquals(fm.get('title'), undefined);
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の ChatlogFrontmatter', () => {
+    describe('When: remove("missing") を呼び出す', () => {
+      describe('Then: T-CLS-CF-20 - エラーにならず無視される', () => {
+        it('T-CLS-CF-20: [エッジケース] - 存在しないキーへの呼び出しはエラーにならない', () => {
+          const fm = new ChatlogFrontmatter({});
+          fm.remove('missing');
+          assertEquals(fm.get('missing'), undefined);
+        });
+      });
+    });
+  });
+
+  describe('Given: 空の ChatlogFrontmatter', () => {
+    describe('When: set("title", "Hello") してから toFrontmatter(["title"]) を呼び出す', () => {
+      describe('Then: T-CLS-CF-21 - set したフィールドが toFrontmatter の出力に含まれる', () => {
+        it('T-CLS-CF-21: [正常] - set で追加したフィールドが toFrontmatter に反映される', () => {
+          const fm = new ChatlogFrontmatter({});
+          fm.set('title', 'Hello');
+          const result = fm.toFrontmatter(['title']);
+          assertEquals(result, '---\ntitle: "Hello"\n---\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: title を含む frontmatter ブロック', () => {
+    describe('When: remove("title") してから toFrontmatter(["title"]) を呼び出す', () => {
+      describe('Then: T-CLS-CF-22 - title が toFrontmatter の出力に含まれない', () => {
+        it('T-CLS-CF-22: [正常] - remove で削除したフィールドが toFrontmatter に含まれない', () => {
+          const fm = new ChatlogFrontmatter({ title: 'Hello' });
+          fm.remove('title');
+          const result = fm.toFrontmatter(['title']);
+          assertEquals(result, '---\n\n---\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: title と category を含む frontmatter ブロック', () => {
+    describe('When: toFrontmatter() を引数なしで呼び出す', () => {
+      describe('Then: T-CLS-CF-23 - DEFAULT_FIELD_ORDER に従い title → category の順で出力される', () => {
+        it('T-CLS-CF-23: [正常] - fieldOrder 省略時は _DEFAULT_FIELD_ORDER が使われる', () => {
+          const fm = new ChatlogFrontmatter({ title: 'Hello', category: 'dev' });
+          const result = fm.toFrontmatter();
+          assertEquals(result, '---\ntitle: "Hello"\ncategory: "dev"\n---\n');
+        });
+      });
+    });
+  });
+
+  describe('Given: entries オブジェクト { title: "Hello", category: "dev" }', () => {
+    describe('When: new ChatlogFrontmatter(entries) を呼び出す', () => {
+      describe('Then: T-CLS-CF-24 - title と category が entries に格納される', () => {
+        it('T-CLS-CF-24: entries オブジェクトから ChatlogFrontmatter を構築できる', () => {
+          const entries = { title: 'Hello', category: 'dev' };
+          const fm = new ChatlogFrontmatter(entries);
+          assertEquals(fm.get('title'), 'Hello');
+          assertEquals(fm.get('category'), 'dev');
+        });
+      });
+    });
+  });
+
+  describe('Given: entries オブジェクトを渡した後に外部から変更', () => {
+    describe('When: コンストラクタ引数オブジェクトのプロパティを変更する', () => {
+      describe('Then: T-CLS-CF-25 - 内部状態は変更されない（shallow copy）', () => {
+        it('T-CLS-CF-25: コンストラクタ引数の mutation は内部状態に影響しない', () => {
+          const entries: Record<string, string | string[]> = { title: 'Hello' };
+          const fm = new ChatlogFrontmatter(entries);
+          entries['title'] = 'Changed';
+          assertEquals(fm.get('title'), 'Hello');
+        });
+      });
+    });
+  });
+});

--- a/skills/_scripts/constants/chatlog-error.constants.ts
+++ b/skills/_scripts/constants/chatlog-error.constants.ts
@@ -8,4 +8,6 @@ export const ERROR_KIND_LABELS = {
   ForbiddenOutput: 'Forbidden Output',
   InvalidArgs: 'Invalid Args',
   InputNotFound: 'Input Not Found',
+  InvalidFormat: 'Invalid Format',
+  InvalidYaml: 'Invalid Yaml',
 } as const;

--- a/skills/_scripts/constants/common.constants.ts
+++ b/skills/_scripts/constants/common.constants.ts
@@ -6,6 +6,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+/** Markdown フロントマターの開始・終了区切り文字。 */
+export const FRONTMATTER_DELIMITER = '---';
+
 /** Claude Code CLI が受け付けるモデル ID およびエイリアスの集合。 */
 export const VALID_AI_MODELS = new Set([
   'default',

--- a/skills/_scripts/libs/text/frontmatter-utils.ts
+++ b/skills/_scripts/libs/text/frontmatter-utils.ts
@@ -10,6 +10,7 @@
 import { parse as parseYaml } from '@std/yaml';
 
 // unknown → string 変換ユーティリティ
+import { FRONTMATTER_DELIMITER } from '../../constants/common.constants.ts';
 import { normalizeLine } from './line-utils.ts';
 import { toStringWithNull } from './string-utils.ts';
 
@@ -26,16 +27,16 @@ type _BlockResult = {
 /** 正規化済みテキストから frontmatter ブロックを抽出する。見つからない場合は null を返す。 */
 const _extractBlock = (normalized: string): _BlockResult | null => {
   const _lines = normalized.split('\n');
-  if (_lines[0] !== '---') { return null; }
+  if (_lines[0] !== FRONTMATTER_DELIMITER) { return null; }
 
-  const _closeIdx = _lines.indexOf('---', 1);
+  const _closeIdx = _lines.indexOf(FRONTMATTER_DELIMITER, 1);
   // 閉じ --- の後に必ず改行が必要（末尾が --- で終わる場合は不正）
   if (_closeIdx === -1 || _closeIdx === _lines.length - 1) { return null; }
 
   const _yamlLines = _lines.slice(1, _closeIdx);
   return {
     yamlText: _yamlLines.join('\n'),
-    frontmatterEnd: ['---', ..._yamlLines, '---', ''].join('\n').length,
+    frontmatterEnd: [FRONTMATTER_DELIMITER, ..._yamlLines, FRONTMATTER_DELIMITER, ''].join('\n').length,
   };
 };
 


### PR DESCRIPTION
## Overview

**Summary**
Add `ChatlogEntry` and `ChatlogFrontmatter` classes to encapsulate frontmatter parsing, normalization, and rendering
for Markdown chatlogs.

**Background / Motivation**
フロントマターの分割・パース・描画がユーティリティ関数に散在しており、責務が不明確でした。
`ChatlogEntry` と `ChatlogFrontmatter` クラスに集約することで責務を明確化し、型安全なアクセサと安定した出力を保証します。
あわせて `FRONTMATTER_DELIMITER` 定数を導入し、`frontmatter-utils.ts` 内の `---` リテラルを統一しました。

## Changes

- `skills/_scripts/classes/ChatlogEntry.class.ts` を追加 — フロントマターとコンテンツへの分割・正規化・描画を担うクラス
  - `_divideEntry`: 開始/終了デリミタを検証しフロントマターテキストとコンテンツを分離。終了デリミタが欠如した場合 `ChatlogError('InvalidFormat')` を送出
  - `_normalizeContent`: 先頭/末尾の余分な空行を除去し、末尾改行を補完
  - `renderEntry(fieldOrder)`: フィールド順序を受け取り安定したMarkdown出力を生成
- `skills/_scripts/classes/ChatlogFrontmatter.class.ts` を追加 — YAMLパースとフィールドアクセサを持つクラス
  - `@std/yaml` を用いた厳格なパース。失敗時は `ChatlogError('InvalidYaml', detail)` を送出
  - `get / set / remove` アクセサ、`toFrontmatter()` で安定した順序・重複排除・空値スキップを実現
- `skills/_scripts/constants/common.constants.ts` に `FRONTMATTER_DELIMITER = '---'` 定数を追加
- `skills/_scripts/constants/chatlog-error.constants.ts` の `ERROR_KIND_LABELS` に `InvalidFormat` / `InvalidYaml` ラベルを追加
- `skills/_scripts/libs/text/frontmatter-utils.ts` の `---` リテラルを `FRONTMATTER_DELIMITER` に統一（リファクタリング）
- ユニットテスト追加: `ChatlogEntry`（+301行）、`ChatlogFrontmatter`（+200行）
- フィクスチャテスト追加: `divide-entry.fixtures.spec.ts`（normal/edge/error 12ケース）

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Related to #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

- Breaking Changes なし。既存の `frontmatter-utils.ts` の公開 API は変更されていません
- フィクスチャの `expected.yaml` は YAML ブロックスカラー `|`（trailing newline あり）で統一
- `ChatlogFrontmatter` のコンストラクタは文字列と `Record` の両方を受け付け、shallow copy によるイミュータビリティを保証
