### PR TITLE
config(renovate): restrict managers to github-actions and deno

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,15 +6,5 @@
   },
   // deno settings
   "deno.enable": true,
-  "deno.config": "deno.json",
-  // trusted JSON schema hosts
-  "json.schemaDownload.enable": true,
-  "json.schemaDownload.trustedDomains": {
-    "https://raw.githubusercontent.com/microsoft/vscode/": true,
-    "https://raw.githubusercontent.com/devcontainers/spec/": true,
-    "https://raw.githubusercontent.com/streetsidesoftware/cspell/": true,
-    "https://developer.microsoft.com/json-schemas/": true,
-    "https://raw.githubusercontent.com/denoland/": true,
-    "https://dprint.dev/schemas/": true
-  }
+  "deno.config": "deno.json"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>aglabo/renovate-config"
+  ],
+
+  "enableManagers": [
+    "github-actions",
+    "deno"
   ]
 }


### PR DESCRIPTION
## Overview

**Summary**
Restrict Renovate's managed ecosystems to github-actions and deno only.

**Background / Motivation**
Renovate と dependabot が重複して依存関係を管理していた。npm エコシステムは `.github/dependabot.yml` で管理しているため
、Renovate の管理対象を `github-actions` と `deno` に限定し、役割分担を明確にする。
あわせて、不要になった VSCode の JSON スキーマダウンロード設定を削除した。

## Changes

- `renovate.json`: `enableManagers: ["github-actions", "deno"]` を追加し、Renovate の管理対象を限定
- `.vscode/settings.json`: `json.schemaDownload.enable` と `json.schemaDownload.trustedDomains` の設定を削除

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

とくになし
