### PR TITLE
docs(rules): add testing-conventions rule and integrate into project guidelines

### DIFF
--- a/.claude/rules/coding-guidelines.md
+++ b/.claude/rules/coding-guidelines.md
@@ -26,6 +26,8 @@
 - 新機能には必ずユニットテストを追加する
 - テストは `skills/<module>/__tests__/` 配下に配置する
 - テストファイル名: `<name>.<type>.spec.ts`（例: `backup.unit.spec.ts`）
+- テストコードの詳細規約（import 構成・JSDoc・テスト ID・命名）は以下を参照する
 
 @.claude/rules/naming-conventions.md
 @.claude/rules/directory-structure.md
+@.claude/rules/testing-conventions.md

--- a/.claude/rules/testing-conventions.md
+++ b/.claude/rules/testing-conventions.md
@@ -1,0 +1,259 @@
+# テストコード規約
+
+## 適用範囲
+
+`**/*.spec.ts` のすべてのテストファイル（unit / functional / integration / e2e / system）に適用する。
+
+---
+
+## 1. ファイルヘッダ
+
+各テストファイルの先頭には以下のヘッダを記載する。
+
+```typescript
+// src: <モジュール相対パス>/__tests__/<type>/<name>.<type>.spec.ts
+// @(#): <テスト対象の短い説明>
+//       対象: <テスト対象関数・クラス名>
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+```
+
+---
+
+## 2. import 文の構成
+
+import はコメントで区切られた **5グループ** を決まった順序で並べる。
+グループ間は **空行 1行** で区切る。グループヘッダは `// ─── <名前>` 形式（U+2500 × 3 + 半角スペース）を使う。
+
+```typescript
+// ─── BDD modules
+// ─── Test target
+// ─── Helpers
+// ─── Internal Helpers
+// ─── Tests
+```
+
+### グループ 1: BDD modules
+
+`@std/assert` の assertion 関数、`@std/testing/bdd` の BDD 関数、モック系の順に並べる。
+型 import (`import type`) が混在する場合はその直後に配置する。
+型、stubはサブブロックに配置し、その上に1行コメントを付加する
+
+```typescript
+// ─── BDD modules
+import { assertEquals, assertThrows } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+// stub
+import { stub } from '@std/testing/mock'; // stub/spy が必要な場合のみ
+// types
+import type { Stub } from '@std/testing/mock'; // 型が必要な場合のみ
+```
+
+### グループ 2: Test target
+
+テスト対象の関数・クラス・定数を import する。
+複数ある場合はテスト対象関数を先頭に、依存クラスをその後に並べる。
+依存する関数、定数はサブブロックに配置し、1行コメントを付加する
+
+```typescript
+// ─── Test target
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
+// functions
+import { buildConfig } from '../../export-chatlog.ts';
+```
+
+### グループ 3: Helpers
+
+テスト対象の動作確認に必要な補助関数・ライブラリを import する。
+型、クラス、定数はサブブロックに配置し、1行コメントを付加する
+
+```typescript
+// ─── Helpers
+import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
+// constants
+import { BASE_CONFIG } from '../constants/config.ts';
+// types
+import type { ExportConfig } from '../../types/export-config.types.ts';
+import type { PeriodRange } from '../../types/filter.types.ts';
+```
+
+Helpers が不要なテストでは、このグループを省略してよい。
+
+### グループ 4: Internal Helpers
+
+テストファイル内でのみ使うヘルパー定数・型・関数を定義する。
+`// constants` / `// types` / `// functions` のサブコメントで区別する。
+
+```typescript
+// ─── Internal Helpers
+
+// constants
+const ALL_PERIOD: PeriodRange = parsePeriod(undefined);
+const BASE_CONFIG: ExportConfig = { ...DEFAULT_EXPORT_CONFIG };
+
+// types
+interface FixtureData { ... }
+
+// functions
+function _makeSession(overrides: Partial<ExportedSession> = {}): ExportedSession { ... }
+async function _writeJsonl(filePath: string, lines: unknown[]): Promise<void> { ... }
+```
+
+不要なサブグループは省略してよい。Internal Helpers が一切不要なテストではグループ自体を省略してよい。
+
+### グループ 5: Tests
+
+`describe` ブロックを配置する。グループヘッダと `describe` の間に空行を 1行入れる。
+
+```typescript
+// ─── Tests
+
+describe('FunctionName', () => { ... });
+```
+
+---
+
+## 3. JSDoc の付加対象と形式
+
+### 3-1. Internal Helpers の各シンボル
+
+**定数**（1行 JSDoc）
+
+```typescript
+/** 期間フィルタを設定しない（全期間対象）`PeriodRange`。テスト内で期間外除外を行わない場合に使用する。 */
+const ALL_PERIOD: PeriodRange = parsePeriod(undefined);
+```
+
+**クラス**（クラス本体・constructor・各メソッドの 3箇所）
+
+```typescript
+/**
+ * git コマンドを実行しない `CommandProvider` モック。
+ *
+ * `GlobalConfig.getInstance()` に渡す `commandProvider` として使用し、
+ * 実際の git rev-parse を発行せずに成功レスポンスを返す。
+ */
+class _NoopCommandProvider {
+  /** コマンドと引数を受け取るが何も実行しない（インターフェース互換用）。 */
+  constructor(_cmd: string, _opts: { args: string[] }) {}
+
+  /** 常に `{ success: true, code: 0, stdout: 空バイト列 }` を返す。 */
+  output(): Promise<...> { ... }
+}
+```
+
+**関数**（`@param` / `@returns` を含む複数行 JSDoc）
+
+```typescript
+/**
+ * テスト用 `GlobalConfig` インスタンスを YAML 文字列から生成する。
+ *
+ * 毎回 `GlobalConfig.resetInstance()` でシングルトンをリセットしてから
+ * `_NoopCommandProvider` と `_existsStat` を注入して初期化する。
+ *
+ * @param yaml - GlobalConfig に読み込ませる YAML テキスト（例: `'agent: chatgpt'`）
+ * @returns 初期化済みの `GlobalConfig` インスタンス
+ */
+async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> { ... }
+```
+
+**スタブ定数**（戻り値の意味を1行で説明）
+
+```typescript
+/** ファイル存在チェックを常に `true` で返すスタブ。テスト環境で `statProvider` として使用する。 */
+const _existsStat = (_path: string) => Promise.resolve({ isFile: true } as Deno.FileInfo);
+```
+
+### 3-2. describe ブロックの JSDoc
+
+| レベル        | JSDoc 種別 | 記載内容                                                         |
+| ------------- | ---------- | ---------------------------------------------------------------- |
+| TOP（関数名） | 複数行     | 関数の責務・テスト対象シナリオの概要・テスト ID 範囲・`@see`     |
+| Given         | 複数行     | 前提条件の意味・そのシナリオで検証する動作・フォールバック先など |
+| When          | 1行        | 呼び出す操作の簡潔な説明                                         |
+| Then          | 1行        | 期待結果の簡潔な説明                                             |
+
+**TOP レベルの例**
+
+```typescript
+/**
+ * `buildConfig` 関数の機能テストスイート。
+ *
+ * `buildConfig(parsed, globalConfig, defaults?)` は
+ * `ParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `ExportConfig` を構築する。
+ *
+ * ## 優先順位ルール
+ * - `agent`     : parsed > globalConfig > defaults
+ * - `outputDir` : parsed > globalConfig.chatlogDir > defaults
+ * - `baseDir`   : parsed のみ（GlobalConfig 連携なし）
+ *
+ * テスト ID 範囲: T-EC-BC-01 〜 T-EC-BC-14
+ *
+ * @see buildConfig
+ */
+describe('buildConfig', () => {
+```
+
+**Given レベルの例**
+
+```typescript
+/**
+ * `parsed.agent` がセットされている前提条件グループ。
+ *
+ * CLI 引数または呼び出しコードが明示的にエージェントを指定したケースを表す。
+ * `globalConfig` に agent が設定されていても `parsed.agent` が優先されることを検証する。
+ */
+describe('Given: parsed.agent が指定されている', () => {
+```
+
+**When / Then レベルの例**
+
+```typescript
+/** `globalConfig` にも `agent` が設定されているとき。 */
+describe('When: GlobalConfig にも agent が設定されている', () => {
+
+/** `parsed.agent` が `globalConfig.agent` より優先されることを検証する。 */
+describe('Then: T-EC-BC-01 - parsed.agent が優先される', () => {
+```
+
+---
+
+## 4. テスト ID 命名規則
+
+テスト ID は `T-<スコープ>-<機能略語>-<連番>[-<枝番>]` の形式にする。
+
+- `T-EC-BC-01-01`: export-chatlog / buildConfig / テスト 01 / ケース 01
+- `T-EC-PA-06-02`: export-chatlog / parseArgs / テスト 06 / ケース 02
+
+`it` のラベルには必ずテスト ID を先頭に付ける。
+
+```typescript
+it('T-EC-BC-01-01: parsed.agent=codex → result.agent === codex', () => { ... });
+```
+
+---
+
+## 5. ファイル名
+
+```
+<テスト対象名>.<テスト種別>.spec.ts
+```
+
+| テスト種別  | ファイル名例                               |
+| ----------- | ------------------------------------------ |
+| unit        | `period-filter.unit.spec.ts`               |
+| functional  | `parse-claude-session.functional.spec.ts`  |
+| integration | `find-claude-sessions.integration.spec.ts` |
+| e2e         | `main.e2e.spec.ts`                         |
+| system      | `export-chatlog.main.system.spec.ts`       |
+
+---
+
+## 6. 内部シンボルの命名（テストファイル固有の補足）
+
+- Internal Helpers の関数・クラス・定数はすべて `_` プレフィックスを付ける（命名規則 参照）
+- テーブル駆動ケース配列も `_cases` / `_errorCases` のように `_` プレフィックスを付ける
+- `beforeEach`/`afterEach` スコープの変数（`tempDir`, `globalConfig` 等）は `_` なし（ループ変数相当）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ assets/prompts/        # AI プロンプト
 
 @.claude/rules/coding-guidelines.md
 @.claude/rules/workflow.md
+@.claude/rules/testing-conventions.md
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 


### PR DESCRIPTION
## Overview

**Summary**
Adds `testing-conventions.md` rule file and integrates it into project coding guidelines.

**Background / Motivation**
テストコードの書き方がプロジェクト内に明文化されておらず、ファイルヘッダ形式・import グループ構成・JSDoc 付加ルール・テスト ID 命名規則が各開発者の判断に委ねられていた。
規約を `.claude/rules/testing-conventions.md` として定義し、`coding-guidelines.md` および `CLAUDE.md` の参照リストに追加することで、Claude Code が一貫したテストコードを生成できる体制を整備する。

---

## Changes

- `.claude/rules/testing-conventions.md` — テストコード規約を新規追加
  - 適用範囲: `**/*.spec.ts` 全テストファイル
  - ファイルヘッダ形式（著作権表示・ライセンス）
  - import 5グループ構成（BDD modules / Test target / Helpers / Internal Helpers / Tests）
  - Internal Helpers・describe ブロックへの JSDoc 付加形式
  - テスト ID 命名規則: `T-<スコープ>-<機能略語>-<連番>[-<枝番>]`
  - ファイル名規則・内部シンボルの `_` プレフィックス補足
- `.claude/rules/coding-guidelines.md` — テストセクションに `testing-conventions.md` への参照を追加
- `CLAUDE.md` — ルール参照リストに `@.claude/rules/testing-conventions.md` を追記

---

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

なし

---

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

ドキュメントのみの変更であり、実装コードへの影響はない。
`testing-conventions.md` は今後のテストコードレビュー・自動生成の基準として使用される。
