### PR TITLE
refactor: consolidate file-ops libs into unified file-ops module

### DIFF
--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -7,9 +7,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { findDirectories } from '../../libs/file-io/find-entries.ts';
 import { normalizePath } from '../../libs/file-io/path-utils.ts';
 import { fileExists } from '../../libs/file-ops/exists-utils.ts';
+import { findDirectories } from '../../libs/file-ops/find-entries.ts';
 
 // ─────────────────────────────────────────────
 // 型定義

--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -7,9 +7,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { fileExists } from '../../libs/file-io/exists-utils.ts';
 import { findDirectories } from '../../libs/file-io/find-entries.ts';
 import { normalizePath } from '../../libs/file-io/path-utils.ts';
+import { fileExists } from '../../libs/file-ops/exists-utils.ts';
 
 // ─────────────────────────────────────────────
 // 型定義

--- a/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
@@ -19,8 +19,8 @@ import { ChatlogError } from '../../ChatlogError.class.ts';
 // -- helpers --
 import { findFixtureDirs, type IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // exists
-import { fileExists } from '../../../libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../libs/file-io/read-utils.ts';
+import { fileExists } from '../../../libs/file-ops/exists-utils.ts';
 
 // -- test target --
 import { ChatlogEntry } from '../../ChatlogEntry.class.ts';

--- a/skills/_scripts/classes/__tests__/fixtures/render-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/render-entry.fixtures.spec.ts
@@ -21,9 +21,9 @@ import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
 import { findFixtureDirs } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // type
 import type { IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
-// exists
-import { fileExists } from '../../../libs/file-io/exists-utils.ts';
+// file libs
 import { readTextFile } from '../../../libs/file-io/read-utils.ts';
+import { fileExists } from '../../../libs/file-ops/exists-utils.ts';
 // -- error class --
 import { ChatlogError } from '../../ChatlogError.class.ts';
 

--- a/skills/_scripts/classes/__tests__/fixtures/to-frontmatter.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/to-frontmatter.fixtures.spec.ts
@@ -17,9 +17,9 @@ import { parse as parseYaml } from '@std/yaml';
 import { findFixtureDirs } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // types
 import type { IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
-// exists
-import { fileExists } from '../../../libs/file-io/exists-utils.ts';
+// file libs
 import { readTextFile } from '../../../libs/file-io/read-utils.ts';
+import { fileExists } from '../../../libs/file-ops/exists-utils.ts';
 
 // -- error class --
 import { ChatlogError } from '../../ChatlogError.class.ts';

--- a/skills/_scripts/libs/file-ops/__tests__/functional/find-files.functional.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/functional/find-files.functional.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/__tests__/functional/find-files.functional.spec.ts
+// src: skills/_scripts/libs/file-ops/__tests__/functional/find-files.functional.spec.ts
 // @(#): findFiles の機能テスト - 実ファイルシステムを使った検証
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/file-ops/__tests__/system/backup-old-path.system.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/system/backup-old-path.system.spec.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2026 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 // src: skills/_scripts/libs/file-ops/__tests__/system/backup-old-path.system.spec.ts
 // @(#): backupOldPath のシステムテスト（Deno ファイルシステム実使用、file-ops）
 //       対象: backupOldPath

--- a/skills/_scripts/libs/file-ops/__tests__/system/backup-old-path.system.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/system/backup-old-path.system.spec.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { backupOldPath } from '../../backup-old-path.ts';
 
 // ─── Helpers
-import { fileExists, fileOrDirExists } from '../../../file-io/exists-utils.ts';
+import { fileExists, fileOrDirExists } from '../../exists-utils.ts';
 
 // ─── Tests
 

--- a/skills/_scripts/libs/file-ops/__tests__/unit/exists-utils.unit.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/unit/exists-utils.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/__tests__/unit/exists-utils.unit.spec.ts
+// src: skills/_scripts/libs/file-ops/__tests__/unit/exists-utils.unit.spec.ts
 // @(#): exists-utils ユニットテスト
 //       対象: fileExists, fileOrDirExists, dirExists
 //

--- a/skills/_scripts/libs/file-ops/__tests__/unit/find-entries.unit.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/unit/find-entries.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/__tests__/unit/find-entries.unit.spec.ts
+// src: skills/_scripts/libs/file-ops/__tests__/unit/find-entries.unit.spec.ts
 // @(#): findDirectories / findEntries のユニットテスト
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/file-ops/__tests__/unit/find-files.unit.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/unit/find-files.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/__tests__/unit/find-files.unit.spec.ts
+// src: skills/_scripts/libs/file-ops/__tests__/unit/find-files.unit.spec.ts
 // @(#): findFiles のユニットテスト - GlobProvider モックによる検証
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/file-ops/__tests__/unit/walk-files.unit.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/unit/walk-files.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/__tests__/unit/walk-files.unit.spec.ts
+// src: skills/_scripts/libs/file-ops/__tests__/unit/walk-files.unit.spec.ts
 // @(#): walk-files ユニットテスト
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/file-ops/backup-old-path.ts
+++ b/skills/_scripts/libs/file-ops/backup-old-path.ts
@@ -15,7 +15,7 @@
 
 // --- shared modules
 // functions
-import { fileExists } from '../file-io/exists-utils.ts';
+import { fileExists } from './exists-utils.ts';
 // types
 import type { ListDirProvider, StatProvider } from '../../types/providers.types.ts';
 // classes

--- a/skills/_scripts/libs/file-ops/exists-utils.ts
+++ b/skills/_scripts/libs/file-ops/exists-utils.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/exists-utils.ts
+// src: skills/_scripts/libs/file-ops/exists-utils.ts
 // @(#): ファイル・ディレクトリ存在チェックユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/file-ops/find-entries.ts
+++ b/skills/_scripts/libs/file-ops/find-entries.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/find-entries.ts
+// src: skills/_scripts/libs/file-ops/find-entries.ts
 // @(#): ディレクトリ一覧・ファイルエントリ収集ユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -11,7 +11,7 @@ import { expandGlob } from '@std/fs';
 
 // -- internal --
 import type { GlobProvider } from '../../types/providers.types.ts';
-import { normalizePath } from './path-utils.ts';
+import { normalizePath } from '../file-io/path-utils.ts';
 
 // ─────────────────────────────────────────────
 // Internal utilities

--- a/skills/_scripts/libs/file-ops/find-files.ts
+++ b/skills/_scripts/libs/file-ops/find-files.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/find-files.ts
+// src: skills/_scripts/libs/file-ops/find-files.ts
 // @(#): ファイル一覧取得共通ユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -9,7 +9,7 @@
 import { expandGlob } from '@std/fs';
 
 import type { GlobProvider } from '../../types/providers.types.ts';
-import { normalizePath } from './path-utils.ts';
+import { normalizePath } from '../file-io/path-utils.ts';
 
 // ─────────────────────────────────────────────
 // 型定義

--- a/skills/_scripts/libs/file-ops/walk-files.ts
+++ b/skills/_scripts/libs/file-ops/walk-files.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/walk-files.ts
+// src: skills/_scripts/libs/file-ops/walk-files.ts
 // @(#): ディレクトリ再帰走査ユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
@@ -37,9 +37,9 @@ import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-st
 // classes
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 // exists
-import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── テスト用一時ディレクトリセットアップ ─────────────────────────────────────
 

--- a/skills/classify-chatlog/scripts/__tests__/fixtures/classify-chatlog.fixtures.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/fixtures/classify-chatlog.fixtures.spec.ts
@@ -15,7 +15,7 @@ import { parse as parseYaml } from '@std/yaml';
 import { processChunk } from '../../classify-chatlog.ts';
 
 // utils
-import { findDirectories } from '../../../../_scripts/libs/file-io/find-entries.ts';
+import { findDirectories } from '../../../../_scripts/libs/file-ops/find-entries.ts';
 // constants
 import { DEFAULT_AI_MODEL } from '../../../../_scripts/constants/defaults.constants.ts';
 // classes

--- a/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.classify-file.integration.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/integration/classify-chatlog.classify-file.integration.spec.ts
@@ -20,8 +20,8 @@ import { ClassifyChatlogEntry } from '../../classes/ClassifyChatlogEntry.class.t
 // types
 import type { ClassifyStats } from '../../types/classify.types.ts';
 // exists
-import { dirExists, fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { dirExists, fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── ヘルパー ────────────────────────────────────────────────────────────────
 

--- a/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts
@@ -12,8 +12,8 @@ import { assertEquals, assertStringIncludes } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Helpers
-import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
+import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── Internal Helpers
 

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -17,10 +17,10 @@
 // -- external --
 import { isValidModel } from '../../_scripts/libs/ai/model-utils.ts';
 import { runAI } from '../../_scripts/libs/ai/run-ai.ts';
-import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
-import { findEntries } from '../../_scripts/libs/file-io/find-entries.ts';
 import { getDirectory } from '../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
+import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
+import { findEntries } from '../../_scripts/libs/file-ops/find-entries.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
 import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';

--- a/skills/export-chatlog/scripts/__tests__/functional/write-session.functional.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/functional/write-session.functional.spec.ts
@@ -19,8 +19,8 @@ import { writeSession } from '../../libs/session-writer.ts';
 // types
 import type { ExportedSession } from '../../types/session.types.ts';
 // exists
-import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── Internal Helpers
 

--- a/skills/export-chatlog/scripts/__tests__/integration/walk-files.integration.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/integration/walk-files.integration.spec.ts
@@ -11,7 +11,7 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { walkFiles } from '../../../../_scripts/libs/file-io/walk-files.ts';
+import { walkFiles } from '../../../../_scripts/libs/file-ops/walk-files.ts';
 
 // ─── Tests
 /**

--- a/skills/export-chatlog/scripts/exporter/__tests__/fixtures/export-chatlog.fixtures.spec.ts
+++ b/skills/export-chatlog/scripts/exporter/__tests__/fixtures/export-chatlog.fixtures.spec.ts
@@ -25,8 +25,8 @@ import { findFixtureDirs } from '../../../../../_scripts/__tests__/helpers/find-
 import type { IsFixtureDirProvider } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
 import type { PeriodRange } from '../../../types/filter.types.ts';
 // exists
-import { fileExists } from '../../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── Internal Helpers
 

--- a/skills/export-chatlog/scripts/exporter/claude-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/claude-exporter.ts
@@ -9,9 +9,9 @@
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
 import { homeDir } from '../../../_scripts/libs/file-io/dir-utils.ts';
-import { findDirectories, findEntries } from '../../../_scripts/libs/file-io/find-entries.ts';
 import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { findDirectories, findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────

--- a/skills/export-chatlog/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/codex-exporter.ts
@@ -9,9 +9,9 @@
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
 import { homeDir } from '../../../_scripts/libs/file-io/dir-utils.ts';
-import { findEntries } from '../../../_scripts/libs/file-io/find-entries.ts';
 import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────

--- a/skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-asserts.ts
+++ b/skills/filter-chatlog/scripts/__tests__/_helpers/chatlog-asserts.ts
@@ -11,7 +11,7 @@
 import { assert, assertFalse } from '@std/assert';
 
 // ─── Helpers
-import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
+import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 /**
  * 指定パスが通常ファイルとして存在することをアサートする。

--- a/skills/filter-chatlog/scripts/__tests__/e2e/filter-chatlog.main.e2e.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/e2e/filter-chatlog.main.e2e.spec.ts
@@ -39,7 +39,7 @@ import { FILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 import type { CommandMockHandle } from '../../../../../skills/_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../../skills/_scripts/__tests__/helpers/logger-stub.ts';
 // e2e helpers
-import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
+import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { assertFileNotExists } from '../_helpers/chatlog-asserts.ts';
 import { makeRepeatedContent, makeTestDirs } from '../_helpers/chatlog-fixtures.ts';
 

--- a/skills/filter-chatlog/scripts/__tests__/e2e/prefilter-chatlog.main.e2e.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/e2e/prefilter-chatlog.main.e2e.spec.ts
@@ -26,7 +26,7 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 // constants
 import { PREFILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // e2e helpers
-import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
+import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { assertFileExists, assertFileNotExists } from '../_helpers/chatlog-asserts.ts';
 import { makeRepeatedContent, makeTestDirs } from '../_helpers/chatlog-fixtures.ts';
 

--- a/skills/filter-chatlog/scripts/__tests__/functional/filter/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/filter/process-chunk.functional.spec.ts
@@ -31,7 +31,7 @@ import {
 import type { CommandMockHandle } from '../../../../../../skills/_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makePeriodDir } from '../../_helpers/chatlog-fixtures.ts';
 // exists
-import { fileExists, fileOrDirExists } from '../../../../../_scripts/libs/file-io/exists-utils.ts';
+import { fileExists, fileOrDirExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── Internal Helpers
 

--- a/skills/filter-chatlog/scripts/__tests__/functional/prefilter/process-noise-filter-files.functional.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/functional/prefilter/process-noise-filter-files.functional.spec.ts
@@ -16,7 +16,7 @@ import { processNoiseFilterFiles } from '../../../libs/process-noise-filter.ts';
 
 // ─── Helpers
 import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
-import { fileExists } from '../../../../../_scripts/libs/file-io/exists-utils.ts';
+import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 // types
 import type { LoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants

--- a/skills/filter-chatlog/scripts/__tests__/integration/filter-chatlog.file-ops.integration.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/integration/filter-chatlog.file-ops.integration.spec.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { stub } from '@std/testing/mock';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { buildBatchPrompt } from '../../../../filter-chatlog/scripts/libs/batch-prompt.ts';
 import { prefilterFiles } from '../../../../filter-chatlog/scripts/libs/prefilter.ts';
 

--- a/skills/filter-chatlog/scripts/__tests__/integration/prefilter-chatlog.integration.spec.ts
+++ b/skills/filter-chatlog/scripts/__tests__/integration/prefilter-chatlog.integration.spec.ts
@@ -13,9 +13,9 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { classifyFile } from '../../libs/classify-file.ts';
 
 // ─── Helpers
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { resolveChatlogsDir } from '../../../../_scripts/libs/file-io/resolve-directory.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { makeRepeatedContent } from '../_helpers/chatlog-fixtures.ts';
 // constants
 import { PREFILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';

--- a/skills/filter-chatlog/scripts/filter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/filter-chatlog.ts
@@ -23,7 +23,7 @@ import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.
 // -- external --
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
-import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
+import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
@@ -34,8 +34,8 @@ import { DEFAULT_FILTER_CONFIG } from './constants/filter.constants.ts';
 // types
 import type { FilterConfig, ParsedConfig } from './types/filter.types.ts';
 // libs
-import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
+import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { prefilterFiles } from './libs/prefilter.ts';
 import { processChunk } from './libs/process-chunk.ts';
 

--- a/skills/filter-chatlog/scripts/prefilter-chatlog.ts
+++ b/skills/filter-chatlog/scripts/prefilter-chatlog.ts
@@ -31,9 +31,9 @@
 
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
-import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
-import { findFiles as findFilesLib } from '../../_scripts/libs/file-io/find-files.ts';
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
+import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
+import { findFiles as findFilesLib } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { buildConfig, parseArgs } from './config/prefilter-config.ts';
 import { processNoiseFilterFiles } from './libs/process-noise-filter.ts';

--- a/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-full.e2e.spec.ts
@@ -21,8 +21,8 @@ import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-st
 import { assertAllOutputFiles } from '../../../../_scripts/__tests__/helpers/output-validator.ts';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { main } from '../../normalize-chatlog.ts';
 import type { HashProvider } from '../../normalize-chatlog.ts';
 

--- a/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts
@@ -25,8 +25,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
 import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { main } from '../../normalize-chatlog.ts';
 import type { HashProvider } from '../../normalize-chatlog.ts';
 

--- a/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-output-structure.e2e.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-output-structure.e2e.spec.ts
@@ -20,7 +20,7 @@ import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-st
 import { assertAllOutputFiles } from '../../../../_scripts/__tests__/helpers/output-validator.ts';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { main } from '../../normalize-chatlog.ts';
 
 // ─── 構造テスト ────────────────────────────────────────────────────────────────

--- a/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-reproducibility.e2e.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-reproducibility.e2e.spec.ts
@@ -25,8 +25,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { main } from '../../normalize-chatlog.ts';
 import type { HashProvider } from '../../normalize-chatlog.ts';
 

--- a/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-segments.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-segments.spec.ts
@@ -30,8 +30,8 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { DenoCommandLike } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // exists
-import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // test target
 import { segmentChatlog } from '../../normalize-chatlog.ts';

--- a/skills/normalize-chatlog/scripts/__tests__/functional/find-files.functional.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/functional/find-files.functional.spec.ts
@@ -12,7 +12,7 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import type { GlobProvider } from '../../../../_scripts/types/providers.types.ts';
 
 // ─── local helpers ────────────────────────────────────────────────────────────

--- a/skills/normalize-chatlog/scripts/__tests__/integration/find-files.integration.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/integration/find-files.integration.spec.ts
@@ -13,7 +13,7 @@ import { assertEquals, assertGreater } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 
 // ─── findFiles integration tests ───────────────────────────────────────────
 

--- a/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/unit/normalize-chatlog.file-ops.unit.spec.ts
@@ -19,8 +19,8 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // exists
-import { fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // test target
 import {

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -23,10 +23,10 @@ import { isValidModel } from '../../_scripts/libs/ai/model-utils.ts';
 import { backupOldPath } from '../../_scripts/libs/file-ops/backup-old-path.ts';
 
 // -- file-io --
-import { dirExistsSync } from '../../_scripts/libs/file-io/exists-utils.ts';
-import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
+import { dirExistsSync } from '../../_scripts/libs/file-ops/exists-utils.ts';
+import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 
 // -- io --
 import { logger } from '../../_scripts/libs/io/logger.ts';

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/set-frontmatter.fixtures.spec.ts
@@ -20,8 +20,8 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
-import { fileExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { normalizeLine } from '../../../../_scripts/libs/text/line-utils.ts';
 
 // test target

--- a/skills/set-frontmatter/scripts/__tests__/functional/find-files.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/find-files.functional.spec.ts
@@ -10,7 +10,7 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // test target
-import { findFiles } from '../../../../_scripts/libs/file-io/find-files.ts';
+import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 
 // ─── テスト共通セットアップ ───────────────────────────────────────────────────
 

--- a/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/write-frontmatter.functional.spec.ts
@@ -16,8 +16,8 @@ import type { FrontmatterFileMeta, FrontmatterResult, Stats } from '../../set-fr
 import { writeFrontmatter } from '../../set-frontmatter.ts';
 
 // exists
-import { fileOrDirExists } from '../../../../_scripts/libs/file-io/exists-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // ─── テスト共通セットアップ ───────────────────────────────────────────────────
 

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -26,9 +26,9 @@
 // -- external --
 import { parse as parseYaml } from '@std/yaml';
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
-import { dirExists } from '../../_scripts/libs/file-io/exists-utils.ts';
-import { findFiles } from '../../_scripts/libs/file-io/find-files.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
+import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
+import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
 import { parseFrontmatterEntries } from '../../_scripts/libs/text/frontmatter-utils.ts';


### PR DESCRIPTION
## Overview

**Summary**
Consolidate scattered file-operation modules under a single `file-ops` submodule within `skills/_scripts/libs/`. All skill scripts and their test suites are updated to use the new import paths.

**Background / Motivation**
Previously, file-operation utilities (`find-files`, `find-entries`, `walk-files`, `exists-utils`, `backup-old-path`) were placed directly under `skills/_scripts/libs/`. This change groups them into a dedicated `file-ops` subdirectory, making the library structure clearer and easier to navigate. All skill scripts and test files across the codebase are updated to reference the new paths.

## Changes

### Core Library — moved to `skills/_scripts/libs/file-ops/`

- `backup-old-path.ts`
- `exists-utils.ts`
- `find-entries.ts`
- `find-files.ts`
- `walk-files.ts`

### Tests — relocated to `skills/_scripts/libs/file-ops/__tests__/`

- `unit/exists-utils.unit.spec.ts`
- `unit/find-entries.unit.spec.ts`
- `unit/find-files.unit.spec.ts`
- `unit/walk-files.unit.spec.ts`
- `functional/find-files.functional.spec.ts`
- `system/backup-old-path.system.spec.ts`

### Skill Scripts — import paths updated

- `classify-chatlog/scripts/classify-chatlog.ts`
- `export-chatlog/scripts/exporter/claude-exporter.ts`
- `export-chatlog/scripts/exporter/codex-exporter.ts`
- `filter-chatlog/scripts/filter-chatlog.ts`
- `filter-chatlog/scripts/prefilter-chatlog.ts`
- `normalize-chatlog/scripts/normalize-chatlog.ts`
- `set-frontmatter/scripts/set-frontmatter.ts`

### Skill Test Files — import paths updated

All test files under `classify-chatlog`, `export-chatlog`, `filter-chatlog`, `normalize-chatlog`, and `set-frontmatter` updated to reference the new `file-ops` paths.

### Helper / Fixture Files — import paths updated

- `skills/_scripts/__tests__/helpers/find-fixture-dirs.ts`
- `skills/_scripts/classes/__tests__/fixtures/*.fixtures.spec.ts` (3 files)

## Change Type

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (`dprint fmt --check`)
- [x] Tests pass (`deno task test:unit`, `deno task test`)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files
- [ ] No remaining references to old import paths (`libs/find-files`, `libs/exists-utils`, etc.)

## Additional Notes

No public API changes. All moved modules retain the same exported symbols; only internal import paths were updated across the codebase.

Test verification commands:

```bash
dprint check
deno lint
deno task test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
