### PR TITLE
refactor(filter-chatlog): split monolithic script into focused modules

### DIFF
--- a/skills/filter-chatlog/scripts/__tests__/fixtures/filter/filter-chatlog.fixtures.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/fixtures/filter/filter-chatlog.fixtures.spec.ts
@@ -19,7 +19,7 @@ import { runAI } from '../../../../../_scripts/libs/ai/run-ai.ts';
 import { parseJsonArray } from '../../../../../_scripts/libs/text/json-utils.ts';
 
 // constants
-import { SYSTEM_PROMPT } from '../../../filter-chatlog.ts';
+import { SYSTEM_PROMPT } from '../../../constants/filter.constants.ts';
 
 // ─── Helpers
 import { findFixtureDirs } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/build-batch-prompt.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/build-batch-prompt.functional.spec.ts
@@ -12,7 +12,7 @@ import { assert, assertEquals, assertRejects, assertStringIncludes } from '@std/
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { buildBatchPrompt } from '../../../filter-chatlog.ts';
+import { buildBatchPrompt } from '../../../libs/batch-prompt.ts';
 // types
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/find-md.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/find-md.functional.spec.ts
@@ -12,7 +12,7 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { findMdFiles } from '../../../filter-chatlog.ts';
+import { findMdFiles } from '../../../libs/find-files.ts';
 
 // ─── Helpers
 import { makePeriodDir } from '../../_helpers/chatlog-fixtures.ts';

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/prefilter-files.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/prefilter-files.functional.spec.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { stub } from '@std/testing/mock';
 
 // ─── Test target
-import { prefilterFiles } from '../../../filter-chatlog.ts';
+import { prefilterFiles } from '../../../libs/prefilter.ts';
 
 // ─── Helpers
 import { makePeriodDir, makeRepeatedContent } from '../../_helpers/chatlog-fixtures.ts';

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/process-chunk.functional.spec.ts
@@ -14,9 +14,11 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { stub } from '@std/testing/mock';
 
 // ─── Test target
-import { DISCARD_THRESHOLD, processChunk } from '../../../filter-chatlog.ts';
+import { processChunk } from '../../../libs/process-chunk.ts';
+// constants
+import { DISCARD_THRESHOLD } from '../../../constants/filter.constants.ts';
 // types
-import type { Stats } from '../../../filter-chatlog.ts';
+import type { Stats } from '../../../types/filter.types.ts';
 
 // ─── Helpers
 import {

--- a/skills/filter-chatlog/scripts/__tests__/integration/filter-chatlog.file-ops.integration.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/integration/filter-chatlog.file-ops.integration.spec.ts
@@ -11,7 +11,9 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { stub } from '@std/testing/mock';
 
 // test target
-import { buildBatchPrompt, findMdFiles, prefilterFiles } from '../../../../filter-chatlog/scripts/filter-chatlog.ts';
+import { buildBatchPrompt } from '../../../../filter-chatlog/scripts/libs/batch-prompt.ts';
+import { findMdFiles } from '../../../../filter-chatlog/scripts/libs/find-files.ts';
+import { prefilterFiles } from '../../../../filter-chatlog/scripts/libs/prefilter.ts';
 
 // ─── Helpers
 import { makeRepeatedContent } from '../_helpers/chatlog-fixtures.ts';

--- a/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/unit/filter-chatlog.unit.spec.ts
@@ -13,14 +13,11 @@ import { assertEquals, assertNotEquals, assertStringIncludes, assertThrows } fro
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import {
-  type ClaudeResult,
-  extractBodyText,
-  isExcludedByContent,
-  isExcludedByFilename,
-  parseArgs,
-} from '../../filter-chatlog.ts';
+import { parseArgs } from '../../filter-chatlog.ts';
+// functions
+import { extractBodyText, isExcludedByContent, isExcludedByFilename } from '../../libs/prefilter.ts';
 // types
+import type { ClaudeResult } from '../../types/filter.types.ts';
 import type { ParsedConfig } from '../../types/filter.types.ts';
 
 // ─── Helpers

--- a/skills/filter-chatlog/scripts/constants/filter.constants.ts
+++ b/skills/filter-chatlog/scripts/constants/filter.constants.ts
@@ -18,6 +18,19 @@ import type { FilterConfig } from '../types/filter.types.ts';
 // filter-chatlog 固有定数
 // ─────────────────────────────────────────────
 
+/** DISCARD 判定に必要な最低信頼度スコア。 */
+export const DISCARD_THRESHOLD = 0.7;
+
+/** バッチプロンプトに含める本文の最大文字数。 */
+export const MAX_BODY_CHARS = 8000;
+
+/** Claude CLI に渡すシステムプロンプト。 */
+export const SYSTEM_PROMPT = `Output ONLY a JSON array. No markdown, no explanation, no text before or after the array.
+[{"file":"<filename>","decision":"KEEP or DISCARD","confidence":0.0,"reason":"..."},...]
+
+KEEP: design decisions, reusable patterns, new concepts, architecture discussion
+DISCARD: execution-only, trivial Q&A, no reusable insight, context-dependent`;
+
 /** parseArgs で未指定のフィールドに適用するデフォルト設定。 */
 export const DEFAULT_FILTER_CONFIG: FilterConfig = {
   agent: DEFAULT_AGENT,

--- a/skills/filter-chatlog/scripts/constants/patterns.constants.ts
+++ b/skills/filter-chatlog/scripts/constants/patterns.constants.ts
@@ -1,0 +1,38 @@
+// src: scripts/constants/patterns.constants.ts
+// @(#): filter-chatlog ノイズ判定パターン定数
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─────────────────────────────────────────────
+// ノイズ判定パターン定数
+// ─────────────────────────────────────────────
+
+/** システム/コマンドタグとして認識するプレフィックス一覧（`startsWith` 判定用）。 */
+export const SYSTEM_TAG_PREFIXES: string[] = [
+  '<system-reminder',
+  '<command-name',
+  '<command-message',
+  '<local-command-stdout',
+  '<ide_opened_file',
+  '<ide_selection',
+  '---\n',
+] as const;
+
+/** 除外対象ファイル名パターン（文字列部分一致、`includes` 判定用）。 */
+export const EXCLUDE_FILENAME_PATTERNS_STR: string[] = [
+  'you-are-a-topic-and-tag-extraction-assistant',
+  'say-ok-and-nothing-else',
+  'command-message-claude-idd-framework',
+  'command-message-deckrd-deckrd',
+] as const;
+
+/** 除外対象ファイル名パターン（正規表現、`test` 判定用）。 */
+export const EXCLUDE_FILENAME_PATTERNS_RE: RegExp[] = [
+  /you-are-a-topic-and-tag-extraction-assistant/i,
+  /say-ok-and-nothing-else/i,
+  /command-message-claude-idd-framework/i,
+  /command-message-deckrd-deckrd/i,
+] as const;

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -14,7 +14,7 @@
  */
 
 // ─────────────────────────────────────────────
-// 定数
+// import
 // ─────────────────────────────────────────────
 
 // -- constants --
@@ -24,14 +24,9 @@ import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
-import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-files.ts';
-import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { isDirectoryArg, parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
-import { parseFrontmatterEntries } from '../../_scripts/libs/text/frontmatter-utils.ts';
-import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';
-import { parseConversation } from '../../_scripts/libs/text/markdown-utils.ts';
 
 // -- internal --
 // constants
@@ -39,299 +34,10 @@ import { DEFAULT_CHUNK_SIZE, DEFAULT_CONCURRENCY } from '../../_scripts/constant
 import { DEFAULT_FILTER_CONFIG } from './constants/filter.constants.ts';
 // types
 import type { FilterConfig, ParsedConfig } from './types/filter.types.ts';
-
-export const DISCARD_THRESHOLD = 0.7;
-export const MAX_BODY_CHARS = 8000;
-
-export const SYSTEM_PROMPT = `Output ONLY a JSON array. No markdown, no explanation, no text before or after the array.
-[{"file":"<filename>","decision":"KEEP or DISCARD","confidence":0.0,"reason":"..."},...]
-
-KEEP: design decisions, reusable patterns, new concepts, architecture discussion
-DISCARD: execution-only, trivial Q&A, no reusable insight, context-dependent`;
-
-// ─────────────────────────────────────────────
-// 型定義
-// ─────────────────────────────────────────────
-
-export interface ClaudeResult {
-  file: string;
-  decision: 'KEEP' | 'DISCARD';
-  confidence: number;
-  reason: string;
-}
-
-// ─────────────────────────────────────────────
-// 内容ベース事前フィルタ（obsidian_filter.py 移植）
-// ─────────────────────────────────────────────
-
-const _SYSTEM_PREFIXES = [
-  '<system-reminder',
-  '<command-name',
-  '<command-message',
-  '<local-command-stdout',
-  '<ide_opened_file',
-  '<ide_selection',
-  '---\n',
-];
-
-const _EXCLUDE_FILENAME_PATTERNS = [
-  'you-are-a-topic-and-tag-extraction-assistant',
-  'say-ok-and-nothing-else',
-  'command-message-claude-idd-framework',
-  'command-message-deckrd-deckrd',
-];
-
-export const isSystemOnlyMessage = (text: string): boolean => {
-  const stripped = text.trim();
-  return _SYSTEM_PREFIXES.some((prefix) => stripped.startsWith(prefix));
-};
-
-export const isExcludedByFilename = (filename: string): boolean => {
-  const lower = filename.toLowerCase();
-  return _EXCLUDE_FILENAME_PATTERNS.some((pat) => lower.includes(pat));
-};
-
-export const isExcludedByContent = (
-  body: string,
-  minCharCount = 1000,
-  minAssistantChars = 300,
-): { excluded: boolean; reason: string } => {
-  if (body.length < minCharCount) {
-    return { excluded: true, reason: `本文が短すぎる (${body.length} < ${minCharCount} 文字)` };
-  }
-
-  const turns = parseConversation(body);
-  const userTurns = turns.filter((t) => t.role === 'user');
-  const assistantTurns = turns.filter((t) => t.role === 'assistant');
-
-  if (userTurns.length === 0) {
-    return { excluded: true, reason: 'Userターンが存在しない' };
-  }
-
-  if (userTurns.length === 1) {
-    if (isSystemOnlyMessage(userTurns[0].text)) {
-      return { excluded: true, reason: 'Userメッセージがシステム/コマンドタグのみ' };
-    }
-    const totalAssistantChars = assistantTurns.reduce((sum, t) => sum + t.text.length, 0);
-    if (totalAssistantChars < minAssistantChars) {
-      return {
-        excluded: true,
-        reason: `Assistantの応答が短すぎる (${totalAssistantChars} < ${minAssistantChars} 文字)`,
-      };
-    }
-  }
-
-  return { excluded: false, reason: '' };
-};
-
-// ─────────────────────────────────────────────
-// 本文テキスト抽出
-// ─────────────────────────────────────────────
-
-export const extractBodyText = (body: string, maxChars = MAX_BODY_CHARS): string => {
-  const turns = parseConversation(body);
-  const parts = turns.map((t) => {
-    const role = t.role === 'user' ? 'User' : 'Assistant';
-    return `### ${role}\n${t.text}`;
-  });
-  return parts.join('\n\n').slice(0, maxChars);
-};
-
-// ─────────────────────────────────────────────
-// ファイル列挙
-// ─────────────────────────────────────────────
-
-const _resolveSearchDir = (
-  baseDir: string,
-  period?: string,
-): string => {
-  if (!period) {
-    return baseDir;
-  }
-  return `${baseDir}/${period.slice(0, 4)}/${period}`;
-};
-
-export const findMdFiles = (
-  baseDir: string,
-  period?: string,
-): Promise<string[]> => {
-  const _searchDir = _resolveSearchDir(baseDir, period);
-  return findFilesLib(_searchDir);
-};
-
-// ─────────────────────────────────────────────
-// 事前フィルタ
-// ─────────────────────────────────────────────
-
-export const prefilterFiles = async (files: string[]): Promise<string[]> => {
-  const passed: string[] = [];
-  let skipped = 0;
-
-  for (const filePath of files) {
-    const filename = filePath.split(/[/\\]/).pop()!;
-
-    if (isExcludedByFilename(filename)) {
-      logger.info(`  skipped (ファイル名パターン): ${filename}`);
-      skipped++;
-      continue;
-    }
-
-    let text: string;
-    try {
-      text = await readTextFile(filePath);
-    } catch {
-      skipped++;
-      continue;
-    }
-
-    const { content } = parseFrontmatterEntries(text);
-    if (!content.trim()) {
-      skipped++;
-      continue;
-    }
-
-    const { excluded, reason } = isExcludedByContent(content);
-    if (excluded) {
-      logger.info(`  skipped (${reason}): ${filename}`);
-      skipped++;
-      continue;
-    }
-
-    const bodyText = extractBodyText(content);
-    if (!bodyText.trim()) {
-      skipped++;
-      continue;
-    }
-
-    passed.push(filePath);
-  }
-
-  logger.info(`事前フィルタ: 対象=${files.length} 通過=${passed.length} スキップ=${skipped}`);
-  return passed;
-};
-
-// ─────────────────────────────────────────────
-// バッチプロンプト構築
-// ─────────────────────────────────────────────
-
-export const buildBatchPrompt = async (files: string[]): Promise<string> => {
-  const parts: string[] = [];
-
-  for (let i = 0; i < files.length; i++) {
-    const filePath = files[i];
-    const filename = filePath.split(/[/\\]/).pop()!;
-    const text = await readTextFile(filePath);
-    const { content } = parseFrontmatterEntries(text);
-    const bodyText = extractBodyText(content, MAX_BODY_CHARS);
-
-    parts.push(`=== FILE ${i + 1}: ${filename} ===\n${bodyText}`);
-  }
-
-  return parts.join('\n\n');
-};
-
-// ─────────────────────────────────────────────
-// Claude CLI 呼び出し
-// ─────────────────────────────────────────────
-
-export const runClaude = async (prompt: string): Promise<string> => {
-  const cmd = new Deno.Command('claude', {
-    args: ['-p', SYSTEM_PROMPT, '--output-format', 'text'],
-    stdin: 'piped',
-    stdout: 'piped',
-    stderr: 'null',
-  });
-
-  const process = cmd.spawn();
-
-  const writer = process.stdin.getWriter();
-  await writer.write(new TextEncoder().encode(prompt));
-  await writer.close();
-
-  const output = await process.output();
-  if (!output.success) {
-    throw new ChatlogError('CliError', `claude CLI がエラーで終了しました (code=${output.code})`);
-  }
-
-  return new TextDecoder().decode(output.stdout);
-};
-
-// ─────────────────────────────────────────────
-// チャンク処理
-// ─────────────────────────────────────────────
-
-export interface Stats {
-  kept: number;
-  discarded: number;
-  skipped: number;
-  error: number;
-}
-
-export const processChunk = async (
-  chunkFiles: string[],
-  dryRun: boolean,
-  stats: Stats,
-): Promise<void> => {
-  const batchPrompt = await buildBatchPrompt(chunkFiles);
-
-  let rawResult: string;
-  try {
-    rawResult = await runClaude(batchPrompt);
-  } catch (e) {
-    logger.warn(`  警告: claude CLI 実行失敗。チャンク内ファイルをすべて KEEP 扱い`);
-    logger.warn(`  error: ${e}`);
-    for (const f of chunkFiles) {
-      logger.info(`  kept (claude error): ${f.split(/[/\\]/).pop()}`);
-      stats.kept++;
-    }
-    return;
-  }
-
-  const parsed = parseJsonArray<ClaudeResult>(rawResult);
-  if (!parsed) {
-    logger.warn(`  警告: JSON パース失敗。チャンク内ファイルをすべて KEEP 扱い`);
-    logger.warn(`  raw output: ${rawResult.slice(0, 200)}`);
-    for (const f of chunkFiles) {
-      logger.info(`  kept (parse error): ${f.split(/[/\\]/).pop()}`);
-      stats.kept++;
-    }
-    return;
-  }
-
-  for (const filePath of chunkFiles) {
-    const filename = filePath.split(/[/\\]/).pop()!;
-    const result = parsed.find((r) => r.file === filename);
-
-    if (!result) {
-      logger.info(`  kept (not in result): ${filename}`);
-      stats.kept++;
-      continue;
-    }
-
-    const { decision, confidence, reason } = result;
-
-    if (decision === 'DISCARD' && confidence >= DISCARD_THRESHOLD) {
-      if (dryRun) {
-        logger.log(`[dry-run] DISCARD (conf=${confidence}): ${filePath}`);
-        logger.info(`  reason: ${reason}`);
-        stats.discarded++;
-      } else {
-        logger.log(`DISCARD (conf=${confidence}): ${filePath}`);
-        logger.info(`  reason: ${reason}`);
-        try {
-          await Deno.remove(filePath);
-          stats.discarded++;
-        } catch {
-          logger.error(`  削除失敗: ${filePath}`);
-          stats.error++;
-        }
-      }
-    } else {
-      logger.info(`  kept (decision=${decision}, conf=${confidence}): ${filename}`);
-      stats.kept++;
-    }
-  }
-};
+// libs
+import { findMdFiles } from './libs/find-files.ts';
+import { prefilterFiles } from './libs/prefilter.ts';
+import { processChunk } from './libs/process-chunk.ts';
 
 // ─────────────────────────────────────────────
 // 引数解析
@@ -381,11 +87,11 @@ export const parseArgs = (args: string[]): ParsedConfig => {
  * - period: `parsed` のみ（GlobalConfig 連携なし）
  * - `configFile` は FilterConfig に存在しないため結果に含まれない。
  */
-export function buildConfig(
+export const buildConfig = (
   parsed: ParsedConfig,
   globalConfig: GlobalConfig,
   defaults?: FilterConfig,
-): FilterConfig {
+): FilterConfig => {
   const _defaults = defaults ?? DEFAULT_FILTER_CONFIG;
   const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? _defaults.agent;
   const _globalChatlogDir = globalConfig.get('chatlogsDir') as string | undefined;
@@ -404,7 +110,7 @@ export function buildConfig(
     chunkSize: _chunkSize,
     concurrency: _concurrency,
   };
-}
+};
 
 // ─────────────────────────────────────────────
 // メイン
@@ -443,7 +149,7 @@ export const main = async (args?: string[]): Promise<void> => {
     if (_config.dryRun) { logger.info('dry-run モード: ファイルは削除しません'); }
 
     // チャンク分割して並列処理
-    const stats: Stats = { kept: 0, discarded: 0, skipped: 0, error: 0 };
+    const stats = { kept: 0, discarded: 0, skipped: 0, error: 0 };
 
     const _chunkSize = _config.chunkSize ?? DEFAULT_CHUNK_SIZE;
     const _concurrency = _config.concurrency ?? DEFAULT_CONCURRENCY;

--- a/skills/filter-chatlog/scripts/libs/batch-prompt.ts
+++ b/skills/filter-chatlog/scripts/libs/batch-prompt.ts
@@ -1,0 +1,35 @@
+// src: scripts/libs/batch-prompt.ts
+// @(#): Claude CLI へのバッチプロンプト文字列構築
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── external ───
+import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { parseFrontmatterEntries } from '../../../_scripts/libs/text/frontmatter-utils.ts';
+
+// ─── internal ───
+import { MAX_BODY_CHARS } from '../constants/filter.constants.ts';
+import { extractBodyText } from './prefilter.ts';
+
+// ─────────────────────────────────────────────
+// バッチプロンプト構築
+// ─────────────────────────────────────────────
+
+export const buildBatchPrompt = async (files: string[]): Promise<string> => {
+  const parts: string[] = [];
+
+  for (let i = 0; i < files.length; i++) {
+    const filePath = files[i];
+    const filename = filePath.split(/[/\\]/).pop()!;
+    const text = await readTextFile(filePath);
+    const { content } = parseFrontmatterEntries(text);
+    const bodyText = extractBodyText(content, MAX_BODY_CHARS);
+
+    parts.push(`=== FILE ${i + 1}: ${filename} ===\n${bodyText}`);
+  }
+
+  return parts.join('\n\n');
+};

--- a/skills/filter-chatlog/scripts/libs/claude-runner.ts
+++ b/skills/filter-chatlog/scripts/libs/claude-runner.ts
@@ -1,0 +1,39 @@
+// src: scripts/libs/claude-runner.ts
+// @(#): Claude CLI プロセスの起動と結果取得
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── external ───
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+
+// ─── internal ───
+import { SYSTEM_PROMPT } from '../constants/filter.constants.ts';
+
+// ─────────────────────────────────────────────
+// Claude CLI 呼び出し
+// ─────────────────────────────────────────────
+
+export const runClaude = async (prompt: string): Promise<string> => {
+  const cmd = new Deno.Command('claude', {
+    args: ['-p', SYSTEM_PROMPT, '--output-format', 'text'],
+    stdin: 'piped',
+    stdout: 'piped',
+    stderr: 'null',
+  });
+
+  const process = cmd.spawn();
+
+  const writer = process.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(prompt));
+  await writer.close();
+
+  const output = await process.output();
+  if (!output.success) {
+    throw new ChatlogError('CliError', `claude CLI がエラーで終了しました (code=${output.code})`);
+  }
+
+  return new TextDecoder().decode(output.stdout);
+};

--- a/skills/filter-chatlog/scripts/libs/find-files.ts
+++ b/skills/filter-chatlog/scripts/libs/find-files.ts
@@ -1,0 +1,26 @@
+// src: scripts/libs/find-files.ts
+// @(#): チャットログ Markdown ファイルの列挙
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── external ───
+import { findFiles as findFilesLib } from '../../../_scripts/libs/file-io/find-files.ts';
+
+// ─────────────────────────────────────────────
+// ファイル列挙
+// ─────────────────────────────────────────────
+
+const _resolveSearchDir = (baseDir: string, period?: string): string => {
+  if (!period) {
+    return baseDir;
+  }
+  return `${baseDir}/${period.slice(0, 4)}/${period}`;
+};
+
+export const findMdFiles = (baseDir: string, period?: string): Promise<string[]> => {
+  const _searchDir = _resolveSearchDir(baseDir, period);
+  return findFilesLib(_searchDir);
+};

--- a/skills/filter-chatlog/scripts/libs/prefilter.ts
+++ b/skills/filter-chatlog/scripts/libs/prefilter.ts
@@ -1,0 +1,120 @@
+// src: scripts/libs/prefilter.ts
+// @(#): 内容ベース事前フィルタ関数群
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── external ───
+import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { parseFrontmatterEntries } from '../../../_scripts/libs/text/frontmatter-utils.ts';
+import { parseConversation } from '../../../_scripts/libs/text/markdown-utils.ts';
+
+// ─── internal ───
+import { MAX_BODY_CHARS } from '../constants/filter.constants.ts';
+import { EXCLUDE_FILENAME_PATTERNS_STR, SYSTEM_TAG_PREFIXES } from '../constants/patterns.constants.ts';
+
+// ─────────────────────────────────────────────
+// 事前フィルタ関数
+// ─────────────────────────────────────────────
+
+export const isSystemOnlyMessage = (text: string): boolean => {
+  const stripped = text.trim();
+  return SYSTEM_TAG_PREFIXES.some((prefix) => stripped.startsWith(prefix));
+};
+
+export const isExcludedByFilename = (filename: string): boolean => {
+  const lower = filename.toLowerCase();
+  return EXCLUDE_FILENAME_PATTERNS_STR.some((pat) => lower.includes(pat));
+};
+
+export const isExcludedByContent = (
+  body: string,
+  minCharCount = 1000,
+  minAssistantChars = 300,
+): { excluded: boolean; reason: string } => {
+  if (body.length < minCharCount) {
+    return { excluded: true, reason: `本文が短すぎる (${body.length} < ${minCharCount} 文字)` };
+  }
+
+  const turns = parseConversation(body);
+  const userTurns = turns.filter((t) => t.role === 'user');
+  const assistantTurns = turns.filter((t) => t.role === 'assistant');
+
+  if (userTurns.length === 0) {
+    return { excluded: true, reason: 'Userターンが存在しない' };
+  }
+
+  if (userTurns.length === 1) {
+    if (isSystemOnlyMessage(userTurns[0].text)) {
+      return { excluded: true, reason: 'Userメッセージがシステム/コマンドタグのみ' };
+    }
+    const totalAssistantChars = assistantTurns.reduce((sum, t) => sum + t.text.length, 0);
+    if (totalAssistantChars < minAssistantChars) {
+      return {
+        excluded: true,
+        reason: `Assistantの応答が短すぎる (${totalAssistantChars} < ${minAssistantChars} 文字)`,
+      };
+    }
+  }
+
+  return { excluded: false, reason: '' };
+};
+
+export const extractBodyText = (body: string, maxChars = MAX_BODY_CHARS): string => {
+  const turns = parseConversation(body);
+  const parts = turns.map((t) => {
+    const role = t.role === 'user' ? 'User' : 'Assistant';
+    return `### ${role}\n${t.text}`;
+  });
+  return parts.join('\n\n').slice(0, maxChars);
+};
+
+export const prefilterFiles = async (files: string[]): Promise<string[]> => {
+  const passed: string[] = [];
+  let skipped = 0;
+
+  for (const filePath of files) {
+    const filename = filePath.split(/[/\\]/).pop()!;
+
+    if (isExcludedByFilename(filename)) {
+      logger.info(`  skipped (ファイル名パターン): ${filename}`);
+      skipped++;
+      continue;
+    }
+
+    let text: string;
+    try {
+      text = await readTextFile(filePath);
+    } catch {
+      skipped++;
+      continue;
+    }
+
+    const { content } = parseFrontmatterEntries(text);
+    if (!content.trim()) {
+      skipped++;
+      continue;
+    }
+
+    const { excluded, reason } = isExcludedByContent(content);
+    if (excluded) {
+      logger.info(`  skipped (${reason}): ${filename}`);
+      skipped++;
+      continue;
+    }
+
+    const bodyText = extractBodyText(content);
+    if (!bodyText.trim()) {
+      skipped++;
+      continue;
+    }
+
+    passed.push(filePath);
+  }
+
+  logger.info(`事前フィルタ: 対象=${files.length} 通過=${passed.length} スキップ=${skipped}`);
+  return passed;
+};

--- a/skills/filter-chatlog/scripts/libs/process-chunk.ts
+++ b/skills/filter-chatlog/scripts/libs/process-chunk.ts
@@ -1,0 +1,87 @@
+// src: scripts/libs/process-chunk.ts
+// @(#): チャンク単位の Claude 判定とファイル削除
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── external ───
+import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { parseJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
+
+// ─── internal ───
+import { DISCARD_THRESHOLD } from '../constants/filter.constants.ts';
+import type { ClaudeResult, Stats } from '../types/filter.types.ts';
+import { buildBatchPrompt } from './batch-prompt.ts';
+import { runClaude } from './claude-runner.ts';
+
+// ─────────────────────────────────────────────
+// チャンク処理
+// ─────────────────────────────────────────────
+
+export const processChunk = async (
+  chunkFiles: string[],
+  dryRun: boolean,
+  stats: Stats,
+): Promise<void> => {
+  const batchPrompt = await buildBatchPrompt(chunkFiles);
+
+  let rawResult: string;
+  try {
+    rawResult = await runClaude(batchPrompt);
+  } catch (e) {
+    logger.warn(`  警告: claude CLI 実行失敗。チャンク内ファイルをすべて KEEP 扱い`);
+    logger.warn(`  error: ${e}`);
+    for (const f of chunkFiles) {
+      logger.info(`  kept (claude error): ${f.split(/[/\\]/).pop()}`);
+      stats.kept++;
+    }
+    return;
+  }
+
+  const parsed = parseJsonArray<ClaudeResult>(rawResult);
+  if (!parsed) {
+    logger.warn(`  警告: JSON パース失敗。チャンク内ファイルをすべて KEEP 扱い`);
+    logger.warn(`  raw output: ${rawResult.slice(0, 200)}`);
+    for (const f of chunkFiles) {
+      logger.info(`  kept (parse error): ${f.split(/[/\\]/).pop()}`);
+      stats.kept++;
+    }
+    return;
+  }
+
+  for (const filePath of chunkFiles) {
+    const filename = filePath.split(/[/\\]/).pop()!;
+    const result = parsed.find((r) => r.file === filename);
+
+    if (!result) {
+      logger.info(`  kept (not in result): ${filename}`);
+      stats.kept++;
+      continue;
+    }
+
+    const { decision, confidence, reason } = result;
+
+    if (decision === 'DISCARD' && confidence >= DISCARD_THRESHOLD) {
+      if (dryRun) {
+        logger.log(`[dry-run] DISCARD (conf=${confidence}): ${filePath}`);
+        logger.info(`  reason: ${reason}`);
+        stats.discarded++;
+      } else {
+        logger.log(`DISCARD (conf=${confidence}): ${filePath}`);
+        logger.info(`  reason: ${reason}`);
+        try {
+          await Deno.remove(filePath);
+          stats.discarded++;
+        } catch {
+          logger.error(`  削除失敗: ${filePath}`);
+          stats.error++;
+        }
+      }
+    } else {
+      logger.info(`  kept (decision=${decision}, conf=${confidence}): ${filename}`);
+      stats.kept++;
+    }
+  }
+};

--- a/skills/filter-chatlog/scripts/types/filter.types.ts
+++ b/skills/filter-chatlog/scripts/types/filter.types.ts
@@ -37,3 +37,23 @@ export type ParsedConfig = Partial<FilterConfig> & {
   /** `--config` で指定された設定ファイルのパス。省略時は `undefined`。 */
   configFile?: string;
 };
+
+// ─────────────────────────────────────────────
+// Claude CLI 判定結果型
+// ─────────────────────────────────────────────
+
+/** Claude CLI が返すファイル単位の判定結果。 */
+export interface ClaudeResult {
+  file: string;
+  decision: 'KEEP' | 'DISCARD';
+  confidence: number;
+  reason: string;
+}
+
+/** バッチ処理全体の処理統計。 */
+export interface Stats {
+  kept: number;
+  discarded: number;
+  skipped: number;
+  error: number;
+}


### PR DESCRIPTION
# refactor(filter-chatlog): split monolithic script into focused modules

## Overview

**Summary**
Split the 312-line monolithic `filter-chatlog.ts` into six dedicated library modules with shared constants and types.

**Background / Motivation**
The original `filter-chatlog.ts` bundled file discovery, pre-filtering, prompt construction, Claude CLI execution, and chunk-level judgment into a single 312-line script. This made each concern difficult to test in isolation and violated the Single Responsibility Principle.

By applying the project's `skills/_scripts/libs/` pattern to `filter-chatlog`, every function now lives in its own module, is independently importable, and can be unit-tested without pulling in unrelated logic.

## Changes

### Core Changes

- `scripts/filter-chatlog.ts` — reduced to a thin orchestrator; all business logic removed (312 lines deleted)
- `scripts/libs/find-files.ts` — `findMdFiles()`: recursively enumerates Markdown files in a directory
- `scripts/libs/prefilter.ts` — `isSystemOnlyMessage()`, `isExcludedByFilename()`, `isExcludedByContent()`, `extractBodyText()`, `prefilterFiles()`: heuristic noise-filter functions applied before Claude is invoked
- `scripts/libs/batch-prompt.ts` — `buildBatchPrompt()`: constructs the batch prompt payload for the Claude CLI
- `scripts/libs/claude-runner.ts` — `runClaude()`: wraps Claude CLI execution and captures its output
- `scripts/libs/process-chunk.ts` — `processChunk()`: applies per-chunk judgment and deletes files marked as noise
- `scripts/constants/filter.constants.ts` — `DISCARD_THRESHOLD`, `MAX_BODY_CHARS`, `SYSTEM_PROMPT`, `DEFAULT_FILTER_CONFIG`
- `scripts/constants/patterns.constants.ts` — `SYSTEM_TAG_PREFIXES`, `EXCLUDE_FILENAME_PATTERNS_STR`, `EXCLUDE_FILENAME_PATTERNS_RE`
- `scripts/types/filter.types.ts` — `ClaudeResult`, `Stats` interfaces

### Test Updates

- 7 test files — import path updates only; no logic changes

### Removed

- N/A (logic moved to `libs/` modules, not deleted)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Test commands for this module:

```bash
deno task test:unit
deno task test:module unit filter
dprint fmt --check
```
