### PR TITLE
refactor(classes/ChatlogFrontmatter): enforce string input and fixture-based parsing

### DIFF
--- a/skills/_scripts/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_scripts/classes/ChatlogFrontmatter.class.ts
@@ -27,33 +27,41 @@ const _DEFAULT_FIELD_ORDER: string[] = [
 export class ChatlogFrontmatter {
   private _entries: Record<string, string | string[]>;
 
-  constructor(input: string | Record<string, string | string[]>) {
-    if (typeof input !== 'string') {
-      this._entries = { ...input };
-      return;
+  constructor(input: string) {
+    this._entries = this._parseFrontmatter(input);
+  }
+
+  private _parseFrontmatter(input: string): Record<string, string | string[]> {
+    if (input === '') {
+      return {};
     }
-    const _lines = input.split('\n');
-    if (_lines[0] !== FRONTMATTER_DELIMITER) {
-      this._entries = {};
-      return;
-    }
-    const _closeIdx = _lines.indexOf(FRONTMATTER_DELIMITER, 1);
-    if (_closeIdx === -1) {
-      this._entries = {};
-      return;
+    const _body = this._extractBody(input);
+    if (_body.trim() === '') {
+      return {};
     }
     let _parsed: unknown;
     try {
-      _parsed = parseYaml(_lines.slice(1, _closeIdx).join('\n'));
+      _parsed = parseYaml(_body);
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
       throw new ChatlogError('InvalidYaml', detail);
     }
     if (_parsed === null || _parsed === undefined || typeof _parsed !== 'object' || Array.isArray(_parsed)) {
-      this._entries = {};
-      return;
+      throw new ChatlogError('InvalidFormat', 'frontmatter yaml is not a mapping');
     }
-    this._entries = this._toEntries(_parsed as Record<string, unknown>);
+    return this._toEntries(_parsed as Record<string, unknown>);
+  }
+
+  private _extractBody(input: string): string {
+    const _lines = input.split('\n');
+    if (_lines[0] !== FRONTMATTER_DELIMITER) {
+      throw new ChatlogError('InvalidFormat', 'frontmatter does not start with delimiter');
+    }
+    const _closeIdx = _lines.indexOf(FRONTMATTER_DELIMITER, 1);
+    if (_closeIdx === -1) {
+      throw new ChatlogError('InvalidFormat', 'frontmatter block is not closed');
+    }
+    return _lines.slice(1, _closeIdx).join('\n');
   }
 
   private _toStringOrArray(v: unknown): string | string[] {

--- a/skills/_scripts/classes/__tests__/unit/ChatlogEntry.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogEntry.unit.spec.ts
@@ -9,293 +9,232 @@
 // -- BDD modules --
 import { assertEquals, assertThrows } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
-// -- error class --
-import { ChatlogError } from '../../ChatlogError.class.ts';
+
 // -- test target --
 import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
+// error class
+import { ChatlogError } from '../../ChatlogError.class.ts';
 
 // ─────────────────────────────────────────────
 // ChatlogEntry
 // ─────────────────────────────────────────────
 
 describe('ChatlogEntry', () => {
-  describe('Given: title と category を含む frontmatter + body の Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-01 - frontmatter.get("title") が正しい値を返す', () => {
-        it('T-CLS-CE-01: frontmatter フィールドのパース', () => {
-          const text = '---\ntitle: Hello\ncategory: dev\n---\nbody text\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('title'), 'Hello');
-          assertEquals(entry.frontmatter.get('category'), 'dev');
-        });
+  /**
+   * @description コンストラクタのユニットテスト。
+   * frontmatter フィールドのパース・content 抽出・CRLF 正規化・改行正規化を検証する。
+   */
+  describe('コンストラクタ', () => {
+    const _ctorCases: {
+      id: string;
+      label: string;
+      input: string;
+      expectedFrontmatter?: Record<string, string | string[] | undefined>;
+      expectedContent?: string;
+    }[] = [
+      {
+        id: 'T-CLS-CE-01',
+        label: 'frontmatter フィールドのパース',
+        input: '---\ntitle: Hello\ncategory: dev\n---\nbody text\n',
+        expectedFrontmatter: { title: 'Hello', category: 'dev' },
+      },
+      {
+        id: 'T-CLS-CE-02',
+        label: 'content に本文のみが格納される',
+        input: '---\ntitle: Hello\n---\nbody text\n',
+        expectedContent: 'body text\n',
+      },
+      {
+        id: 'T-CLS-CE-03',
+        label: 'frontmatter なし入力',
+        input: 'plain text without frontmatter',
+        expectedFrontmatter: { title: undefined },
+        expectedContent: 'plain text without frontmatter\n',
+      },
+      {
+        id: 'T-CLS-CE-04',
+        label: '空文字列入力',
+        input: '',
+        expectedFrontmatter: { title: undefined },
+        expectedContent: '',
+      },
+      {
+        id: 'T-CLS-CE-05',
+        label: 'CRLF 改行の正規化',
+        input: '---\r\ntitle: Hello\r\n---\r\nbody text\r\n',
+        expectedFrontmatter: { title: 'Hello' },
+        expectedContent: 'body text\n',
+      },
+      {
+        id: 'T-CLS-CE-10',
+        label: '配列フィールドのパース',
+        input: '---\ntags:\n  - foo\n  - bar\n---\nbody',
+        expectedFrontmatter: { tags: ['foo', 'bar'] },
+      },
+      {
+        id: 'T-CLS-CE-11',
+        label: '数値フィールドが文字列に変換される',
+        input: '---\ncount: 42\n---\nbody',
+        expectedFrontmatter: { count: '42' },
+      },
+      {
+        id: 'T-CLS-CE-12',
+        label: 'Date フィールドが YYYY-MM-DD 文字列に変換される',
+        input: '---\ndate: 2026-03-15\n---\nbody',
+        expectedFrontmatter: { date: '2026-03-15' },
+      },
+      {
+        id: 'T-CLS-CE-15',
+        label: 'null 混入配列の null 要素が空文字列に変換される',
+        input: '---\ntags:\n  - foo\n  - ~\n  - bar\n---\nbody',
+        expectedFrontmatter: { tags: ['foo', '', 'bar'] },
+      },
+      {
+        id: 'T-CLS-CE-16',
+        label: '先頭複数改行の削除',
+        input: '---\ntitle: T\n---\n\n\nbody\n',
+        expectedContent: 'body\n',
+      },
+      {
+        id: 'T-CLS-CE-17',
+        label: '末尾複数改行の正規化',
+        input: '---\ntitle: T\n---\nbody\n\n\n',
+        expectedContent: 'body\n',
+      },
+      {
+        id: 'T-CLS-CE-18',
+        label: '改行のみの本文は空文字列に正規化される',
+        input: '---\ntitle: T\n---\n\n\n',
+        expectedContent: '',
+      },
+      {
+        id: 'T-CLS-CE-19',
+        label: '本文中空行の保持',
+        input: '---\ntitle: T\n---\nline1\n\nline2\n',
+        expectedContent: 'line1\n\nline2\n',
+      },
+      {
+        id: 'T-CLS-CE-20',
+        label: '末尾改行なし入力への \\n 付与',
+        input: '---\ntitle: T\n---\nbody',
+        expectedContent: 'body\n',
+      },
+    ];
+
+    for (const tc of _ctorCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const entry = new ChatlogEntry(tc.input);
+        if (tc.expectedFrontmatter) {
+          for (const [k, v] of Object.entries(tc.expectedFrontmatter)) {
+            assertEquals(entry.frontmatter.get(k), v);
+          }
+        }
+        if (tc.expectedContent !== undefined) {
+          assertEquals(entry.content, tc.expectedContent);
+        }
       });
+    }
+  });
+
+  /**
+   * @description renderEntry() のユニットテスト。
+   * 標準出力形式・body 空・fieldOrder 指定・改行正規化後の出力を検証する。
+   */
+  describe('renderEntry()', () => {
+    const _renderCases: {
+      id: string;
+      label: string;
+      input: string;
+      fieldOrder: string[];
+      expected: string;
+    }[] = [
+      {
+        id: 'T-CLS-CE-06',
+        label: 'renderEntry() の基本出力形式',
+        input: '---\ntitle: Hello\n---\nbody text\n',
+        fieldOrder: ['title'],
+        expected: '---\ntitle: "Hello"\n---\n\nbody text\n',
+      },
+      {
+        id: 'T-CLS-CE-07',
+        label: 'body が空の場合の renderEntry() 出力',
+        input: '---\ntitle: Hello\n---\n',
+        fieldOrder: ['title'],
+        expected: '---\ntitle: "Hello"\n---\n',
+      },
+      {
+        id: 'T-CLS-CE-09',
+        label: 'fieldOrder 指定が renderEntry() に反映される',
+        input: '---\ntitle: Hello\ncategory: dev\n---\nbody\n',
+        fieldOrder: ['title'],
+        expected: '---\ntitle: "Hello"\n---\n\nbody\n',
+      },
+      {
+        id: 'T-CLS-CE-21',
+        label: '先頭複数改行入力でも renderEntry() の出力は標準形',
+        input: '---\ntitle: T\n---\n\n\n\nbody\n',
+        fieldOrder: ['title'],
+        expected: '---\ntitle: "T"\n---\n\nbody\n',
+      },
+      {
+        id: 'T-CLS-CE-22',
+        label: '末尾余剰改行入力でも renderEntry() の末尾は単一 \\n',
+        input: '---\ntitle: T\n---\nbody\n\n\n',
+        fieldOrder: ['title'],
+        expected: '---\ntitle: "T"\n---\n\nbody\n',
+      },
+    ];
+
+    for (const tc of _renderCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const entry = new ChatlogEntry(tc.input);
+        assertEquals(entry.renderEntry(tc.fieldOrder), tc.expected);
+      });
+    }
+  });
+
+  /**
+   * @description frontmatter 変更後の renderEntry() のユニットテスト。
+   * set() による変更が renderEntry() 出力に反映されることを検証する。
+   */
+  describe('frontmatter 変更後の renderEntry()', () => {
+    it('T-CLS-CE-08: frontmatter 変更が renderEntry() に反映される', () => {
+      const entry = new ChatlogEntry('---\ntitle: Old\n---\nbody\n');
+      entry.frontmatter.set('title', 'New');
+      assertEquals(entry.renderEntry(['title']), '---\ntitle: "New"\n---\n\nbody\n');
     });
   });
 
-  describe('Given: frontmatter + body の Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-02 - content が本文のみ（frontmatter を除く）', () => {
-        it('T-CLS-CE-02: content に本文のみが格納される', () => {
-          const text = '---\ntitle: Hello\n---\nbody text\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.content, 'body text\n');
-        });
-      });
-    });
-  });
+  /**
+   * @description コンストラクタ 異常系のユニットテスト。
+   * 不正な frontmatter 入力で ChatlogError をスローすることを検証する。
+   */
+  describe('コンストラクタ 異常系', () => {
+    const _errorCases: {
+      id: string;
+      label: string;
+      input: string;
+      kind: string;
+    }[] = [
+      {
+        id: 'T-CLS-CE-13',
+        label: '閉じ --- なし入力では InvalidFormat を throw する',
+        input: '---\ntitle: Hello\nno closing separator',
+        kind: 'InvalidFormat',
+      },
+      {
+        id: 'T-CLS-CE-14',
+        label: 'YAML パース失敗時は InvalidYaml を throw する',
+        input: '---\n: invalid: yaml: {\n---\nbody',
+        kind: 'InvalidYaml',
+      },
+    ];
 
-  describe('Given: frontmatter なしのプレーンテキスト', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-03 - frontmatter は空、content は末尾 \\n 付きテキスト全体', () => {
-        it('T-CLS-CE-03: frontmatter なし入力', () => {
-          const text = 'plain text without frontmatter';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('title'), undefined);
-          assertEquals(entry.content, 'plain text without frontmatter\n');
-        });
+    for (const tc of _errorCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const err = assertThrows(() => new ChatlogEntry(tc.input), ChatlogError);
+        assertEquals(err.kind, tc.kind);
       });
-    });
-  });
-
-  describe('Given: 空文字列', () => {
-    describe('When: new ChatlogEntry("") を呼び出す', () => {
-      describe('Then: T-CLS-CE-04 - frontmatter は空、content は空文字列', () => {
-        it('T-CLS-CE-04: 空文字列入力', () => {
-          const entry = new ChatlogEntry('');
-          assertEquals(entry.frontmatter.get('title'), undefined);
-          assertEquals(entry.content, '');
-        });
-      });
-    });
-  });
-
-  describe('Given: CRLF 改行を含む frontmatter + body の Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-05 - content が正しく取り出される', () => {
-        it('T-CLS-CE-05: CRLF 改行の正規化', () => {
-          const text = '---\r\ntitle: Hello\r\n---\r\nbody text\r\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('title'), 'Hello');
-          assertEquals(entry.content, 'body text\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter + body の Markdown', () => {
-    describe('When: renderEntry() を引数なしで呼び出す', () => {
-      describe('Then: T-CLS-CE-06 - フロントマター + 空行 + 本文の形式で出力される', () => {
-        it('T-CLS-CE-06: renderEntry() の基本出力形式', () => {
-          const text = '---\ntitle: Hello\n---\nbody text\n';
-          const entry = new ChatlogEntry(text);
-          const result = entry.renderEntry(['title']);
-          assertEquals(result, '---\ntitle: "Hello"\n---\n\nbody text\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter のみで body が空の Markdown', () => {
-    describe('When: renderEntry() を呼び出す', () => {
-      describe('Then: T-CLS-CE-07 - フロントマター + 空行で終わる出力', () => {
-        it('T-CLS-CE-07: body が空の場合の renderEntry() 出力', () => {
-          const text = '---\ntitle: Hello\n---\n';
-          const entry = new ChatlogEntry(text);
-          const result = entry.renderEntry(['title']);
-          assertEquals(result, '---\ntitle: "Hello"\n---\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: ChatlogEntry 構築後に frontmatter.set() で値を変更', () => {
-    describe('When: renderEntry() を呼び出す', () => {
-      describe('Then: T-CLS-CE-08 - 変更後の title が出力に反映される', () => {
-        it('T-CLS-CE-08: frontmatter 変更が renderEntry() に反映される', () => {
-          const text = '---\ntitle: Old\n---\nbody\n';
-          const entry = new ChatlogEntry(text);
-          entry.frontmatter.set('title', 'New');
-          const result = entry.renderEntry(['title']);
-          assertEquals(result, '---\ntitle: "New"\n---\n\nbody\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter + body の Markdown', () => {
-    describe('When: renderEntry(["title"]) と fieldOrder を指定して呼び出す', () => {
-      describe('Then: T-CLS-CE-09 - fieldOrder が toFrontmatter に渡され指定フィールドのみ出力', () => {
-        it('T-CLS-CE-09: fieldOrder 指定が renderEntry() に反映される', () => {
-          const text = '---\ntitle: Hello\ncategory: dev\n---\nbody\n';
-          const entry = new ChatlogEntry(text);
-          const result = entry.renderEntry(['title']);
-          assertEquals(result, '---\ntitle: "Hello"\n---\n\nbody\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: tags に配列を含む frontmatter + body の Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-10 - tags が string[] として取得できる', () => {
-        it('T-CLS-CE-10: 配列フィールドのパース', () => {
-          const text = '---\ntags:\n  - foo\n  - bar\n---\nbody';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('tags'), ['foo', 'bar']);
-        });
-      });
-    });
-  });
-
-  describe('Given: count に数値を含む frontmatter + body の Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-11 - count が文字列 "42" として取得できる', () => {
-        it('T-CLS-CE-11: 数値フィールドが文字列に変換される', () => {
-          const text = '---\ncount: 42\n---\nbody';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('count'), '42');
-        });
-      });
-    });
-  });
-
-  describe('Given: date フィールドを含む frontmatter + body の Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-12 - date が YYYY-MM-DD 文字列として取得できる', () => {
-        it('T-CLS-CE-12: Date フィールドが YYYY-MM-DD 文字列に変換される', () => {
-          const text = '---\ndate: 2026-03-15\n---\nbody';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('date'), '2026-03-15');
-        });
-      });
-    });
-  });
-
-  describe('Given: 閉じ --- なしの不完全な frontmatter ブロック', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-13 - InvalidFormat を throw する', () => {
-        it('T-CLS-CE-13: 閉じ --- なし入力では InvalidFormat を throw する', () => {
-          const text = '---\ntitle: Hello\nno closing separator';
-          const err = assertThrows(
-            () => new ChatlogEntry(text),
-            ChatlogError,
-          );
-          assertEquals(err.kind, 'InvalidFormat');
-        });
-      });
-    });
-  });
-
-  describe('Given: 不正な YAML を含む frontmatter ブロック', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-14 - InvalidYaml を throw する', () => {
-        it('T-CLS-CE-14: YAML パース失敗時は InvalidYaml を throw する', () => {
-          const text = '---\n: invalid: yaml: {\n---\nbody';
-          const err = assertThrows(
-            () => new ChatlogEntry(text),
-            ChatlogError,
-          );
-          assertEquals(err.kind, 'InvalidYaml');
-        });
-      });
-    });
-  });
-
-  describe('Given: tags に null 混入配列（~ を含む）を含む frontmatter ブロック', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-15 - null 要素が空文字列に変換される', () => {
-        it('T-CLS-CE-15: null 混入配列の null 要素が空文字列に変換される', () => {
-          const text = '---\ntags:\n  - foo\n  - ~\n  - bar\n---\nbody';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.frontmatter.get('tags'), ['foo', '', 'bar']);
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter の直後に複数の空行が続く Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-16 - content の先頭の複数改行が全て削除される', () => {
-        it('T-CLS-CE-16: 先頭複数改行の削除', () => {
-          const text = '---\ntitle: T\n---\n\n\nbody\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.content, 'body\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter 後の本文末尾に複数の空行が続く Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-17 - content の末尾の複数改行が単一 \\n に正規化される', () => {
-        it('T-CLS-CE-17: 末尾複数改行の正規化', () => {
-          const text = '---\ntitle: T\n---\nbody\n\n\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.content, 'body\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter 後の本文が改行のみの Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-18 - content が空文字列になる', () => {
-        it('T-CLS-CE-18: 改行のみの本文は空文字列に正規化される', () => {
-          const text = '---\ntitle: T\n---\n\n\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.content, '');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter 後の本文中に空行を含む Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-19 - content の本文中の空行は保持される', () => {
-        it('T-CLS-CE-19: 本文中空行の保持', () => {
-          const text = '---\ntitle: T\n---\nline1\n\nline2\n';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.content, 'line1\n\nline2\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter 後の本文が末尾改行なしの Markdown', () => {
-    describe('When: new ChatlogEntry(text) を呼び出す', () => {
-      describe('Then: T-CLS-CE-20 - content の末尾に \\n が付与される', () => {
-        it('T-CLS-CE-20: 末尾改行なし入力への \\n 付与', () => {
-          const text = '---\ntitle: T\n---\nbody';
-          const entry = new ChatlogEntry(text);
-          assertEquals(entry.content, 'body\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter の直後に複数の空行が続く Markdown', () => {
-    describe('When: renderEntry() を呼び出す', () => {
-      describe('Then: T-CLS-CE-21 - 出力は先頭空行 1 つ + 本文の標準形になる', () => {
-        it('T-CLS-CE-21: 先頭複数改行入力でも renderEntry() の出力は標準形', () => {
-          const text = '---\ntitle: T\n---\n\n\n\nbody\n';
-          const entry = new ChatlogEntry(text);
-          const result = entry.renderEntry(['title']);
-          assertEquals(result, '---\ntitle: "T"\n---\n\nbody\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: frontmatter 後の本文末尾に複数の空行が続く Markdown', () => {
-    describe('When: renderEntry() を呼び出す', () => {
-      describe('Then: T-CLS-CE-22 - 出力の本文末尾は単一 \\n のみになる', () => {
-        it('T-CLS-CE-22: 末尾余剰改行入力でも renderEntry() の末尾は単一 \\n', () => {
-          const text = '---\ntitle: T\n---\nbody\n\n\n';
-          const entry = new ChatlogEntry(text);
-          const result = entry.renderEntry(['title']);
-          assertEquals(result, '---\ntitle: "T"\n---\n\nbody\n');
-        });
-      });
-    });
+    }
   });
 });

--- a/skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
@@ -7,194 +7,290 @@
 // https://opensource.org/licenses/MIT
 
 // -- BDD modules --
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertThrows } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 // -- test target --
 import { ChatlogFrontmatter } from '../../ChatlogFrontmatter.class.ts';
+//  error class
+import { ChatlogError } from '../../ChatlogError.class.ts';
 
 // ─────────────────────────────────────────────
 // ChatlogFrontmatter
 // ─────────────────────────────────────────────
-
+/**
+ * @description ChatlogFrontmatter クラスのユニットテストスイート。
+ * get / set / remove / toFrontmatter および各コンストラクタ入力形式を網羅的に検証する。
+ */
 describe('ChatlogFrontmatter', () => {
-  describe('Given: title を含む frontmatter ブロック', () => {
-    describe('When: get("title") を呼び出す', () => {
-      describe('Then: T-CLS-CF-11 - title の文字列値が返る', () => {
-        it('T-CLS-CF-11: [正常] - 存在するキーの文字列値を返す', () => {
-          const fm = new ChatlogFrontmatter({ title: 'Hello' });
-          assertEquals(fm.get('title'), 'Hello');
-        });
+  /**
+   * @description get() メソッドのユニットテスト。
+   * キーの存在有無・型（string/string[]）に応じた取得動作を検証する。
+   */
+  describe('get()', () => {
+    const _getCases: {
+      id: string;
+      label: string;
+      init: string;
+      key: string;
+      expected: string | string[] | undefined;
+    }[] = [
+      {
+        id: 'T-CLS-CF-11',
+        label: '[正常] 存在するキーの文字列値を返す',
+        init: '---\ntitle: "Hello"\n---\n',
+        key: 'title',
+        expected: 'Hello',
+      },
+      {
+        id: 'T-CLS-CF-12',
+        label: '[正常] 存在するキーの配列値を返す',
+        init: '---\ntags:\n  - "foo"\n  - "bar"\n---\n',
+        key: 'tags',
+        expected: ['foo', 'bar'],
+      },
+      {
+        id: 'T-CLS-CF-13',
+        label: '[正常] 存在しないキーは undefined を返す',
+        init: '---\ntitle: "Hello"\n---\n',
+        key: 'missing',
+        expected: undefined,
+      },
+    ];
+
+    for (const tc of _getCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const fm = new ChatlogFrontmatter(tc.init);
+        assertEquals(fm.get(tc.key), tc.expected);
       });
+    }
+  });
+
+  /**
+   * @description set() メソッドのユニットテスト。
+   * 新規キー追加・既存キー上書き・空値のセットを検証する。
+   */
+  describe('set()', () => {
+    const _setCases: {
+      id: string;
+      label: string;
+      init: string;
+      key: string;
+      value: string | string[];
+      expected: string | string[];
+    }[] = [
+      {
+        id: 'T-CLS-CF-14',
+        label: '[正常] 新規キーに文字列をセットできる',
+        init: '',
+        key: 'title',
+        value: 'Hello',
+        expected: 'Hello',
+      },
+      {
+        id: 'T-CLS-CF-15',
+        label: '[正常] 既存キーを上書きできる',
+        init: '---\ntitle: "Old"\n---\n',
+        key: 'title',
+        value: 'New',
+        expected: 'New',
+      },
+      {
+        id: 'T-CLS-CF-16',
+        label: '[正常] 新規キーに配列をセットできる',
+        init: '',
+        key: 'tags',
+        value: ['foo', 'bar'],
+        expected: ['foo', 'bar'],
+      },
+      {
+        id: 'T-CLS-CF-17',
+        label: '[エッジケース] 空文字列をセットできる',
+        init: '',
+        key: 'title',
+        value: '',
+        expected: '',
+      },
+      {
+        id: 'T-CLS-CF-18',
+        label: '[エッジケース] 空配列をセットできる',
+        init: '',
+        key: 'tags',
+        value: [],
+        expected: [],
+      },
+    ];
+
+    for (const tc of _setCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const fm = new ChatlogFrontmatter(tc.init);
+        fm.set(tc.key, tc.value);
+        assertEquals(fm.get(tc.key), tc.expected);
+      });
+    }
+  });
+
+  /**
+   * @description remove() メソッドのユニットテスト。
+   * キー削除と存在しないキーへの呼び出しを検証する。
+   */
+  describe('remove()', () => {
+    const _removeCases: {
+      id: string;
+      label: string;
+      init: string;
+      key: string;
+    }[] = [
+      {
+        id: 'T-CLS-CF-19',
+        label: '[正常] 存在するキーを削除できる',
+        init: '---\ntitle: "Hello"\n---\n',
+        key: 'title',
+      },
+      {
+        id: 'T-CLS-CF-20',
+        label: '[エッジケース] 存在しないキーへの呼び出しはエラーにならない',
+        init: '',
+        key: 'missing',
+      },
+    ];
+
+    for (const tc of _removeCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const fm = new ChatlogFrontmatter(tc.init);
+        fm.remove(tc.key);
+        assertEquals(fm.get(tc.key), undefined);
+      });
+    }
+  });
+
+  /**
+   * @description toFrontmatter() メソッドのユニットテスト。
+   * set/remove の変更反映と fieldOrder 省略時の動作を検証する。
+   */
+  describe('toFrontmatter()', () => {
+    it('T-CLS-CF-21: [正常] - set で追加したフィールドが toFrontmatter に反映される', () => {
+      const fm = new ChatlogFrontmatter('');
+      fm.set('title', 'Hello');
+      const result = fm.toFrontmatter(['title']);
+      assertEquals(result, '---\ntitle: "Hello"\n---\n');
+    });
+
+    it('T-CLS-CF-22: [正常] - remove で削除したフィールドが toFrontmatter に含まれない', () => {
+      const fm = new ChatlogFrontmatter('---\ntitle: "Hello"\n---\n');
+      fm.remove('title');
+      const result = fm.toFrontmatter(['title']);
+      assertEquals(result, '---\n\n---\n');
+    });
+
+    it('T-CLS-CF-23: [正常] - fieldOrder 省略時は _DEFAULT_FIELD_ORDER が使われる', () => {
+      const fm = new ChatlogFrontmatter('---\ntitle: "Hello"\ncategory: "dev"\n---\n');
+      const result = fm.toFrontmatter();
+      assertEquals(result, '---\ntitle: "Hello"\ncategory: "dev"\n---\n');
     });
   });
 
-  describe('Given: tags に配列を含む frontmatter ブロック', () => {
-    describe('When: get("tags") を呼び出す', () => {
-      describe('Then: T-CLS-CF-12 - tags の配列値が返る', () => {
-        it('T-CLS-CF-12: [正常] - 存在するキーの配列値を返す', () => {
-          const fm = new ChatlogFrontmatter({ tags: ['foo', 'bar'] });
-          assertEquals(fm.get('tags'), ['foo', 'bar']);
-        });
+  /**
+   * @description コンストラクタへの文字列入力（正常系）のユニットテスト。
+   * 空文字列・空ブロック・文字列/配列フィールドのパースを検証する。
+   */
+  describe('コンストラクタ - 文字列入力 正常系', () => {
+    const _parseCases: {
+      id: string;
+      label: string;
+      input: string;
+      fields: { key: string; expected: string | string[] | undefined }[];
+    }[] = [
+      {
+        id: 'T-CLS-CF-26',
+        label: '[正常] 空文字列はエラーにならず entries が空になる',
+        input: '',
+        fields: [{ key: 'title', expected: undefined }],
+      },
+      {
+        id: 'T-CLS-CF-27',
+        label: '[正常] 空の frontmatter ブロックはエラーにならず entries が空になる',
+        input: '---\n---\n',
+        fields: [{ key: 'title', expected: undefined }],
+      },
+      {
+        id: 'T-CLS-CF-28',
+        label: '[正常] 文字列フィールドを含む frontmatter 文字列をパースできる',
+        input: '---\ntitle: Hello\n---\n',
+        fields: [{ key: 'title', expected: 'Hello' }],
+      },
+      {
+        id: 'T-CLS-CF-29',
+        label: '[正常] 配列フィールドを含む frontmatter 文字列をパースできる',
+        input: '---\ntitle: Hello\ntags:\n  - a\n  - b\n---\n',
+        fields: [{ key: 'title', expected: 'Hello' }, { key: 'tags', expected: ['a', 'b'] }],
+      },
+    ];
+
+    for (const tc of _parseCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const fm = new ChatlogFrontmatter(tc.input);
+        for (const field of tc.fields) {
+          assertEquals(fm.get(field.key), field.expected);
+        }
       });
-    });
+    }
   });
 
-  describe('Given: title のみを含む frontmatter ブロック', () => {
-    describe('When: get("missing") を呼び出す', () => {
-      describe('Then: T-CLS-CF-13 - undefined が返る', () => {
-        it('T-CLS-CF-13: [正常] - 存在しないキーは undefined を返す', () => {
-          const fm = new ChatlogFrontmatter({ title: 'Hello' });
-          assertEquals(fm.get('missing'), undefined);
-        });
-      });
-    });
-  });
+  /**
+   * @description コンストラクタへの文字列入力（異常系）のユニットテスト。
+   * 不正フォーマット・YAML 構文エラーで ChatlogError がスローされることを検証する。
+   */
+  describe('コンストラクタ - 文字列入力 異常系', () => {
+    const _invalidInputCases: { id: string; label: string; input: string; kind: string }[] = [
+      {
+        id: 'T-CLS-CF-30',
+        label: '[異常] "---" で始まらない非空文字列は InvalidFormat',
+        input: 'title: Hello',
+        kind: 'InvalidFormat',
+      },
+      {
+        id: 'T-CLS-CF-31',
+        label: '[異常] 閉じ区切り記号のない frontmatter 文字列は InvalidFormat',
+        input: '---\ntitle: Hello',
+        kind: 'InvalidFormat',
+      },
+      {
+        id: 'T-CLS-CF-32',
+        label: '[異常] YAML 構文エラーのある frontmatter 文字列は InvalidYaml',
+        input: '---\nfoo: : bad\n---\n',
+        kind: 'InvalidYaml',
+      },
+      {
+        id: 'T-CLS-CF-33',
+        label: '[異常] YAML が配列の frontmatter 文字列は InvalidFormat',
+        input: '---\n- a\n- b\n---\n',
+        kind: 'InvalidFormat',
+      },
+      {
+        id: 'T-CLS-CF-34',
+        label: '[異常] YAML がスカラーの frontmatter 文字列は InvalidFormat',
+        input: '---\nhello\n---\n',
+        kind: 'InvalidFormat',
+      },
+      {
+        id: 'T-CLS-CF-35',
+        label: '[エッジケース] 開き区切り記号のみの文字列は InvalidFormat',
+        input: '---\n',
+        kind: 'InvalidFormat',
+      },
+      {
+        id: 'T-CLS-CF-36',
+        label: '[エッジケース] YAML が null の frontmatter 文字列は InvalidFormat',
+        input: '---\nnull\n---\n',
+        kind: 'InvalidFormat',
+      },
+    ];
 
-  describe('Given: 空の ChatlogFrontmatter', () => {
-    describe('When: set("title", "Hello") を呼び出す', () => {
-      describe('Then: T-CLS-CF-14 - title が "Hello" になる', () => {
-        it('T-CLS-CF-14: [正常] - 新規キーに文字列をセットできる', () => {
-          const fm = new ChatlogFrontmatter({});
-          fm.set('title', 'Hello');
-          assertEquals(fm.get('title'), 'Hello');
-        });
+    for (const tc of _invalidInputCases) {
+      it(`${tc.id}: ${tc.label}`, () => {
+        const err = assertThrows(() => new ChatlogFrontmatter(tc.input), ChatlogError);
+        assertEquals(err.kind, tc.kind);
       });
-    });
-  });
-
-  describe('Given: title: "Old" を含む frontmatter ブロック', () => {
-    describe('When: set("title", "New") を呼び出す', () => {
-      describe('Then: T-CLS-CF-15 - title が "New" に上書きされる', () => {
-        it('T-CLS-CF-15: [正常] - 既存キーを上書きできる', () => {
-          const fm = new ChatlogFrontmatter({ title: 'Old' });
-          fm.set('title', 'New');
-          assertEquals(fm.get('title'), 'New');
-        });
-      });
-    });
-  });
-
-  describe('Given: 空の ChatlogFrontmatter', () => {
-    describe('When: set("tags", ["foo", "bar"]) を呼び出す', () => {
-      describe('Then: T-CLS-CF-16 - tags が ["foo", "bar"] になる', () => {
-        it('T-CLS-CF-16: [正常] - 新規キーに配列をセットできる', () => {
-          const fm = new ChatlogFrontmatter({});
-          fm.set('tags', ['foo', 'bar']);
-          assertEquals(fm.get('tags'), ['foo', 'bar']);
-        });
-      });
-    });
-  });
-
-  describe('Given: 空の ChatlogFrontmatter', () => {
-    describe('When: set("title", "") を呼び出す', () => {
-      describe('Then: T-CLS-CF-17 - title が空文字列になる（有効な値）', () => {
-        it('T-CLS-CF-17: [エッジケース] - 空文字列をセットできる', () => {
-          const fm = new ChatlogFrontmatter({});
-          fm.set('title', '');
-          assertEquals(fm.get('title'), '');
-        });
-      });
-    });
-  });
-
-  describe('Given: 空の ChatlogFrontmatter', () => {
-    describe('When: set("tags", []) を呼び出す', () => {
-      describe('Then: T-CLS-CF-18 - tags が空配列になる（有効な値）', () => {
-        it('T-CLS-CF-18: [エッジケース] - 空配列をセットできる', () => {
-          const fm = new ChatlogFrontmatter({});
-          fm.set('tags', []);
-          assertEquals(fm.get('tags'), []);
-        });
-      });
-    });
-  });
-
-  describe('Given: title を含む frontmatter ブロック', () => {
-    describe('When: remove("title") を呼び出す', () => {
-      describe('Then: T-CLS-CF-19 - title が削除され undefined になる', () => {
-        it('T-CLS-CF-19: [正常] - 存在するキーを削除できる', () => {
-          const fm = new ChatlogFrontmatter({ title: 'Hello' });
-          fm.remove('title');
-          assertEquals(fm.get('title'), undefined);
-        });
-      });
-    });
-  });
-
-  describe('Given: 空の ChatlogFrontmatter', () => {
-    describe('When: remove("missing") を呼び出す', () => {
-      describe('Then: T-CLS-CF-20 - エラーにならず無視される', () => {
-        it('T-CLS-CF-20: [エッジケース] - 存在しないキーへの呼び出しはエラーにならない', () => {
-          const fm = new ChatlogFrontmatter({});
-          fm.remove('missing');
-          assertEquals(fm.get('missing'), undefined);
-        });
-      });
-    });
-  });
-
-  describe('Given: 空の ChatlogFrontmatter', () => {
-    describe('When: set("title", "Hello") してから toFrontmatter(["title"]) を呼び出す', () => {
-      describe('Then: T-CLS-CF-21 - set したフィールドが toFrontmatter の出力に含まれる', () => {
-        it('T-CLS-CF-21: [正常] - set で追加したフィールドが toFrontmatter に反映される', () => {
-          const fm = new ChatlogFrontmatter({});
-          fm.set('title', 'Hello');
-          const result = fm.toFrontmatter(['title']);
-          assertEquals(result, '---\ntitle: "Hello"\n---\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: title を含む frontmatter ブロック', () => {
-    describe('When: remove("title") してから toFrontmatter(["title"]) を呼び出す', () => {
-      describe('Then: T-CLS-CF-22 - title が toFrontmatter の出力に含まれない', () => {
-        it('T-CLS-CF-22: [正常] - remove で削除したフィールドが toFrontmatter に含まれない', () => {
-          const fm = new ChatlogFrontmatter({ title: 'Hello' });
-          fm.remove('title');
-          const result = fm.toFrontmatter(['title']);
-          assertEquals(result, '---\n\n---\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: title と category を含む frontmatter ブロック', () => {
-    describe('When: toFrontmatter() を引数なしで呼び出す', () => {
-      describe('Then: T-CLS-CF-23 - DEFAULT_FIELD_ORDER に従い title → category の順で出力される', () => {
-        it('T-CLS-CF-23: [正常] - fieldOrder 省略時は _DEFAULT_FIELD_ORDER が使われる', () => {
-          const fm = new ChatlogFrontmatter({ title: 'Hello', category: 'dev' });
-          const result = fm.toFrontmatter();
-          assertEquals(result, '---\ntitle: "Hello"\ncategory: "dev"\n---\n');
-        });
-      });
-    });
-  });
-
-  describe('Given: entries オブジェクト { title: "Hello", category: "dev" }', () => {
-    describe('When: new ChatlogFrontmatter(entries) を呼び出す', () => {
-      describe('Then: T-CLS-CF-24 - title と category が entries に格納される', () => {
-        it('T-CLS-CF-24: entries オブジェクトから ChatlogFrontmatter を構築できる', () => {
-          const entries = { title: 'Hello', category: 'dev' };
-          const fm = new ChatlogFrontmatter(entries);
-          assertEquals(fm.get('title'), 'Hello');
-          assertEquals(fm.get('category'), 'dev');
-        });
-      });
-    });
-  });
-
-  describe('Given: entries オブジェクトを渡した後に外部から変更', () => {
-    describe('When: コンストラクタ引数オブジェクトのプロパティを変更する', () => {
-      describe('Then: T-CLS-CF-25 - 内部状態は変更されない（shallow copy）', () => {
-        it('T-CLS-CF-25: コンストラクタ引数の mutation は内部状態に影響しない', () => {
-          const entries: Record<string, string | string[]> = { title: 'Hello' };
-          const fm = new ChatlogFrontmatter(entries);
-          entries['title'] = 'Changed';
-          assertEquals(fm.get('title'), 'Hello');
-        });
-      });
-    });
+    }
   });
 });


### PR DESCRIPTION
## Overview

**Summary**
Enforce string-only input for `ChatlogFrontmatter` constructor and refactor tests to table-driven style.

**Background / Motivation**
`ChatlogFrontmatter` のコンストラクタが `string | Record<string, unknown>` を受け付けていたため、型安全性が低く、パース失敗時のエラーハンドリングも曖昧だった。
入力を `string` 型のみに統一し、不正な frontmatter 構造・YAML エラーを `ChatlogError` として明示的に throw することで、型安全性と一貫性を向上させた。
合わせて `ChatlogFrontmatter` と `ChatlogEntry` のテストをテーブル駆動形式にリファクタリングし、コードの重複を排除した。

## Changes

- `skills/_scripts/classes/ChatlogFrontmatter.class.ts`
  - コンストラクタ入力を `string` 型のみに制限（`Record` 型サポートを削除）
  - 厳格な frontmatter パース処理を実装（不正な区切り文字・構造・YAML エラー時に `ChatlogError` を throw）
  - パースロジックをプライベートメソッドに抽出（`_extractBody`, `_parseFrontmatter`）

- `skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts`
  - 文字列ベースのコンストラクタ入力に対応するようテストを更新
  - テーブル駆動スタイルにリファクタリング（`_cases` テーブル + `for` ループ）

- `skills/_scripts/classes/__tests__/unit/ChatlogEntry.unit.spec.ts`
  - `Given/When/Then` のネスト構造を廃止し、4 つの `describe` ブロックに整理
  - `_ctorCases` / `_renderCases` / `_errorCases` テーブルによるテーブル駆動形式に変換

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

**Breaking Change**: `ChatlogFrontmatter` コンストラクタの入力型が変更された。

- **Before**: `string | Record<string, unknown>` を受け付けていた
- **After**: `string` のみ受け付ける

`Record` 型を渡していた呼び出し元は、`YAML.stringify()` 等で文字列に変換してから渡すよう修正が必要。
