### PR TITLE
refactor(file-io/exists-utils): add shared existence check helpers and migrate all callers

### DIFF
--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -7,6 +7,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { fileExists } from '../../libs/file-io/exists-utils.ts';
 import { findDirectories } from '../../libs/file-io/find-entries.ts';
 import { normalizePath } from '../../libs/file-io/path-utils.ts';
 
@@ -23,15 +24,10 @@ export type IsFixtureDirProvider = (dir: string) => Promise<boolean>;
 
 /**
  * dir 直下に `input.md` が存在すれば true を返す。
- * ファイルが存在しない場合や stat に失敗した場合は false を返す。
+ * ファイルが存在しない場合は false を返す。`NotFound` 以外のエラーは再スローする。
  */
 export const defaultIsFixtureDir = async (dir: string): Promise<boolean> => {
-  try {
-    await Deno.stat(`${dir}/input.md`);
-    return true;
-  } catch {
-    return false;
-  }
+  return await fileExists(`${dir}/input.md`);
 };
 
 /**

--- a/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
@@ -18,6 +18,8 @@ import { ChatlogError } from '../../ChatlogError.class.ts';
 
 // -- helpers --
 import { findFixtureDirs, type IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+// exists
+import { fileExists } from '../../../libs/file-io/exists-utils.ts';
 
 // -- test target --
 import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
@@ -35,12 +37,7 @@ const FIXTURES_DIR = new URL('./fixtures-data/divide-entry', import.meta.url)
   .replace(/^\/([A-Z]:)/, '$1');
 
 const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
-  try {
-    await Deno.stat(`${dir}/input.md`);
-    return true;
-  } catch {
-    return false;
-  }
+  return await fileExists(`${dir}/input.md`);
 };
 
 async function _loadFixture(

--- a/skills/_scripts/classes/__tests__/fixtures/render-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/render-entry.fixtures.spec.ts
@@ -21,6 +21,8 @@ import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
 import { findFixtureDirs } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // type
 import type { IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+// exists
+import { fileExists } from '../../../libs/file-io/exists-utils.ts';
 // -- error class --
 import { ChatlogError } from '../../ChatlogError.class.ts';
 
@@ -58,13 +60,7 @@ async function _loadFixture(
 }
 
 const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
-  try {
-    await Deno.stat(`${dir}/input.md`);
-    await Deno.stat(`${dir}/config.yaml`);
-    return true;
-  } catch {
-    return false;
-  }
+  return await fileExists(`${dir}/input.md`) && await fileExists(`${dir}/config.yaml`);
 };
 
 const _fixtureDirs = await findFixtureDirs(FIXTURES_DIR, _isFixtureDir);

--- a/skills/_scripts/classes/__tests__/fixtures/to-frontmatter.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/to-frontmatter.fixtures.spec.ts
@@ -17,6 +17,8 @@ import { parse as parseYaml } from '@std/yaml';
 import { findFixtureDirs } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // types
 import type { IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+// exists
+import { fileExists } from '../../../libs/file-io/exists-utils.ts';
 
 // -- error class --
 import { ChatlogError } from '../../ChatlogError.class.ts';
@@ -41,13 +43,7 @@ const FIXTURES_DIR = new URL('./fixtures-data/to-frontmatter', import.meta.url)
   .replace(/^\/([A-Z]:)/, '$1');
 
 const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
-  try {
-    await Deno.stat(`${dir}/input.md`);
-    await Deno.stat(`${dir}/config.yaml`);
-    return true;
-  } catch {
-    return false;
-  }
+  return await fileExists(`${dir}/input.md`) && await fileExists(`${dir}/config.yaml`);
 };
 
 async function _loadFixture(

--- a/skills/_scripts/libs/file-io/__tests__/system/backup.system.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/system/backup.system.spec.ts
@@ -10,6 +10,7 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 import { backupOldPath } from '../../backup.ts';
+import { fileExists, fileOrDirExists } from '../../exists-utils.ts';
 
 // ─────────────────────────────────────────────
 // backupOldPath
@@ -64,8 +65,7 @@ describe('backupOldPath', () => {
 
           // assert
           const backupPath = `${tmpDir}/output.old-01.md`;
-          const stat = await Deno.stat(backupPath);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(backupPath), true);
         });
 
         it('T-LIB-B-02-02: 元のファイルが存在しなくなる', async () => {
@@ -77,13 +77,7 @@ describe('backupOldPath', () => {
           await backupOldPath(outputPath);
 
           // assert
-          let exists = true;
-          try {
-            await Deno.stat(outputPath);
-          } catch {
-            exists = false;
-          }
-          assertEquals(exists, false);
+          assertEquals(await fileOrDirExists(outputPath), false);
         });
       });
     });
@@ -105,8 +99,7 @@ describe('backupOldPath', () => {
 
           // assert
           const backupPath = `${tmpDir}/output.old-02.md`;
-          const stat = await Deno.stat(backupPath);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(backupPath), true);
         });
       });
     });
@@ -129,8 +122,7 @@ describe('backupOldPath', () => {
 
           // assert
           const backupPath = `${subDir}/file.old-01.md`;
-          const stat = await Deno.stat(backupPath);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(backupPath), true);
         });
       });
     });

--- a/skills/_scripts/libs/file-io/__tests__/unit/exists-utils.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/exists-utils.unit.spec.ts
@@ -1,0 +1,287 @@
+// src: skills/_scripts/libs/file-io/__tests__/unit/exists-utils.unit.spec.ts
+// @(#): exists-utils ユニットテスト
+//       対象: fileExists, fileOrDirExists, dirExists
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertRejects } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { dirExists, fileExists, fileOrDirExists } from '../../exists-utils.ts';
+
+// ─── Helpers
+// types
+import type { StatProvider } from '../../../../types/providers.types.ts';
+
+// ─── Internal Helpers
+
+/** ファイルとして存在することを示す `StatProvider` モック。`isFile: true, isDirectory: false` を返す。 */
+const _existsFileStat: StatProvider = (_path: string) =>
+  Promise.resolve({ isFile: true, isDirectory: false } as Deno.FileInfo);
+
+/** ディレクトリとして存在することを示す `StatProvider` モック。`isFile: false, isDirectory: true` を返す。 */
+const _existsDirStat: StatProvider = (_path: string) =>
+  Promise.resolve({ isFile: false, isDirectory: true } as Deno.FileInfo);
+
+/** 存在しないパスを示す `StatProvider` モック。`Deno.errors.NotFound` をスローする。 */
+const _notFoundStat: StatProvider = (_path: string) => Promise.reject(new Deno.errors.NotFound('no such file'));
+
+/** 権限不足を示す `StatProvider` モック。`Deno.errors.PermissionDenied` をスローする。 */
+const _permissionDeniedStat: StatProvider = (_path: string) =>
+  Promise.reject(new Deno.errors.PermissionDenied('permission denied'));
+
+// ─── Tests
+
+/**
+ * `fileExists` 関数のユニットテストスイート。
+ *
+ * `fileExists(path, statProvider?)` は `statProvider` の `isFile` フラグでファイル存在を判定し、
+ * 通常ファイルなら `true`、ディレクトリや不在なら `false` を返す。
+ *
+ * テスト ID 範囲: T-LIB-SU-01 〜 T-LIB-SU-04
+ *
+ * @see fileExists
+ */
+describe('fileExists', () => {
+  /**
+   * `statProvider` がファイル情報を返す前提条件グループ。
+   *
+   * ファイルとして存在するパスに対して `true` が返ることを検証する。
+   */
+  describe('Given: statProvider がファイル情報を返す', () => {
+    /** `fileExists` を呼び出すとき。 */
+    describe('When: fileExists を実行する', () => {
+      /** `true` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-01 - true が返る', () => {
+        it('T-LIB-SU-01-01: statProvider が成功を返す場合、true が返る', async () => {
+          assertEquals(await fileExists('/some/file.md', _existsFileStat), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` がディレクトリ情報を返す前提条件グループ。
+   *
+   * ディレクトリとして存在するパスは `isFile === false` のため `false` が返ることを検証する。
+   */
+  describe('Given: statProvider がディレクトリ情報を返す', () => {
+    /** `fileExists` を呼び出すとき。 */
+    describe('When: fileExists を実行する', () => {
+      /** ディレクトリはファイルではないため `false` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-02 - false が返る', () => {
+        it('T-LIB-SU-02-01: statProvider がディレクトリ情報を返す場合、false が返る', async () => {
+          assertEquals(await fileExists('/some/dir', _existsDirStat), false);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` が `NotFound` 例外をスローする前提条件グループ。
+   *
+   * パスが存在しない場合に `false` が返ることを検証する。
+   */
+  describe('Given: statProvider が NotFound 例外をスローする', () => {
+    /** `fileExists` を呼び出すとき。 */
+    describe('When: fileExists を実行する', () => {
+      /** `false` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-03 - false が返る', () => {
+        it('T-LIB-SU-03-01: statProvider が NotFound をスローする場合、false が返る', async () => {
+          assertEquals(await fileExists('/nonexistent/file.md', _notFoundStat), false);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` が `NotFound` 以外の例外をスローする前提条件グループ。
+   *
+   * パーミッションエラーなど回復不可能なエラーは握りつぶさず再スローすることを検証する。
+   */
+  describe('Given: statProvider が PermissionDenied 例外をスローする', () => {
+    /** `fileExists` を呼び出すとき。 */
+    describe('When: fileExists を実行する', () => {
+      /** `PermissionDenied` が再スローされることを検証する。 */
+      describe('Then: T-LIB-SU-04 - PermissionDenied が再スローされる', () => {
+        it('T-LIB-SU-04-01: statProvider が PermissionDenied をスローする場合、そのまま再スローされる', async () => {
+          await assertRejects(
+            () => fileExists('/restricted/file.md', _permissionDeniedStat),
+            Deno.errors.PermissionDenied,
+          );
+        });
+      });
+    });
+  });
+});
+
+/**
+ * `fileOrDirExists` 関数のユニットテストスイート。
+ *
+ * `fileOrDirExists(path, statProvider?)` は `statProvider` の成否でパス存在を判定し、
+ * ファイル・ディレクトリ問わず存在すれば `true`、存在しなければ `false` を返す。
+ *
+ * テスト ID 範囲: T-LIB-SU-05 〜 T-LIB-SU-08
+ *
+ * @see fileOrDirExists
+ */
+describe('fileOrDirExists', () => {
+  /**
+   * `statProvider` がファイル情報を返す前提条件グループ。
+   *
+   * ファイルとして存在するパスに対して `true` が返ることを検証する。
+   */
+  describe('Given: statProvider がファイル情報を返す', () => {
+    /** `fileOrDirExists` を呼び出すとき。 */
+    describe('When: fileOrDirExists を実行する', () => {
+      /** `true` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-05 - true が返る', () => {
+        it('T-LIB-SU-05-01: statProvider がファイル情報を返す場合、true が返る', async () => {
+          assertEquals(await fileOrDirExists('/some/file.md', _existsFileStat), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` がディレクトリ情報を返す前提条件グループ。
+   *
+   * ディレクトリとして存在するパスに対しても `true` が返ることを検証する。
+   */
+  describe('Given: statProvider がディレクトリ情報を返す', () => {
+    /** `fileOrDirExists` を呼び出すとき。 */
+    describe('When: fileOrDirExists を実行する', () => {
+      /** `true` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-06 - true が返る', () => {
+        it('T-LIB-SU-06-01: statProvider がディレクトリ情報を返す場合、true が返る', async () => {
+          assertEquals(await fileOrDirExists('/some/dir', _existsDirStat), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` が `NotFound` 例外をスローする前提条件グループ。
+   *
+   * パスが存在しない場合に `false` が返ることを検証する。
+   */
+  describe('Given: statProvider が NotFound 例外をスローする', () => {
+    /** `fileOrDirExists` を呼び出すとき。 */
+    describe('When: fileOrDirExists を実行する', () => {
+      /** `false` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-07 - false が返る', () => {
+        it('T-LIB-SU-07-01: statProvider が NotFound をスローする場合、false が返る', async () => {
+          assertEquals(await fileOrDirExists('/nonexistent/path', _notFoundStat), false);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` が `NotFound` 以外の例外をスローする前提条件グループ。
+   *
+   * パーミッションエラーなど回復不可能なエラーは握りつぶさず再スローすることを検証する。
+   */
+  describe('Given: statProvider が PermissionDenied 例外をスローする', () => {
+    /** `fileOrDirExists` を呼び出すとき。 */
+    describe('When: fileOrDirExists を実行する', () => {
+      /** `PermissionDenied` が再スローされることを検証する。 */
+      describe('Then: T-LIB-SU-08 - PermissionDenied が再スローされる', () => {
+        it('T-LIB-SU-08-01: statProvider が PermissionDenied をスローする場合、そのまま再スローされる', async () => {
+          await assertRejects(
+            () => fileOrDirExists('/restricted/path', _permissionDeniedStat),
+            Deno.errors.PermissionDenied,
+          );
+        });
+      });
+    });
+  });
+});
+
+/**
+ * `dirExists` 関数のユニットテストスイート。
+ *
+ * `dirExists(path, statProvider?)` は `statProvider` の成否と `isDirectory` フラグで
+ * ディレクトリ存在を判定し、ディレクトリなら `true`、ファイルや不在なら `false` を返す。
+ *
+ * テスト ID 範囲: T-LIB-SU-09 〜 T-LIB-SU-12
+ *
+ * @see dirExists
+ */
+describe('dirExists', () => {
+  /**
+   * `statProvider` がディレクトリ情報を返す前提条件グループ。
+   *
+   * ディレクトリとして存在するパスに対して `true` が返ることを検証する。
+   */
+  describe('Given: statProvider がディレクトリ情報を返す', () => {
+    /** `dirExists` を呼び出すとき。 */
+    describe('When: dirExists を実行する', () => {
+      /** `true` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-09 - true が返る', () => {
+        it('T-LIB-SU-09-01: statProvider が isDirectory:true を返す場合、true が返る', async () => {
+          assertEquals(await dirExists('/some/dir', _existsDirStat), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` がファイル情報を返す前提条件グループ。
+   *
+   * ファイルとして存在するパスに対して `false` が返ることを検証する（ディレクトリではないため）。
+   */
+  describe('Given: statProvider がファイル情報を返す（isDirectory: false）', () => {
+    /** `dirExists` を呼び出すとき。 */
+    describe('When: dirExists を実行する', () => {
+      /** ファイルはディレクトリではないため `false` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-10 - false が返る', () => {
+        it('T-LIB-SU-10-01: statProvider が isDirectory:false を返す場合、false が返る', async () => {
+          assertEquals(await dirExists('/some/file.md', _existsFileStat), false);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` が `NotFound` 例外をスローする前提条件グループ。
+   *
+   * パスが存在しない場合に `false` が返ることを検証する。
+   */
+  describe('Given: statProvider が NotFound 例外をスローする', () => {
+    /** `dirExists` を呼び出すとき。 */
+    describe('When: dirExists を実行する', () => {
+      /** `false` が返ることを検証する。 */
+      describe('Then: T-LIB-SU-11 - false が返る', () => {
+        it('T-LIB-SU-11-01: statProvider が NotFound をスローする場合、false が返る', async () => {
+          assertEquals(await dirExists('/nonexistent/dir', _notFoundStat), false);
+        });
+      });
+    });
+  });
+
+  /**
+   * `statProvider` が `NotFound` 以外の例外をスローする前提条件グループ。
+   *
+   * パーミッションエラーなど回復不可能なエラーは握りつぶさず再スローすることを検証する。
+   */
+  describe('Given: statProvider が PermissionDenied 例外をスローする', () => {
+    /** `dirExists` を呼び出すとき。 */
+    describe('When: dirExists を実行する', () => {
+      /** `PermissionDenied` が再スローされることを検証する。 */
+      describe('Then: T-LIB-SU-12 - PermissionDenied が再スローされる', () => {
+        it('T-LIB-SU-12-01: statProvider が PermissionDenied をスローする場合、そのまま再スローされる', async () => {
+          await assertRejects(
+            () => dirExists('/restricted/dir', _permissionDeniedStat),
+            Deno.errors.PermissionDenied,
+          );
+        });
+      });
+    });
+  });
+});

--- a/skills/_scripts/libs/file-io/backup.ts
+++ b/skills/_scripts/libs/file-io/backup.ts
@@ -5,6 +5,7 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
+
 /**
  * backup.ts — 既存ファイルを連番バックアップ (.old-NN.md) するユーティリティ
  *
@@ -12,8 +13,13 @@
  * リネームする。outputPath が存在しない場合は何もしない。
  */
 
-import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+// --- hared modules
+// functions
+import { fileExists } from './exists-utils.ts';
+// types
 import type { ListDirProvider } from '../../types/providers.types.ts';
+// classes
+import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 
 // ─────────────────────────────────────────────
 // 内部ユーティリティ
@@ -57,10 +63,7 @@ export const backupOldPath = async (
   outputPath: string,
   listDir: ListDirProvider = defaultListDir,
 ): Promise<void> => {
-  try {
-    await Deno.stat(outputPath);
-  } catch {
-    // File does not exist → nothing to back up
+  if (!await fileExists(outputPath)) {
     return;
   }
 

--- a/skills/_scripts/libs/file-io/exists-utils.ts
+++ b/skills/_scripts/libs/file-io/exists-utils.ts
@@ -1,0 +1,94 @@
+// src: skills/_scripts/libs/file-io/exists-utils.ts
+// @(#): ファイル・ディレクトリ存在チェックユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// types
+import type { StatProvider } from '../../types/providers.types.ts';
+
+// ─────────────────────────────────────────────
+// 内部定数
+// ─────────────────────────────────────────────
+
+/** ファイル情報取得プロバイダのデフォルト実装 */
+const _DEFAULT_STAT_PROVIDER: StatProvider = (path: string) => Deno.stat(path);
+
+// ─────────────────────────────────────────────
+// 内部ヘルパー
+// ─────────────────────────────────────────────
+
+// NotFound のみ null に縮約し、それ以外は再スロー
+const _getFileStat = async (
+  path: string,
+  statProvider: StatProvider,
+): Promise<Deno.FileInfo | null> => {
+  try {
+    return await statProvider(path);
+  } catch (e) {
+    if (!(e instanceof Deno.errors.NotFound)) { throw e; }
+    return null;
+  }
+};
+
+// ─────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────
+
+/**
+ * 指定パスが通常ファイルとして存在するかどうかを返す。
+ *
+ * `stat.isFile === true` の場合のみ `true` を返す。ディレクトリは `false`。
+ * `Deno.errors.NotFound` のみ `false` として扱い、それ以外のエラー（権限不足など）は再スローする。
+ *
+ * @param path - 確認するファイルの絶対パス
+ * @param statProvider - テスト用注入可能な stat 関数（デフォルト: `Deno.stat`）
+ * @returns 通常ファイルとして存在すれば `true`、ディレクトリや不在なら `false`
+ * @throws パーミッションエラーなど `NotFound` 以外のエラー
+ */
+export const fileExists = async (
+  path: string,
+  statProvider: StatProvider = _DEFAULT_STAT_PROVIDER,
+): Promise<boolean> => {
+  const _stat = await _getFileStat(path, statProvider);
+  return _stat !== null && _stat.isFile;
+};
+
+/**
+ * 指定パスがディレクトリとして存在するかどうかを返す。
+ *
+ * `Deno.errors.NotFound` のみ `false` として扱い、それ以外のエラー（権限不足など）は再スローする。
+ *
+ * @param path - 確認するディレクトリの絶対パス
+ * @param statProvider - テスト用注入可能な stat 関数（デフォルト: `Deno.stat`）
+ * @returns ディレクトリとして存在すれば `true`、存在しないかファイルなら `false`
+ * @throws パーミッションエラーなど `NotFound` 以外のエラー
+ */
+export const dirExists = async (
+  path: string,
+  statProvider: StatProvider = _DEFAULT_STAT_PROVIDER,
+): Promise<boolean> => {
+  const _stat = await _getFileStat(path, statProvider);
+  return _stat !== null && _stat.isDirectory;
+};
+
+/**
+ * 指定パスがファイルまたはディレクトリとして存在するかどうかを返す。
+ *
+ * `stat` が成功すれば `true` を返す（ファイル・ディレクトリを区別しない）。
+ * `Deno.errors.NotFound` のみ `false` として扱い、それ以外のエラーは再スローする。
+ *
+ * @param path - 確認するパスの絶対パス
+ * @param statProvider - テスト用注入可能な stat 関数（デフォルト: `Deno.stat`）
+ * @returns 存在すれば `true`、存在しなければ `false`
+ * @throws パーミッションエラーなど `NotFound` 以外のエラー
+ */
+export const fileOrDirExists = async (
+  path: string,
+  statProvider: StatProvider = _DEFAULT_STAT_PROVIDER,
+): Promise<boolean> => {
+  const _stat = await _getFileStat(path, statProvider);
+  return _stat !== null;
+};

--- a/skills/_scripts/libs/file-io/path-utils.ts
+++ b/skills/_scripts/libs/file-io/path-utils.ts
@@ -8,9 +8,10 @@
 
 // utils
 import { getProjectRootDir } from './dir-utils.ts';
+import { fileOrDirExists } from './exists-utils.ts';
 // types
 import type { ResolveConfigPathOptions } from '../../types/file-io.types.ts';
-import type { CommandProvider, StatProvider } from '../../types/providers.types.ts';
+import type { CommandProvider } from '../../types/providers.types.ts';
 // error class
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 
@@ -23,8 +24,6 @@ const _WIN_ABS = /^[A-Za-z]:\//;
 
 /** コマンドプロバイダのデフォルト実装 */
 const _DEFAULT_COMMAND_PROVIDER = Deno.Command as unknown as CommandProvider;
-/** ファイル情報取得プロバイダのデフォルト実装 */
-const _DEFAULT_STAT_PROVIDER: StatProvider = (path: string) => Deno.stat(path);
 
 // ─────────────────────────────────────────────
 // パス正規化
@@ -72,7 +71,7 @@ export const resolveConfigPath = async ({
   configPath,
   defaultPath,
   commandProvider = _DEFAULT_COMMAND_PROVIDER,
-  statProvider = _DEFAULT_STAT_PROVIDER,
+  statProvider,
 }: ResolveConfigPathOptions): Promise<string> => {
   const _path = configPath ?? defaultPath;
   let _resolved: string;
@@ -84,7 +83,10 @@ export const resolveConfigPath = async ({
   }
 
   try {
-    await statProvider(_resolved);
+    const _exists = await fileOrDirExists(_resolved, statProvider);
+    if (!_exists) {
+      throw new ChatlogError('FileDirNotFound', `設定ファイル/ディレクトリが見つかりません: ${_resolved}`);
+    }
   } catch (e) {
     if (e instanceof ChatlogError) { throw e; }
     throw new ChatlogError('FileDirNotFound', `設定ファイル/ディレクトリが見つかりません: ${_resolved}`);

--- a/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
@@ -36,6 +36,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // classes
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
+// exists
+import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // ─── テスト用一時ディレクトリセットアップ ─────────────────────────────────────
 
@@ -104,8 +106,7 @@ describe('main - dry-run モード', () => {
         it('T-CL-E2E-01-01: 元ファイルが移動せず残っている', async () => {
           await main(['claude', '2026-03', '--dry-run', '--input', inputDir, '--config', configFile]);
 
-          const stat = await Deno.stat(`${monthDir}/chat.md`);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(`${monthDir}/chat.md`), true);
         });
 
         it('T-CL-E2E-01-02: "[dry-run]" がログに出力される', async () => {
@@ -158,8 +159,7 @@ describe('main - 正常分類', () => {
         it('T-CL-E2E-02-01: ファイルが app1/ サブディレクトリに移動している', async () => {
           await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
-          const stat = await Deno.stat(`${monthDir}/app1/chat.md`);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(`${monthDir}/app1/chat.md`), true);
         });
 
         it('T-CL-E2E-02-02: 移動先ファイルに "project: \\"app1\\"" が含まれる', async () => {
@@ -310,21 +310,13 @@ describe('main - project 設定済みファイルの実移動', () => {
         it('T-CL-E2E-08-01: existing-project/ にファイルが移動している', async () => {
           await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
-          const stat = await Deno.stat(`${monthDir}/existing-project/chat.md`);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(`${monthDir}/existing-project/chat.md`), true);
         });
 
         it('T-CL-E2E-08-02: 元のパスにファイルが存在しない', async () => {
           await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
-          let srcExists = false;
-          try {
-            await Deno.stat(`${monthDir}/chat.md`);
-            srcExists = true;
-          } catch (e) {
-            if (!(e instanceof Deno.errors.NotFound)) { throw e; }
-          }
-          assertEquals(srcExists, false);
+          assertEquals(await fileOrDirExists(`${monthDir}/chat.md`), false);
         });
       });
     });
@@ -383,14 +375,7 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
         it('T-CL-E2E-09-02: app1/app1/ ディレクトリが作成されない', async () => {
           await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
-          let doubleNestedExists = false;
-          try {
-            await Deno.stat(`${inputDir}/claude/2026-03/app1/app1`);
-            doubleNestedExists = true;
-          } catch (e) {
-            if (!(e instanceof Deno.errors.NotFound)) { throw e; }
-          }
-          assertEquals(doubleNestedExists, false);
+          assertEquals(await fileOrDirExists(`${inputDir}/claude/2026-03/app1/app1`), false);
         });
       });
     });
@@ -543,8 +528,7 @@ describe('main - AI 失敗フォールバック', () => {
         it('T-CL-E2E-06-01: misc/ にファイルが移動している', async () => {
           await main(['claude', '2026-03', '--input', inputDir, '--config', configFile]);
 
-          const stat = await Deno.stat(`${monthDir}/misc/chat.md`);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(`${monthDir}/misc/chat.md`), true);
         });
 
         it('T-CL-E2E-06-02: 完了ログに moved=1 が含まれる', async () => {

--- a/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.classify-file.integration.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.classify-file.integration.spec.ts
@@ -19,6 +19,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { ClassifyChatlogEntry } from '../../classes/ClassifyChatlogEntry.class.ts';
 // types
 import type { ClassifyStats } from '../../types/classify.types.ts';
+// exists
+import { dirExists, fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // ─── ヘルパー ────────────────────────────────────────────────────────────────
 
@@ -68,8 +70,7 @@ describe('classifyFile', () => {
 
           await classifyFile(fileMeta, 'app1', false, stats);
 
-          const dstDirStat = await Deno.stat(`${tempDir}/app1`);
-          assertEquals(dstDirStat.isDirectory, true);
+          assertEquals(await dirExists(`${tempDir}/app1`), true);
         });
 
         it('T-CL-CF-02-01: dstPath にファイルが存在する', async () => {
@@ -81,8 +82,7 @@ describe('classifyFile', () => {
 
           await classifyFile(fileMeta, 'app1', false, stats);
 
-          const dstStat = await Deno.stat(`${tempDir}/app1/a.md`);
-          assertEquals(dstStat.isFile, true);
+          assertEquals(await fileExists(`${tempDir}/app1/a.md`), true);
         });
 
         it('T-CL-CF-02-02: srcPath が存在しない', async () => {
@@ -94,14 +94,7 @@ describe('classifyFile', () => {
 
           await classifyFile(fileMeta, 'app1', false, stats);
 
-          let srcStillExists = false;
-          try {
-            await Deno.stat(srcPath);
-            srcStillExists = true;
-          } catch (e) {
-            if (!(e instanceof Deno.errors.NotFound)) { throw e; }
-          }
-          assertEquals(srcStillExists, false, 'srcPath がまだ存在する');
+          assertEquals(await fileOrDirExists(srcPath), false, 'srcPath がまだ存在する');
         });
 
         it('T-CL-CF-02-03: dstPath のテキストに "project: app1" が含まれる', async () => {

--- a/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts
@@ -6,8 +6,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { assert, assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
+import { assert, assertEquals, assertStringIncludes } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 
 const SCRIPT_PATH = new URL('../../classify-chatlog.ts', import.meta.url).pathname;
 const FIXTURE_SYSTEM_DATA = new URL('./fixtures', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
@@ -62,13 +63,9 @@ describe('[AI] main - 短文ファイルの misc 分類', { ignore: !_shouldRunA
           // AI をスキップしたことを stderr の warn ヘッダーで保証
           assertStringIncludes(stderr, '[skip-ai: too-short]');
 
-          const moved = await Deno.stat(`${monthDir}/misc/test-file.md`);
-          assert(moved.isFile);
+          assertEquals(await fileExists(`${monthDir}/misc/test-file.md`), true);
 
-          await assertRejects(
-            () => Deno.stat(`${monthDir}/test-file.md`),
-            Deno.errors.NotFound,
-          );
+          assertEquals(await fileOrDirExists(`${monthDir}/test-file.md`), false);
         });
       });
     });

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -17,6 +17,7 @@
 // -- external --
 import { isValidModel } from '../../_scripts/libs/ai/model-utils.ts';
 import { runAI } from '../../_scripts/libs/ai/run-ai.ts';
+import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { findEntries } from '../../_scripts/libs/file-io/find-entries.ts';
 import { getDirectory } from '../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
@@ -332,13 +333,7 @@ export const main = async (argv?: string[]): Promise<void> => {
 
     // 入力ディレクトリ確認
     const agentDir = `${_config.inputDir}/${_config.agent}`;
-    try {
-      const stat = await Deno.stat(agentDir);
-      if (!stat.isDirectory) {
-        throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
-      }
-    } catch (e) {
-      if (e instanceof ChatlogError) { throw e; }
+    if (!await dirExists(agentDir)) {
       throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
     }
 

--- a/skills/export-chatlog/scripts/__tests__/functional/write-session.functional.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/functional/write-session.functional.spec.ts
@@ -18,6 +18,8 @@ import { writeSession } from '../../libs/session-writer.ts';
 // ─── Helpers
 // types
 import type { ExportedSession } from '../../types/session.types.ts';
+// exists
+import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // ─── Internal Helpers
 
@@ -95,8 +97,7 @@ describe('writeSession', () => {
           const outPath = await writeSession(tempDir, 'claude', session);
           // Windows パス対応
           const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
-          const stat = await Deno.stat(normalizedPath);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(normalizedPath), true);
         });
       });
     });
@@ -212,8 +213,7 @@ describe('writeSession', () => {
           const nestedBase = `${tempDir}/deep/nested/dir`;
           const outPath = await writeSession(nestedBase, 'codex', session);
           const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
-          const stat = await Deno.stat(normalizedPath);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(normalizedPath), true);
         });
       });
     });

--- a/skills/export-chatlog/scripts/exporter/__tests__/fixtures/export-chatlog.fixtures.spec.ts
+++ b/skills/export-chatlog/scripts/exporter/__tests__/fixtures/export-chatlog.fixtures.spec.ts
@@ -24,6 +24,8 @@ import { findFixtureDirs } from '../../../../../_scripts/__tests__/helpers/find-
 // types
 import type { IsFixtureDirProvider } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
 import type { PeriodRange } from '../../../types/filter.types.ts';
+// exists
+import { fileExists } from '../../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // ─── Internal Helpers
 
@@ -53,12 +55,7 @@ const FIXTURES_DIR = new URL('../fixtures-data', import.meta.url)
 // functions
 /**  fixture ディレクトリチェック */
 const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
-  try {
-    await Deno.stat(`${dir}/input.jsonl`);
-    return true;
-  } catch {
-    return false;
-  }
+  return await fileExists(`${dir}/input.jsonl`);
 };
 
 /** output.yaml が存在する場合に読み込む（edge 系は null） */

--- a/skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-asserts.ts
+++ b/skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-asserts.ts
@@ -10,28 +10,24 @@
 // ─── BDD modules
 import { assertEquals } from '@std/assert';
 
+// ─── Helpers
+import { fileExists as _fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
+
 /**
  * 指定パスが通常ファイルとして存在することをアサートする。
  *
  * @param path - 確認するファイルの絶対パス
  */
 export const assertFileExists = async (path: string): Promise<void> => {
-  assertEquals((await Deno.stat(path)).isFile, true);
+  assertEquals(await _fileExists(path), true);
 };
 
 /**
  * 指定パスのファイルが存在するかどうかを返す。
  *
- * `Deno.stat` の成否でファイル存在を判定し、存在しない場合は `false` を返す。
+ * `fileOrDirExists` への alias。ファイル・ディレクトリを区別しない。
  *
  * @param path - 確認するファイルの絶対パス
  * @returns ファイルが存在すれば `true`、存在しなければ `false`
  */
-export const fileExists = async (path: string): Promise<boolean> => {
-  try {
-    await Deno.stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const fileExists = fileOrDirExists;

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/process-chunk.functional.spec.ts
@@ -28,6 +28,8 @@ import {
 // types
 import type { CommandMockHandle } from '../../../../../../skills/_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makePeriodDir } from '../../_helpers/chatlog-fixtures.ts';
+// exists
+import { fileExists, fileOrDirExists } from '../../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // ─── Internal Helpers
 
@@ -115,8 +117,7 @@ describe('processChunk', () => {
           errStub.restore();
           logStub.restore();
 
-          const stat = await Deno.stat(filePath);
-          assertEquals(stat.isFile, true);
+          assertEquals(await fileExists(filePath), true);
         });
 
         it('T-FL-PCK-01-02: stats.discarded が 1 になる', async () => {
@@ -167,13 +168,7 @@ describe('processChunk', () => {
           errStub.restore();
           logStub.restore();
 
-          let fileExists = true;
-          try {
-            await Deno.stat(filePath);
-          } catch {
-            fileExists = false;
-          }
-          assertEquals(fileExists, false);
+          assertEquals(await fileOrDirExists(filePath), false);
         });
 
         it('T-FL-PCK-02-02: stats.discarded が 1 になる', async () => {

--- a/skills/filter-chatlog/scripts/__tests__/functional/prefilter/classify-file.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/prefilter/classify-file.functional.spec.ts
@@ -49,7 +49,10 @@ describe('classifyFile', () => {
       /** isNoise=true かつ reason にファイル名パターンの説明が含まれることを検証する。 */
       describe('Then: T-PF-CL-01 - isNoise=true が返される', () => {
         it('T-PF-CL-01-01: isNoise が true になる', () => {
-          const { isNoise } = classifyFile('say-ok-and-nothing-else.md', makeValidContent(PREFILTER_MIN_CONTENT_LENGTH));
+          const { isNoise } = classifyFile(
+            'say-ok-and-nothing-else.md',
+            makeValidContent(PREFILTER_MIN_CONTENT_LENGTH),
+          );
 
           assertEquals(isNoise, true);
         });

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -22,6 +22,7 @@ import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.
 
 // -- external --
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
+import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
@@ -143,12 +144,10 @@ const _resolveSearchDir = async (
   // YYYY-MM 形式の場合、YYYY/YYYY-MM 構造にも対応
   const yearDir = `${baseDir}/${period.slice(0, 4)}/${period}`;
   const flatDir = `${baseDir}/${period}`;
-  try {
-    await Deno.stat(yearDir);
+  if (await dirExists(yearDir)) {
     return project ? `${yearDir}/${project}` : yearDir;
-  } catch {
-    return project ? `${flatDir}/${project}` : flatDir;
   }
+  return project ? `${flatDir}/${project}` : flatDir;
 };
 
 export const findMdFiles = async (
@@ -390,13 +389,7 @@ export const main = async (args?: string[]): Promise<void> => {
     const agentDir = `${inputDir}/${agent}`;
 
     // 入力ディレクトリ確認
-    try {
-      const stat = await Deno.stat(agentDir);
-      if (!stat.isDirectory) {
-        throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
-      }
-    } catch (e) {
-      if (e instanceof ChatlogError) { throw e; }
+    if (!await dirExists(agentDir)) {
       throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
     }
 

--- a/skills/filter-chatlog/scripts/prefilter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/prefilter-chatlog.ts
@@ -30,6 +30,7 @@
  */
 
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
+import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-files.ts';
 import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
@@ -231,12 +232,7 @@ const _resolveSearchDir = async (baseDir: string, agent: string, period?: string
   // YYYY-MM 直下構造（claude等）
   const _flat = `${_agentDir}/${period}`;
 
-  try {
-    const stat = await Deno.stat(_withYear);
-    return stat.isDirectory ? _withYear : _flat;
-  } catch {
-    return _flat;
-  }
+  return await dirExists(_withYear) ? _withYear : _flat;
 };
 
 export const findMdFiles = async (baseDir: string, agent: string, period?: string): Promise<string[]> => {
@@ -293,11 +289,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
   try {
     const { agent, period, inputDir, dryRun, report } = parseArgs(args);
 
-    try {
-      const stat = await Deno.stat(inputDir);
-      if (!stat.isDirectory) { throw new Error(); }
-    } catch (e) {
-      if (e instanceof ChatlogError) { throw e; }
+    if (!await dirExists(inputDir)) {
       throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${inputDir}`);
     }
 

--- a/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-segments.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-segments.spec.ts
@@ -29,6 +29,8 @@ import {
   makeSuccessMock,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { DenoCommandLike } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+// exists
+import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // test target
 import { segmentChatlog } from '../../normalize-chatlog.ts';
@@ -93,10 +95,9 @@ async function _collectFixtureDirs(rootDir: string): Promise<string[]> {
       if (!entry.isDirectory) { continue; }
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       const childAbs = `${dir}/${entry.name}`;
-      try {
-        await Deno.stat(`${childAbs}/input.md`);
+      if (await fileExists(`${childAbs}/input.md`)) {
         dirs.push(childRel);
-      } catch {
+      } else {
         await _walk(childAbs, childRel);
       }
     }

--- a/skills/normalize-chatlog/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/functional/normalize-chatlog.functional.spec.ts
@@ -158,6 +158,11 @@ describe('segmentChatlog', () => {
 
 // ─── writeOutput tests ────────────────────────────────────────────────────────
 
+// ─── Internal Helpers
+
+/** ファイルとして存在することを示す `stat` スタブ返し値。`fileExists` が `true` を返す前提条件に使用する。 */
+const _existingFileStat = () => Promise.resolve({ isFile: true } as Deno.FileInfo);
+
 /**
  * writeOutput の機能テスト。
  * Deno.stat / Deno.rename / Deno.writeTextFile をモック化し、
@@ -227,7 +232,7 @@ describe('writeOutput', () => {
     describe('When: writeOutput を呼び出す', () => {
       describe('Then: Task T-13-02 - 既存ファイルのリネームと新規書き込み', () => {
         it('T-13-02-01: 既存ファイルを .old-01.md にリネームしてから書き込む', async () => {
-          statStub = stub(Deno, 'stat', () => Promise.resolve({} as Deno.FileInfo));
+          statStub = stub(Deno, 'stat', _existingFileStat);
           const renamedArgs: Array<[string, string]> = [];
           renameStub = stub(Deno, 'rename', (from: string | URL, to: string | URL) => {
             renamedArgs.push([String(from), String(to)]);
@@ -246,7 +251,7 @@ describe('writeOutput', () => {
         });
 
         it('T-13-02-02: .old-01.md が既にある場合は .old-02.md にリネームする', async () => {
-          statStub = stub(Deno, 'stat', () => Promise.resolve({} as Deno.FileInfo));
+          statStub = stub(Deno, 'stat', _existingFileStat);
           const renamedArgs: Array<[string, string]> = [];
           renameStub = stub(Deno, 'rename', (from: string | URL, to: string | URL) => {
             renamedArgs.push([String(from), String(to)]);
@@ -314,7 +319,7 @@ describe('writeOutput', () => {
       describe('When: writeOutput を呼び出す', () => {
         describe('Then: Task T-13-05 - バックアップスロット上限超過で Error をスローする', () => {
           it('T-13-05-01: "too many backups" エラーをスローする', async () => {
-            statStub = stub(Deno, 'stat', () => Promise.resolve({} as Deno.FileInfo));
+            statStub = stub(Deno, 'stat', _existingFileStat);
             renameStub = stub(Deno, 'rename', () => Promise.resolve());
             const allSlots = Array.from({ length: 99 }, (_, i) => `entry.old-${String(i + 1).padStart(2, '0')}.md`);
             const stats: Stats = { success: 0, skip: 0, fail: 0 };

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
@@ -18,6 +18,8 @@ import {
   makeSuccessMock,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+// exists
+import { fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 
 // test target
 import {
@@ -92,13 +94,7 @@ describe('writeOutput', () => {
       await writeOutput(outputPath, 'content', true, stats);
 
       // assert
-      let fileExists = true;
-      try {
-        await Deno.stat(outputPath);
-      } catch {
-        fileExists = false;
-      }
-      assertEquals(fileExists, false);
+      assertEquals(await fileOrDirExists(outputPath), false);
       assertEquals(stats.success, 0);
     });
   });

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { normalizeLine } from '../../../../_scripts/libs/text/line-utils.ts';
 
 // test target
@@ -81,10 +82,9 @@ async function _collectFixtureDirs(rootDir: string): Promise<string[]> {
       if (!entry.isDirectory) { continue; }
       const childAbs = `${dir}/${entry.name}`;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
-      try {
-        await Deno.stat(`${childAbs}/input.md`);
+      if (await fileExists(`${childAbs}/input.md`)) {
         dirs.push(childRel);
-      } catch {
+      } else {
         // input.md がなければ子ディレクトリを再帰的にスキャン
         await _scan(childAbs, childRel);
       }

--- a/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
@@ -15,6 +15,9 @@ import { stub } from '@std/testing/mock';
 import type { FrontmatterFileMeta, FrontmatterResult, Stats } from '../../set-frontmatter.ts';
 import { writeFrontmatter } from '../../set-frontmatter.ts';
 
+// exists
+import { fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
+
 // ─── テスト共通セットアップ ───────────────────────────────────────────────────
 
 let tempDir: string;
@@ -213,14 +216,7 @@ describe('writeFrontmatter', () => {
 
           await writeFrontmatter(fm, result, false, stats);
 
-          let tmpExists = false;
-          try {
-            await Deno.stat(`${filePath}.tmp`);
-            tmpExists = true;
-          } catch {
-            tmpExists = false;
-          }
-          assertEquals(tmpExists, false);
+          assertEquals(await fileOrDirExists(`${filePath}.tmp`), false);
         });
       });
     });

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -26,6 +26,7 @@
 // -- external --
 import { parse as parseYaml } from '@std/yaml';
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
+import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
@@ -558,11 +559,7 @@ export const main = async (args: string[]): Promise<void> => {
   try {
     const { targetDir, dicsDir, dryRun, review, concurrency } = parseArgs(args);
 
-    try {
-      const stat = await Deno.stat(targetDir);
-      if (!stat.isDirectory) { throw new Error(); }
-    } catch (e) {
-      if (e instanceof ChatlogError) { throw e; }
+    if (!await dirExists(targetDir)) {
       throw new ChatlogError('InputNotFound', `ディレクトリが見つかりません: ${targetDir}`);
     }
 


### PR DESCRIPTION
## Overview

**Summary**
Add shared file/directory existence utilities and migrate all callers across the project.

**Background / Motivation**
各スクリプトやテストで `Deno.stat` を直接呼び出し、`NotFound` エラー処理を個別に記述していた。
共有ヘルパーを導入することで重複コードを排除し、存在チェックのロジックを一元管理できるようにした。

## Changes

- `skills/_scripts/libs/file-io/exists-utils.ts` を新規追加: `fileExists`/`dirExists`/`fileOrDirExists` ユーティリティ
  （`StatProvider` 型注入によりテスタビリティを確保）
- スクリプト側（5ファイル）: `Deno.stat` の直接呼び出しを `dirExists`/`fileExists` に置き換え
- テスト側（21ファイル）: `Deno.stat` / `stat` 呼び出しを `fileExists`/`fileOrDirExists` に統一

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #cle-f1o

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional Notes

プロジェクト全体（スクリプト・テスト・ヘルパー計26ファイル）の `Deno.stat` 呼び出しを一括移行。
ロジックの変更はなく、純粋なリファクタリング。