### PR TITLE
config(beads): initialize beads issue tracker with project settings

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -7,21 +7,25 @@
 # If not set, bd init will auto-detect from directory name
 # Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
 # issue-prefix: ""
+issue_prefix: "cle"
 
 # Use no-db mode: JSONL-only, no Dolt database
 # When true, bd will use .beads/issues.jsonl as the source of truth
 # no-db: false
+no-db: false
 
 # Enable JSON output by default
-# json: false
+# json: fals
 
 # Feedback title formatting for mutating commands (create/update/close/dep/edit)
 # 0 = hide titles, N > 0 = truncate to N characters
 # output:
 #   title-length: 255
 
+
 # Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
 # actor: ""
+actor: "atsushifx"
 
 # Export events (audit trail) to .beads/events.jsonl on each flush/sync
 # When enabled, new events are appended incrementally using a high-water mark.

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -12,7 +12,7 @@ issue_prefix: "cle"
 # Use no-db mode: JSONL-only, no Dolt database
 # When true, bd will use .beads/issues.jsonl as the source of truth
 # no-db: false
-no-db: false
+no-db: true
 
 # Enable JSON output by default
 # json: fals

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -7,7 +7,7 @@
 # If not set, bd init will auto-detect from directory name
 # Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
 # issue-prefix: ""
-issue_prefix: "cle"
+issue-prefix: "cle"
 
 # Use no-db mode: JSONL-only, no Dolt database
 # When true, bd will use .beads/issues.jsonl as the source of truth


### PR DESCRIPTION
## Overview

**Summary**
Initialize beads issue tracker configuration for chatlog-exporter project.

**Background / Motivation**
beads を用いた issue tracking ワークフローを本プロジェクトで開始するにあたり、
プロジェクト固有の設定（issue prefix、DB モード、actor）を `.beads/config.yaml` に定義した。

## Changes

- `.beads/config.yaml` に `issue-prefix: "cle"` を追加 — このリポジトリの issue ID プレフィックス
- `.beads/config.yaml` に `no-db: true` を追加 — Dolt DB 不要の JSONL モードで運用
- `.beads/config.yaml` に `actor: "atsushifx"` を追加 — 監査ログのデフォルト actor

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

- `bd list`、`bd create` コマンドで `cle-NNN` 形式の issue が作成・管理できることを確認済み
- `.beads/issues.jsonl` に保存されること（DB 不使用）を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
