### PR TITLE
config(renovate): limit enabled package managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>aglabo/renovate-config"
+  ],
+  // Enabled package managers
+  "enabledManagers": [
+    "github-actions",
+    "deno"
   ]
 }


### PR DESCRIPTION
## Overview

**Summary**
Limit Renovate to manage only `github-actions` and `deno` package managers.

**Background / Motivation**
共有Renovate設定（`github>aglabo/renovate-config`）を継承しているが、このプロジェクトでは `github-actions` と `deno` のみを使用している。`enabledManagers` を明示的に設定することで、npm等の未使用パッケージマネージャーへの不要な更新PRが生成されるのを防ぐ。

---

## Changes

- `renovate.json` に `enabledManagers` フィールドを追加
- 有効なパッケージマネージャーを `github-actions` と `deno` のみに限定

---

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

Link any issues this PR closes or relates to:

> Related #2

---

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

`renovate.json` の JSON 構文はスキーマバリデーション（`$schema` フィールド）で確認済み。
