### PR TITLE
feat(set-frontmatter): add subindex to ChatlogError calls

### DIFF
--- a/skills/set-frontmatter/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -83,17 +83,27 @@ describe('parseArgs', () => {
   describe('Given: 不正な引数', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
-        const _errorCases: { id: string; args: string[]; label: string }[] = [
-          { id: 'T-SF-PA-10-01', args: [], label: 'targetDir なし（空配列）' },
-          { id: 'T-SF-PA-11-01', args: ['/path', '--unknown'], label: '未知オプション' },
+        const _errorCases: { id: string; args: string[]; label: string; subindex: string }[] = [
+          { id: 'T-SF-PA-10-01', args: [], label: 'targetDir なし（空配列）', subindex: 'TargetDir' },
+          { id: 'T-SF-PA-11-01', args: ['/path', '--unknown'], label: '未知オプション', subindex: 'Option' },
         ];
-        for (const { id, args, label } of _errorCases) {
+        for (const { id, args, label, subindex } of _errorCases) {
           it(`${id}: ${label} → ChatlogError(InvalidArgs) がスローされる`, () => {
             assertThrows(
               () => parseArgs(args),
               ChatlogError,
               'Invalid Args',
             );
+          });
+
+          it(`${id}-sub: err.subindex が "${subindex}" になる`, () => {
+            let err: unknown;
+            try {
+              parseArgs(args);
+            } catch (e) {
+              err = e;
+            }
+            assertEquals((err as ChatlogError).subindex, subindex);
           });
         }
       });

--- a/skills/set-frontmatter/scripts/__tests__/unit/render-prompt.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/render-prompt.unit.spec.ts
@@ -82,6 +82,16 @@ describe('renderPrompt', () => {
             'Invalid Args',
           );
         });
+
+        it('T-SF-RP-05-02: err.subindex が "VarName" になる', () => {
+          let err: unknown;
+          try {
+            renderPrompt('${BadName}', { BadName: 'val' });
+          } catch (e) {
+            err = e;
+          }
+          assertEquals((err as ChatlogError).subindex, 'VarName');
+        });
       });
     });
   });
@@ -97,6 +107,16 @@ describe('renderPrompt', () => {
             ChatlogError,
             'Invalid Args',
           );
+        });
+
+        it('T-SF-RP-06-02: err.subindex が "VarName" になる', () => {
+          let err: unknown;
+          try {
+            renderPrompt('${missing}', {});
+          } catch (e) {
+            err = e;
+          }
+          assertEquals((err as ChatlogError).subindex, 'VarName');
         });
       });
     });

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -229,10 +229,10 @@ export const loadDics = async (dicsDir: string): Promise<Dics> => {
 export const renderPrompt = (template: string, vars: Record<string, string>): string => {
   return template.replace(/\$\{([^}]+)\}/g, (_match, name: string) => {
     if (!/^[a-z_]+$/.test(name)) {
-      throw new ChatlogError('InvalidArgs', `不正な変数名 "${name}" — 英小文字と "_" のみ使用可能`);
+      throw new ChatlogError('InvalidArgs', 'VarName', `不正な変数名 "${name}" — 英小文字と "_" のみ使用可能`);
     }
     if (!(name in vars)) {
-      throw new ChatlogError('InvalidArgs', `未定義の変数 "${name}"`);
+      throw new ChatlogError('InvalidArgs', 'VarName', `未定義の変数 "${name}"`);
     }
     return vars[name];
   });
@@ -310,7 +310,7 @@ export const runClaude = async (systemPrompt: string, userPrompt: string): Promi
   await writer.write(new TextEncoder().encode(userPrompt));
   await writer.close();
   const output = await process.output();
-  if (!output.success) { throw new ChatlogError('CliError', `claude CLI エラー (code=${output.code})`); }
+  if (!output.success) { throw new ChatlogError('CliError', 'ClaudeCmd', `claude CLI エラー (code=${output.code})`); }
   return new TextDecoder().decode(output.stdout).trim();
 };
 
@@ -540,12 +540,13 @@ export const parseArgs = (args: string[]): Args => {
     } else if (!arg.startsWith('-')) {
       targetDir = arg;
     } else {
-      throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
+      throw new ChatlogError('InvalidArgs', 'Option', `不明なオプション: ${arg}`);
     }
   }
   if (!targetDir) {
     throw new ChatlogError(
       'InvalidArgs',
+      'TargetDir',
       'Usage: set_frontmatter.ts <target_dir> [--dry-run] [--no-review] [--concurrency N] [--dics DIR]',
     );
   }
@@ -561,7 +562,7 @@ export const main = async (args: string[]): Promise<void> => {
     const { targetDir, dicsDir, dryRun, review, concurrency } = parseArgs(args);
 
     if (!await dirExists(targetDir)) {
-      throw new ChatlogError('InputNotFound', `ディレクトリが見つかりません: ${targetDir}`);
+      throw new ChatlogError('InputNotFound', 'TargetDir', `ディレクトリが見つかりません: ${targetDir}`);
     }
 
     const dics = await loadDics(dicsDir);


### PR DESCRIPTION
## Overview

**Summary**
Adds `subindex` arguments to all `ChatlogError` calls in `set-frontmatter.ts` for more precise error context.

**Background / Motivation**
Previously, errors such as `InvalidArgs` and `InputNotFound` were thrown without a subindex, making it harder to identify which specific argument or input was the source of the error.
By adding `subindex` values (`'VarName'`, `'Option'`, `'TargetDir'`, `'ClaudeCmd'`), callers and error handlers can now distinguish the exact location of each error.

Related to #164.

## Changes

### Core Changes

- `skills/set-frontmatter/scripts/set-frontmatter.ts`
  - `renderPrompt`: added `subindex: 'VarName'` to two `InvalidArgs` `ChatlogError` calls (uppercase variable name detection)
  - `runClaude`: added `subindex: 'ClaudeCmd'` to the `CliError` `ChatlogError` call
  - `parseArgs`: added `subindex: 'Option'` for unknown option errors and `subindex: 'TargetDir'` for missing `targetDir` errors
  - `main`: added `subindex: 'TargetDir'` to the `InputNotFound` `ChatlogError` call

### Test Updates

- `skills/set-frontmatter/scripts/__tests__/unit/parse-args.unit.spec.ts`
  - Added `subindex` field to all `_errorCases` entries (`'TargetDir'` / `'Option'`)
  - Added `${id}-sub` test iterations to assert `err.subindex` values

- `skills/set-frontmatter/scripts/__tests__/unit/render-prompt.unit.spec.ts`
  - Added `T-SF-RP-05-02`: asserts `ChatlogError.subindex === 'VarName'` when a variable name contains uppercase letters
  - Added `T-SF-RP-06-02`: asserts `ChatlogError.subindex === 'VarName'` for undefined variable errors

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Closes #cle-e30

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This change is a continuation of the subindex propagation work done in the merged PRs for `normalize-chatlogs` (#170) and `filter-chatlogs` (#169), applying the same pattern consistently to `set-frontmatter`.
