### PR TITLE
feat(export-chatlogs): add subindex arg to ChatlogError calls

### DIFF
--- a/skills/export-chatlogs/scripts/__tests__/unit/period-filter.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/period-filter.unit.spec.ts
@@ -12,6 +12,8 @@ import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { inPeriod, parsePeriod } from '../../libs/period-filter.ts';
+// chatlog error
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 
 // ─── Tests
 
@@ -101,8 +103,28 @@ describe('parsePeriod', () => {
     describe('When: parsePeriod("invalid") を呼び出す', () => {
       /** T-EC-PF-01: Error をスローする */
       describe('Then: T-EC-PF-01 - Error をスローする', () => {
-        it('T-EC-PF-01-06: Error がスローされる', () => {
-          assertThrows(() => parsePeriod('invalid'), Error);
+        it('T-EC-PF-01-06: ChatlogError がスローされる', () => {
+          assertThrows(() => parsePeriod('invalid'), ChatlogError);
+        });
+
+        it('T-EC-PF-01-07: throw された ChatlogError の kind が InvalidPeriod である', () => {
+          let err: unknown;
+          try {
+            parsePeriod('invalid');
+          } catch (e) {
+            err = e;
+          }
+          assertEquals((err as ChatlogError).kind, 'InvalidPeriod');
+        });
+
+        it('T-EC-PF-01-08: throw された ChatlogError の subindex が "Period" になる', () => {
+          let err: unknown;
+          try {
+            parsePeriod('invalid');
+          } catch (e) {
+            err = e;
+          }
+          assertEquals((err as ChatlogError).subindex, 'Period');
         });
       });
     });

--- a/skills/export-chatlogs/scripts/export-chatlogs.ts
+++ b/skills/export-chatlogs/scripts/export-chatlogs.ts
@@ -138,13 +138,14 @@ export const main = async (argv?: string[]): Promise<void> => {
         if (!config.inputDir && !config.baseDir) {
           throw new ChatlogError(
             'InvalidArgs',
+            'InputDir',
             'chatgpt エージェントには入力ディレクトリを指定してください (位置引数または --input)',
           );
         }
         result = await exportChatGPT(config);
         break;
       default:
-        throw new ChatlogError('InvalidArgs', `未対応のエージェント: ${agent}`);
+        throw new ChatlogError('InvalidArgs', 'Agent', `未対応のエージェント: ${agent}`);
     }
 
     for (const outPath of result.outputPaths) {

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
@@ -15,6 +15,8 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { exportChatGPT } from '../../chatgpt-exporter.ts';
+// chatlog error
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 
 // ─── Helpers
 // types
@@ -229,19 +231,36 @@ describe('exportChatGPT', () => {
   describe('Given: config.baseDir が undefined', () => {
     /** `exportChatGPT` を呼び出したときにエラーがスローされることを検証する。 */
     describe('When: exportChatGPT(config) を呼び出す', () => {
-      it('T-EC-GE-04: エラーをスローする', async () => {
+      it('T-EC-GE-04-01: ChatlogError がスローされる', async () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           outputDir,
           baseDir: undefined,
           period: undefined,
         };
+        await assertRejects(() => exportChatGPT(config), ChatlogError);
+      });
 
-        await assertRejects(
-          () => exportChatGPT(config),
-          Error,
-          'ChatGPT エクスポートには --input/--base でディレクトリを指定してください',
-        );
+      it('T-EC-GE-04-02: throw された ChatlogError の kind が MissingArg である', async () => {
+        const config: ExportConfig = {
+          agent: 'chatgpt',
+          outputDir,
+          baseDir: undefined,
+          period: undefined,
+        };
+        const err = await exportChatGPT(config).catch((e) => e);
+        assertEquals((err as ChatlogError).kind, 'MissingArg');
+      });
+
+      it('T-EC-GE-04-03: throw された ChatlogError の subindex が "InputDir" になる', async () => {
+        const config: ExportConfig = {
+          agent: 'chatgpt',
+          outputDir,
+          baseDir: undefined,
+          period: undefined,
+        };
+        const err = await exportChatGPT(config).catch((e) => e);
+        assertEquals((err as ChatlogError).subindex, 'InputDir');
       });
     });
   });

--- a/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
@@ -306,7 +306,11 @@ export const exportChatGPT = async (
 ): Promise<ExportResult> => {
   const inputDir = config.inputDir ?? config.baseDir;
   if (!inputDir) {
-    throw new ChatlogError('MissingArg', 'ChatGPT エクスポートには --input/--base でディレクトリを指定してください');
+    throw new ChatlogError(
+      'MissingArg',
+      'InputDir',
+      'ChatGPT エクスポートには --input/--base でディレクトリを指定してください',
+    );
   }
 
   const range = parsePeriod(config.period);

--- a/skills/export-chatlogs/scripts/libs/period-filter.ts
+++ b/skills/export-chatlogs/scripts/libs/period-filter.ts
@@ -39,7 +39,7 @@ export const parsePeriod = (period: string | undefined): PeriodRange => {
     const end = new Date(year + 1, 0, 1).getTime();
     return { startMs: start, endMs: end };
   }
-  throw new ChatlogError('InvalidPeriod', `期間の形式が不正です（例: 2026-03 または 2026）: ${period}`);
+  throw new ChatlogError('InvalidPeriod', 'Period', `期間の形式が不正です（例: 2026-03 または 2026）: ${period}`);
 };
 
 /** ISO8601 タイムスタンプが指定した期間範囲内にあるかを判定する。 */


### PR DESCRIPTION
## Overview

**Summary**
Add `subindex` argument to all `ChatlogError` calls in the `export-chatlogs` skill.

**Background / Motivation**
`ChatlogError` gained the `subindex` field in #166, and `classify-chatlogs` already uses it (#167)
to identify which argument or field triggered each error. The `export-chatlogs` skill was still
calling `ChatlogError` with only two arguments (`kind`, `detail`), leaving `subindex` as an empty
string. This PR completes the rollout to `export-chatlogs`, making error context consistent across
skills and easier to pinpoint without inspecting stack traces.

## Changes

### Core Changes

- `skills/export-chatlogs/scripts/libs/period-filter.ts` — added `'Period'` as `subindex` to the `ChatlogError('InvalidPeriod')` thrown by `parsePeriod`
- `skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts` — added `'InputDir'` as `subindex` to the `ChatlogError` thrown when `inputDir` is missing in `exportChatGPT`
- `skills/export-chatlogs/scripts/export-chatlogs.ts` — added `'InputDir'` to the chatgpt agent input-directory error and `'Agent'` to the unsupported-agent error

### Test Updates

- `skills/export-chatlogs/scripts/__tests__/unit/period-filter.unit.spec.ts` — tightened `T-EC-PF-01-06` to assert `ChatlogError` (was `Error`); added `T-EC-PF-01-07` (kind is `'InvalidPeriod'`) and `T-EC-PF-01-08` (subindex is `'Period'`)
- `skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts` — split the former `T-EC-GE-04` into three cases: `T-EC-GE-04-01` (`ChatlogError` is thrown), `T-EC-GE-04-02` (kind is `'MissingArg'`), `T-EC-GE-04-03` (subindex is `'InputDir'`)

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #164

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

The `subindex` field was introduced in `ChatlogError` as part of issue #166. This PR completes
the rollout to `export-chatlogs`, mirroring the work done in `classify-chatlogs` (#167).
No breaking changes — existing code that inspects only `kind` is unaffected.
