### PR TITLE
refactor(libs/logger): replace console spy with stub in unit tests

### DIFF
--- a/skills/_scripts/libs/io/__tests__/unit/logger.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/logger.unit.spec.ts
@@ -8,7 +8,7 @@
 
 // -- BDD modules --
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-import { assertSpyCalls, spy } from '@std/testing/mock';
+import { assertSpyCalls, stub, type Stub } from '@std/testing/mock';
 
 // -- test target --
 import { logger } from '../../logger.ts';
@@ -23,14 +23,12 @@ import { logger } from '../../logger.ts';
  * 各メソッドの出力先（stdout / stderr）と prefix の有無をカバーする。
  */
 describe('logger', () => {
-  // deno-lint-ignore no-explicit-any
-  let logSpy: any;
-  // deno-lint-ignore no-explicit-any
-  let errorSpy: any;
+  let logSpy: Stub;
+  let errorSpy: Stub;
 
   beforeEach(() => {
-    logSpy = spy(console, 'log');
-    errorSpy = spy(console, 'error');
+    logSpy = stub(console, 'log', () => {});
+    errorSpy = stub(console, 'error', () => {});
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Overview

**Summary**
Replace console spy with stub in logger unit tests to suppress output and improve type safety.

**Background / Motivation**
ユニットテスト実行時に `console.log` / `console.error` がそのまま出力されていた。
`spy` は呼び出しを記録するだけで出力を抑制しないため、テストログが汚れる問題があった。
また、変数型が `any` のため lint 抑制コメントが必要な状態だった。

## Changes

- `spy(console, 'log')` / `spy(console, 'error')` を `stub(console, 'log', () => {})` /
  `stub(console, 'error', () => {})` に置き換え、テスト実行中のコンソール出力を抑制
- 変数型を `any` から `Stub` に変更し、`deno-lint-ignore no-explicit-any` 抑制コメントを削除
- インポートを `spy` → `stub`, `type Stub` に更新

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

変更対象ファイル: `skills/_scripts/libs/io/__tests__/unit/logger.unit.spec.ts`

テストの動作・検証ロジックに変更はなく、実装の品質改善のみ。
