### PR TITLE
feat(normalize-chatlogs): add subindex to ChatlogError calls

### DIFF
--- a/skills/normalize-chatlogs/scripts/__tests__/unit/file-ops.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/unit/file-ops.unit.spec.ts
@@ -23,6 +23,7 @@ import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileOrDirExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
 // test target
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import {
   segmentChatlogs,
   writeOutput,
@@ -113,6 +114,18 @@ describe('writeOutput', () => {
         Error,
         'Forbidden Output',
       );
+    });
+
+    it('T-WO-04-02: throw された ChatlogError の subindex が "OutputPath" になる', async () => {
+      // arrange
+      const outputPath = 'chatlogs/agent/2026/2026-01/output.md';
+      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+
+      // act
+      const err = await writeOutput(outputPath, 'content', false, stats).catch((e) => e);
+
+      // assert
+      assertEquals((err as ChatlogError).subindex, 'OutputPath');
     });
   });
 });

--- a/skills/normalize-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -116,5 +116,15 @@ describe('parseArgs', () => {
         'Invalid Args',
       );
     });
+
+    it('T-08-03-02: err.subindex が "Option" になる', () => {
+      let err: unknown;
+      try {
+        parseArgs(['--unknown']);
+      } catch (e) {
+        err = e;
+      }
+      assertEquals((err as ChatlogError).subindex, 'Option');
+    });
   });
 });

--- a/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
+++ b/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
@@ -360,7 +360,7 @@ export const writeOutput = async (
   }
 
   if (outputPath.includes('chatlogs/')) {
-    throw new ChatlogError('ForbiddenOutput', `writing to input directory is forbidden: ${outputPath}`);
+    throw new ChatlogError('ForbiddenOutput', 'OutputPath', `writing to input directory is forbidden: ${outputPath}`);
   }
 
   await backupOldPath(outputPath, listDir);
@@ -504,7 +504,7 @@ export const parseArgs = (argv: string[]): ParsedArgs => {
           // Positional path argument: already normalized, assign to dir
           result.dir = normalized;
         } else {
-          throw new ChatlogError('InvalidArgs', `unknown option: ${arg}`);
+          throw new ChatlogError('InvalidArgs', 'Option', `unknown option: ${arg}`);
         }
       }
     }
@@ -532,10 +532,10 @@ export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void
     const args = parseArgs(argv ?? Deno.args);
     const resolved = resolveInputDir(args);
     if (!resolved.ok) {
-      throw new ChatlogError('InputNotFound', resolved.error);
+      throw new ChatlogError('InputNotFound', 'InputDir', resolved.error);
     }
     if (!validateInputDir(resolved.dir)) {
-      throw new ChatlogError('InputNotFound', `directory not found: ${resolved.dir}`);
+      throw new ChatlogError('InputNotFound', 'InputDir', `directory not found: ${resolved.dir}`);
     }
     const inputDir = resolved.dir;
     const outputBase = args.output ?? _DEFAULT_OUTPUT_DIR;


### PR DESCRIPTION
## Overview

**Summary**
Add `subindex` argument to `ChatlogError` calls in `normalize-chatlogs.ts` and add tests to verify each `subindex` value.

**Background / Motivation**
`ChatlogError` was updated to support a `subindex` field for more precise error location tracking,
 but existing `throw` statements in `normalize-chatlogs` were not yet passing `subindex`.
 This PR adds the appropriate `subindex` to each throw site so errors can be traced to specific input paths.

## Changes

### Core Changes

- `skills/normalize-chatlogs/scripts/normalize-chatlogs.ts`
  - `writeOutput`: `new ChatlogError('ForbiddenOutput', msg)` → `new ChatlogError('ForbiddenOutput', 'OutputPath', msg)`
  - `parseArgs`: `new ChatlogError('InvalidArgs', msg)` → `new ChatlogError('InvalidArgs', 'Option', msg)`
  - `main` (×2): `new ChatlogError('InputNotFound', msg)` → `new ChatlogError('InputNotFound', 'InputDir', msg)`

### Test Updates

- `skills/normalize-chatlogs/scripts/__tests__/unit/file-ops.unit.spec.ts`
  - `T-WO-04-02`: verify `ChatlogError.subindex === 'OutputPath'` thrown by `writeOutput`
- `skills/normalize-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts`
  - `T-08-03-02`: verify `ChatlogError.subindex === 'Option'` thrown by `parseArgs`

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #cle-e30

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Branch: `feat-164/normalize/add-subindex`
