### PR TITLE
refactor(classify): extract buildConfig and update ParsedConfig type

### DIFF
--- a/assets/configs/defaults.yaml
+++ b/assets/configs/defaults.yaml
@@ -17,3 +17,7 @@ maxRandomLength: 16
 # 並列処理・バッチ処理系
 chunkSize: 10
 concurrency: 4
+
+# アセットディレクトリ
+dicsDir: "./assets/dics"
+promptsDir: "./assets/prompts"

--- a/skills/_scripts/constants/schema.constants.ts
+++ b/skills/_scripts/constants/schema.constants.ts
@@ -27,6 +27,10 @@ export const DEFAULT_SCHEMA: Record<string, SchemaValueTypeName> = {
   chunkSize: 'number',
   /** 同時実行する並列タスク数の上限。 */
   concurrency: 'number',
+  /** 辞書ファイルが置かれたディレクトリのパス。 */
+  dicsDir: 'string',
+  /** プロンプトテンプレートが置かれたディレクトリのパス。 */
+  promptsDir: 'string',
 };
 
 /** DEFAULT_SCHEMA のキーのユニオン型。 */
@@ -55,4 +59,8 @@ export const DEFAULT_VALUES: ConfigValues = {
   chunkSize: 10,
   /** デフォルト並列数は 4 タスク */
   concurrency: 4,
+  /** デフォルト辞書ディレクトリ */
+  dicsDir: './assets/dics',
+  /** デフォルトプロンプトディレクトリ */
+  promptsDir: './assets/prompts',
 } as const;

--- a/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
@@ -18,6 +18,8 @@ import { stub } from '@std/testing/mock';
 
 // test target
 import { main } from '../../classify-chatlog.ts';
+// classes
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 
 // helpers
 import {
@@ -31,20 +33,28 @@ import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-st
 // ─── テスト用一時ディレクトリセットアップ ─────────────────────────────────────
 
 /**
- * inputDir / dicsDir を作成して返す。
- * agent=claude 形式のディレクトリ構造: inputDir/claude/2026-03/
+ * inputDir / configsDir を作成して返す。
+ * - configsDir/defaults.yaml: 空の設定ファイル（GlobalConfig 用）
+ * - configsDir/projects.dic: テスト用プロジェクト辞書（YAML 形式）
+ * - inputDir/claude/2026-03/: 月別ディレクトリ
  */
 async function _makeTestDirs(agent = 'claude', period = '2026-03'): Promise<{
   inputDir: string;
-  dicsDir: string;
+  configsDir: string;
+  configFile: string;
   monthDir: string;
 }> {
   const inputDir = await Deno.makeTempDir();
-  const dicsDir = await Deno.makeTempDir();
+  const configsDir = await Deno.makeTempDir();
+  const configFile = `${configsDir}/defaults.yaml`;
   const monthDir = `${inputDir}/${agent}/${period}`;
   await Deno.mkdir(monthDir, { recursive: true });
-  await Deno.writeTextFile(`${dicsDir}/projects.dic`, 'app1\napp2\n');
-  return { inputDir, dicsDir, monthDir };
+  await Deno.writeTextFile(configFile, '{}\n');
+  await Deno.writeTextFile(
+    `${configsDir}/projects.dic`,
+    'app1:\n  def: Test project 1\napp2:\n  def: Test project 2\n',
+  );
+  return { inputDir, configsDir, configFile, monthDir };
 }
 
 // ─── T-CL-E2E-01: dry-run モード ─────────────────────────────────────────────
@@ -54,13 +64,14 @@ describe('main - dry-run モード', () => {
     describe('When: main([...args, "--dry-run"]) を呼び出す', () => {
       describe('Then: T-CL-E2E-01 - dry-run → ファイルが移動しない', () => {
         let inputDir: string;
-        let dicsDir: string;
+        let configsDir: string;
+        let configFile: string;
         let monthDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ inputDir, dicsDir, monthDir } = await _makeTestDirs());
+          ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
           await Deno.writeTextFile(
             `${monthDir}/chat.md`,
             '---\ntitle: テスト\ncategory: development\n---\n本文',
@@ -72,24 +83,26 @@ describe('main - dry-run モード', () => {
             makeSuccessMock(new TextEncoder().encode(response)),
           );
           loggerStub = makeLoggerStub();
+          GlobalConfig.resetInstance();
         });
 
         afterEach(async () => {
           commandHandle.restore();
           loggerStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(inputDir, { recursive: true });
-          await Deno.remove(dicsDir, { recursive: true });
+          await Deno.remove(configsDir, { recursive: true });
         });
 
         it('T-CL-E2E-01-01: 元ファイルが移動せず残っている', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--config', configFile]);
 
           const stat = await Deno.stat(`${monthDir}/chat.md`);
           assertEquals(stat.isFile, true);
         });
 
         it('T-CL-E2E-01-02: "[dry-run]" がログに出力される', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--config', configFile]);
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]')), true);
         });
@@ -105,13 +118,14 @@ describe('main - 正常分類', () => {
     describe('When: main([...args]) を呼び出す（dryRun=false）', () => {
       describe('Then: T-CL-E2E-02 - ファイルがプロジェクトサブディレクトリに移動', () => {
         let inputDir: string;
-        let dicsDir: string;
+        let configsDir: string;
+        let configFile: string;
         let monthDir: string;
         let commandHandle: CommandMockHandle;
         let errStub: Stub;
 
         beforeEach(async () => {
-          ({ inputDir, dicsDir, monthDir } = await _makeTestDirs());
+          ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
           await Deno.writeTextFile(
             `${monthDir}/chat.md`,
             '---\ntitle: テスト\ncategory: development\n---\n本文',
@@ -123,24 +137,26 @@ describe('main - 正常分類', () => {
             makeSuccessMock(new TextEncoder().encode(response)),
           );
           errStub = stub(console, 'error', () => {});
+          GlobalConfig.resetInstance();
         });
 
         afterEach(async () => {
           commandHandle.restore();
           errStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(inputDir, { recursive: true });
-          await Deno.remove(dicsDir, { recursive: true });
+          await Deno.remove(configsDir, { recursive: true });
         });
 
         it('T-CL-E2E-02-01: ファイルが app1/ サブディレクトリに移動している', async () => {
-          await main(['claude', '2026-03', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
           const stat = await Deno.stat(`${monthDir}/app1/chat.md`);
           assertEquals(stat.isFile, true);
         });
 
         it('T-CL-E2E-02-02: 移動先ファイルに "project: \'app1\'" が含まれる', async () => {
-          await main(['claude', '2026-03', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
           const content = await Deno.readTextFile(`${monthDir}/app1/chat.md`);
           assertStringIncludes(content, "project: 'app1'");
@@ -157,7 +173,8 @@ describe('main - スキップ', () => {
     describe('When: main([...args]) を呼び出す', () => {
       describe('Then: T-CL-E2E-03 - スキップされ skipped カウント増加', () => {
         let inputDir: string;
-        let dicsDir: string;
+        let configsDir: string;
+        let configFile: string;
         let monthDir: string;
         let commandHandle: CommandMockHandle;
         let errLogs: string[];
@@ -165,7 +182,7 @@ describe('main - スキップ', () => {
         let exitStub: Stub;
 
         beforeEach(async () => {
-          ({ inputDir, dicsDir, monthDir } = await _makeTestDirs());
+          ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
           await Deno.writeTextFile(
             `${monthDir}/chat.md`,
             '---\ntitle: テスト\nproject: existing-project\n---\n本文',
@@ -180,24 +197,26 @@ describe('main - スキップ', () => {
           });
           // targetMetas が空になると Deno.exit(0) が呼ばれる
           exitStub = stub(Deno, 'exit');
+          GlobalConfig.resetInstance();
         });
 
         afterEach(async () => {
           commandHandle.restore();
           errStub.restore();
           exitStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(inputDir, { recursive: true });
-          await Deno.remove(dicsDir, { recursive: true });
+          await Deno.remove(configsDir, { recursive: true });
         });
 
         it('T-CL-E2E-03-01: "skipped" メッセージがログに出力される', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('skipped')), true);
         });
 
         it('T-CL-E2E-03-02: 完了ログに skipped=1 が含まれる', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('skipped=1')), true);
         });
@@ -213,14 +232,15 @@ describe('main - 対象ファイルなし', () => {
     describe('When: main([...args]) を呼び出す', () => {
       describe('Then: T-CL-E2E-04 - moved=0 skipped=0 error=0 が出力される', () => {
         let inputDir: string;
-        let dicsDir: string;
+        let configsDir: string;
+        let configFile: string;
         let commandHandle: CommandMockHandle;
         let errLogs: string[];
         let errStub: Stub;
         let exitStub: Stub;
 
         beforeEach(async () => {
-          ({ inputDir, dicsDir } = await _makeTestDirs());
+          ({ inputDir, configsDir, configFile } = await _makeTestDirs());
           // monthDir は _makeTestDirs で作成済み、.md ファイルは置かない
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode('[]')),
@@ -230,18 +250,20 @@ describe('main - 対象ファイルなし', () => {
             errLogs.push(args.map(String).join(' '));
           });
           exitStub = stub(Deno, 'exit');
+          GlobalConfig.resetInstance();
         });
 
         afterEach(async () => {
           commandHandle.restore();
           errStub.restore();
           exitStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(inputDir, { recursive: true });
-          await Deno.remove(dicsDir, { recursive: true });
+          await Deno.remove(configsDir, { recursive: true });
         });
 
         it('T-CL-E2E-04-01: "moved=0 skipped=0 error=0" がログに出力される', async () => {
-          await main(['claude', '2026-03', '--input', inputDir, '--dics', dicsDir]);
+          await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('moved=0 skipped=0 error=0')), true);
         });

--- a/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
@@ -19,11 +19,20 @@ import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts
 import { DEFAULT_AI_MODEL } from '../../../../_scripts/constants/defaults.constants.ts';
 import { DEFAULT_CLASSIFY_CONFIG } from '../../constants/classify.constants.ts';
 // types
+import type { CommandProvider } from '../../../../_scripts/types/providers.types.ts';
 import type { ParsedConfig } from '../../types/classify.types.ts';
 
 // ─── ヘルパー ──────────────────────────────────────────────────────────────────
 
 const _existsStat = (_path: string) => Promise.resolve({ isFile: true } as Deno.FileInfo);
+
+/** git コマンドを実行しない CommandProvider モック。 */
+class _NoopCommandProvider {
+  constructor(_cmd: string, _opts: { args: string[] }) {}
+  output(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: new Uint8Array() });
+  }
+}
 
 /** テスト用 GlobalConfig を作成する（YAML 文字列から）。 */
 async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
@@ -31,6 +40,7 @@ async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
   return await GlobalConfig.getInstance({
     readTextFileProvider: () => Promise.resolve(yaml),
     statProvider: _existsStat,
+    commandProvider: _NoopCommandProvider as unknown as CommandProvider,
     configFile: 'dummy.yaml',
   });
 }
@@ -172,6 +182,182 @@ describe('buildConfig', () => {
         it('T-CL-BC-08-01: parsed.configFile → result に configFile が含まれない', () => {
           const result = buildConfig({ ..._EMPTY_PARSED, configFile: 'custom.yaml' }, globalConfig);
           assertEquals('configFile' in result, false);
+        });
+      });
+    });
+  });
+
+  // ─── agent 優先順位 ─────────────────────────────────────────────────────────
+
+  describe('Given: parsed.agent が指定されている', () => {
+    describe('When: GlobalConfig にも agent が設定されている', () => {
+      describe('Then: T-CL-BC-09 - parsed.agent が優先される', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: chatgpt');
+        });
+        it('T-CL-BC-09-01: parsed.agent=codex → result.agent === codex', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, agent: 'codex' }, globalConfig);
+          assertEquals(result.agent, 'codex');
+        });
+      });
+    });
+  });
+
+  describe('Given: parsed.agent が未指定', () => {
+    describe('When: GlobalConfig に agent が設定されている', () => {
+      describe('Then: T-CL-BC-10 - GlobalConfig の agent が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: chatgpt');
+        });
+        it('T-CL-BC-10-01: globalConfig.agent=chatgpt → result.agent === chatgpt', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.agent, 'chatgpt');
+        });
+      });
+    });
+
+    describe('When: GlobalConfig にも agent が設定されていない', () => {
+      describe('Then: T-CL-BC-11 - DEFAULT_CLASSIFY_CONFIG.agent が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('model: sonnet');
+        });
+        it('T-CL-BC-11-01: agent 未設定 → result.agent === DEFAULT_CLASSIFY_CONFIG.agent', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.agent, DEFAULT_CLASSIFY_CONFIG.agent);
+        });
+      });
+    });
+  });
+
+  // ─── dryRun 優先順位 ─────────────────────────────────────────────────────────
+
+  describe('Given: parsed.dryRun=true が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-12 - result.dryRun === true', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-12-01: parsed.dryRun=true → result.dryRun === true', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, dryRun: true }, globalConfig);
+          assertEquals(result.dryRun, true);
+        });
+      });
+    });
+  });
+
+  describe('Given: parsed.dryRun が未指定', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-13 - DEFAULT_CLASSIFY_CONFIG.dryRun が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-13-01: dryRun 未指定 → result.dryRun === DEFAULT_CLASSIFY_CONFIG.dryRun', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.dryRun, DEFAULT_CLASSIFY_CONFIG.dryRun);
+        });
+      });
+    });
+  });
+
+  // ─── inputDir 優先順位 ───────────────────────────────────────────────────────
+
+  describe('Given: parsed.inputDir が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-14 - result.inputDir === parsed.inputDir', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-14-01: parsed.inputDir=/custom/input → result.inputDir === /custom/input', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom/input' }, globalConfig);
+          assertEquals(result.inputDir, '/custom/input');
+        });
+      });
+    });
+  });
+
+  describe('Given: parsed.inputDir が未指定', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-15 - DEFAULT_CLASSIFY_CONFIG.inputDir が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-15-01: inputDir 未指定 → result.inputDir === DEFAULT_CLASSIFY_CONFIG.inputDir', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.inputDir, DEFAULT_CLASSIFY_CONFIG.inputDir);
+        });
+      });
+    });
+  });
+
+  // ─── period フィールド（parsedのみ） ─────────────────────────────────────────
+
+  describe('Given: parsed.period が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-16 - result.period === parsed.period', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-16-01: parsed.period=2026-01 → result.period === 2026-01', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, period: '2026-01' }, globalConfig);
+          assertEquals(result.period, '2026-01');
+        });
+      });
+    });
+  });
+
+  describe('Given: parsed.period が未指定', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-17 - result.period === undefined', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-17-01: period 未指定 → result.period === undefined', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.period, undefined);
+        });
+      });
+    });
+  });
+
+  // ─── projectsDic 導出 ────────────────────────────────────────────────────────
+
+  describe('Given: parsed.configFile が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-18 - configFile のディレクトリ + /projects.dic が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-18-01: configFile=/custom/config/defaults.yaml → projectsDic === /custom/config/projects.dic', () => {
+          const result = buildConfig(
+            { ..._EMPTY_PARSED, configFile: '/custom/config/defaults.yaml' },
+            globalConfig,
+          );
+          assertEquals(result.projectsDic, '/custom/config/projects.dic');
+        });
+      });
+    });
+  });
+
+  describe('Given: parsed.configFile が未指定', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-19 - DEFAULT_CLASSIFY_CONFIG.projectsDic が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-19-01: configFile 未指定 → result.projectsDic === DEFAULT_CLASSIFY_CONFIG.projectsDic', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.projectsDic, DEFAULT_CLASSIFY_CONFIG.projectsDic);
         });
       });
     });

--- a/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
@@ -1,0 +1,179 @@
+// src: scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
+// @(#): buildConfig の機能テスト
+//       ParsedConfig + GlobalConfig + デフォルト値から ClassifyConfig を構築するロジック
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+
+// -- BDD modules --
+import { assertEquals, assertThrows } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// test target
+import { buildConfig } from '../../classify-chatlog.ts';
+// classes
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_AI_MODEL } from '../../../../_scripts/constants/defaults.constants.ts';
+import { DEFAULT_CLASSIFY_CONFIG } from '../../constants/classify.constants.ts';
+// types
+import type { ParsedConfig } from '../../types/classify.types.ts';
+
+// ─── ヘルパー ──────────────────────────────────────────────────────────────────
+
+const _existsStat = (_path: string) => Promise.resolve({ isFile: true } as Deno.FileInfo);
+
+/** テスト用 GlobalConfig を作成する（YAML 文字列から）。 */
+async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
+  GlobalConfig.resetInstance();
+  return await GlobalConfig.getInstance({
+    readTextFileProvider: () => Promise.resolve(yaml),
+    statProvider: _existsStat,
+    configFile: 'dummy.yaml',
+  });
+}
+
+/** 空の ParsedConfig。 */
+const _EMPTY_PARSED: ParsedConfig = {};
+
+// ─── T-CL-BC-01: model 優先順位 parsed > globalConfig ─────────────────────────
+
+describe('buildConfig', () => {
+  afterEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
+  // ─── model 優先順位 ─────────────────────────────────────────────────────────
+
+  describe('Given: parsed.model が指定されている', () => {
+    describe('When: GlobalConfig にも model が設定されている', () => {
+      describe('Then: T-CL-BC-01 - parsed.model が優先される', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('model: haiku');
+        });
+        it('T-CL-BC-01-01: parsed.model=opus → result.model === opus', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, model: 'opus' }, globalConfig);
+          assertEquals(result.model, 'opus');
+        });
+      });
+    });
+  });
+
+  describe('Given: parsed.model が未指定', () => {
+    describe('When: GlobalConfig に model が設定されている', () => {
+      describe('Then: T-CL-BC-02 - GlobalConfig の model が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('model: haiku');
+        });
+        it('T-CL-BC-02-01: globalConfig.model=haiku → result.model === haiku', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.model, 'haiku');
+        });
+      });
+    });
+
+    describe('When: GlobalConfig にも model が設定されていない', () => {
+      describe('Then: T-CL-BC-03 - DEFAULT_CLASSIFY_CONFIG.model が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: claude');
+        });
+        it('T-CL-BC-03-01: model 未設定 → result.model === DEFAULT_AI_MODEL', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.model, DEFAULT_AI_MODEL);
+        });
+      });
+    });
+
+    describe('When: GlobalConfig に不正モデル名が設定されている', () => {
+      describe('Then: T-CL-BC-04 - ChatlogError(InvalidArgs) がスローされる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          // model キーを持たない空スキーマ → get('model') が undefined を返す
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it('T-CL-BC-04-01: globalConfig に model なし + defaults.model=invalid → ChatlogError(InvalidArgs)', () => {
+          assertThrows(
+            () =>
+              buildConfig(_EMPTY_PARSED, globalConfig, {
+                ...DEFAULT_CLASSIFY_CONFIG,
+                model: 'invalid-model',
+              }),
+            ChatlogError,
+          );
+        });
+      });
+    });
+  });
+
+  // ─── dicsDir 優先順位 ────────────────────────────────────────────────────────
+
+  describe('Given: GlobalConfig に dicsDir が設定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-05 - GlobalConfig の dicsDir が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('dicsDir: /custom/dics');
+        });
+        it('T-CL-BC-05-01: globalConfig.dicsDir=/custom/dics → result.dicsDir === /custom/dics', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.dicsDir, '/custom/dics');
+        });
+      });
+    });
+  });
+
+  describe('Given: GlobalConfig に dicsDir が設定されていない', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-06 - DEFAULT_CLASSIFY_CONFIG.dicsDir が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: claude');
+        });
+        it('T-CL-BC-06-01: dicsDir 未設定 → result.dicsDir === DEFAULT_CLASSIFY_CONFIG.dicsDir', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.dicsDir, DEFAULT_CLASSIFY_CONFIG.dicsDir);
+        });
+      });
+    });
+  });
+
+  // ─── parsed フィールドの上書き ───────────────────────────────────────────────
+
+  describe('Given: parsed に dryRun=true, inputDir が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-07 - parsed フィールドがデフォルトを上書きする', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-07-01: parsed.dryRun=true → result.dryRun === true', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, dryRun: true, inputDir: '/custom/input' }, globalConfig);
+          assertEquals(result.dryRun, true);
+          assertEquals(result.inputDir, '/custom/input');
+        });
+      });
+    });
+  });
+
+  // ─── configFile が結果に含まれない ───────────────────────────────────────────
+
+  describe('Given: parsed に configFile が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      describe('Then: T-CL-BC-08 - result に configFile フィールドが含まれない', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-CL-BC-08-01: parsed.configFile → result に configFile が含まれない', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, configFile: 'custom.yaml' }, globalConfig);
+          assertEquals('configFile' in result, false);
+        });
+      });
+    });
+  });
+});

--- a/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
@@ -15,8 +15,128 @@ import { describe, it } from '@std/testing/bdd';
 import { parseArgs } from '../../classify-chatlog.ts';
 // classes
 import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
+// types
+import type { ParsedConfig } from '../../types/classify.types.ts';
 
 describe('parseArgs', () => {
+  // ─── T-CL-PA-01: デフォルト値（未指定時は undefined） ───────────────────────
+
+  describe('Given: 空の引数配列 []', () => {
+    describe('When: parseArgs([]) を呼び出す', () => {
+      describe('Then: T-CL-PA-01 - 各フィールドが undefined になる', () => {
+        const _cases: Array<[string, keyof ParsedConfig]> = [
+          ['T-CL-PA-01-01: inputDir → undefined', 'inputDir'],
+          ['T-CL-PA-01-02: dicsDir → undefined', 'dicsDir'],
+          ['T-CL-PA-01-03: configFile → undefined', 'configFile'],
+          ['T-CL-PA-01-04: dryRun → undefined', 'dryRun'],
+        ];
+        for (const [id, key] of _cases) {
+          it(id, () => {
+            const result = parseArgs([]);
+            assertEquals(result[key], undefined);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-CL-PA-02: --input オプション ─────────────────────────────────────────
+
+  describe('Given: --input または --input=VALUE', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-CL-PA-02 - inputDir に値が設定される', () => {
+        const _cases: Array<[string, string[], string]> = [
+          ['T-CL-PA-02-01: --input VALUE → inputDir が設定される', ['--input', '/data/chatlog'], '/data/chatlog'],
+          ['T-CL-PA-02-02: --input=VALUE → inputDir が設定される', ['--input=/data/chatlog'], '/data/chatlog'],
+        ];
+        for (const [id, args, expected] of _cases) {
+          it(id, () => {
+            const result = parseArgs(args);
+            assertEquals(result.inputDir, expected);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-CL-PA-03: --dics オプション ─────────────────────────────────────────
+
+  describe('Given: --dics または --dics=VALUE', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-CL-PA-03 - dicsDir に値が設定される', () => {
+        const _cases: Array<[string, string[], string]> = [
+          ['T-CL-PA-03-01: --dics VALUE → dicsDir が設定される', ['--dics', '/assets/dics'], '/assets/dics'],
+          ['T-CL-PA-03-02: --dics=VALUE → dicsDir が設定される', ['--dics=/assets/dics'], '/assets/dics'],
+        ];
+        for (const [id, args, expected] of _cases) {
+          it(id, () => {
+            const result = parseArgs(args);
+            assertEquals(result.dicsDir, expected);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-CL-PA-04: --config オプション ───────────────────────────────────────
+
+  describe('Given: --config または --config=VALUE', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-CL-PA-04 - configFile に値が設定される', () => {
+        const _cases: Array<[string, string[], string]> = [
+          [
+            'T-CL-PA-04-01: --config VALUE → configFile が設定される',
+            ['--config', '/etc/classify.yaml'],
+            '/etc/classify.yaml',
+          ],
+          [
+            'T-CL-PA-04-02: --config=VALUE → configFile が設定される',
+            ['--config=/etc/classify.yaml'],
+            '/etc/classify.yaml',
+          ],
+        ];
+        for (const [id, args, expected] of _cases) {
+          it(id, () => {
+            const result = parseArgs(args);
+            assertEquals(result.configFile, expected);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-CL-PA-05: --model 正常系（有効モデル名） ──────────────────────────────
+
+  describe('Given: --model または --model=VALUE（有効モデル名）', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-CL-PA-05 - model に値が設定される（スローされない）', () => {
+        const _cases: Array<[string, string[], string]> = [
+          ['T-CL-PA-05-01: --model VALUE → model が設定される', ['--model', 'opus'], 'opus'],
+          ['T-CL-PA-05-02: --model=VALUE → model が設定される', ['--model=haiku'], 'haiku'],
+        ];
+        for (const [id, args, expected] of _cases) {
+          it(id, () => {
+            const result = parseArgs(args);
+            assertEquals(result.model, expected);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-CL-PA-06: --dry-run フラグ ───────────────────────────────────────────
+
+  describe('Given: --dry-run フラグ', () => {
+    describe('When: parseArgs(["--dry-run"]) を呼び出す', () => {
+      describe('Then: T-CL-PA-06 - dryRun が true になる', () => {
+        it('T-CL-PA-06-01: --dry-run → dryRun が true になる', () => {
+          const result = parseArgs(['--dry-run']);
+          assertEquals(result.dryRun, true);
+        });
+      });
+    });
+  });
+
   // ─── 異常系: 不正なモデル名 ───────────────────────────────────────────────
 
   describe('Given: 不正なモデル名', () => {

--- a/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
@@ -26,9 +26,8 @@ describe('parseArgs', () => {
       describe('Then: T-CL-PA-01 - 各フィールドが undefined になる', () => {
         const _cases: Array<[string, keyof ParsedConfig]> = [
           ['T-CL-PA-01-01: inputDir → undefined', 'inputDir'],
-          ['T-CL-PA-01-02: dicsDir → undefined', 'dicsDir'],
-          ['T-CL-PA-01-03: configFile → undefined', 'configFile'],
-          ['T-CL-PA-01-04: dryRun → undefined', 'dryRun'],
+          ['T-CL-PA-01-02: configFile → undefined', 'configFile'],
+          ['T-CL-PA-01-03: dryRun → undefined', 'dryRun'],
         ];
         for (const [id, key] of _cases) {
           it(id, () => {
@@ -53,25 +52,6 @@ describe('parseArgs', () => {
           it(id, () => {
             const result = parseArgs(args);
             assertEquals(result.inputDir, expected);
-          });
-        }
-      });
-    });
-  });
-
-  // ─── T-CL-PA-03: --dics オプション ─────────────────────────────────────────
-
-  describe('Given: --dics または --dics=VALUE', () => {
-    describe('When: parseArgs(args) を呼び出す', () => {
-      describe('Then: T-CL-PA-03 - dicsDir に値が設定される', () => {
-        const _cases: Array<[string, string[], string]> = [
-          ['T-CL-PA-03-01: --dics VALUE → dicsDir が設定される', ['--dics', '/assets/dics'], '/assets/dics'],
-          ['T-CL-PA-03-02: --dics=VALUE → dicsDir が設定される', ['--dics=/assets/dics'], '/assets/dics'],
-        ];
-        for (const [id, args, expected] of _cases) {
-          it(id, () => {
-            const result = parseArgs(args);
-            assertEquals(result.dicsDir, expected);
           });
         }
       });

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -60,7 +60,6 @@ import type {
 /** `--option value` 形式のオプションと ParsedConfig キーのマッピング。 */
 const _OPT_KEYS: Record<string, keyof ParsedConfig> = {
   '--input': 'inputDir',
-  '--dics': 'dicsDir',
   '--model': 'model',
   '--config': 'configFile',
 };
@@ -82,6 +81,32 @@ export const parseArgs = (args: string[]): ParsedConfig => {
   }
   return _parsed;
 };
+
+// ─────────────────────────────────────────────
+// 設定構築
+// ─────────────────────────────────────────────
+
+/**
+ * ParsedConfig・GlobalConfig・デフォルト値から完全な ClassifyConfig を構築する。
+ * - model 優先順位: `parsed.model` > `globalConfig.get('model')` > `defaults.model`
+ * - dicsDir 優先順位: `globalConfig.get('dicsDir')` > `defaults.dicsDir`
+ * - 不正なモデル名は `ChatlogError('InvalidArgs')` をスローする。
+ * - `configFile` は ClassifyConfig に存在しないため結果に含まれない。
+ */
+export function buildConfig(
+  parsed: ParsedConfig,
+  globalConfig: GlobalConfig,
+  defaults?: ClassifyConfig,
+): ClassifyConfig {
+  const _defaults = defaults ?? DEFAULT_CLASSIFY_CONFIG;
+  const _model = parsed.model ?? (globalConfig.get('model') as string | undefined) ?? _defaults.model;
+  if (!isValidModel(_model)) {
+    throw new ChatlogError('InvalidArgs', `不正なモデル名: ${_model}`);
+  }
+  const _dicsDir = (globalConfig.get('dicsDir') as string | undefined) ?? _defaults.dicsDir;
+  const { configFile: _cf, ...rest } = parsed;
+  return { ..._defaults, ...rest, model: _model, dicsDir: _dicsDir };
+}
 
 // ─────────────────────────────────────────────
 // フロントマター操作
@@ -311,11 +336,7 @@ export const main = async (argv?: string[]): Promise<void> => {
   try {
     const _parsed = parseArgs(argv ?? Deno.args);
     const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
-    const _model = _parsed.model ?? (_globalConfig.get('model') as string) ?? DEFAULT_CLASSIFY_CONFIG.model;
-    if (!isValidModel(_model)) {
-      throw new ChatlogError('InvalidArgs', `不正なモデル名: ${_model}`);
-    }
-    const _config: ClassifyConfig = { ...DEFAULT_CLASSIFY_CONFIG, ..._parsed, model: _model };
+    const _config = buildConfig(_parsed, _globalConfig);
 
     // 入力ディレクトリ確認
     const agentDir = `${_config.inputDir}/${_config.agent}`;

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -11,7 +11,7 @@
  *
  * 使い方:
  *   deno run --allow-read --allow-run --allow-write classify_chatlog.ts \
- *     [agent] [YYYY-MM] [--dry-run] [--config FILE] --input DIR --dics DIR
+ *     [agent] [YYYY-MM] [--dry-run] [--config FILE] --input DIR
  */
 
 // -- external --
@@ -88,8 +88,10 @@ export const parseArgs = (args: string[]): ParsedConfig => {
 
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な ClassifyConfig を構築する。
+ * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - model 優先順位: `parsed.model` > `globalConfig.get('model')` > `defaults.model`
  * - dicsDir 優先順位: `globalConfig.get('dicsDir')` > `defaults.dicsDir`
+ * - projectsDic: `parsed.configFile` のディレクトリ + `/projects.dic`。未指定時は `defaults.projectsDic`。
  * - 不正なモデル名は `ChatlogError('InvalidArgs')` をスローする。
  * - `configFile` は ClassifyConfig に存在しないため結果に含まれない。
  */
@@ -103,9 +105,13 @@ export function buildConfig(
   if (!isValidModel(_model)) {
     throw new ChatlogError('InvalidArgs', `不正なモデル名: ${_model}`);
   }
+  const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? _defaults.agent;
   const _dicsDir = (globalConfig.get('dicsDir') as string | undefined) ?? _defaults.dicsDir;
+  const _projectsDic = parsed.configFile
+    ? `${getDirectory(parsed.configFile)}/projects.dic`
+    : _defaults.projectsDic;
   const { configFile: _cf, ...rest } = parsed;
-  return { ..._defaults, ...rest, model: _model, dicsDir: _dicsDir };
+  return { ..._defaults, ...rest, agent: _agent, model: _model, dicsDir: _dicsDir, projectsDic: _projectsDic };
 }
 
 // ─────────────────────────────────────────────

--- a/skills/classify-chatlog/scripts/types/classify.types.ts
+++ b/skills/classify-chatlog/scripts/types/classify.types.ts
@@ -89,8 +89,8 @@ export interface ClassifyConfig {
   model: string;
 }
 
-/** `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
-export type ParsedConfig = Partial<ClassifyConfig> & {
+/** `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。`dicsDir` は GlobalConfig で管理するため含まない。 */
+export type ParsedConfig = Omit<Partial<ClassifyConfig>, 'dicsDir'> & {
   /** `--config` で指定された設定ファイルのパス。省略時は `undefined`。 */
   configFile?: string;
 };


### PR DESCRIPTION
## Overview

**Summary**
Extract `buildConfig` from `main` and remove `dicsDir` from `ParsedConfig` type.

**Background / Motivation**
`classify-chatlog` の `main` 関数に設定構築ロジック（モデル解決・設定マージ）が埋め込まれており、テストが困難な状態だった。
`buildConfig` として切り出すことでユニットテスト・機能テストが可能になる。

また `ParsedConfig` が `dicsDir` を保持していたため、CLI オプション（`--dics`）と `GlobalConfig` の二経路が混在していた。
`dicsDir` を型から除外し `GlobalConfig` / `defaults.yaml` による一元管理に統一した。

## Changes

- `skills/classify-chatlog/scripts/classify-chatlog.ts` — `buildConfig` 関数を `main` から抽出。`agent` 解決ロジック
  （`parsed > GlobalConfig > defaults`）と `projectsDic` パス導出を追加
- `skills/classify-chatlog/scripts/types/classify.types.ts` — `ParsedConfig` を
  `Omit<Partial<ClassifyConfig>, 'dicsDir'>` に変更し `dicsDir` を除外
- `assets/configs/defaults.yaml` — `dicsDir` と `promptsDir` のデフォルトパスを追加
- `skills/_scripts/constants/schema.constants.ts` — `DEFAULT_SCHEMA` / `DEFAULT_VALUES` に `dicsDir` と `promptsDir` を追加
- `tests/functional/classify-chatlog.build-config.functional.spec.ts` — `buildConfig` の機能テストを新規追加（T-CL-BC-01〜19）
- `tests/e2e/classify-chatlog.main.e2e.spec.ts` — `GlobalConfig` ベースに移行、`--dics` 引数を `--config` に置き換え
- `tests/unit/classify-chatlog.parse-args.unit.spec.ts` — `dicsDir` 関連ケースを削除、ハッピーパスのテストケースを追加

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

該当する Issue なし

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

**Breaking Change**: `--dics` CLI オプションを廃止。既存スクリプトで `--dics` を使用している場合は `--config` フラグと `defaults.yaml` への `dicsDir` 設定追記が必要。

`buildConfig` を切り出したことで、今後の e2e テスト・機能テストにおいて設定構築ロジックを単独で検証できるようになった。`GlobalConfig.resetInstance()` をテスト間で呼び出すことでテスト間の状態汚染も解消している。
