### PR TITLE
feat(classify-chatlogs): add subindex arg to ChatlogError calls

### DIFF
--- a/skills/classify-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
@@ -110,6 +110,13 @@ describe('buildConfig', () => {
             ChatlogError,
           );
         });
+        it('T-CL-BC-04-02: err.subindex === "ModelName"', () => {
+          const err = assertThrows(
+            () => buildConfig(_EMPTY_PARSED, globalConfig),
+            ChatlogError,
+          );
+          assertEquals(err.subindex, 'ModelName');
+        });
       });
     });
   });

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -92,7 +92,7 @@ export function buildConfig(
   const _defaults = defaults ?? DEFAULT_CLASSIFY_CONFIG;
   const _model = parsed.model ?? globalConfig.get('model') as string;
   if (!isValidModel(_model)) {
-    throw new ChatlogError('InvalidArgs', `不正なモデル名: ${_model}`);
+    throw new ChatlogError('InvalidArgs', 'ModelName', `不正なモデル名: ${_model}`);
   }
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _dicsDir = globalConfig.get('dicsDir') as string;
@@ -320,7 +320,7 @@ export const main = async (argv?: string[]): Promise<void> => {
     // 入力ディレクトリ確認
     const agentDir = `${_config.inputDir}/${_config.agent}`;
     if (!await dirExists(agentDir)) {
-      throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${agentDir}`);
+      throw new ChatlogError('InputNotFound', 'InputDir', `入力ディレクトリが見つかりません: ${agentDir}`);
     }
 
     // プロジェクト辞書読み込み

--- a/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
@@ -235,6 +235,17 @@ describe('loadProjectDic', () => {
       assertEquals(err instanceof ChatlogError, true);
       assertEquals((err as ChatlogError).kind, 'InvalidYaml');
     });
+
+    it('T-CL-LPD-16-03: throw された ChatlogError の subindex が "ProjectsDic" になる', async () => {
+      const err = await loadProjectDic(
+        'assets/configs/projects.dic',
+        _resolveToFixture,
+        _readInvalidYaml,
+      ).catch((e) => e);
+
+      assertEquals(err instanceof ChatlogError, true);
+      assertEquals((err as ChatlogError).subindex, 'ProjectsDic');
+    });
   });
 
   // ─── エッジケース ─────────────────────────────────────────────────────────

--- a/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
+++ b/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
@@ -115,7 +115,7 @@ export const loadProjectDic = async (
     _parsed = parseYaml(text);
   } catch (e) {
     if (e instanceof SyntaxError) {
-      throw new ChatlogError('InvalidYaml', `YAML 構文エラー: ${e.message}`);
+      throw new ChatlogError('InvalidYaml', 'ProjectsDic', `YAML 構文エラー: ${e.message}`);
     }
     throw e;
   }


### PR DESCRIPTION
## Overview

**Summary**
Add `subindex` argument to all `ChatlogError` constructor calls in the `classify-chatlogs` skill.

**Background / Motivation**
PR #166 merged the `subindex` field and overloaded constructor into `ChatlogError`.
This PR applies that capability to `classify-chatlogs`, where existing `ChatlogError` calls
lacked the subindex argument. Without subindex, callers could only identify the error *type*
(e.g. `InvalidArgs`) but not *which* field or resource triggered it. Adding subindex makes
errors actionable — `InvalidArgs` now indicates `ModelName` was invalid, and `InputNotFound`
indicates `InputDir` is missing.

## Changes

### Core Changes

- `skills/classify-chatlogs/scripts/classify-chatlogs.ts`
  - `buildConfig`: `ChatlogError('InvalidArgs', ...)` → `ChatlogError('InvalidArgs', 'ModelName', ...)`
  - `main`: `ChatlogError('InputNotFound', ...)` → `ChatlogError('InputNotFound', 'InputDir', ...)`
- `skills/classify-chatlogs/scripts/libs/load-project-dic.ts`
  - `loadProjectDic`: `ChatlogError('InvalidYaml', ...)` → `ChatlogError('InvalidYaml', 'ProjectsDic', ...)`

### Test Updates

- `skills/classify-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts`
  - Added assertion: `err.subindex === 'ModelName'` (T-CL-BC-04-02)
- `skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts`
  - Added assertion: `err.subindex === 'ProjectsDic'` (T-CL-LPD-16-03)

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #164
> Related to #166

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

*Optional: add screenshots, design notes, or concerns for reviewers.*
