### PR TITLE
refactor(shared-libs): move path-utils module from file-io to dedicated directory

### DIFF
--- a/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
+++ b/skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 // -- test target --
 import { defaultIsFixtureDir, findFixtureDirs } from '../find-fixture-dirs.ts';
 // -- utils --
-import { normalizePath } from '../../../libs/file-io/path-utils.ts';
+import { normalizePath } from '../../../libs/path-utils/path-utils.ts';
 // -- types --
 import type { IsFixtureDirProvider } from '../find-fixture-dirs.ts';
 

--- a/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
+++ b/skills/_scripts/__tests__/helpers/find-fixture-dirs.ts
@@ -7,9 +7,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { normalizePath } from '../../libs/file-io/path-utils.ts';
 import { fileExists } from '../../libs/file-ops/exists-utils.ts';
 import { findDirectories } from '../../libs/file-ops/find-entries.ts';
+import { normalizePath } from '../../libs/path-utils/path-utils.ts';
 
 // ─────────────────────────────────────────────
 // 型定義

--- a/skills/_scripts/classes/GlobalConfig.class.ts
+++ b/skills/_scripts/classes/GlobalConfig.class.ts
@@ -12,7 +12,7 @@ import { parse } from '@std/yaml';
 
 // --- local modules
 // libs
-import { resolveConfigPath } from '../libs/file-io/path-utils.ts';
+import { resolveConfigPath } from '../libs/path-utils/path-utils.ts';
 import { parseNumber, parseString } from '../libs/text/string-utils.ts';
 // constants
 import { DEFAULT_CONFIG_FILE } from '../constants/defaults.constants.ts';

--- a/skills/_scripts/libs/file-ops/find-entries.ts
+++ b/skills/_scripts/libs/file-ops/find-entries.ts
@@ -11,7 +11,7 @@ import { expandGlob } from '@std/fs';
 
 // -- internal --
 import type { GlobProvider } from '../../types/providers.types.ts';
-import { normalizePath } from '../file-io/path-utils.ts';
+import { normalizePath } from '../path-utils/path-utils.ts';
 
 // ─────────────────────────────────────────────
 // Internal utilities

--- a/skills/_scripts/libs/file-ops/find-files.ts
+++ b/skills/_scripts/libs/file-ops/find-files.ts
@@ -9,7 +9,7 @@
 import { expandGlob } from '@std/fs';
 
 import type { GlobProvider } from '../../types/providers.types.ts';
-import { normalizePath } from '../file-io/path-utils.ts';
+import { normalizePath } from '../path-utils/path-utils.ts';
 
 // ─────────────────────────────────────────────
 // 型定義

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -6,16 +6,21 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+// --- shared modules ---
+// functions
 import { isKnownAgent } from '../../constants/agents.constants.ts';
-import { normalizePath } from '../file-io/path-utils.ts';
+import { normalizePath } from '../path-utils/path-utils.ts';
+// classes
+import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 
+// -- internal modules ---
+// functions
 /** 正規化後に `/` を含む場合 `true` を返す（CLI 位置引数のディレクトリパス判定）。 */
 export const isDirectoryArg = (arg: string): boolean => {
   return normalizePath(arg).includes('/');
 };
 
-// functions
+// --- Public API ---
 
 /**
  * CLI 引数を解析して Partial<T> を返す汎用パーサー。

--- a/skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/__tests__/unit/dir-utils.unit.spec.ts
+// src: skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
 // @(#): dir-utils ユニットテスト
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/__tests__/file-io/unit/path-utils.unit.spec.ts
+// src: skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
 // @(#): path-utils ユニットテスト
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/path-utils/dir-utils.ts
+++ b/skills/_scripts/libs/path-utils/dir-utils.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/dir-utils.ts
+// src: skills/_scripts/libs/path-utils/dir-utils.ts
 // @(#): ディレクトリ取得ユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>

--- a/skills/_scripts/libs/path-utils/path-utils.ts
+++ b/skills/_scripts/libs/path-utils/path-utils.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/libs/file-io/path-utils.ts
+// src: skills/_scripts/libs/path-utils/path-utils.ts
 // @(#): パスユーティリティ
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -9,7 +9,7 @@
 // utils
 import { getProjectRootDir } from './dir-utils.ts';
 // types
-import type { ResolveConfigPathOptions } from '../../types/file-io.types.ts';
+import type { ResolveConfigPathOptions } from '../../types/path-utils.types.ts';
 import type { CommandProvider } from '../../types/providers.types.ts';
 
 // ─────────────────────────────────────────────

--- a/skills/_scripts/types/file-io.types.ts
+++ b/skills/_scripts/types/file-io.types.ts
@@ -5,20 +5,3 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
-
-// types
-import type { CommandProvider } from './providers.types.ts';
-
-// ─────────────────────────────────────────────
-// パス解決系
-// ─────────────────────────────────────────────
-
-/** resolveConfigPath のオプション引数。 */
-export interface ResolveConfigPathOptions {
-  /** 設定ファイル/ディレクトリのパス */
-  configPath?: string;
-  /** デフォルトパス */
-  defaultPath: string;
-  /** コマンドプロバイダ: `Git`用 (テスト用に置き換え可能) */
-  commandProvider?: CommandProvider;
-}

--- a/skills/_scripts/types/path-utils.types.ts
+++ b/skills/_scripts/types/path-utils.types.ts
@@ -1,0 +1,23 @@
+// src: skills/_scripts/types/path-utils.types.ts
+// @(#): path-utils ライブラリ専用の型定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import type { CommandProvider } from './providers.types.ts';
+
+// ─────────────────────────────────────────────
+// パス解決系
+// ─────────────────────────────────────────────
+
+/** resolveConfigPath のオプション引数。 */
+export interface ResolveConfigPathOptions {
+  /** 設定ファイル/ディレクトリのパス */
+  configPath?: string;
+  /** デフォルトパス */
+  defaultPath: string;
+  /** コマンドプロバイダ: `Git`用 (テスト用に置き換え可能) */
+  commandProvider?: CommandProvider;
+}

--- a/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts
@@ -37,9 +37,9 @@ import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-st
 // classes
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 // exists
-import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── テスト用一時ディレクトリセットアップ ─────────────────────────────────────
 

--- a/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts
+++ b/skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts
@@ -12,8 +12,8 @@ import { assertEquals, assertStringIncludes } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Helpers
-import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
 import { fileExists, fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Internal Helpers
 

--- a/skills/classify-chatlog/scripts/classes/ClassifyChatlogEntry.class.ts
+++ b/skills/classify-chatlog/scripts/classes/ClassifyChatlogEntry.class.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
-import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
+import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
 export class ClassifyChatlogEntry extends ChatlogEntry {
   readonly filePath: string;

--- a/skills/classify-chatlog/scripts/classify-chatlog.ts
+++ b/skills/classify-chatlog/scripts/classify-chatlog.ts
@@ -17,12 +17,12 @@
 // -- external --
 import { isValidModel } from '../../_scripts/libs/ai/model-utils.ts';
 import { runAI } from '../../_scripts/libs/ai/run-ai.ts';
-import { getDirectory } from '../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { findEntries } from '../../_scripts/libs/file-ops/find-entries.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
+import { getDirectory } from '../../_scripts/libs/path-utils/path-utils.ts';
 import { parseJsonArray } from '../../_scripts/libs/text/json-utils.ts';
 import { normalizeLine } from '../../_scripts/libs/text/line-utils.ts';
 // instances

--- a/skills/classify-chatlog/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
+++ b/skills/classify-chatlog/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
@@ -13,7 +13,7 @@ import { describe, it } from '@std/testing/bdd';
 // test target
 import { loadProjectDic } from '../../load-project-dic.ts';
 // types
-import type { ResolveConfigPathOptions } from '../../../../../_scripts/types/file-io.types.ts';
+import type { ResolveConfigPathOptions } from '../../../../../_scripts/types/path-utils.types.ts';
 import type { ProjectDicEntry } from '../../../types/classify.types.ts';
 // classed
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';

--- a/skills/classify-chatlog/scripts/libs/load-project-dic.ts
+++ b/skills/classify-chatlog/scripts/libs/load-project-dic.ts
@@ -10,8 +10,8 @@
 import { parse as parseYaml } from '@std/yaml';
 
 // utils
-import { resolveConfigPath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { resolveConfigPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // types
 import type { ProjectDicEntry } from '../types/classify.types.ts';
 // classes

--- a/skills/export-chatlog/scripts/__tests__/integration/find-claude-sessions.integration.spec.ts
+++ b/skills/export-chatlog/scripts/__tests__/integration/find-claude-sessions.integration.spec.ts
@@ -15,7 +15,7 @@ import { stub } from '@std/testing/mock';
 import type { Stub } from '@std/testing/mock';
 
 // ─── Test target
-import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { findClaudeSessions } from '../../exporter/claude-exporter.ts';
 import { parsePeriod } from '../../libs/period-filter.ts';
 

--- a/skills/export-chatlog/scripts/exporter/claude-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/claude-exporter.ts
@@ -8,10 +8,10 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
-import { homeDir } from '../../../_scripts/libs/file-io/dir-utils.ts';
-import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { findDirectories, findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
+import { homeDir } from '../../../_scripts/libs/path-utils/dir-utils.ts';
+import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────

--- a/skills/export-chatlog/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlog/scripts/exporter/codex-exporter.ts
@@ -8,10 +8,10 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
-import { homeDir } from '../../../_scripts/libs/file-io/dir-utils.ts';
-import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
+import { homeDir } from '../../../_scripts/libs/path-utils/dir-utils.ts';
+import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────

--- a/skills/export-chatlog/scripts/libs/session-writer.ts
+++ b/skills/export-chatlog/scripts/libs/session-writer.ts
@@ -8,7 +8,7 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
-import { getDirectory } from '../../../_scripts/libs/file-io/path-utils.ts';
+import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 import { textToSlug } from '../../../_scripts/libs/text/slug-utils.ts';
 import { quoteString } from '../../../_scripts/libs/text/string-utils.ts';

--- a/skills/filter-chatlog/scripts/libs/process-noise-filter.ts
+++ b/skills/filter-chatlog/scripts/libs/process-noise-filter.ts
@@ -6,9 +6,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { normalizePath } from '../../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { classifyFile } from './classify-file.ts';
 
 // ─────────────────────────────────────────────

--- a/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts
+++ b/skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts
@@ -25,8 +25,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 
 // test target
-import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
 import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { main } from '../../normalize-chatlog.ts';
 import type { HashProvider } from '../../normalize-chatlog.ts';
 

--- a/skills/normalize-chatlog/scripts/normalize-chatlog.ts
+++ b/skills/normalize-chatlog/scripts/normalize-chatlog.ts
@@ -23,10 +23,10 @@ import { isValidModel } from '../../_scripts/libs/ai/model-utils.ts';
 import { backupOldPath } from '../../_scripts/libs/file-ops/backup-old-path.ts';
 
 // -- file-io --
-import { normalizePath } from '../../_scripts/libs/file-io/path-utils.ts';
 import { readTextFile } from '../../_scripts/libs/file-io/read-utils.ts';
 import { dirExistsSync } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
+import { normalizePath } from '../../_scripts/libs/path-utils/path-utils.ts';
 
 // -- io --
 import { logger } from '../../_scripts/libs/io/logger.ts';


### PR DESCRIPTION
## Overview

**Summary**
Move `path-utils` and `dir-utils` from `_scripts/libs/file-io/` to a new `_scripts/libs/path-utils/` directory, and extract `ResolveConfigPathOptions` into a dedicated type file.

**Background / Motivation**
The `file-io/` directory had grown to hold both low-level file I/O helpers and higher-level path resolution utilities (`normalizePath`, `homeDir`, `resolveConfigPath`, `getDirectory`). Mixing these responsibilities reduced cohesion and made the module boundary unclear. Moving path utilities to their own `path-utils/` namespace clarifies ownership, and extracting `ResolveConfigPathOptions` into `path-utils.types.ts` places the type definition with the code that owns it.

All 25 commits in this branch are pure import-path updates — no logic was changed.

## Changes

### Core Changes

- `skills/_scripts/libs/path-utils/path-utils.ts` — moved from `file-io/`; import updated to use `path-utils.types.ts`
- `skills/_scripts/libs/path-utils/dir-utils.ts` — moved from `file-io/`; header comment updated to new path
- `skills/_scripts/types/path-utils.types.ts` — **new file**: extracted `ResolveConfigPathOptions` interface
- `skills/_scripts/types/file-io.types.ts` — removed `ResolveConfigPathOptions` and now-unused `CommandProvider` import
- Import paths updated in 12 production files:
  - `skills/_scripts/classes/GlobalConfig.class.ts`
  - `skills/_scripts/libs/file-ops/find-entries.ts`
  - `skills/_scripts/libs/file-ops/find-files.ts`
  - `skills/_scripts/libs/io/parse-args.ts`
  - `skills/classify-chatlog/scripts/classify-chatlog.ts`
  - `skills/classify-chatlog/scripts/classes/ClassifyChatlogEntry.class.ts`
  - `skills/classify-chatlog/scripts/libs/load-project-dic.ts`
  - `skills/export-chatlog/scripts/exporter/claude-exporter.ts`
  - `skills/export-chatlog/scripts/exporter/codex-exporter.ts`
  - `skills/export-chatlog/scripts/libs/session-writer.ts`
  - `skills/filter-chatlog/scripts/libs/process-noise-filter.ts`
  - `skills/normalize-chatlog/scripts/normalize-chatlog.ts`

### Test Updates

- `skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts` — moved from `file-io/__tests__/`
- `skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts` — moved from `file-io/__tests__/`
- `skills/_scripts/__tests__/helpers/find-fixture-dirs.ts` — import path updated
- `skills/_scripts/__tests__/helpers/__tests__/find-fixture-dirs.unit.spec.ts` — import path updated
- `skills/classify-chatlog/scripts/__tests__/e2e/classify-chatlog.main.e2e.spec.ts` — import path updated
- `skills/classify-chatlog/scripts/__tests__/system/classify-chatlog.short.system.spec.ts` — import path updated
- `skills/classify-chatlog/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts` — import path updated
- `skills/export-chatlog/scripts/__tests__/integration/find-claude-sessions.integration.spec.ts` — import path updated
- `skills/normalize-chatlog/scripts/__tests__/e2e/normalize-chatlog-io.e2e.spec.ts` — import path updated

### Removed

- `skills/_scripts/libs/file-io/path-utils.ts` — replaced by `path-utils/path-utils.ts`
- `skills/_scripts/libs/file-io/dir-utils.ts` — replaced by `path-utils/dir-utils.ts`
- `ResolveConfigPathOptions` from `file-io.types.ts` — moved to `path-utils.types.ts`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is step A-08 in the ongoing `shared-libs` reorganisation series. The old `file-io/path-utils.ts` and `file-io/dir-utils.ts` files have been removed; any remaining references to the old paths will produce import errors and will be caught by CI.
