### PR TITLE
feat(export): グローバル設定統合とCLI引数解析の拡張

### DIFF
--- a/assets/configs/config.yaml
+++ b/assets/configs/config.yaml
@@ -21,4 +21,4 @@ concurrency: 4
 # アセットディレクトリ
 dicsDir: "./assets/dics"
 promptsDir: "./assets/prompts"
-chatlogDir: "./chatlog"
+chatlogDir: "./chatlogs"

--- a/skills/_scripts/constants/defaults.constants.ts
+++ b/skills/_scripts/constants/defaults.constants.ts
@@ -16,6 +16,13 @@ import type { KnownAgent } from './agents.constants.ts';
 export const DEFAULT_CONFIG_FILE = 'assets/configs/config.yaml';
 
 // ─────────────────────────────────────────────
+// ディレクトリ
+// ─────────────────────────────────────────────
+
+/** config.yaml の chatlogDir に対応するデフォルトのチャットログ出力ディレクトリ。 */
+export const DEFAULT_CHATLOG_DIR = './chatlogs';
+
+// ─────────────────────────────────────────────
 // エージェント
 // ─────────────────────────────────────────────
 

--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -106,14 +106,18 @@ describe('parseArgsToConfig', () => {
     });
   });
 
-  // ─── T-PA-05: 位置引数 — YYYY-MM ─────────────────────────────────────────
+  // ─── T-PA-05: 位置引数 — 期間文字列 ─────────────────────────────────────
 
-  describe('Given: YYYY-MM 形式の位置引数', () => {
+  describe('Given: 期間形式の位置引数', () => {
     describe('When: parseArgsToConfig(args) を呼び出す', () => {
       describe('Then: T-PA-05 - period に設定される', () => {
         it('T-PA-05-01: "2026-03" → period が "2026-03" になる', () => {
           const result = parseArgsToConfig<TestConfig>(['2026-03'], OPT_KEYS, OPT_FLAGS);
           assertEquals(result.period, '2026-03');
+        });
+        it('T-PA-05-02: "2026" → period が "2026" になる（年のみ指定）', () => {
+          const result = parseArgsToConfig<TestConfig>(['2026'], OPT_KEYS, OPT_FLAGS);
+          assertEquals(result.period, '2026');
         });
       });
     });
@@ -143,15 +147,15 @@ describe('parseArgsToConfig', () => {
   describe('Given: ディレクトリパスの位置引数', () => {
     describe('When: parseArgsToConfig(args) を呼び出す', () => {
       describe('Then: T-PA-07 - inputDir に設定される', () => {
-        const _cases: { id: string; path: string }[] = [
-          { id: 'T-PA-07-01', path: '/absolute/path' },
-          { id: 'T-PA-07-02', path: './relative/path' },
-          { id: 'T-PA-07-03', path: 'C:\\Windows\\path' },
+        const _cases: { id: string; input: string; expected: string }[] = [
+          { id: 'T-PA-07-01', input: '/absolute/path', expected: '/absolute/path' },
+          { id: 'T-PA-07-02', input: './relative/path', expected: './relative/path' },
+          { id: 'T-PA-07-03', input: 'C:\\Windows\\path', expected: 'C:/Windows/path' },
         ];
-        for (const { id, path } of _cases) {
-          it(`${id}: "${path}" → inputDir が "${path}" になる`, () => {
-            const result = parseArgsToConfig<TestConfig>([path], OPT_KEYS, OPT_FLAGS);
-            assertEquals(result.inputDir, path);
+        for (const { id, input, expected } of _cases) {
+          it(`${id}: "${input}" → inputDir が "${expected}" になる`, () => {
+            const result = parseArgsToConfig<TestConfig>([input], OPT_KEYS, OPT_FLAGS);
+            assertEquals(result.inputDir, expected);
           });
         }
       });

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -74,12 +74,12 @@ export const parseArgsToConfig = <T extends { period?: string; agent?: string; i
       throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
     }
 
-    if (/^\d{4}-\d{2}$/.test(arg)) {
+    if (/^\d{4}-\d{2}$/.test(arg) || /^\d{4}$/.test(arg)) {
       _set('period', arg);
     } else if (isKnownAgent(arg)) {
       _set('agent', arg);
     } else if (isDirectoryArg(arg)) {
-      _set('inputDir', arg);
+      _set('inputDir', normalizePath(arg));
     } else {
       throw new ChatlogError('InvalidArgs', `不明な引数: ${arg}`);
     }

--- a/skills/export-chatlog/scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts
@@ -1,0 +1,444 @@
+// src: scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts
+// @(#): buildConfig の機能テスト
+//       ParsedConfig + GlobalConfig + デフォルト値から ExportConfig を構築するロジック
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// -- BDD modules --
+import { assertEquals } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// test target
+import { buildConfig } from '../../export-chatlog.ts';
+// classes
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_EXPORT_CONFIG, DEFAULT_OUTPUT_DIR } from '../../constants/defaults.constants.ts';
+// types
+import type { CommandProvider } from '../../../../_scripts/types/providers.types.ts';
+import type { ParsedConfig } from '../../types/export-config.types.ts';
+
+// ─── ヘルパー ──────────────────────────────────────────────────────────────────
+
+/** ファイル存在チェックを常に `true` で返すスタブ。テスト環境で `statProvider` として使用する。 */
+const _existsStat = (_path: string) => Promise.resolve({ isFile: true } as Deno.FileInfo);
+
+/**
+ * git コマンドを実行しない `CommandProvider` モック。
+ *
+ * `GlobalConfig.getInstance()` に渡す `commandProvider` として使用し、
+ * 実際の git rev-parse を発行せずに成功レスポンスを返す。
+ */
+class _NoopCommandProvider {
+  /** コマンドと引数を受け取るが何も実行しない（インターフェース互換用）。 */
+  constructor(_cmd: string, _opts: { args: string[] }) {}
+
+  /**
+   * 常に `{ success: true, code: 0, stdout: 空バイト列 }` を返す。
+   * git rev-parse の成功を模倣し、GlobalConfig の初期化を通過させる。
+   */
+  output(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: new Uint8Array() });
+  }
+}
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを YAML 文字列から生成する。
+ *
+ * 毎回 `GlobalConfig.resetInstance()` でシングルトンをリセットしてから
+ * `_NoopCommandProvider` と `_existsStat` を注入して初期化する。
+ *
+ * @param yaml - GlobalConfig に読み込ませる YAML テキスト（例: `'agent: chatgpt'`）
+ * @returns 初期化済みの `GlobalConfig` インスタンス
+ */
+async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
+  GlobalConfig.resetInstance();
+  return await GlobalConfig.getInstance({
+    readTextFileProvider: () => Promise.resolve(yaml),
+    statProvider: _existsStat,
+    commandProvider: _NoopCommandProvider as unknown as CommandProvider,
+    configFile: 'dummy.yaml',
+  });
+}
+
+/**
+ * 全フィールドが未指定の空の `ParsedConfig`。
+ *
+ * 各テストで「parsed 側が何も指定されていない」ケースを表すベース値として使用する。
+ * スプレッド構文で特定フィールドだけ上書きして部分指定のケースも表現する。
+ */
+const _EMPTY_PARSED: ParsedConfig = {};
+
+// ─── buildConfig テストスイート ────────────────────────────────────────────────
+
+/**
+ * `buildConfig` 関数の機能テストスイート。
+ *
+ * `buildConfig(parsed, globalConfig, defaults?)` は
+ * `ParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `ExportConfig` を構築する。
+ *
+ * ## 優先順位ルール
+ * - `agent`     : parsed > globalConfig > defaults
+ * - `outputDir` : parsed > globalConfig.chatlogDir > defaults
+ * - `baseDir`   : parsed のみ（GlobalConfig 連携なし）
+ * - `inputDir`  : parsed のみ（GlobalConfig 連携なし）
+ * - `period`    : parsed のみ
+ *
+ * テスト ID 範囲: T-EC-BC-01 〜 T-EC-BC-14
+ */
+describe('buildConfig', () => {
+  afterEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
+  // ─── agent 優先順位 ─────────────────────────────────────────────────────────
+
+  /**
+   * `parsed.agent` がセットされている前提条件グループ。
+   *
+   * CLI 引数または呼び出しコードが明示的にエージェントを指定したケースを表す。
+   * `globalConfig` に agent が設定されていても `parsed.agent` が優先されることを検証する。
+   */
+  describe('Given: parsed.agent が指定されている', () => {
+    /** `globalConfig` にも `agent` が設定されているとき。 */
+    describe('When: GlobalConfig にも agent が設定されている', () => {
+      /** `parsed.agent` が `globalConfig.agent` より優先されることを検証する。 */
+      describe('Then: T-EC-BC-01 - parsed.agent が優先される', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: chatgpt');
+        });
+        it('T-EC-BC-01-01: parsed.agent=codex → result.agent === codex', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, agent: 'codex' }, globalConfig);
+          assertEquals(result.agent, 'codex');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.agent` が未設定である前提条件グループ。
+   *
+   * CLI 引数でエージェントが指定されなかったケースを表す。
+   * `globalConfig` の agent 設定、さらに未設定の場合はデフォルト値にフォールバックすることを検証する。
+   */
+  describe('Given: parsed.agent が未指定', () => {
+    /** `globalConfig` に `agent` が設定されているとき。 */
+    describe('When: GlobalConfig に agent が設定されている', () => {
+      /** `globalConfig.agent` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-02 - GlobalConfig の agent が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: chatgpt');
+        });
+        it('T-EC-BC-02-01: globalConfig.agent=chatgpt → result.agent === chatgpt', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.agent, 'chatgpt');
+        });
+      });
+    });
+
+    /** `globalConfig` にも `agent` が設定されていないとき。 */
+    describe('When: GlobalConfig にも agent が設定されていない', () => {
+      /** `DEFAULT_EXPORT_CONFIG.agent` にフォールバックされることを検証する。 */
+      describe('Then: T-EC-BC-03 - DEFAULT_EXPORT_CONFIG.agent が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('model: haiku');
+        });
+        it("T-EC-BC-03-01: agent 未設定 → result.agent === DEFAULT_EXPORT_CONFIG.agent ('claude')", () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.agent, DEFAULT_EXPORT_CONFIG.agent);
+        });
+      });
+    });
+  });
+
+  // ─── outputDir 優先順位 ─────────────────────────────────────────────────────
+
+  /**
+   * `parsed.outputDir` がセットされている前提条件グループ。
+   *
+   * CLI 引数 `--output` で出力ディレクトリが明示されたケースを表す。
+   * `globalConfig.chatlogDir` より `parsed.outputDir` が優先されることを検証する。
+   */
+  describe('Given: parsed.outputDir が指定されている', () => {
+    /** `globalConfig` に `chatlogDir` が設定されているとき。 */
+    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
+      /** `parsed.outputDir` が `globalConfig.chatlogDir` より優先されることを検証する。 */
+      describe('Then: T-EC-BC-04 - parsed.outputDir が優先される', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('chatlogDir: /global');
+        });
+        it('T-EC-BC-04-01: parsed.outputDir=/out → result.outputDir === /out', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, outputDir: '/out' }, globalConfig);
+          assertEquals(result.outputDir, '/out');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.outputDir` が未設定である前提条件グループ。
+   *
+   * CLI 引数 `--output` が省略されたケースを表す。
+   * `globalConfig.chatlogDir` が設定されていればそれを使い、
+   * なければ `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
+   */
+  describe('Given: parsed.outputDir が未指定', () => {
+    /** `globalConfig` に `chatlogDir` が設定されているとき。 */
+    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
+      /** `globalConfig.chatlogDir` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-05 - GlobalConfig の chatlogDir が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('chatlogDir: /global/chatlog');
+        });
+        it('T-EC-BC-05-01: globalConfig.chatlogDir=/global/chatlog → result.outputDir === /global/chatlog', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.outputDir, '/global/chatlog');
+        });
+      });
+    });
+
+    /** `globalConfig` のスキーマに `chatlogDir` が登録されていないとき。 */
+    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+      /** `DEFAULT_OUTPUT_DIR` にフォールバックされることを検証する。 */
+      describe('Then: T-EC-BC-06 - DEFAULT_OUTPUT_DIR が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it("T-EC-BC-06-01: outputDir 未設定, chatlogDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.outputDir, DEFAULT_OUTPUT_DIR);
+        });
+      });
+    });
+  });
+
+  // ─── baseDir 優先順位 ───────────────────────────────────────────────────────
+
+  /**
+   * `parsed.baseDir` がセットされている前提条件グループ。
+   *
+   * CLI 引数 `--base` でベースディレクトリが明示されたケースを表す。
+   * `baseDir` は `GlobalConfig` 連携がなく `parsed` の値のみが反映されることを検証する。
+   */
+  describe('Given: parsed.baseDir が指定されている', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.baseDir` が `parsed.baseDir` と一致することを検証する。 */
+      describe('Then: T-EC-BC-07 - result.baseDir === parsed.baseDir', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-EC-BC-07-01: parsed.baseDir=/data → result.baseDir === /data', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, baseDir: '/data' }, globalConfig);
+          assertEquals(result.baseDir, '/data');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.baseDir` が未設定である前提条件グループ。
+   *
+   * CLI 引数 `--base` が省略されたケースを表す。
+   * `baseDir` は `GlobalConfig` 連携がないため、未指定時は `undefined` になることを検証する。
+   */
+  describe('Given: parsed.baseDir が未指定', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.baseDir` が `undefined` になることを検証する。 */
+      describe('Then: T-EC-BC-08 - result.baseDir === undefined', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-EC-BC-08-01: baseDir 未指定 → result.baseDir === undefined', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.baseDir, undefined);
+        });
+      });
+    });
+  });
+
+  // ─── inputDir 優先順位 ──────────────────────────────────────────────────────
+
+  /**
+   * `parsed.inputDir` がセットされている前提条件グループ。
+   *
+   * CLI 引数 `--input` または位置引数でパスが指定されたケースを表す。
+   * `inputDir` は `GlobalConfig` 連携がなく `parsed` の値のみが反映されることを検証する。
+   */
+  describe('Given: parsed.inputDir が指定されている', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.inputDir` が `parsed.inputDir` と一致することを検証する。 */
+      describe('Then: T-EC-BC-09 - result.inputDir === parsed.inputDir', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-EC-BC-09-01: parsed.inputDir=/input → result.inputDir === /input', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/input' }, globalConfig);
+          assertEquals(result.inputDir, '/input');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.inputDir` が未設定である前提条件グループ。
+   *
+   * CLI 引数 `--input` が省略されたケースを表す。
+   * `inputDir` は `GlobalConfig` 連携がないため、未指定時は `undefined` になることを検証する。
+   */
+  describe('Given: parsed.inputDir が未指定', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.inputDir` が `undefined` になることを検証する。 */
+      describe('Then: T-EC-BC-10 - result.inputDir === undefined', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-EC-BC-10-01: inputDir 未指定 → result.inputDir === undefined', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.inputDir, undefined);
+        });
+      });
+    });
+  });
+
+  // ─── period フィールド（parsedのみ） ─────────────────────────────────────────
+
+  /**
+   * `parsed.period` がセットされている前提条件グループ。
+   *
+   * CLI 引数で `YYYY-MM` または `YYYY` 形式の期間が指定されたケースを表す。
+   * `period` は `GlobalConfig` 連携がなく `parsed` の値のみが反映されることを検証する。
+   */
+  describe('Given: parsed.period が指定されている', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.period` が `parsed.period` と一致することを検証する。 */
+      describe('Then: T-EC-BC-11 - result.period === parsed.period', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-EC-BC-11-01: parsed.period=2026-01 → result.period === 2026-01', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, period: '2026-01' }, globalConfig);
+          assertEquals(result.period, '2026-01');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.period` が未設定である前提条件グループ。
+   *
+   * CLI 引数で期間が指定されなかったケースを表す。
+   * `period` は `GlobalConfig` 連携がないため、未指定時は `undefined` になることを検証する。
+   */
+  describe('Given: parsed.period が未指定', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.period` が `undefined` になることを検証する。 */
+      describe('Then: T-EC-BC-12 - result.period === undefined', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-EC-BC-12-01: period 未指定 → result.period === undefined', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.period, undefined);
+        });
+      });
+    });
+  });
+
+  // ─── defaults 引数 ──────────────────────────────────────────────────────────
+
+  /**
+   * `buildConfig` の第 3 引数 `defaults` が省略されている前提条件グループ。
+   *
+   * 省略時は内部で `DEFAULT_EXPORT_CONFIG` が使われる。
+   * `chatlogDir` も未登録の場合に `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
+   */
+  describe('Given: defaults 引数が省略されている', () => {
+    /** `globalConfig` のスキーマに `chatlogDir` が登録されていないとき。 */
+    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+      /** `DEFAULT_OUTPUT_DIR` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-13 - DEFAULT_OUTPUT_DIR が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it("T-EC-BC-13-01: defaults 省略, chatlogDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.outputDir, DEFAULT_OUTPUT_DIR);
+        });
+      });
+    });
+  });
+
+  /**
+   * `defaults.outputDir` にカスタム値が指定されている前提条件グループ。
+   *
+   * `buildConfig` の第 3 引数でデフォルト値を上書きするケースを表す。
+   * `globalConfig` に `chatlogDir` が未登録の場合、`defaults.outputDir` が採用されることを検証する。
+   */
+  describe('Given: defaults.outputDir=/custom が指定されている', () => {
+    /** `globalConfig` のスキーマに `chatlogDir` が登録されていないとき。 */
+    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+      /** `defaults.outputDir` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-14 - defaults.outputDir が使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it('T-EC-BC-14-01: defaults.outputDir=/custom, chatlogDir 未登録 → result.outputDir === /custom', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig, {
+            ...DEFAULT_EXPORT_CONFIG,
+            outputDir: '/custom',
+          });
+          assertEquals(result.outputDir, '/custom');
+        });
+      });
+    });
+  });
+
+  // ─── configFile の ExportConfig 混入防止 ─────────────────────────────────────
+
+  /**
+   * configFile フィールドが ExportConfig に混入しないことを確認する。
+   *
+   * ParsedConfig の configFile は GlobalConfig 初期化専用フィールドであり、
+   * buildConfig の戻り値 ExportConfig には含まれてはならない。
+   */
+  describe('Given: ParsedConfig に configFile が指定されている', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result` に `configFile` フィールドが含まれないことを検証する。 */
+      describe('Then: T-EC-BC-15 - result に configFile フィールドが含まれない', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it('T-EC-BC-15-01: configFile を含む ParsedConfig → result に configFile が含まれない', () => {
+          const _parsed: ParsedConfig = { agent: 'claude', configFile: '/path/to/config.yaml' };
+          const result = buildConfig(_parsed, globalConfig);
+          assertEquals((result as unknown as Record<string, unknown>).configFile, undefined);
+        });
+      });
+    });
+  });
+});

--- a/skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -16,7 +16,7 @@ import { parseArgs } from '../../../../export-chatlog/scripts/export-chatlog.ts'
 // ─── Helpers
 import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 // types
-import type { ExportConfig } from '../../../../export-chatlog/scripts/types/export-config.types.ts';
+import type { ParsedConfig } from '../../../../export-chatlog/scripts/types/export-config.types.ts';
 
 // ─── Tests
 
@@ -44,7 +44,7 @@ describe('parseArgs', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
       /** 対応フィールドに期待値が設定されることを確認する。 */
       describe('Then: 対応フィールドに値が設定される', () => {
-        const _cases: { id: string; args: string[]; field: keyof ExportConfig; expected: unknown }[] = [
+        const _cases: { id: string; args: string[]; field: keyof ParsedConfig; expected: unknown }[] = [
           { id: 'T-EC-PA-02-01', args: ['codex'], field: 'agent', expected: 'codex' },
           { id: 'T-EC-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
           { id: 'T-EC-PA-03-02', args: ['2026'], field: 'period', expected: '2026' },
@@ -165,6 +165,32 @@ describe('parseArgs', () => {
       const result = parseArgs(['chatgpt', '/path/to/export', '2026-03']);
       assertEquals(result.period, '2026-03');
       assertEquals(result.inputDir, '/path/to/export');
+    });
+  });
+
+  // ─── T-EC-PA-16: --config オプション ────────────────────────────────────────
+
+  /**
+   * `--config` オプションによるグローバル設定ファイルパスの解析検証。
+   * `--config VALUE` 形式と `--config=VALUE` 形式の両方が
+   * `configFile` フィールドに正しくマッピングされることを確認する。
+   */
+  describe('Given: --config または --config=VALUE', () => {
+    /** `parseArgs(args)` を呼び出す。 */
+    describe('When: parseArgs(args) を呼び出す', () => {
+      /** `configFile` に値が設定されることを確認する。 */
+      describe('Then: T-EC-PA-16 - configFile に値が設定される', () => {
+        const _cases = [
+          { id: 'T-EC-PA-16-01', args: ['--config', '/path/to/config.yaml'], expected: '/path/to/config.yaml' },
+          { id: 'T-EC-PA-16-02', args: ['--config=/path/to/config.yaml'], expected: '/path/to/config.yaml' },
+        ];
+        for (const { id, args, expected } of _cases) {
+          it(`${id}: ${args.join(' ')} → configFile が "${expected}" になる`, () => {
+            const result = parseArgs(args);
+            assertEquals(result.configFile, expected);
+          });
+        }
+      });
     });
   });
 

--- a/skills/export-chatlog/scripts/constants/defaults.constants.ts
+++ b/skills/export-chatlog/scripts/constants/defaults.constants.ts
@@ -6,7 +6,12 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { DEFAULT_AGENT } from '../../../_scripts/constants/defaults.constants.ts';
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// constants
+import { DEFAULT_AGENT, DEFAULT_CHATLOG_DIR } from '../../../_scripts/constants/defaults.constants.ts';
+
+// ─── Local modules ───────────────────────────────────────────────────────────
+// types
 import type { ExportConfig } from '../types/export-config.types.ts';
 
 /**
@@ -17,7 +22,7 @@ import type { ExportConfig } from '../types/export-config.types.ts';
  *
  * @see parseArgs
  */
-export const DEFAULT_OUTPUT_DIR = './chatlogs';
+export const DEFAULT_OUTPUT_DIR = DEFAULT_CHATLOG_DIR;
 
 /**
  * `parseArgs()` が引数なしで呼ばれた場合に返す `ExportConfig` のデフォルト値。

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -18,87 +18,80 @@
  *   codex   — ~/.codex/sessions/YYYY/MM/DD/ 以下のJSONL
  */
 
-// ─── External modules ───────────────────────────────────────────────────────
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// error
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
-import { isKnownAgent } from '../../_scripts/constants/agents.constants.ts';
-import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
+// config
+import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
+// libs
 import { logger } from '../../_scripts/libs/io/logger.ts';
+import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 
-// ─── Internal modules ───────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
+// exporters
 import { exportChatGPT } from './exporter/chatgpt-exporter.ts';
 import { exportClaude } from './exporter/claude-exporter.ts';
 import { exportCodex } from './exporter/codex-exporter.ts';
 // constants
 import { DEFAULT_EXPORT_CONFIG } from './constants/defaults.constants.ts';
 // types
-import type { ExportConfig } from './types/export-config.types.ts';
+import type { ExportConfig, ParsedConfig } from './types/export-config.types.ts';
 
 // ─────────────────────────────────────────────
 // 引数解析
 // ─────────────────────────────────────────────
 
-/**
- * CLI 引数配列を解析して `ExportConfig` を生成する。
- *
- * 認識する引数:
- * - `--output <dir>` または `--output=<dir>`: 出力ベースディレクトリを設定
- * - `--base <dir>` または `--base=<dir>`: 入力ベースディレクトリ（baseDir）を設定
- * - `--input <dir>` または `--input=<dir>`: ChatGPT エクスポートディレクトリ（inputDir）を設定
- * - `KNOWN_AGENTS` に含まれる文字列: エージェント名として認識（"claude", "codex", "chatgpt"）
- * - `/^\d{4}-\d{2}$/` または `/^\d{4}$/` にマッチする文字列: 期間として認識
- * - `/` を含む位置引数（`\` → `/` 正規化後): ChatGPT エクスポートディレクトリ（inputDir）として認識
- *
- * 未知のオプション（`--` で始まる認識外の文字列）または
- * 未知の位置引数（エージェント名・期間・パス以外）が指定された場合は
- * `console.error` にエラーメッセージを出力して `Deno.exit(1)` を呼ぶ。
- *
- * `DEFAULT_EXPORT_CONFIG` をベースとしてスプレッドコピーし、
- * 指定された引数で上書きした `ExportConfig` を返す。
- *
- * @param args CLI 引数の配列（通常は `Deno.args` または `main()` の `argv` パラメータ）
- * @returns 解析済みの `ExportConfig`
- */
-export const parseArgs = (args: string[]): ExportConfig => {
-  const _config: ExportConfig = { ...DEFAULT_EXPORT_CONFIG };
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    const eqIdx = arg.indexOf('=');
-    const flag = eqIdx >= 0 ? arg.slice(0, eqIdx) : arg;
-    const eqVal = eqIdx >= 0 ? arg.slice(eqIdx + 1) : undefined;
-
-    switch (flag) {
-      case '--output':
-        _config.outputDir = eqVal ?? args[++i];
-        break;
-      case '--base':
-        _config.baseDir = eqVal ?? args[++i];
-        break;
-      case '--input':
-        _config.inputDir = eqVal ?? args[++i];
-        break;
-      default: {
-        if (flag.startsWith('-')) {
-          throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
-        }
-        if (isKnownAgent(arg)) {
-          _config.agent = arg;
-        } else if (/^\d{4}-\d{2}$/.test(arg) || /^\d{4}$/.test(arg)) {
-          _config.period = arg;
-        } else {
-          const normalized = normalizePath(arg);
-          if (normalized.includes('/')) {
-            _config.inputDir = normalized;
-          } else {
-            throw new ChatlogError('InvalidArgs', `不明な引数: ${arg}`);
-          }
-        }
-      }
-    }
-  }
-
-  return _config;
+const _OPT_KEYS: Record<string, keyof ParsedConfig> = {
+  '--output': 'outputDir',
+  '--base': 'baseDir',
+  '--input': 'inputDir',
+  '--config': 'configFile',
 };
+
+const _OPT_FLAGS: Record<string, keyof ParsedConfig> = {};
+
+/**
+ * CLI 引数配列を解析して `ParsedConfig` を返す。
+ *
+ * @param args CLI 引数の配列 (通常は `Deno.args` または `main()` の `argv` パラメータ)
+ * @returns 解析済みの `ParsedConfig`
+ */
+export const parseArgs = (args: string[]): ParsedConfig => {
+  return parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
+};
+
+// ─────────────────────────────────────────────
+// 設定構築
+// ─────────────────────────────────────────────
+
+/**
+ * ParsedConfig・GlobalConfig・デフォルト値から完全な ExportConfig を構築する。
+ * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
+ * - outputDir 優先順位: `parsed.outputDir` > `globalConfig.get('chatlogDir')` > `defaults.outputDir`
+ * - baseDir 優先順位: `parsed.baseDir` > `defaults.baseDir`
+ * - inputDir 優先順位: `parsed.inputDir` > `defaults.inputDir`
+ * - period: `parsed.period` のみ (GlobalConfig に期間設定なし)
+ */
+export function buildConfig(
+  parsed: ParsedConfig,
+  globalConfig: GlobalConfig,
+  defaults?: ExportConfig,
+): ExportConfig {
+  const _defaults = defaults ?? DEFAULT_EXPORT_CONFIG;
+  const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? _defaults.agent;
+  const _outputDir = parsed.outputDir ?? (globalConfig.get('chatlogDir') as string | undefined) ?? _defaults.outputDir;
+  const _baseDir = parsed.baseDir ?? _defaults.baseDir;
+  const _inputDir = parsed.inputDir ?? _defaults.inputDir;
+  const { configFile: _configFile, ...parsedRest } = parsed;
+  return {
+    ..._defaults,
+    ...parsedRest,
+    agent: _agent,
+    outputDir: _outputDir,
+    baseDir: _baseDir,
+    inputDir: _inputDir,
+  };
+}
 
 // ─────────────────────────────────────────────
 // メイン
@@ -117,14 +110,16 @@ export const parseArgs = (args: string[]): ExportConfig => {
  * 5. 生成した Markdown ファイルパスを `console.log` に出力し、
  *    進行状況・エラーを `console.error` に出力する
  *
- * `argv` 省略時は `Deno.args` を使用する（`import.meta.main` からの呼び出し用）。
+ * `argv` 省略時は `Deno.args` を使用する (`import.meta.main` からの呼び出し用) 。
  * テストでは `argv` にモック引数を渡して実行できる。
  *
  * @param argv CLI 引数の配列。省略時は `Deno.args` を使用
  */
 export const main = async (argv?: string[]): Promise<void> => {
   try {
-    const config = parseArgs(argv ?? Deno.args);
+    const _parsed = parseArgs(argv ?? Deno.args);
+    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const config = buildConfig(_parsed, _globalConfig);
     const { agent, period, outputDir } = config;
 
     logger.info(`対象 agent: ${agent}`);
@@ -132,20 +127,24 @@ export const main = async (argv?: string[]): Promise<void> => {
 
     let result: Awaited<ReturnType<typeof exportClaude>>;
 
-    if (agent === 'claude') {
-      result = await exportClaude(config);
-    } else if (agent === 'codex') {
-      result = await exportCodex(config);
-    } else if (agent === 'chatgpt') {
-      if (!config.inputDir && !config.baseDir) {
-        throw new ChatlogError(
-          'InvalidArgs',
-          'chatgpt エージェントには入力ディレクトリを指定してください（位置引数または --input）',
-        );
-      }
-      result = await exportChatGPT(config);
-    } else {
-      throw new ChatlogError('InvalidArgs', `未対応のエージェント: ${agent}`);
+    switch (agent) {
+      case 'claude':
+        result = await exportClaude(config);
+        break;
+      case 'codex':
+        result = await exportCodex(config);
+        break;
+      case 'chatgpt':
+        if (!config.inputDir && !config.baseDir) {
+          throw new ChatlogError(
+            'InvalidArgs',
+            'chatgpt エージェントには入力ディレクトリを指定してください (位置引数または --input)',
+          );
+        }
+        result = await exportChatGPT(config);
+        break;
+      default:
+        throw new ChatlogError('InvalidArgs', `未対応のエージェント: ${agent}`);
     }
 
     for (const outPath of result.outputPaths) {
@@ -154,7 +153,7 @@ export const main = async (argv?: string[]): Promise<void> => {
 
     const total = result.exportedCount + result.skippedCount + result.errorCount;
     logger.info(
-      `\n完了: ${total} 件処理（出力: ${result.exportedCount} / スキップ: ${result.skippedCount} / エラー: ${result.errorCount}）`,
+      `\n完了: ${total} 件処理 (出力: ${result.exportedCount} / スキップ: ${result.skippedCount} / エラー: ${result.errorCount}) `,
     );
     logger.info(`出力先: ${outputDir}/${agent}/`);
   } catch (e) {

--- a/skills/export-chatlog/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/chatgpt-exporter.ts
@@ -8,16 +8,18 @@
 
 // cspell:words conv
 
-// ─── External modules ───────────────────────────────────────────────────────
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// error
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+// libs
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
-// ─── Internal modules ───────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
+// libs
 import { inPeriod, parsePeriod } from '../libs/period-filter.ts';
 import { writeSession } from '../libs/session-writer.ts';
 import { isSkippable, isSkippableSession } from '../libs/skip-rules.ts';
-
-// ─── Types ──────────────────────────────────────────────────────────────────
+// types
 import type { ExportConfig } from '../types/export-config.types.ts';
 import type { ExportResult } from '../types/export-result.types.ts';
 import type { FileResult } from '../types/file-result.types.ts';

--- a/skills/export-chatlog/scripts/exporter/claude-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/claude-exporter.ts
@@ -6,18 +6,19 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// ─── External modules ───────────────────────────────────────────────────────
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// libs
 import { homeDir } from '../../../_scripts/libs/file-io/dir-utils.ts';
 import { findDirectories, findEntries } from '../../../_scripts/libs/file-io/find-entries.ts';
 import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
-// ─── Internal modules ───────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
+// libs
 import { inPeriod, parsePeriod } from '../libs/period-filter.ts';
 import { writeSession } from '../libs/session-writer.ts';
 import { isSkippable, isSkippableSession } from '../libs/skip-rules.ts';
-
-// ─── Types ──────────────────────────────────────────────────────────────────
+// types
 import type { ExportConfig } from '../types/export-config.types.ts';
 import type { ExportResult } from '../types/export-result.types.ts';
 import type { PeriodRange } from '../types/filter.types.ts';

--- a/skills/export-chatlog/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/codex-exporter.ts
@@ -6,18 +6,19 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// ─── External modules ───────────────────────────────────────────────────────
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// libs
 import { homeDir } from '../../../_scripts/libs/file-io/dir-utils.ts';
 import { findEntries } from '../../../_scripts/libs/file-io/find-entries.ts';
 import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
-// ─── Internal modules ───────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
+// libs
 import { inPeriod, parsePeriod } from '../libs/period-filter.ts';
 import { writeSession } from '../libs/session-writer.ts';
 import { isSkippable, isSkippableSession } from '../libs/skip-rules.ts';
-
-// ─── Types ──────────────────────────────────────────────────────────────────
+// types
 import type { ExportConfig } from '../types/export-config.types.ts';
 import type { ExportResult } from '../types/export-result.types.ts';
 import type { PeriodRange } from '../types/filter.types.ts';

--- a/skills/export-chatlog/scripts/exporter/types/chatgpt-provider.types.ts
+++ b/skills/export-chatlog/scripts/exporter/types/chatgpt-provider.types.ts
@@ -6,6 +6,8 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// ─── Local modules ───────────────────────────────────────────────────────────
+// types
 import type { PeriodRange } from '../../types/filter.types.ts';
 import type { ExportedSession } from '../../types/session.types.ts';
 import type { ChatGPTConversation } from './chatgpt-entry.types.ts';

--- a/skills/export-chatlog/scripts/exporter/types/session-provider.types.ts
+++ b/skills/export-chatlog/scripts/exporter/types/session-provider.types.ts
@@ -6,6 +6,8 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// ─── Local modules ───────────────────────────────────────────────────────────
+// types
 import type { PeriodRange } from '../../types/filter.types.ts';
 import type { ExportedSession } from '../../types/session.types.ts';
 

--- a/skills/export-chatlog/scripts/libs/period-filter.ts
+++ b/skills/export-chatlog/scripts/libs/period-filter.ts
@@ -6,11 +6,14 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// ─── External modules ───────────────────────────────────────────────────────
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// error
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+// libs
 import { isoToLocalDayMs } from '../../../_scripts/libs/text/date-utils.ts';
 
-// ─── Types ──────────────────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
+// types
 import type { PeriodRange } from '../types/filter.types.ts';
 
 // ----------

--- a/skills/export-chatlog/scripts/libs/session-writer.ts
+++ b/skills/export-chatlog/scripts/libs/session-writer.ts
@@ -6,13 +6,15 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// ─── External modules ───────────────────────────────────────────────────────
+// ─── Shared modules ─────────────────────────────────────────────────────────
+// libs
 import { getDirectory } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 import { textToSlug } from '../../../_scripts/libs/text/slug-utils.ts';
 import { quoteString } from '../../../_scripts/libs/text/string-utils.ts';
 
-// ─── Types ──────────────────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
+// types
 import type { ExportedSession, SessionMeta, Turn } from '../types/session.types.ts';
 
 /** セッションの Markdown ファイル出力パスを生成する。 */

--- a/skills/export-chatlog/scripts/libs/skip-rules.ts
+++ b/skills/export-chatlog/scripts/libs/skip-rules.ts
@@ -6,7 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// ─── Internal modules ───────────────────────────────────────────────────────
+// ─── Local modules ───────────────────────────────────────────────────────────
 // constants
 import {
   SESSION_SKIP_KEYWORDS,

--- a/skills/export-chatlog/scripts/types/export-config.types.ts
+++ b/skills/export-chatlog/scripts/types/export-config.types.ts
@@ -37,3 +37,14 @@ export interface ExportConfig {
   /** 出力先ディレクトリのベースパス。デフォルトは "./chatlogs" */
   outputDir: string;
 }
+
+/**
+ * `parseArgs()` が CLI 引数から生成する未解決設定。`buildConfig()` が完全な `ExportConfig` に解決する。
+ *
+ * `configFile` は `GlobalConfig.getInstance()` に渡す設定ファイルパスを保持する専用フィールドであり、
+ * `ExportConfig` には含まれない。
+ */
+export type ParsedConfig = Partial<ExportConfig> & {
+  /** グローバル設定ファイルのパス。`--config` オプションで指定する。 */
+  configFile?: string;
+};


### PR DESCRIPTION
## Overview

**Summary**
Add GlobalConfig integration to export-chatlog and extend parseArgs with YYYY period support and path normalization.

**Background / Motivation**
export-chatlog スキルは従来 CLI 引数のみで設定を解決していたが、GlobalConfig との連携が必要になった。
`buildConfig` による多層設定解決（CLI引数 > GlobalConfig > デフォルト値）を導入することで、
グローバル設定を反映しつつ CLI 引数で上書きできる柔軟な設定管理を実現する。
あわせて、共有 `parseArgs` の YYYY 年指定対応とパス正規化、`ParsedConfig` 型による未解決オプションの明示的管理を追加した。

## Changes

- `skills/export-chatlog/scripts/export-chatlog.ts` — `buildConfig` による多層設定解決を追加、`--config` オプション対応
- `skills/export-chatlog/scripts/types/export-config.types.ts` — 未解決CLIオプションを表す `ParsedConfig` 型を追加
- `skills/export-chatlog/scripts/constants/defaults.constants.ts` — `DEFAULT_CHATLOG_DIR` 共有定数から `DEFAULT_OUTPUT_DIR` を導出
- `skills/_scripts/libs/io/parse-args.ts` — YYYY形式の period 引数対応、`inputDir` への `normalizePath` 適用
- `skills/_scripts/constants/defaults.constants.ts` — `DEFAULT_CHATLOG_DIR` 定数を追加
- `skills/export-chatlog/scripts/exporter/` 配下 — import グループをプロジェクト規約に沿って再編成
- `assets/configs/config.yaml` — `chatlogDir` のデフォルト値を `./chatlog` → `./chatlogs` に変更
- `skills/export-chatlog/scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts` — `buildConfig` の多層優先解決を包括的にカバーするfunctionalテストを追加
- `skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts` — YYYY period、パス正規化、引数解析シナリオを拡充

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

> Closes #113

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

`buildConfig` の設定解決優先順位:

- `agent`: `parsed` > `globalConfig` > `defaults`
- `outputDir`: `parsed` > `globalConfig.chatlogDir` > `defaults`
- `baseDir`: `parsed` のみ（GlobalConfig連携なし）
- `configFile`: `ParsedConfig` 専用フィールドとして管理し、`ExportConfig` には含まれない
