### PR TITLE
chore(deps): remove npm ecosystem from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## Overview

**Summary**
Remove npm ecosystem from Dependabot configuration to simplify dependency management.

**Background / Motivation**
The npm ecosystem entry in `.github/dependabot.yml` was generating automated PRs for npm dependencies, which is unnecessary for this project.
Limiting Dependabot to `github-actions` only reduces noise and focuses automated updates on the most critical dependency type.

## Changes

- Removed npm package ecosystem configuration from `.github/dependabot.yml`
- Dependabot now monitors `github-actions` only

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

*No additional notes.*
