### PR TITLE
refactor(file-io/backup-old-path): rename module and improve testability

### DIFF
--- a/skills/_scripts/libs/file-io/__tests__/system/backup-old-path.system.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/system/backup-old-path.system.spec.ts
@@ -1,4 +1,4 @@
-// src: scripts/libs/__tests__/system/backup.system.spec.ts
+// src: scripts/libs/__tests__/system/backup-old-path.system.spec.ts
 // @(#): backupOldPath のシステムテスト（Deno ファイルシステム実使用）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -9,7 +9,7 @@
 import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
-import { backupOldPath } from '../../backup.ts';
+import { backupOldPath } from '../../backup-old-path.ts';
 import { fileExists, fileOrDirExists } from '../../exists-utils.ts';
 
 // ─────────────────────────────────────────────

--- a/skills/_scripts/libs/file-io/__tests__/unit/backup-old-path.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/backup-old-path.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: scripts/libs/__tests__/unit/backup.unit.spec.ts
+// src: scripts/libs/__tests__/unit/backup-old-path.unit.spec.ts
 // @(#): backupOldPath のユニットテスト
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -6,19 +6,25 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// ─── BDD modules
 import { assertRejects } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
-import { backupOldPath } from '../../backup.ts';
+// ─── Test target
+import { backupOldPath } from '../../backup-old-path.ts';
 
-// ─────────────────────────────────────────────
-// backupOldPath
-// ─────────────────────────────────────────────
+// ─── Internal Helpers
+
+// functions
+/** ファイルが常に存在するように見せる `StatProvider` フェイク。 */
+const _fakeStatExists = (_path: string): Promise<Deno.FileInfo> => Promise.resolve({ isFile: true } as Deno.FileInfo);
+
+// ─── Tests
 
 /**
  * `backupOldPath` のユニットテストスイート。
  *
- * Fake の listDir を使い、Deno ファイルシステムに依存せず
+ * Fake の listDir / statProvider を使い、Deno ファイルシステムに依存せず
  * エラー処理ロジックをカバーする。
  *
  * @see backupOldPath
@@ -39,22 +45,12 @@ describe('backupOldPath', () => {
             return Array.from({ length: 99 }, (_, i) => `output.old-${String(i + 1).padStart(2, '0')}.md`);
           };
 
-          // フェイクの stat: ファイルが存在するように見せる
-          const origStat = Deno.stat;
-          // deno-lint-ignore no-explicit-any
-          (Deno as any).stat = (_path: string) => ({ isFile: true });
-
-          try {
-            // act & assert
-            await assertRejects(
-              () => backupOldPath(outputPath, fakeListDir),
-              Error,
-              'too many backups',
-            );
-          } finally {
-            // deno-lint-ignore no-explicit-any
-            (Deno as any).stat = origStat;
-          }
+          // act & assert
+          await assertRejects(
+            () => backupOldPath(outputPath, fakeListDir, _fakeStatExists),
+            Error,
+            'too many backups',
+          );
         });
       });
     });

--- a/skills/_scripts/libs/file-io/backup-old-path.ts
+++ b/skills/_scripts/libs/file-io/backup-old-path.ts
@@ -1,5 +1,5 @@
-// src: skills/_scripts/libs/file-io/backup.ts
-// @(#): ファイルバックアップユーティリティ
+// src: skills/_scripts/libs/file-io/backup-old-path.ts
+// @(#): 既存ファイルを連番バックアップ (.old-NN.md) にリネームするユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -17,7 +17,7 @@
 // functions
 import { fileExists } from './exists-utils.ts';
 // types
-import type { ListDirProvider } from '../../types/providers.types.ts';
+import type { ListDirProvider, StatProvider } from '../../types/providers.types.ts';
 // classes
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 
@@ -32,12 +32,24 @@ import { ChatlogError } from '../../classes/ChatlogError.class.ts';
  * @param dir - スキャンするディレクトリパス
  * @returns ファイル名の配列
  */
-export const defaultListDir = async (dir: string): Promise<string[]> => {
-  const names: string[] = [];
-  for await (const entry of Deno.readDir(dir)) {
-    names.push(entry.name);
-  }
-  return names;
+const _defaultListDir = async (dir: string): Promise<string[]> =>
+  (await Array.fromAsync(Deno.readDir(dir))).map((e) => e.name);
+
+/**
+ * ファイル名一覧から `<baseName>.old-NN.md` 形式のスロット番号を検索し、
+ * 次の空きスロット番号を返す。
+ *
+ * @param files    - ディレクトリ内のファイル名一覧
+ * @param baseName - バックアップ対象のベース名（拡張子なし）
+ * @returns 次の空きスロット番号（1〜100、100 は上限超過を示す）
+ */
+const _findNextSlot = (files: string[], baseName: string): number => {
+  const _pattern = new RegExp(`^${baseName}\\.old-(\\d{2})\\.md$`);
+  const _used = files
+    .map((name) => _pattern.exec(name))
+    .filter((m) => m !== null)
+    .map((m) => Number(m![1]));
+  return _used.length === 0 ? 1 : Math.max(..._used) + 1;
 };
 
 // ─────────────────────────────────────────────
@@ -54,31 +66,27 @@ export const defaultListDir = async (dir: string): Promise<string[]> => {
  * - `entry.md`（バックアップなし）→ `entry.old-01.md` にリネーム
  * - `entry.md`（`entry.old-01.md` 既存）→ `entry.old-02.md` にリネーム
  *
- * @param outputPath - バックアップ対象のファイルパス（`.md` 拡張子推奨）
- * @param listDir    - ディレクトリ一覧取得関数（テスト用インジェクション可能、デフォルト: `defaultListDir`）
+ * @param outputPath   - バックアップ対象のファイルパス（`.md` 拡張子推奨）
+ * @param listDir      - ディレクトリ一覧取得関数（テスト用インジェクション可能、デフォルト: `defaultListDir`）
+ * @param statProvider - ファイル存在確認関数（テスト用インジェクション可能、デフォルト: `Deno.stat`）
  * @returns void
  * @throws {Error} バックアップスロットが 99 を超えた場合
  */
 export const backupOldPath = async (
   outputPath: string,
-  listDir: ListDirProvider = defaultListDir,
+  listDir: ListDirProvider = _defaultListDir,
+  statProvider: StatProvider = Deno.stat,
 ): Promise<void> => {
-  if (!await fileExists(outputPath)) {
+  if (!await fileExists(outputPath, statProvider)) {
     return;
   }
 
   const base = outputPath.endsWith('.md') ? outputPath.slice(0, -3) : outputPath;
   const dir = base.includes('/') ? base.slice(0, base.lastIndexOf('/')) : '.';
   const baseName = base.includes('/') ? base.slice(base.lastIndexOf('/') + 1) : base;
-  const backupPattern = new RegExp(`^${baseName}\\.old-(\\d{2})\\.md$`);
 
-  const files = await listDir(dir);
-  const usedSlots = files
-    .map((name) => backupPattern.exec(name))
-    .filter((m) => m !== null)
-    .map((m) => Number(m![1]));
-
-  const next = usedSlots.length === 0 ? 1 : Math.max(...usedSlots) + 1;
+  const _files = await listDir(dir);
+  const next = _findNextSlot(_files, baseName);
   if (next > 99) { throw new ChatlogError('TooManyBackups', `too many backups for: ${outputPath}`); }
 
   const idx = String(next).padStart(2, '0');

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -11,7 +11,7 @@
 // ─────────────────────────────────────────────
 
 // types
-import type { StatSyncProvider } from '../../_scripts/types/providers.types.ts';
+import type { ListDirProvider, StatSyncProvider } from '../../_scripts/types/providers.types.ts';
 
 // classes
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
@@ -20,7 +20,7 @@ import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { isValidModel } from '../../_scripts/libs/ai/model-utils.ts';
 
 // -- file-io --
-import { backupOldPath, defaultListDir } from '../../_scripts/libs/file-io/backup.ts';
+import { backupOldPath } from '../../_scripts/libs/file-io/backup-old-path.ts';
 import { dirExistsSync } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
@@ -349,7 +349,7 @@ export const writeOutput = async (
   content: string,
   dryRun: boolean,
   stats: Stats,
-  listDir: (dir: string) => Promise<string[]> = defaultListDir,
+  listDir: ListDirProvider = (dir) => Array.fromAsync(Deno.readDir(dir), (e) => e.name),
 ): Promise<void> => {
   if (dryRun) {
     logger.info(`[dry-run] would write: ${outputPath}`);


### PR DESCRIPTION
## Overview

**Summary**
Rename `backup.ts` to `backup-old-path.ts` and introduce an injectable `StatProvider` for improved testability.

**Background / Motivation**
The original `backup.ts` filename did not reflect its single responsibility (backing up old paths). Renaming to `backup-old-path.ts` clarifies intent. Additionally, the module relied on direct `Deno.stat` calls, making unit tests difficult. Introducing an injectable `StatProvider` dependency aligns this module with the `ListDirProvider` convention used throughout `file-io`.

## Changes

### Core Changes

- `skills/_scripts/libs/file-io/backup-old-path.ts` — renamed from `backup.ts`; added injectable `StatProvider`; extracted `_findNextSlot` and `_defaultListDir` helpers; improved parameter documentation
- `skills/normalize-chatlog/scripts/normalize-chatlog.ts` — updated import path from `backup.ts` to `backup-old-path.ts`; imported `ListDirProvider` type from `providers.types.ts`

### Test Updates

- `skills/_scripts/libs/file-io/__tests__/unit/backup-old-path.unit.spec.ts` — renamed from `backup.unit.spec.ts`; replaced `Deno.stat` monkey-patching with injectable `StatProvider` stub; improved helper organization
- `skills/_scripts/libs/file-io/__tests__/system/backup-old-path.system.spec.ts` — renamed from `backup.system.spec.ts`; updated import path and source header

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Related to #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes) — N/A (internal utility)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

No breaking changes. The rename is internal to `_scripts/libs/`; all consumers in this PR have been updated accordingly. No public API surface is affected.

The injectable `StatProvider` pattern aligns with the existing `ListDirProvider` convention used throughout `file-io`.
