### PR TITLE
refactor(filter): rename chatlogDir to chatlogsDir and add --chatlogs-dir option

### DIFF
--- a/assets/configs/config.yaml
+++ b/assets/configs/config.yaml
@@ -21,4 +21,4 @@ concurrency: 4
 # アセットディレクトリ
 dicsDir: "./assets/dics"
 promptsDir: "./assets/prompts"
-chatlogDir: "./chatlogs"
+chatlogsDir: "./chatlogs"

--- a/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
@@ -342,40 +342,40 @@ describe('GlobalConfig', () => {
     });
   });
 
-  // ─── chatlogDir ────────────────────────────────────────────────────────────
+  // ─── chatlogsDir ────────────────────────────────────────────────────────────
 
-  describe('chatlogDir', () => {
+  describe('chatlogsDir', () => {
     const _existsStat: StatProvider = (_path) => Promise.resolve({ isFile: true } as Deno.FileInfo);
     const _makeReadOk = (content: string): ReadTextFileProvider => (_path) => Promise.resolve(content);
 
-    it('T-CLS-GC-50: get("chatlogDir") がデフォルト値 "./chatlog" を返す', async () => {
+    it('T-CLS-GC-50: get("chatlogsDir") がデフォルト値 "./chatlogs" を返す', async () => {
       const _config = await GlobalConfig.getInstance();
-      assertEquals(_config.get('chatlogDir'), './chatlog');
+      assertEquals(_config.get('chatlogsDir'), './chatlogs');
     });
 
-    it('T-CLS-GC-51: parseYaml({ chatlogDir: "/custom/chatlog" }) が正しく返す', async () => {
+    it('T-CLS-GC-51: parseYaml({ chatlogsDir: "/custom/chatlog" }) が正しく返す', async () => {
       const _config = await GlobalConfig.getInstance();
-      assertEquals(_config.parseYaml({ chatlogDir: '/custom/chatlog' }), { chatlogDir: '/custom/chatlog' });
+      assertEquals(_config.parseYaml({ chatlogsDir: '/custom/chatlog' }), { chatlogsDir: '/custom/chatlog' });
     });
 
-    it('T-CLS-GC-52: parseYaml({ chatlogDir: null }) が { chatlogDir: "" } を返す', async () => {
+    it('T-CLS-GC-52: parseYaml({ chatlogsDir: null }) が { chatlogsDir: "" } を返す', async () => {
       const _config = await GlobalConfig.getInstance();
-      assertEquals(_config.parseYaml({ chatlogDir: null }), { chatlogDir: '' });
+      assertEquals(_config.parseYaml({ chatlogsDir: null }), { chatlogsDir: '' });
     });
 
-    it('T-CLS-GC-53: parseYaml({ chatlogDir: 42 }) が TypeError をスローする', async () => {
+    it('T-CLS-GC-53: parseYaml({ chatlogsDir: 42 }) が TypeError をスローする', async () => {
       const _config = await GlobalConfig.getInstance();
-      assertThrows(() => _config.parseYaml({ chatlogDir: 42 }), TypeError);
+      assertThrows(() => _config.parseYaml({ chatlogsDir: 42 }), TypeError);
     });
 
-    it('T-CLS-GC-54: loadConfigFile で chatlogDir を含む YAML が正しく変換される', async () => {
+    it('T-CLS-GC-54: loadConfigFile で chatlogsDir を含む YAML が正しく変換される', async () => {
       const _config = await GlobalConfig.getInstance();
       const _result = await _config.loadConfigFile({
         configPath: '/mock/config.yaml',
-        readTextFileProvider: _makeReadOk('chatlogDir: /custom/chatlog\n'),
+        readTextFileProvider: _makeReadOk('chatlogsDir: /custom/chatlog\n'),
         statProvider: _existsStat,
       });
-      assertEquals(_result, { chatlogDir: '/custom/chatlog' });
+      assertEquals(_result, { chatlogsDir: '/custom/chatlog' });
     });
   });
 });

--- a/skills/_scripts/constants/defaults.constants.ts
+++ b/skills/_scripts/constants/defaults.constants.ts
@@ -19,7 +19,7 @@ export const DEFAULT_CONFIG_FILE = 'assets/configs/config.yaml';
 // ディレクトリ
 // ─────────────────────────────────────────────
 
-/** config.yaml の chatlogDir に対応するデフォルトのチャットログ出力ディレクトリ。 */
+/** config.yaml の chatlogsDir に対応するデフォルトのチャットログ出力ディレクトリ。 */
 export const DEFAULT_CHATLOG_DIR = './chatlogs';
 
 // ─────────────────────────────────────────────

--- a/skills/_scripts/constants/schema.constants.ts
+++ b/skills/_scripts/constants/schema.constants.ts
@@ -32,7 +32,7 @@ export const DEFAULT_SCHEMA: Record<string, SchemaValueTypeName> = {
   /** プロンプトテンプレートが置かれたディレクトリのパス。 */
   promptsDir: 'string',
   /** チャットログの入出力ディレクトリのパス。 */
-  chatlogDir: 'string',
+  chatlogsDir: 'string',
 };
 
 /** DEFAULT_SCHEMA のキーのユニオン型。 */
@@ -66,5 +66,5 @@ export const DEFAULT_VALUES: ConfigValues = {
   /** デフォルトプロンプトディレクトリ */
   promptsDir: './assets/prompts',
   /** デフォルトチャットログディレクトリ */
-  chatlogDir: './chatlog',
+  chatlogsDir: './chatlogs',
 } as const;

--- a/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts
@@ -284,11 +284,11 @@ describe('buildConfig', () => {
   });
 
   describe('Given: parsed.inputDir が指定されている', () => {
-    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
+    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
       describe('Then: T-CL-BC-20 - parsed.inputDir が最優先される', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogDir: /global/chatlog');
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /global/chatlog');
         });
         it('T-CL-BC-20-01: parsed.inputDir=/custom/input → result.inputDir === /custom/input', () => {
           const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom/input' }, globalConfig);
@@ -299,26 +299,26 @@ describe('buildConfig', () => {
   });
 
   describe('Given: parsed.inputDir が未指定', () => {
-    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
-      describe('Then: T-CL-BC-21 - GlobalConfig の chatlogDir が使われる', () => {
+    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
+      describe('Then: T-CL-BC-21 - GlobalConfig の chatlogsDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogDir: /global/chatlog');
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /global/chatlog');
         });
-        it('T-CL-BC-21-01: inputDir 未指定, globalConfig.chatlogDir=/global/chatlog → result.inputDir === /global/chatlog', () => {
+        it('T-CL-BC-21-01: inputDir 未指定, globalConfig.chatlogsDir=/global/chatlog → result.inputDir === /global/chatlog', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
           assertEquals(result.inputDir, '/global/chatlog');
         });
       });
     });
 
-    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+    describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
       describe('Then: T-CL-BC-15 - DEFAULT_CLASSIFY_CONFIG.inputDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it('T-CL-BC-15-01: inputDir 未指定, chatlogDir 未登録 → result.inputDir === DEFAULT_CLASSIFY_CONFIG.inputDir', () => {
+        it('T-CL-BC-15-01: inputDir 未指定, chatlogsDir 未登録 → result.inputDir === DEFAULT_CLASSIFY_CONFIG.inputDir', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
           assertEquals(result.inputDir, DEFAULT_CLASSIFY_CONFIG.inputDir);
         });

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -90,7 +90,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
  * ParsedConfig・GlobalConfig・デフォルト値から完全な ClassifyConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - model 優先順位: `parsed.model` > `globalConfig.get('model')` > `defaults.model`
- * - inputDir 優先順位: `parsed.inputDir` > `globalConfig.get('chatlogDir')` > `defaults.inputDir`
+ * - inputDir 優先順位: `parsed.inputDir` > `globalConfig.get('chatlogsDir')` > `defaults.inputDir`
  * - dicsDir 優先順位: `globalConfig.get('dicsDir')` > `defaults.dicsDir`
  * - projectsDic: `parsed.configFile` のディレクトリ + `/projects.dic`。未指定時は `defaults.projectsDic`。
  * - 不正なモデル名は `ChatlogError('InvalidArgs')` をスローする。
@@ -108,7 +108,7 @@ export function buildConfig(
   }
   const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? _defaults.agent;
   const _dicsDir = (globalConfig.get('dicsDir') as string | undefined) ?? _defaults.dicsDir;
-  const _inputDir = parsed.inputDir ?? (globalConfig.get('chatlogDir') as string | undefined) ?? _defaults.inputDir;
+  const _inputDir = parsed.inputDir ?? (globalConfig.get('chatlogsDir') as string | undefined) ?? _defaults.inputDir;
   const _projectsDic = parsed.configFile
     ? `${getDirectory(parsed.configFile)}/projects.dic`
     : _defaults.projectsDic;

--- a/skills/export-chatlog/scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts
@@ -82,7 +82,7 @@ const _EMPTY_PARSED: ParsedConfig = {};
  *
  * ## 優先順位ルール
  * - `agent`     : parsed > globalConfig > defaults
- * - `outputDir` : parsed > globalConfig.chatlogDir > defaults
+ * - `outputDir` : parsed > globalConfig.chatlogsDir > defaults
  * - `baseDir`   : parsed のみ（GlobalConfig 連携なし）
  * - `inputDir`  : parsed のみ（GlobalConfig 連携なし）
  * - `period`    : parsed のみ
@@ -163,16 +163,16 @@ describe('buildConfig', () => {
    * `parsed.outputDir` がセットされている前提条件グループ。
    *
    * CLI 引数 `--output` で出力ディレクトリが明示されたケースを表す。
-   * `globalConfig.chatlogDir` より `parsed.outputDir` が優先されることを検証する。
+   * `globalConfig.chatlogsDir` より `parsed.outputDir` が優先されることを検証する。
    */
   describe('Given: parsed.outputDir が指定されている', () => {
-    /** `globalConfig` に `chatlogDir` が設定されているとき。 */
-    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
-      /** `parsed.outputDir` が `globalConfig.chatlogDir` より優先されることを検証する。 */
+    /** `globalConfig` に `chatlogsDir` が設定されているとき。 */
+    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
+      /** `parsed.outputDir` が `globalConfig.chatlogsDir` より優先されることを検証する。 */
       describe('Then: T-EC-BC-04 - parsed.outputDir が優先される', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogDir: /global');
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
         it('T-EC-BC-04-01: parsed.outputDir=/out → result.outputDir === /out', () => {
           const result = buildConfig({ ..._EMPTY_PARSED, outputDir: '/out' }, globalConfig);
@@ -186,34 +186,34 @@ describe('buildConfig', () => {
    * `parsed.outputDir` が未設定である前提条件グループ。
    *
    * CLI 引数 `--output` が省略されたケースを表す。
-   * `globalConfig.chatlogDir` が設定されていればそれを使い、
+   * `globalConfig.chatlogsDir` が設定されていればそれを使い、
    * なければ `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
    */
   describe('Given: parsed.outputDir が未指定', () => {
-    /** `globalConfig` に `chatlogDir` が設定されているとき。 */
-    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
-      /** `globalConfig.chatlogDir` が採用されることを検証する。 */
-      describe('Then: T-EC-BC-05 - GlobalConfig の chatlogDir が使われる', () => {
+    /** `globalConfig` に `chatlogsDir` が設定されているとき。 */
+    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
+      /** `globalConfig.chatlogsDir` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-05 - GlobalConfig の chatlogsDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogDir: /global/chatlog');
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /global/chatlog');
         });
-        it('T-EC-BC-05-01: globalConfig.chatlogDir=/global/chatlog → result.outputDir === /global/chatlog', () => {
+        it('T-EC-BC-05-01: globalConfig.chatlogsDir=/global/chatlog → result.outputDir === /global/chatlog', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
           assertEquals(result.outputDir, '/global/chatlog');
         });
       });
     });
 
-    /** `globalConfig` のスキーマに `chatlogDir` が登録されていないとき。 */
-    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+    /** `globalConfig` のスキーマに `chatlogsDir` が登録されていないとき。 */
+    describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
       /** `DEFAULT_OUTPUT_DIR` にフォールバックされることを検証する。 */
       describe('Then: T-EC-BC-06 - DEFAULT_OUTPUT_DIR が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it("T-EC-BC-06-01: outputDir 未設定, chatlogDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
+        it("T-EC-BC-06-01: outputDir 未設定, chatlogsDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
           assertEquals(result.outputDir, DEFAULT_OUTPUT_DIR);
         });
@@ -371,18 +371,18 @@ describe('buildConfig', () => {
    * `buildConfig` の第 3 引数 `defaults` が省略されている前提条件グループ。
    *
    * 省略時は内部で `DEFAULT_EXPORT_CONFIG` が使われる。
-   * `chatlogDir` も未登録の場合に `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
+   * `chatlogsDir` も未登録の場合に `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
    */
   describe('Given: defaults 引数が省略されている', () => {
-    /** `globalConfig` のスキーマに `chatlogDir` が登録されていないとき。 */
-    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+    /** `globalConfig` のスキーマに `chatlogsDir` が登録されていないとき。 */
+    describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
       /** `DEFAULT_OUTPUT_DIR` が採用されることを検証する。 */
       describe('Then: T-EC-BC-13 - DEFAULT_OUTPUT_DIR が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it("T-EC-BC-13-01: defaults 省略, chatlogDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
+        it("T-EC-BC-13-01: defaults 省略, chatlogsDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
           assertEquals(result.outputDir, DEFAULT_OUTPUT_DIR);
         });
@@ -394,18 +394,18 @@ describe('buildConfig', () => {
    * `defaults.outputDir` にカスタム値が指定されている前提条件グループ。
    *
    * `buildConfig` の第 3 引数でデフォルト値を上書きするケースを表す。
-   * `globalConfig` に `chatlogDir` が未登録の場合、`defaults.outputDir` が採用されることを検証する。
+   * `globalConfig` に `chatlogsDir` が未登録の場合、`defaults.outputDir` が採用されることを検証する。
    */
   describe('Given: defaults.outputDir=/custom が指定されている', () => {
-    /** `globalConfig` のスキーマに `chatlogDir` が登録されていないとき。 */
-    describe('When: GlobalConfig に chatlogDir が未登録（schema: {}）', () => {
+    /** `globalConfig` のスキーマに `chatlogsDir` が登録されていないとき。 */
+    describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
       /** `defaults.outputDir` が採用されることを検証する。 */
       describe('Then: T-EC-BC-14 - defaults.outputDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it('T-EC-BC-14-01: defaults.outputDir=/custom, chatlogDir 未登録 → result.outputDir === /custom', () => {
+        it('T-EC-BC-14-01: defaults.outputDir=/custom, chatlogsDir 未登録 → result.outputDir === /custom', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig, {
             ...DEFAULT_EXPORT_CONFIG,
             outputDir: '/custom',

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -67,7 +67,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な ExportConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - outputDir 優先順位: `parsed.outputDir` > `globalConfig.get('chatlogDir')` > `defaults.outputDir`
+ * - outputDir 優先順位: `parsed.outputDir` > `globalConfig.get('chatlogsDir')` > `defaults.outputDir`
  * - baseDir 優先順位: `parsed.baseDir` > `defaults.baseDir`
  * - inputDir 優先順位: `parsed.inputDir` > `defaults.inputDir`
  * - period: `parsed.period` のみ (GlobalConfig に期間設定なし)
@@ -79,7 +79,7 @@ export function buildConfig(
 ): ExportConfig {
   const _defaults = defaults ?? DEFAULT_EXPORT_CONFIG;
   const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? _defaults.agent;
-  const _outputDir = parsed.outputDir ?? (globalConfig.get('chatlogDir') as string | undefined) ?? _defaults.outputDir;
+  const _outputDir = parsed.outputDir ?? (globalConfig.get('chatlogsDir') as string | undefined) ?? _defaults.outputDir;
   const _baseDir = parsed.baseDir ?? _defaults.baseDir;
   const _inputDir = parsed.inputDir ?? _defaults.inputDir;
   const { configFile: _configFile, ...parsedRest } = parsed;

--- a/skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-fixtures.ts
+++ b/skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-fixtures.ts
@@ -103,21 +103,21 @@ export const makePeriodDir = async (
 };
 
 /**
- * テスト用の一時ディレクトリを 1 期間分作成し、chatlogDir を返す。
+ * テスト用の一時ディレクトリを 1 期間分作成し、chatlogsDir を返す。
  *
  * E2E テスト向けの単一期間ヘルパー。`tempDir/agent/YYYY/YYYY-MM/` を作成し、
- * そのパスを `chatlogDir` として返す。
+ * そのパスを `chatlogsDir` として返す。
  *
  * @param agent - エージェント名（デフォルト: 'claude'）
  * @param period - 対象月（YYYY-MM 形式、デフォルト: '2026-03'）
- * @returns `{ tempDir, chatlogDir }` — `chatlogDir` = `tempDir/agent/YYYY/YYYY-MM/`
+ * @returns `{ tempDir, chatlogsDir }` — `chatlogsDir` = `tempDir/agent/YYYY/YYYY-MM/`
  */
 export const makeTestDirs = async (agent = 'claude', period = '2026-03'): Promise<{
   tempDir: string;
-  chatlogDir: string;
+  chatlogsDir: string;
 }> => {
   const tempDir = await Deno.makeTempDir();
-  const chatlogDir = `${tempDir}/${agent}/${periodToPath(period)}`;
-  await Deno.mkdir(chatlogDir, { recursive: true });
-  return { tempDir, chatlogDir };
+  const chatlogsDir = `${tempDir}/${agent}/${periodToPath(period)}`;
+  await Deno.mkdir(chatlogsDir, { recursive: true });
+  return { tempDir, chatlogsDir };
 };

--- a/skills/filter-chatlog/scripts/__tests__/e2e/filter-chatlog.main.e2e.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/e2e/filter-chatlog.main.e2e.spec.ts
@@ -79,12 +79,12 @@ describe('main - dry-run モード', () => {
       /** dry-run モードではファイルが削除されず、`[dry-run]` ログが出力されること。 */
       describe('Then: T-FL-E2E-01 - dry-run → ファイルが削除されない', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([{ file: 'chat.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' }]),
@@ -99,15 +99,15 @@ describe('main - dry-run モード', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: chat.md を chatlogDir に配置', () => {
+        describe('Given: chat.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/chat.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/chat.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-01-01: ファイルが削除されずに残り "[dry-run]" がログに出力される', async () => {
             await main(['claude', '2026-03', '--dry-run', '--input', tempDir]);
 
-            assertEquals(await fileExists(`${chatlogDir}/chat.md`), true);
+            assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
             assertEquals(loggerStub.logLogs.some((l) => l.includes('[dry-run]')), true);
           });
         });
@@ -140,12 +140,12 @@ describe('main - DISCARD 判定', () => {
       /** DISCARD 判定のファイルがファイルシステムから削除されること。 */
       describe('Then: T-FL-E2E-02 - ファイルが削除される', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([{ file: 'discard.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' }]),
@@ -160,15 +160,15 @@ describe('main - DISCARD 判定', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: discard.md を chatlogDir に配置', () => {
+        describe('Given: discard.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/discard.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/discard.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-02-01: ファイルが削除される', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            await assertFileNotExists(`${chatlogDir}/discard.md`);
+            await assertFileNotExists(`${chatlogsDir}/discard.md`);
           });
         });
       });
@@ -199,12 +199,12 @@ describe('main - KEEP 判定', () => {
       /** KEEP 判定のファイルがファイルシステムに残っていること。 */
       describe('Then: T-FL-E2E-03 - ファイルが残る', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([{ file: 'keep.md', decision: 'KEEP', confidence: 0.9, reason: 'valuable' }]),
@@ -219,15 +219,15 @@ describe('main - KEEP 判定', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: keep.md を chatlogDir に配置', () => {
+        describe('Given: keep.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/keep.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/keep.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-03-01: ファイルが残っている', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            assertEquals(await fileExists(`${chatlogDir}/keep.md`), true);
+            assertEquals(await fileExists(`${chatlogsDir}/keep.md`), true);
           });
         });
       });
@@ -312,12 +312,12 @@ describe('main - DISCARD + KEEP 混在', () => {
       /** DISCARD ファイルが削除され、KEEP ファイルがファイルシステムに残ること。 */
       describe('Then: T-FL-E2E-05 - DISCARD のみ削除、KEEP は残る', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([
@@ -335,22 +335,22 @@ describe('main - DISCARD + KEEP 混在', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: discard.md と keep.md を chatlogDir に配置', () => {
+        describe('Given: discard.md と keep.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/discard.md`, _makeValidContent());
-            await Deno.writeTextFile(`${chatlogDir}/keep.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/discard.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/keep.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-05-01: discard.md が削除される', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            await assertFileNotExists(`${chatlogDir}/discard.md`);
+            await assertFileNotExists(`${chatlogsDir}/discard.md`);
           });
 
           it('T-FL-E2E-05-02: keep.md が残っている', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            assertEquals(await fileExists(`${chatlogDir}/keep.md`), true);
+            assertEquals(await fileExists(`${chatlogsDir}/keep.md`), true);
           });
         });
       });
@@ -452,12 +452,12 @@ describe('main - Claude CLI NotFound', () => {
       /** Claude CLI NotFound 時にファイルが全件 KEEP 扱いで残ること。 */
       describe('Then: T-FL-E2E-07 - ファイルが削除されない', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(makeNotFoundMock());
           loggerStub = makeLoggerStub();
         });
@@ -468,15 +468,15 @@ describe('main - Claude CLI NotFound', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: chat.md を chatlogDir に配置', () => {
+        describe('Given: chat.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/chat.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/chat.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-07-01: ファイルが残っている（全件 KEEP 扱い）', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            assertEquals(await fileExists(`${chatlogDir}/chat.md`), true);
+            assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
           });
         });
       });
@@ -507,12 +507,12 @@ describe('main - confidence 閾値未満', () => {
       /** confidence < 0.7 の DISCARD ファイルがファイルシステムに残ること。 */
       describe('Then: T-FL-E2E-08 - ファイルが削除されない', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([{ file: 'low-conf.md', decision: 'DISCARD', confidence: 0.69, reason: 'uncertain' }]),
@@ -527,15 +527,15 @@ describe('main - confidence 閾値未満', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: low-conf.md を chatlogDir に配置', () => {
+        describe('Given: low-conf.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/low-conf.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/low-conf.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-08-01: confidence=0.69 の DISCARD ファイルが削除されずに残っている', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            assertEquals(await fileExists(`${chatlogDir}/low-conf.md`), true);
+            assertEquals(await fileExists(`${chatlogsDir}/low-conf.md`), true);
           });
         });
       });
@@ -568,12 +568,12 @@ describe('main - Claude CLI 異常終了', () => {
       /** CLI 異常終了時にファイルが全件 KEEP 扱いで残ること。 */
       describe('Then: T-FL-E2E-09 - ファイルが削除されない', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(makeFailMock(1));
           loggerStub = makeLoggerStub();
         });
@@ -584,15 +584,15 @@ describe('main - Claude CLI 異常終了', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        describe('Given: chat.md を chatlogDir に配置', () => {
+        describe('Given: chat.md を chatlogsDir に配置', () => {
           beforeEach(async () => {
-            await Deno.writeTextFile(`${chatlogDir}/chat.md`, _makeValidContent());
+            await Deno.writeTextFile(`${chatlogsDir}/chat.md`, _makeValidContent());
           });
 
           it('T-FL-E2E-09-01: ファイルが残っている（全件 KEEP 扱い）', async () => {
             await main(['claude', '2026-03', '--input', tempDir]);
 
-            assertEquals(await fileExists(`${chatlogDir}/chat.md`), true);
+            assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
           });
         });
       });

--- a/skills/filter-chatlog/scripts/__tests__/e2e/prefilter-chatlog.main.e2e.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/e2e/prefilter-chatlog.main.e2e.spec.ts
@@ -66,11 +66,11 @@ describe('main (prefilter) - dry-run モード', () => {
       /** ファイルが削除されず、stdout にノイズファイルのパスが出力されること。 */
       describe('Then: T-PF-E2E-01 - ファイルが削除されずパスが stdout に出力される', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           loggerStub = makeLoggerStub();
         });
 
@@ -80,7 +80,7 @@ describe('main (prefilter) - dry-run モード', () => {
         });
 
         it('T-PF-E2E-01-01: ファイルが削除されずに残り、stdout にパスが出力される', async () => {
-          const filePath = `${chatlogDir}/say-ok-and-nothing-else.md`;
+          const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, _makeValidContent());
 
           await main(['claude', '2026-03', '--dry-run', '--input', tempDir]);
@@ -118,11 +118,11 @@ describe('main (prefilter) - report モード', () => {
       /** `NOISE\t{reason}\t{path}` 形式でログ出力され、ファイルが削除されないこと。 */
       describe('Then: T-PF-E2E-02 - NOISE タブ区切り形式で出力、削除なし', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           loggerStub = makeLoggerStub();
         });
 
@@ -132,7 +132,7 @@ describe('main (prefilter) - report モード', () => {
         });
 
         it('T-PF-E2E-02-01: NOISE タブ区切り形式で出力され、ファイルが削除されずに残っている', async () => {
-          const filePath = `${chatlogDir}/say-ok-and-nothing-else.md`;
+          const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, _makeValidContent());
 
           await main(['claude', '2026-03', '--report', '--input', tempDir]);
@@ -172,11 +172,11 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
       /** ノイズファイルが削除され、正常ファイルはファイルシステムに残ること。 */
       describe('Then: T-PF-E2E-03 - ノイズは削除、正常は残る', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           loggerStub = makeLoggerStub();
         });
 
@@ -186,8 +186,8 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
         });
 
         it('T-PF-E2E-03-01: ノイズファイルが削除され、正常ファイルが残っている', async () => {
-          const noisePath = `${chatlogDir}/say-ok-and-nothing-else.md`;
-          const validPath = `${chatlogDir}/valid-chat.md`;
+          const noisePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
+          const validPath = `${chatlogsDir}/valid-chat.md`;
           await Deno.writeTextFile(noisePath, _makeValidContent());
           await Deno.writeTextFile(validPath, _makeValidContent());
 
@@ -225,11 +225,11 @@ describe('main (prefilter) - 全件 keep', () => {
       /** 全ファイルが残り、完了ログに `noise=0` が含まれること。 */
       describe('Then: T-PF-E2E-04 - 全ファイルが残っており keep=2 のログ', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           loggerStub = makeLoggerStub();
         });
 
@@ -239,8 +239,8 @@ describe('main (prefilter) - 全件 keep', () => {
         });
 
         it('T-PF-E2E-04-01: 全ファイルが削除されずに残り、完了ログに "noise=0" が含まれる', async () => {
-          const path1 = `${chatlogDir}/valid-1.md`;
-          const path2 = `${chatlogDir}/valid-2.md`;
+          const path1 = `${chatlogsDir}/valid-1.md`;
+          const path2 = `${chatlogsDir}/valid-2.md`;
           await Deno.writeTextFile(path1, _makeValidContent());
           await Deno.writeTextFile(path2, _makeValidContent());
 
@@ -328,14 +328,14 @@ describe('main (prefilter) - period 絞り込み', () => {
       /** 指定月（2026-03）のファイルが削除され、他月（2026-04）が残ること。 */
       describe('Then: T-PF-E2E-07 - 2026-03 のみ削除され 2026-04 は残る', () => {
         let tempDir: string;
-        let chatlogDir03: string;
-        let chatlogDir04: string;
+        let chatlogsDir03: string;
+        let chatlogsDir04: string;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir: chatlogDir03 } = await _makeTestDirs('claude', '2026-03'));
-          chatlogDir04 = `${tempDir}/claude/2026/2026-04`;
-          await Deno.mkdir(chatlogDir04, { recursive: true });
+          ({ tempDir, chatlogsDir: chatlogsDir03 } = await _makeTestDirs('claude', '2026-03'));
+          chatlogsDir04 = `${tempDir}/claude/2026/2026-04`;
+          await Deno.mkdir(chatlogsDir04, { recursive: true });
           loggerStub = makeLoggerStub();
         });
 
@@ -345,8 +345,8 @@ describe('main (prefilter) - period 絞り込み', () => {
         });
 
         it('T-PF-E2E-07-01: 2026-03 のノイズファイルが削除され、2026-04 のファイルは残っている', async () => {
-          const noisePath03 = `${chatlogDir03}/say-ok-and-nothing-else.md`;
-          const noisePath04 = `${chatlogDir04}/say-ok-and-nothing-else.md`;
+          const noisePath03 = `${chatlogsDir03}/say-ok-and-nothing-else.md`;
+          const noisePath04 = `${chatlogsDir04}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(noisePath03, _makeValidContent());
           await Deno.writeTextFile(noisePath04, _makeValidContent());
 
@@ -383,11 +383,11 @@ describe('main (prefilter) - report 完了ログ', () => {
       /** 完了ログに `report` キーワードが含まれること。 */
       describe('Then: T-PF-E2E-08 - 完了ログに "report" が含まれる', () => {
         let tempDir: string;
-        let chatlogDir: string;
+        let chatlogsDir: string;
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, chatlogDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           loggerStub = makeLoggerStub();
         });
 
@@ -397,7 +397,7 @@ describe('main (prefilter) - report 完了ログ', () => {
         });
 
         it('T-PF-E2E-08-01: 完了ログに "report" が含まれる', async () => {
-          await Deno.writeTextFile(`${chatlogDir}/valid.md`, _makeValidContent());
+          await Deno.writeTextFile(`${chatlogsDir}/valid.md`, _makeValidContent());
 
           await main(['claude', '2026-03', '--report', '--input', tempDir]);
 

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/build-batch-prompt.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/build-batch-prompt.functional.spec.ts
@@ -43,10 +43,10 @@ describe('buildBatchPrompt', () => {
    */
   describe('Given: 単一の .md ファイルを渡す', () => {
     let tempDir: string;
-    let chatlogDir: string;
+    let chatlogsDir: string;
 
     beforeEach(async () => {
-      ({ tempDir, chatlogDir } = await makeTestDirs());
+      ({ tempDir, chatlogsDir } = await makeTestDirs());
     });
 
     afterEach(async () => {
@@ -57,7 +57,7 @@ describe('buildBatchPrompt', () => {
       /** フロントマターが除外され本文が抽出されることを検証する。 */
       describe('Then: [Normal] T-FL-BP-01 - フロントマターが除外され本文が抽出される', () => {
         it('T-FL-BP-01-01: [Normal] フロントマターの "title:" が出力に含まれない', async () => {
-          const file = `${chatlogDir}/chat.md`;
+          const file = `${chatlogsDir}/chat.md`;
           await Deno.writeTextFile(file, makeValidContent('テスト', '質問', '回答'));
 
           const result = await buildBatchPrompt([file]);
@@ -66,7 +66,7 @@ describe('buildBatchPrompt', () => {
         });
 
         it('T-FL-BP-01-02: [Normal] 本文テキスト "質問" が出力に含まれる', async () => {
-          const file = `${chatlogDir}/chat.md`;
+          const file = `${chatlogsDir}/chat.md`;
           await Deno.writeTextFile(file, makeValidContent('テスト', '質問', '回答'));
 
           const result = await buildBatchPrompt([file]);
@@ -75,7 +75,7 @@ describe('buildBatchPrompt', () => {
         });
 
         it('T-FL-BP-01-04: [Normal] ヘッダーが "=== FILE 1: <filename> ===" の形式で出力される', async () => {
-          const file = `${chatlogDir}/chat.md`;
+          const file = `${chatlogsDir}/chat.md`;
           await Deno.writeTextFile(file, makeValidContent('テスト', '質問', '回答'));
 
           const result = await buildBatchPrompt([file]);
@@ -84,7 +84,7 @@ describe('buildBatchPrompt', () => {
         });
 
         it('T-FL-BP-01-03: [Normal] サブディレクトリ内ファイルでもファイル名のみが抽出される', async () => {
-          const subDir = `${chatlogDir}/sub`;
+          const subDir = `${chatlogsDir}/sub`;
           await Deno.mkdir(subDir, { recursive: true });
           const file = `${subDir}/deep.md`;
           await Deno.writeTextFile(file, makeValidContent('テスト'));
@@ -101,7 +101,7 @@ describe('buildBatchPrompt', () => {
       /** フロントマターのみのファイルでヘッダーは出力され本文が空になることを検証する。 */
       describe('Then: [Edgecase] T-FL-BP-02 - フロントマターのみのファイルは本文が空になる', () => {
         it('T-FL-BP-02-01: [Edgecase] "=== FILE 1:" ヘッダーは出力される', async () => {
-          const file = `${chatlogDir}/empty.md`;
+          const file = `${chatlogsDir}/empty.md`;
           await Deno.writeTextFile(file, makeFrontmatter('空'));
 
           const result = await buildBatchPrompt([file]);
@@ -110,7 +110,7 @@ describe('buildBatchPrompt', () => {
         });
 
         it('T-FL-BP-02-02: [Edgecase] ヘッダーに続く本文が空になる', async () => {
-          const file = `${chatlogDir}/empty.md`;
+          const file = `${chatlogsDir}/empty.md`;
           await Deno.writeTextFile(file, makeFrontmatter('空'));
 
           const result = await buildBatchPrompt([file]);
@@ -125,7 +125,7 @@ describe('buildBatchPrompt', () => {
        */
       describe('Then: [Edgecase] T-FL-BP-03 - ターンマーカーのないファイルは本文が空になる', () => {
         it('T-FL-BP-03-01: [Edgecase] "=== FILE 1:" ヘッダーは出力される', async () => {
-          const file = `${chatlogDir}/plain.md`;
+          const file = `${chatlogsDir}/plain.md`;
           await Deno.writeTextFile(file, makePlainContent('生テキスト', 'これは会話形式でない生テキストです。'));
 
           const result = await buildBatchPrompt([file]);
@@ -134,7 +134,7 @@ describe('buildBatchPrompt', () => {
         });
 
         it('T-FL-BP-03-02: [Edgecase] ヘッダーに続く本文が空になる', async () => {
-          const file = `${chatlogDir}/plain.md`;
+          const file = `${chatlogsDir}/plain.md`;
           await Deno.writeTextFile(file, makePlainContent('生テキスト', 'これは会話形式でない生テキストです。'));
 
           const result = await buildBatchPrompt([file]);
@@ -147,7 +147,7 @@ describe('buildBatchPrompt', () => {
       describe('Then: [Edgecase] T-FL-BP-04 - 長大な本文は切り詰められる', () => {
         it('T-FL-BP-04-01: [Edgecase] 結果の長さが無制限に増大しない', async () => {
           const longText = 'x'.repeat(OVER_MAX_CHARS_LENGTH);
-          const file = `${chatlogDir}/long.md`;
+          const file = `${chatlogsDir}/long.md`;
           await Deno.writeTextFile(file, makeValidContent('Long', longText, '回答'));
 
           const result = await buildBatchPrompt([file]);
@@ -166,10 +166,10 @@ describe('buildBatchPrompt', () => {
    */
   describe('Given: 複数（2 件）の .md ファイルを渡す', () => {
     let tempDir: string;
-    let chatlogDir: string;
+    let chatlogsDir: string;
 
     beforeEach(async () => {
-      ({ tempDir, chatlogDir } = await makeTestDirs());
+      ({ tempDir, chatlogsDir } = await makeTestDirs());
     });
 
     afterEach(async () => {
@@ -180,8 +180,8 @@ describe('buildBatchPrompt', () => {
       /** 2 ファイルが `\n\n` 区切りで順番に結合されることを検証する。 */
       describe('Then: [Normal] T-FL-BP-05 - 2 ファイルが \\n\\n 区切りで結合される', () => {
         it('T-FL-BP-05-01: [Normal] FILE 1/2 のヘッダーにそれぞれのファイル名が対応して出力される', async () => {
-          const file1 = `${chatlogDir}/chat-a.md`;
-          const file2 = `${chatlogDir}/chat-b.md`;
+          const file1 = `${chatlogsDir}/chat-a.md`;
+          const file2 = `${chatlogsDir}/chat-b.md`;
           await Deno.writeTextFile(file1, makeValidContent('A', '質問A', '回答A'));
           await Deno.writeTextFile(file2, makeValidContent('B', '質問B', '回答B'));
 
@@ -192,8 +192,8 @@ describe('buildBatchPrompt', () => {
         });
 
         it('T-FL-BP-05-02: [Normal] FILE 2 ヘッダーの直前が \\n\\n で区切られる', async () => {
-          const file1 = `${chatlogDir}/chat-a.md`;
-          const file2 = `${chatlogDir}/chat-b.md`;
+          const file1 = `${chatlogsDir}/chat-a.md`;
+          const file2 = `${chatlogsDir}/chat-b.md`;
           await Deno.writeTextFile(file1, makeValidContent('A', '質問A', '回答A'));
           await Deno.writeTextFile(file2, makeValidContent('B', '質問B', '回答B'));
 
@@ -212,10 +212,10 @@ describe('buildBatchPrompt', () => {
    */
   describe(`Given: CHUNK_SIZE（${CHUNK_SIZE} 件）の .md ファイルを渡す`, () => {
     let tempDir: string;
-    let chatlogDir: string;
+    let chatlogsDir: string;
 
     beforeEach(async () => {
-      ({ tempDir, chatlogDir } = await makeTestDirs());
+      ({ tempDir, chatlogsDir } = await makeTestDirs());
     });
 
     afterEach(async () => {
@@ -228,7 +228,7 @@ describe('buildBatchPrompt', () => {
         it(`T-FL-BP-06-01: [Normal] "=== FILE ${CHUNK_SIZE}:" が含まれる`, async () => {
           const files: string[] = [];
           for (let i = 1; i <= CHUNK_SIZE; i++) {
-            const file = `${chatlogDir}/chat-${i}.md`;
+            const file = `${chatlogsDir}/chat-${i}.md`;
             await Deno.writeTextFile(file, makeValidContent(`タイトル${i}`, `質問${i}`, `回答${i}`));
             files.push(file);
           }
@@ -241,7 +241,7 @@ describe('buildBatchPrompt', () => {
         it('T-FL-BP-06-02: [Normal] すべての FILE ヘッダーが連続して含まれる', async () => {
           const files: string[] = [];
           for (let i = 1; i <= CHUNK_SIZE; i++) {
-            const file = `${chatlogDir}/chat-${i}.md`;
+            const file = `${chatlogsDir}/chat-${i}.md`;
             await Deno.writeTextFile(file, makeValidContent(`タイトル${i}`, `質問${i}`, `回答${i}`));
             files.push(file);
           }
@@ -286,10 +286,10 @@ describe('buildBatchPrompt', () => {
    */
   describe('Given: 有効ファイルと存在しないファイルが混在する', () => {
     let tempDir: string;
-    let chatlogDir: string;
+    let chatlogsDir: string;
 
     beforeEach(async () => {
-      ({ tempDir, chatlogDir } = await makeTestDirs());
+      ({ tempDir, chatlogsDir } = await makeTestDirs());
     });
 
     afterEach(async () => {
@@ -300,7 +300,7 @@ describe('buildBatchPrompt', () => {
       /** `ChatlogError(FileDirNotFound)` が throw されることを検証する。 */
       describe('Then: [Error] T-FL-BP-08 - ChatlogError(FileDirNotFound) が throw される', () => {
         it('T-FL-BP-08-01: [Error] ChatlogError(FileDirNotFound) を throw する', async () => {
-          const validFile = `${chatlogDir}/valid.md`;
+          const validFile = `${chatlogsDir}/valid.md`;
           await Deno.writeTextFile(validFile, makeValidContent('有効'));
           const nonExistent = '/nonexistent/missing.md';
 

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -77,7 +77,7 @@ const _EMPTY_PARSED: ParsedConfig = {};
  *
  * ## 優先順位ルール
  * - `agent`    : parsed > globalConfig > defaults
- * - `inputDir` : parsed > globalConfig.chatlogDir > defaults
+ * - `inputDir` : parsed > globalConfig.chatlogsDir > defaults
  * - `dryRun`   : parsed > defaults (false)
  * - `period`   : parsed のみ（GlobalConfig 連携なし）
  * - `configFile` は FilterConfig に存在しないため結果に含まれない
@@ -144,7 +144,7 @@ describe('buildConfig', () => {
       describe('Then: T-FL-BC-03 - DEFAULT_FILTER_CONFIG.agent が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogDir: /some/dir');
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /some/dir');
         });
         it('T-FL-BC-03: agent 未設定 → result.agent === DEFAULT_FILTER_CONFIG.agent', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
@@ -180,24 +180,24 @@ describe('buildConfig', () => {
   /**
    * `parsed.inputDir` が未指定の前提条件グループ。
    *
-   * GlobalConfig.chatlogDir がある場合はその値が、ない場合はデフォルト値が使われることを検証する。
+   * GlobalConfig.chatlogsDir がある場合はその値が、ない場合はデフォルト値が使われることを検証する。
    */
   describe('Given: parsed.inputDir が未指定', () => {
-    describe('When: GlobalConfig に chatlogDir が設定されている', () => {
-      /** GlobalConfig.chatlogDir が使われることを検証する。 */
-      describe('Then: T-FL-BC-05 - GlobalConfig の chatlogDir が使われる', () => {
+    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
+      /** GlobalConfig.chatlogsDir が使われることを検証する。 */
+      describe('Then: T-FL-BC-05 - GlobalConfig の chatlogsDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogDir: /global');
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-FL-BC-05: globalConfig.chatlogDir=/global → result.inputDir === /global', () => {
+        it('T-FL-BC-05: globalConfig.chatlogsDir=/global → result.inputDir === /global', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
           assertEquals(result.inputDir, '/global');
         });
       });
     });
 
-    describe('When: GlobalConfig に chatlogDir が設定されていない', () => {
+    describe('When: GlobalConfig に chatlogsDir が設定されていない', () => {
       /** DEFAULT_FILTER_CONFIG.inputDir が使われることを検証する。 */
       describe('Then: T-FL-BC-06 - DEFAULT_FILTER_CONFIG.inputDir が使われる', () => {
         let globalConfig: GlobalConfig;
@@ -428,6 +428,91 @@ describe('buildConfig', () => {
             globalConfig,
           );
           assertEquals('configFile' in result, false);
+        });
+      });
+    });
+  });
+
+  // ─── chatlogsDir の解決と inputDir へのフォールバック ───────────────────────
+
+  /**
+   * `parsed.chatlogsDir` が `inputDir` のフォールバックとして機能し、かつ結果に保持されることを検証するグループ。
+   *
+   * `parsed.inputDir` が未指定のとき `parsed.chatlogsDir` が `inputDir` に使われる。
+   * 同時に `chatlogsDir` も結果に含まれることを検証する。
+   * 優先順位: `parsed.inputDir` > `parsed.chatlogsDir` > `globalConfig.chatlogsDir` > `defaults.inputDir`
+   */
+  describe('Given: parsed.inputDir が未指定で parsed.chatlogsDir が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** `parsed.chatlogsDir` が `inputDir` として使われ、結果に `chatlogsDir` が含まれることを検証する。 */
+      describe('Then: T-FL-BC-17 - parsed.chatlogsDir が inputDir に使われ、結果に保持される', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
+        });
+        it('T-FL-BC-17-01: parsed.chatlogsDir=/base → result.inputDir === /base', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, chatlogsDir: '/base' }, globalConfig);
+          assertEquals(result.inputDir, '/base');
+        });
+        it('T-FL-BC-17-02: parsed.chatlogsDir=/base → result.chatlogsDir === /base', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, chatlogsDir: '/base' }, globalConfig);
+          assertEquals(result.chatlogsDir, '/base');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.inputDir` と `parsed.chatlogsDir` の両方が指定された前提条件グループ。
+   *
+   * `parsed.inputDir`（`--input`）が `parsed.chatlogsDir`（`--chatlogs-dir`）より優先されることを検証する。
+   * `chatlogsDir` は結果にそのまま保持される。
+   */
+  describe('Given: parsed.inputDir と parsed.chatlogsDir の両方が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** `parsed.inputDir` が優先され、`chatlogsDir` も保持されることを検証する。 */
+      describe('Then: T-FL-BC-18 - parsed.inputDir が parsed.chatlogsDir より優先され、chatlogsDir は保持される', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it('T-FL-BC-18-01: inputDir=/custom, chatlogsDir=/base → result.inputDir === /custom', () => {
+          const result = buildConfig(
+            { ..._EMPTY_PARSED, inputDir: '/custom', chatlogsDir: '/base' },
+            globalConfig,
+          );
+          assertEquals(result.inputDir, '/custom');
+        });
+        it('T-FL-BC-18-02: inputDir=/custom, chatlogsDir=/base → result.chatlogsDir === /base', () => {
+          const result = buildConfig(
+            { ..._EMPTY_PARSED, inputDir: '/custom', chatlogsDir: '/base' },
+            globalConfig,
+          );
+          assertEquals(result.chatlogsDir, '/base');
+        });
+      });
+    });
+  });
+
+  /**
+   * `parsed.chatlogsDir` が結果に含まれることを検証するグループ。
+   *
+   * `chatlogsDir` は `FilterConfig` に追加されたため、buildConfig の結果に含まれる。
+   */
+  describe('Given: parsed.chatlogsDir が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result` に `chatlogsDir` フィールドが含まれることを検証する。 */
+      describe('Then: T-FL-BC-19 - result に chatlogsDir フィールドが含まれる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-FL-BC-19: parsed.chatlogsDir=/base → result.chatlogsDir === /base', () => {
+          const result: FilterConfig = buildConfig(
+            { ..._EMPTY_PARSED, chatlogsDir: '/base' },
+            globalConfig,
+          );
+          assertEquals(result.chatlogsDir, '/base');
         });
       });
     });

--- a/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
@@ -49,6 +49,7 @@ describe('parseArgs', () => {
           { id: 'T-FL-PA-01-02', field: 'dryRun', expected: undefined },
           { id: 'T-FL-PA-01-03', field: 'inputDir', expected: undefined },
           { id: 'T-FL-PA-01-04', field: 'period', expected: undefined },
+          { id: 'T-FL-PA-01-05', field: 'chatlogsDir', expected: undefined },
         ];
         for (const { id, field, expected } of _defaultCases) {
           it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
@@ -115,6 +116,103 @@ describe('parseArgs', () => {
 
         it('T-FL-PA-10-02: --config=cfg.yaml → configFile が "cfg.yaml" になる', () => {
           assertEquals(parseArgs(['--config=cfg.yaml']).configFile, 'cfg.yaml');
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-PA-11: --chatlogs-dir オプション ───────────────────────────────────
+
+  describe('Given: --chatlogs-dir オプションが渡される', () => {
+    describe('When: parseArgs を呼び出す', () => {
+      describe('Then: chatlogsDir フィールドに値が設定される', () => {
+        it('T-FL-PA-11-01: --chatlogs-dir /base → chatlogsDir が "/base" になる', () => {
+          assertEquals(parseArgs(['--chatlogs-dir', '/base']).chatlogsDir, '/base');
+        });
+
+        it('T-FL-PA-11-02: --chatlogs-dir=/base → chatlogsDir が "/base" になる', () => {
+          assertEquals(parseArgs(['--chatlogs-dir=/base']).chatlogsDir, '/base');
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-PA-12: --chatlogs-dir と --input の組み合わせ ──────────────────────
+
+  describe('Given: --chatlogs-dir と --input の両方が渡される', () => {
+    describe('When: parseArgs を呼び出す', () => {
+      describe('Then: 両フィールドに別々の値が設定される', () => {
+        it('T-FL-PA-12-01: --chatlogs-dir と --input が同時指定できる', () => {
+          const result = parseArgs(['--chatlogs-dir', '/base', '--input', '/custom']);
+          assertEquals(result.chatlogsDir, '/base');
+          assertEquals(result.inputDir, '/custom');
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-PA-13: 全オプション組み合わせ ─────────────────────────────────────
+
+  describe('Given: claude 2026-03 --dry-run --chatlogs-dir /base を渡す', () => {
+    describe('When: parseArgs を呼び出す', () => {
+      describe('Then: 全フィールドが正しく解析される', () => {
+        it('T-FL-PA-13-01: 全フィールドが正しく解析される', () => {
+          const result = parseArgs(['claude', '2026-03', '--dry-run', '--chatlogs-dir', '/base']);
+          assertEquals(result.agent, 'claude');
+          assertEquals(result.period, '2026-03');
+          assertEquals(result.dryRun, true);
+          assertEquals(result.chatlogsDir, '/base');
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-PA-14: --chatlogs-dir バリデーション ───────────────────────────────
+
+  /**
+   * `--chatlogs-dir` にディレクトリパスでない値を渡した場合の異常系グループ。
+   *
+   * ディレクトリパス（`/` を含む正規化済みパス）でない値は `ChatlogError(InvalidArgs)` をスローする。
+   */
+  describe('Given: --chatlogs-dir にディレクトリパスでない値を渡す', () => {
+    describe('When: parseArgs を呼び出す', () => {
+      describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
+        it('T-FL-PA-14-01: --chatlogs-dir foo（スラッシュなし）→ ChatlogError(InvalidArgs) がスローされる', () => {
+          assertThrows(
+            () => parseArgs(['--chatlogs-dir', 'foo']),
+            ChatlogError,
+            'Invalid Args',
+          );
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-PA-15: --chatlogs-dir 未指定時の inputDir フォールバック ────────────
+
+  /**
+   * `--chatlogs-dir` 未指定・`--input` 指定のとき `chatlogsDir` に `inputDir` の値が入ることを検証するグループ。
+   */
+  describe('Given: --chatlogs-dir が未指定で --input が指定されている', () => {
+    describe('When: parseArgs を呼び出す', () => {
+      describe('Then: chatlogsDir が inputDir の値になる', () => {
+        it('T-FL-PA-15-01: --input /path/to → chatlogsDir が "/path/to" になる', () => {
+          assertEquals(parseArgs(['--input', '/path/to']).chatlogsDir, '/path/to');
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-PA-16: --chatlogs-dir と --input 両方未指定 ─────────────────────────
+
+  /**
+   * `--chatlogs-dir` も `--input` も未指定のとき `chatlogsDir` が `undefined` になることを検証するグループ。
+   */
+  describe('Given: --chatlogs-dir も --input も未指定', () => {
+    describe('When: parseArgs を呼び出す', () => {
+      describe('Then: chatlogsDir が undefined になる', () => {
+        it('T-FL-PA-16-01: 引数なし → chatlogsDir が undefined になる', () => {
+          assertEquals(parseArgs([]).chatlogsDir, undefined);
         });
       });
     });

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -27,7 +27,7 @@ import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-files.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { isDirectoryArg, parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
 import { parseFrontmatterEntries } from '../../_scripts/libs/text/frontmatter-utils.ts';
 import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';
@@ -341,6 +341,7 @@ export const processChunk = async (
 const _OPT_KEYS: Record<string, keyof ParsedConfig> = {
   '--input': 'inputDir',
   '--config': 'configFile',
+  '--chatlogs-dir': 'chatlogsDir',
 };
 
 /** `--flag` 形式（値なし）のオプションと ParsedConfig キーのマッピング。 */
@@ -350,10 +351,21 @@ const _OPT_FLAGS: Record<string, keyof ParsedConfig> = {
 
 /**
  * コマンドライン引数を解析して ParsedConfig を返す。
- * - モデルのデフォルト値解決は `main()` で GlobalConfig を取得した後に行う。
+ * - `--chatlogs-dir` の値はディレクトリパス形式（`/` を含む）でなければ `ChatlogError(InvalidArgs)` をスローする。
+ * - `chatlogsDir` が未指定の場合は `inputDir` の値をフォールバックとして設定する。
  */
 export const parseArgs = (args: string[]): ParsedConfig => {
-  return parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
+  const _parsed = parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
+  if (_parsed.chatlogsDir !== undefined && !isDirectoryArg(_parsed.chatlogsDir)) {
+    throw new ChatlogError(
+      'InvalidArgs',
+      `--chatlogs-dir にはディレクトリパスを指定してください: ${_parsed.chatlogsDir}`,
+    );
+  }
+  return {
+    ..._parsed,
+    chatlogsDir: _parsed.chatlogsDir ?? _parsed.inputDir,
+  };
 };
 
 // ─────────────────────────────────────────────
@@ -363,7 +375,8 @@ export const parseArgs = (args: string[]): ParsedConfig => {
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な FilterConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - inputDir 優先順位: `parsed.inputDir` > `globalConfig.get('chatlogDir')` > `defaults.inputDir`
+ * - chatlogsDir 優先順位: `parsed.chatlogsDir` > `globalConfig.get('chatlogsDir')`
+ * - inputDir 優先順位: `parsed.inputDir` > `parsed.chatlogsDir` > `globalConfig.get('chatlogsDir')` > `defaults.inputDir`
  * - dryRun: `parsed.dryRun` > `defaults.dryRun`（false）
  * - period: `parsed` のみ（GlobalConfig 連携なし）
  * - `configFile` は FilterConfig に存在しないため結果に含まれない。
@@ -375,7 +388,9 @@ export function buildConfig(
 ): FilterConfig {
   const _defaults = defaults ?? DEFAULT_FILTER_CONFIG;
   const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? _defaults.agent;
-  const _inputDir = parsed.inputDir ?? (globalConfig.get('chatlogDir') as string | undefined) ?? _defaults.inputDir;
+  const _globalChatlogDir = globalConfig.get('chatlogsDir') as string | undefined;
+  const _inputDir = parsed.inputDir ?? parsed.chatlogsDir ?? _globalChatlogDir ?? _defaults.inputDir;
+  const _chatlogsDir = parsed.chatlogsDir ?? _globalChatlogDir;
   const _chunkSize = parsed.chunkSize ?? (globalConfig.get('chunkSize') as number | undefined) ?? _defaults.chunkSize;
   const _concurrency = parsed.concurrency ?? (globalConfig.get('concurrency') as number | undefined)
     ?? _defaults.concurrency;
@@ -385,6 +400,7 @@ export function buildConfig(
     ...rest,
     agent: _agent,
     inputDir: _inputDir,
+    chatlogsDir: _chatlogsDir,
     chunkSize: _chunkSize,
     concurrency: _concurrency,
   };
@@ -400,7 +416,7 @@ export const main = async (args?: string[]): Promise<void> => {
     const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const _config = buildConfig(_parsed, _globalConfig);
 
-    const agentDir = `${_config.inputDir}/${_config.agent}`;
+    const agentDir = `${_config.chatlogsDir ?? _config.inputDir}/${_config.agent}`;
 
     // 入力ディレクトリ確認
     if (!await dirExists(agentDir)) {

--- a/skills/filter-chatlog/scripts/types/filter.types.ts
+++ b/skills/filter-chatlog/scripts/types/filter.types.ts
@@ -16,8 +16,10 @@ export interface FilterConfig {
   agent: string;
   /** 対象年月（`YYYY-MM` 形式）。省略時は全期間。 */
   period?: string;
-  /** チャットログが格納された入力ディレクトリのパス。 */
+  /** チャットログが格納された入力ディレクトリのパス (obsolete) */
   inputDir: string;
+  /** チャットログ基底ディレクトリのパス。`inputDir` の後継として利用予定。省略時は `undefined`。 */
+  chatlogsDir?: string;
 
   // flags
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */


### PR DESCRIPTION
## Overview

**Summary**
Rename `chatlogDir` config key to `chatlogsDir` across the codebase and add `--chatlogs-dir` CLI option to `filter-chatlog`.

**Background / Motivation**
The directory holds multiple chatlogs, so the plural form `chatlogsDir` better reflects its purpose. The previous name `chatlogDir` was inconsistent with the actual directory name (`./chatlogs`). Additionally, `filter-chatlog` lacked a dedicated CLI option to specify the chatlogs directory; callers had to rely on the internal `inputDir` field, which was not part of the public interface.

## Changes

### Core Changes

- `assets/configs/config.yaml` — rename global config key `chatlogDir` → `chatlogsDir`
- `skills/_scripts/constants/schema.constants.ts` — update `DEFAULT_SCHEMA` and `DEFAULT_VALUES` keys; change default value from `'./chatlog'` to `'./chatlogs'`
- `skills/_scripts/constants/defaults.constants.ts` — update JSDoc comment reference
- `skills/filter-chatlog/scripts/filter-chatlog.ts` — add `--chatlogs-dir` CLI option, parse-time fallback from `inputDir`, and update `buildConfig` resolution
- `skills/filter-chatlog/scripts/types/filter.types.ts` — add optional `chatlogsDir` field to `FilterConfig`; mark `inputDir` as obsolete
- `skills/classify-chatlog/scripts/classify-chatlog.ts` — update `globalConfig.get()` call to `chatlogsDir`
- `skills/export-chatlog/scripts/export-chatlog.ts` — update `globalConfig.get()` call to `chatlogsDir`

### Test Updates

- `skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts` — update test IDs T-CLS-GC-50–54 and expected default value
- `skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts` — add `parseArgs` coverage for `--chatlogs-dir`, default behavior, fallback logic, combined option scenarios, and invalid argument validation
- `skills/filter-chatlog/scripts/__tests__/functional/filter/build-config.functional.spec.ts` — add `chatlogsDir` resolution, retention, `inputDir` fallback, and precedence tests
- `skills/filter-chatlog/scripts/__tests__/functional/filter/build-batch-prompt.functional.spec.ts` — rename fixture variable `chatlogDir` → `chatlogsDir`
- `skills/filter-chatlog/scripts/__tests__/e2e/filter-chatlog.main.e2e.spec.ts` — rename variable, describe label, and path references
- `skills/filter-chatlog/scripts/__tests__/e2e/prefilter-chatlog.main.e2e.spec.ts` — rename fixture variable and month-dir variables
- `skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-fixtures.ts` — rename `makeTestDirs` return property
- `skills/classify-chatlog/scripts/__tests__/functional/classify-chatlog.build-config.functional.spec.ts` — update YAML key and test labels
- `skills/export-chatlog/scripts/__tests__/functional/export-chatlog.build-config.functional.spec.ts` — update JSDoc, describe labels, test IDs, and YAML fixtures

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #131

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

> **Breaking Change:** The global config key `chatlogDir` has been renamed to `chatlogsDir`. Any existing `config.yaml` files using `chatlogDir` must be updated manually. The default directory value also changes from `./chatlog` to `./chatlogs`.
>
> Deprecated `inputDir` is retained as a fallback in `filter-chatlog` for backward compatibility.
