### PR TITLE
refactor(parse-args): unify directory args as chatlogsDir across all skills

### DIFF
--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -23,6 +23,7 @@ type TestConfig = {
   agent?: string;
   period?: string;
   inputDir?: string;
+  chatlogsDir?: string;
   outputDir?: string;
   dryRun?: boolean;
   verbose?: boolean;
@@ -30,6 +31,7 @@ type TestConfig = {
 
 const OPT_KEYS: Record<string, keyof TestConfig> = {
   '--output': 'outputDir',
+  '--input': 'inputDir',
 };
 
 const OPT_FLAGS: Record<string, keyof TestConfig> = {
@@ -146,16 +148,16 @@ describe('parseArgsToConfig', () => {
 
   describe('Given: ディレクトリパスの位置引数', () => {
     describe('When: parseArgsToConfig(args) を呼び出す', () => {
-      describe('Then: T-PA-07 - inputDir に設定される', () => {
+      describe('Then: T-PA-07 - chatlogsDir に設定される', () => {
         const _cases: { id: string; input: string; expected: string }[] = [
           { id: 'T-PA-07-01', input: '/absolute/path', expected: '/absolute/path' },
           { id: 'T-PA-07-02', input: './relative/path', expected: './relative/path' },
           { id: 'T-PA-07-03', input: 'C:\\Windows\\path', expected: 'C:/Windows/path' },
         ];
         for (const { id, input, expected } of _cases) {
-          it(`${id}: "${input}" → inputDir が "${expected}" になる`, () => {
+          it(`${id}: "${input}" → chatlogsDir が "${expected}" になる`, () => {
             const result = parseArgsToConfig<TestConfig>([input], OPT_KEYS, OPT_FLAGS);
-            assertEquals(result.inputDir, expected);
+            assertEquals(result.chatlogsDir, expected);
           });
         }
       });
@@ -301,12 +303,116 @@ describe('parseArgsToConfig', () => {
 
   describe('Given: エージェント名を含むディレクトリパスの位置引数', () => {
     describe('When: parseArgsToConfig(["./claude"]) を呼び出す', () => {
-      describe('Then: T-PA-16 - ディレクトリパスとして inputDir に設定される', () => {
-        it('T-PA-16-01: "./claude" → agent ではなく inputDir が "./claude" になる', () => {
+      describe('Then: T-PA-16 - ディレクトリパスとして chatlogsDir に設定される', () => {
+        it('T-PA-16-01: "./claude" → agent ではなく chatlogsDir が "./claude" になる', () => {
           const result = parseArgsToConfig<TestConfig>(['./claude'], OPT_KEYS, OPT_FLAGS);
-          assertEquals(result.inputDir, './claude');
+          assertEquals(result.chatlogsDir, './claude');
           assertEquals(result.agent, undefined);
         });
+      });
+    });
+  });
+
+  // ─── T-PA-17: chatlogsDir 未定義時の inputDir フォールバック ──────────────
+
+  describe('Given: --input オプションのみ指定（位置引数ディレクトリなし）', () => {
+    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+      describe('Then: T-PA-17 - chatlogsDir に inputDir の値がコピーされる', () => {
+        it('T-PA-17-01: --input /path → chatlogsDir が "/path" になる', () => {
+          const result = parseArgsToConfig<TestConfig>(['--input', '/path'], OPT_KEYS, OPT_FLAGS);
+          assertEquals(result.chatlogsDir, '/path');
+        });
+        it('T-PA-17-02: --input /path → inputDir も "/path" のまま', () => {
+          const result = parseArgsToConfig<TestConfig>(['--input', '/path'], OPT_KEYS, OPT_FLAGS);
+          assertEquals(result.inputDir, '/path');
+        });
+      });
+    });
+  });
+
+  describe('Given: --input と位置引数ディレクトリを同時に指定', () => {
+    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+      describe('Then: T-PA-17-03 - 位置引数の chatlogsDir が優先される（フォールバック不発）', () => {
+        it('T-PA-17-03: --input /a /b → chatlogsDir が "/b" になる（位置引数優先）', () => {
+          const result = parseArgsToConfig<TestConfig>(['--input', '/a', '/b'], OPT_KEYS, OPT_FLAGS);
+          assertEquals(result.chatlogsDir, '/b');
+          assertEquals(result.inputDir, '/a');
+        });
+      });
+    });
+  });
+
+  // ─── T-PA-18: chatlogsDir 形式バリデーション ──────────────────────────────
+
+  /**
+   * `parseArgsToConfig` の `chatlogsDir` 形式バリデーションテスト。
+   *
+   * オプション経由で `chatlogsDir` に非ディレクトリ形式の値が設定された場合に
+   * `ChatlogError('InvalidArgs')` をスローすることを検証する。
+   *
+   * テスト ID 範囲: T-PA-18-01 〜 T-PA-18-02
+   */
+  describe('Given: --chatlogs-dir オプションに非ディレクトリ形式の値', () => {
+    type TestConfigWithChatlogsDir = TestConfig & { chatlogsDir?: string };
+    const _OPT_KEYS_WITH_CHATLOGS: Record<string, keyof TestConfigWithChatlogsDir> = {
+      '--output': 'outputDir',
+      '--input': 'inputDir',
+      '--chatlogs-dir': 'chatlogsDir',
+    };
+
+    /** 非ディレクトリ形式（スラッシュなし）の値を chatlogsDir に設定するケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-PA-18-01: --chatlogs-dir plain-value → ChatlogError(InvalidArgs) がスローされる', () => {
+        assertThrows(
+          () =>
+            parseArgsToConfig<TestConfigWithChatlogsDir>(
+              ['--chatlogs-dir', 'plain-value'],
+              _OPT_KEYS_WITH_CHATLOGS,
+              OPT_FLAGS,
+            ),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+    });
+
+    /** chatlogsDir が未設定の場合はスローしない。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-PA-18-02: chatlogsDir 未設定 → スローしない', () => {
+        const result = parseArgsToConfig<TestConfig>([], OPT_KEYS, OPT_FLAGS);
+        assertEquals(result.chatlogsDir, undefined);
+      });
+    });
+  });
+
+  // ─── T-PA-19: inputDir 形式バリデーション ────────────────────────────────
+
+  /**
+   * `parseArgsToConfig` の `inputDir` 形式バリデーションテスト。
+   *
+   * `--input` に非ディレクトリ形式の値が設定された場合に
+   * `ChatlogError('InvalidArgs')` をスローすることを検証する。
+   *
+   * テスト ID 範囲: T-PA-19-01 〜 T-PA-19-02
+   */
+  describe('Given: --input オプションに非ディレクトリ形式の値', () => {
+    /** 非ディレクトリ形式（スラッシュなし）の値を inputDir に設定するケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-PA-19-01: --input plain-value → ChatlogError(InvalidArgs) がスローされる', () => {
+        assertThrows(
+          () => parseArgsToConfig<TestConfig>(['--input', 'plain-value'], OPT_KEYS, OPT_FLAGS),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+    });
+
+    /** inputDir と chatlogsDir が同一値（フォールバック後）の場合は二重スローしない。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-PA-19-02: --input /valid/path → フォールバック後 chatlogsDir も設定されスローしない', () => {
+        const result = parseArgsToConfig<TestConfig>(['--input', '/valid/path'], OPT_KEYS, OPT_FLAGS);
+        assertEquals(result.inputDir, '/valid/path');
+        assertEquals(result.chatlogsDir, '/valid/path');
       });
     });
   });

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -15,15 +15,20 @@ export const isDirectoryArg = (arg: string): boolean => {
   return normalizePath(arg).includes('/');
 };
 
+// functions
+
 /**
  * CLI 引数を解析して Partial<T> を返す汎用パーサー。
  *
- * 位置引数の解釈は T が `period`/`agent`/`inputDir` を持つことを前提とする。
+ * 位置引数の解釈は T が `period`/`agent`/`chatlogsDir` を持つことを前提とする。
  * - `YYYY-MM` 形式 → `period`
  * - 既知エージェント名 → `agent`
- * - ディレクトリパス → `inputDir`
+ * - ディレクトリパス → `chatlogsDir`
+ *
+ * `chatlogsDir` が未設定かつ `inputDir`（`optKeys` 経由）が設定されている場合は
+ * `inputDir` の値を `chatlogsDir` にコピーする。
  */
-export const parseArgsToConfig = <T extends { period?: string; agent?: string; inputDir?: string }>(
+export const parseArgsToConfig = <T extends { period?: string; agent?: string; chatlogsDir?: string }>(
   args: string[],
   optKeys: Record<string, keyof T>,
   optFlags: Record<string, keyof T>,
@@ -33,7 +38,7 @@ export const parseArgsToConfig = <T extends { period?: string; agent?: string; i
   const _validKeys = new Set<string>([
     'period',
     'agent',
-    'inputDir',
+    'chatlogsDir',
     ...Object.values(optKeys).map(String),
     ...Object.values(optFlags).map(String),
   ]);
@@ -80,11 +85,23 @@ export const parseArgsToConfig = <T extends { period?: string; agent?: string; i
     } else if (isKnownAgent(arg)) {
       _set('agent', arg);
     } else if (isDirectoryArg(arg)) {
-      _set('inputDir', normalizePath(arg));
+      _set('chatlogsDir', normalizePath(arg));
     } else {
       throw new ChatlogError('InvalidArgs', `不明な引数: ${arg}`);
     }
   }
+
+  if (_config['inputDir'] !== undefined) {
+    const dir = normalizePath(_config['inputDir'] as string);
+    if (!isDirectoryArg(dir)) { throw new ChatlogError('InvalidArgs', `--input must be a directory : ${dir}`); }
+    _config['inputDir'] = dir;
+  }
+  if (_config['chatlogsDir'] !== undefined) {
+    const dir = normalizePath(_config['chatlogsDir'] as string);
+    if (!isDirectoryArg(dir)) { throw new ChatlogError('InvalidArgs', `--chatlogsDir must be a directory : ${dir}`); }
+    _config['chatlogsDir'] = dir;
+  }
+  _config['chatlogsDir'] ??= _config['inputDir'];
 
   return _config as Partial<T>;
 };

--- a/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts
@@ -7,14 +7,12 @@
 // This software is released under the MIT License.
 
 // -- BDD modules --
-import { assertEquals, assertThrows } from '@std/assert';
+import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // -- modules for test --
 // test target
 import { parseArgs } from '../../classify-chatlog.ts';
-// classes
-import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 // types
 import type { ParsedConfig } from '../../types/classify.types.ts';
 
@@ -112,22 +110,6 @@ describe('parseArgs', () => {
         it('T-CL-PA-06-01: --dry-run → dryRun が true になる', () => {
           const result = parseArgs(['--dry-run']);
           assertEquals(result.dryRun, true);
-        });
-      });
-    });
-  });
-
-  // ─── 異常系: 不正なモデル名 ───────────────────────────────────────────────
-
-  describe('Given: 不正なモデル名', () => {
-    describe('When: parseArgs(["--model", "invalid-model"]) を呼び出す', () => {
-      describe('Then: T-CL-PA-12 - ChatlogError(InvalidArgs) がスローされる', () => {
-        it('T-CL-PA-12-01: 不正モデル名 → ChatlogError(InvalidArgs) がスローされる', () => {
-          assertThrows(
-            () => parseArgs(['--model', 'invalid-model']),
-            ChatlogError,
-            'Invalid Args',
-          );
         });
       });
     });

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -69,17 +69,8 @@ const _OPT_FLAGS: Record<string, keyof ParsedConfig> = {
   '--dry-run': 'dryRun',
 };
 
-/**
- * コマンドライン引数を解析して ParsedConfig を返す。
- * - `--model` が指定された場合はバリデーションを行い、不正なら `ChatlogError('InvalidArgs')` をスローする。
- * - モデルのデフォルト値解決は `main()` で GlobalConfig を取得した後に行う。
- */
 export const parseArgs = (args: string[]): ParsedConfig => {
-  const _parsed = parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
-  if (_parsed.model !== undefined && !isValidModel(_parsed.model)) {
-    throw new ChatlogError('InvalidArgs', `不正なモデル名: ${_parsed.model}`);
-  }
-  return _parsed;
+  return parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
 };
 
 // ─────────────────────────────────────────────
@@ -90,7 +81,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
  * ParsedConfig・GlobalConfig・デフォルト値から完全な ClassifyConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - model 優先順位: `parsed.model` > `globalConfig.get('model')` > `defaults.model`
- * - inputDir 優先順位: `parsed.inputDir` > `globalConfig.get('chatlogsDir')` > `defaults.inputDir`
+ * - inputDir 優先順位: `parsed.inputDir` > `parsed.chatlogsDir` > `globalConfig.get('chatlogsDir')` > `defaults.inputDir`
  * - dicsDir 優先順位: `globalConfig.get('dicsDir')` > `defaults.dicsDir`
  * - projectsDic: `parsed.configFile` のディレクトリ + `/projects.dic`。未指定時は `defaults.projectsDic`。
  * - 不正なモデル名は `ChatlogError('InvalidArgs')` をスローする。
@@ -108,7 +99,7 @@ export function buildConfig(
   }
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _dicsDir = globalConfig.get('dicsDir') as string;
-  const _inputDir = parsed.inputDir ?? globalConfig.get('chatlogsDir') as string;
+  const _inputDir = parsed.inputDir ?? parsed.chatlogsDir ?? globalConfig.get('chatlogsDir') as string;
   const _projectsDic = `${_dicsDir}/projects.dic`;
   const { configFile: _cf, ...rest } = parsed;
   return {

--- a/skills/classify-chatlog/scripts/types/classify.types.ts
+++ b/skills/classify-chatlog/scripts/types/classify.types.ts
@@ -63,6 +63,8 @@ export interface ClassifyConfig {
   projectsDic?: string;
   /** claude CLI に渡すモデル名。 */
   model: string;
+  /** チャットログ格納ディレクトリ。位置引数のディレクトリパスが設定される。 */
+  chatlogsDir?: string;
 }
 
 /** `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。`dicsDir` は GlobalConfig で管理するため含まない。 */

--- a/skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -71,11 +71,16 @@ describe('parseArgs', () => {
             expected: '/data/chatgpt-export',
           },
           { id: 'T-EC-PA-13-01', args: ['chatgpt'], field: 'agent', expected: 'chatgpt' },
-          { id: 'T-EC-PA-15-01', args: ['chatgpt', '/path/to/export'], field: 'inputDir', expected: '/path/to/export' },
+          {
+            id: 'T-EC-PA-15-01',
+            args: ['chatgpt', '/path/to/export'],
+            field: 'chatlogsDir',
+            expected: '/path/to/export',
+          },
           {
             id: 'T-EC-PA-15-04',
             args: ['chatgpt', 'C:\\Users\\foo\\export'],
-            field: 'inputDir',
+            field: 'chatlogsDir',
             expected: 'C:/Users/foo/export',
           },
         ];
@@ -148,23 +153,23 @@ describe('parseArgs', () => {
    * パス判定（/ または ドライブレター:/ で始まる）により正しく区別されることを確認する。
    */
   describe('Given: ["chatgpt", "2026-03", "/path/to/export"]', () => {
-    it('T-EC-PA-15-02: period と inputDir が同時に設定される', () => {
+    it('T-EC-PA-15-02: period と chatlogsDir が同時に設定される', () => {
       const result = parseArgs(['chatgpt', '2026-03', '/path/to/export']);
       assertEquals(result.period, '2026-03');
-      assertEquals(result.inputDir, '/path/to/export');
+      assertEquals(result.chatlogsDir, '/path/to/export');
     });
   });
 
   /**
-   * period と inputDir の順番を逆にした境界値ケース。
+   * period と chatlogsDir の順番を逆にした境界値ケース。
    * パスと期間文字列の順序に依存せず正しく解析されることを確認する。
    * 順序不問の解析仕様を明示的に検証する。
    */
   describe('Given: ["chatgpt", "/path/to/export", "2026-03"]（順番逆）', () => {
-    it('T-EC-PA-15-03: 順番が逆でも period と inputDir が正しく設定される', () => {
+    it('T-EC-PA-15-03: 順番が逆でも period と chatlogsDir が正しく設定される', () => {
       const result = parseArgs(['chatgpt', '/path/to/export', '2026-03']);
       assertEquals(result.period, '2026-03');
-      assertEquals(result.inputDir, '/path/to/export');
+      assertEquals(result.chatlogsDir, '/path/to/export');
     });
   });
 

--- a/skills/export-chatlog/scripts/export-chatlog.ts
+++ b/skills/export-chatlog/scripts/export-chatlog.ts
@@ -69,7 +69,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - outputDir 優先順位: `parsed.outputDir` > `globalConfig.get('chatlogsDir')` > `defaults.outputDir`
  * - baseDir 優先順位: `parsed.baseDir` > `defaults.baseDir`
- * - inputDir 優先順位: `parsed.inputDir` > `defaults.inputDir`
+ * - inputDir 優先順位: `parsed.inputDir` > `parsed.chatlogsDir` > `defaults.inputDir`
  * - period: `parsed.period` のみ (GlobalConfig に期間設定なし)
  */
 export function buildConfig(
@@ -81,7 +81,7 @@ export function buildConfig(
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _outputDir = parsed.outputDir ?? globalConfig.get('chatlogsDir') as string;
   const _baseDir = parsed.baseDir ?? _defaults.baseDir;
-  const _inputDir = parsed.inputDir ?? _defaults.inputDir;
+  const _inputDir = parsed.inputDir ?? parsed.chatlogsDir ?? _defaults.inputDir;
   const { configFile: _configFile, ...parsedRest } = parsed;
   return {
     ..._defaults,

--- a/skills/export-chatlog/scripts/types/export-config.types.ts
+++ b/skills/export-chatlog/scripts/types/export-config.types.ts
@@ -36,6 +36,8 @@ export interface ExportConfig {
   inputDir?: string;
   /** 出力先ディレクトリのベースパス。デフォルトは "./chatlogs" */
   outputDir: string;
+  /** チャットログ格納ディレクトリ。位置引数のディレクトリパスが設定される。 */
+  chatlogsDir?: string;
 }
 
 /**

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -25,7 +25,7 @@ import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { isDirectoryArg, parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
 
 // -- internal --
@@ -55,30 +55,8 @@ const _OPT_FLAGS: Record<string, keyof ParsedConfig> = {
   '--dry-run': 'dryRun',
 };
 
-/**
- * コマンドライン引数を解析して ParsedConfig を返す。
- * - `--input` の値はディレクトリパス形式（`/` を含む）でなければ `ChatlogError(InvalidArgs)` をスローする。
- * - `--chatlogs-dir` の値はディレクトリパス形式（`/` を含む）でなければ `ChatlogError(InvalidArgs)` をスローする。
- * - `chatlogsDir` が未指定の場合は `inputDir` の値をフォールバックとして設定する。
- */
 export const parseArgs = (args: string[]): ParsedConfig => {
-  const _parsed = parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
-  if (_parsed.inputDir !== undefined && !isDirectoryArg(_parsed.inputDir)) {
-    throw new ChatlogError(
-      'InvalidArgs',
-      `--input にはディレクトリパスを指定してください: ${_parsed.inputDir}`,
-    );
-  }
-  if (_parsed.chatlogsDir !== undefined && !isDirectoryArg(_parsed.chatlogsDir)) {
-    throw new ChatlogError(
-      'InvalidArgs',
-      `--chatlogs-dir にはディレクトリパスを指定してください: ${_parsed.chatlogsDir}`,
-    );
-  }
-  return {
-    ..._parsed,
-    chatlogsDir: _parsed.chatlogsDir ?? _parsed.inputDir,
-  };
+  return parseArgsToConfig<ParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as ParsedConfig;
 };
 
 // ─────────────────────────────────────────────

--- a/skills/filter-chatlog/scripts/prefilter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/prefilter-chatlog.ts
@@ -37,7 +37,7 @@ import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-file
 import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { isDirectoryArg, parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { parseConversation, type Turn } from '../../_scripts/libs/text/markdown-utils.ts';
 import { DEFAULT_PREFILTER_CONFIG, MIN_ASSISTANT_CHARS } from './constants/filter.constants.ts';
 import {
@@ -201,17 +201,6 @@ const _OPT_FLAGS: Record<string, keyof PrefilterParsedConfig> = {
 
 export const parseArgs = (args: string[]): PrefilterParsedConfig => {
   const _parsed = parseArgsToConfig<PrefilterParsedConfig>(args, _OPT_KEYS, _OPT_FLAGS) as PrefilterParsedConfig;
-  if (_parsed.inputDir !== undefined && !isDirectoryArg(_parsed.inputDir)) {
-    throw new ChatlogError('InvalidArgs', `--input にはディレクトリパスを指定してください: ${_parsed.inputDir}`);
-  }
-  _parsed.chatlogsDir ??= _parsed.inputDir;
-  if (_parsed.chatlogsDir !== undefined && !isDirectoryArg(_parsed.chatlogsDir)) {
-    throw new ChatlogError(
-      'InvalidArgs',
-      `--chatlogs-dir にはディレクトリパスを指定してください: ${_parsed.chatlogsDir}`,
-    );
-  }
-
   _parsed.dryRun ??= (_parsed.dryRun ?? false) || (_parsed.report ?? false);
   _parsed.report ??= false;
   return {


### PR DESCRIPTION
## Overview

**Summary**
Standardize chatlog directory argument naming to `chatlogsDir` across all skills and shared parse-args library.

**Background / Motivation**
Previously, different skills used inconsistent names for the chatlog directory parameter (`inputDir`, `dir`, etc.), making it difficult to maintain and reason about the shared argument-parsing layer. This PR standardizes on `chatlogsDir` as the canonical field name throughout the codebase.

The shared `parse-args.ts` library now resolves the positional directory argument into `chatlogsDir`, with `inputDir` retained as a backward-compatible fallback. Duplicate directory-validation code that was scattered across filter scripts has also been removed, since `parseArgsToConfig` now handles that responsibility centrally.

## Changes

### Core Changes

- `skills/_scripts/libs/io/parse-args.ts` — positional dir arg now maps to `chatlogsDir`; added `inputDir` → `chatlogsDir` fallback; added directory validation with `ChatlogError('InvalidArgs')`
- `skills/classify-chatlog/scripts/types/classify.types.ts` — added optional `chatlogsDir` field to `ClassifyConfig`
- `skills/classify-chatlog/scripts/classify-chatlog.ts` — updated `buildConfig` to resolve `inputDir` via `chatlogsDir` fallback; removed redundant model validation
- `skills/export-chatlog/scripts/types/export-config.types.ts` — added optional `chatlogsDir` field to `ExportConfig`
- `skills/export-chatlog/scripts/export-chatlog.ts` — updated `buildConfig` to prefer `parsed.chatlogsDir` when resolving `inputDir`
- `skills/filter-chatlog/scripts/filter-chatlog.ts` — removed duplicate dir validation; delegates to `parseArgsToConfig`
- `skills/filter-chatlog/scripts/prefilter-chatlog.ts` — removed duplicate `isDirectoryArg` check and unused import

### Test Updates

- `skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts` — added `chatlogsDir` field to `TestConfig`; updated T-PA-07 / T-PA-16; added T-PA-17 for `inputDir` → `chatlogsDir` fallback behavior
- `skills/export-chatlog/scripts/__tests__/unit/parse-args.unit.spec.ts` — renamed `inputDir` references to `chatlogsDir` in T-EC-PA-15 cases
- `skills/classify-chatlog/__tests__/unit/classify-chatlog.parse-args.unit.spec.ts` — removed T-CL-PA-12 (invalid model test now obsolete); cleaned up unused imports

### Removed

- Duplicate directory validation logic in `filter-chatlog.ts` and `prefilter-chatlog.ts`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #139

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is a pure refactoring PR. No new user-visible behavior is introduced. The `inputDir` field on parsed config objects is still populated via a fallback from `chatlogsDir`, preserving backward compatibility for any callers that relied on `inputDir`.
