### PR TITLE
config(dev-env): update development environment configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 {
   //  chatlog dictionary files
   "files.associations": {
-    "*.dic": "yaml"
+    "*.dic": "yaml",
   },
   // deno settings
   "deno.enable": true,
@@ -10,13 +10,11 @@
   // trusted JSON schema hosts
   "json.schemaDownload.enable": true,
   "json.schemaDownload.trustedDomains": {
-    "https://schemastore.azurewebsites.net/": true,
     "https://raw.githubusercontent.com/microsoft/vscode/": true,
     "https://raw.githubusercontent.com/devcontainers/spec/": true,
-    "https://www.schemastore.org/": true,
-    "https://json.schemastore.org/": true,
-    "https://json-schema.org/": true,
+    "https://raw.githubusercontent.com/streetsidesoftware/cspell/": true,
     "https://developer.microsoft.com/json-schemas/": true,
-    "https://raw.githubusercontent.com/denoland/": true
+    "https://raw.githubusercontent.com/denoland/": true,
+    "https://dprint.dev/schemas/": true,
   }
 }

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -41,7 +41,6 @@
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
-    "https://plugins.dprint.dev/ruff-0.7.7.wasm",
   ],
   // Language-specific settings
   "typescript": {


### PR DESCRIPTION
## Overview

**Summary**
Update development environment configuration for consistency and accuracy.

**Background / Motivation**
開発環境の設定ファイルが実際の使用状況と乖離していた。
dprint に不要な ruff プラグイン（Python 専用）が残っており、VSCode の JSON スキーマ信頼ドメインも整理されていなかった。
また、dependabot に npm エコシステムの監視が欠けていたため、npm 依存関係の自動更新が有効でなかった。

## Changes

- `dprint.jsonc` — plugins から `ruff-0.7.7.wasm` を削除（本プロジェクトは TypeScript/Deno のため不要）
- `.vscode/settings.json` — `json.schemaDownload.trustedDomains` を実際に使用する cspell・dprint のドメインに限定
- `.github/dependabot.yml` — npm エコシステムを weekly スケジュールで追加

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

なし

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

ruff は Python フォーマッタであり、本プロジェクト（TypeScript/Deno）では使用しないため削除した。
dependabot の npm 監視追加により、将来的な npm 依存関係の自動更新が有効になる。
