### PR TITLE
refactor(classify): reorganize import groups across classify-chatlogs module

### DIFF
--- a/skills/classify-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -6,18 +6,19 @@
 //
 // This software is released under the MIT License.
 
-// -- BDD modules --
+// ─── BDD modules
 import { assert, assertEquals, assertThrows } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
-// -- modules for test --
-// test target
+// ─── Test target
 import { parseArgs } from '../../modules/classify-config.ts';
 
-// classes
+// ─── Helpers
 import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 // types
 import type { ParsedConfig } from '../../types/classify.types.ts';
+
+// ─── Tests
 
 describe('parseArgs', () => {
   // ─── T-CL-PA-01: デフォルト値（未指定時は undefined） ───────────────────────

--- a/skills/classify-chatlogs/scripts/__tests__/unit/process-classify.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/unit/process-classify.unit.spec.ts
@@ -15,14 +15,13 @@ import { describe, it } from '@std/testing/bdd';
 import { processClassify } from '../../classify-chatlogs.ts';
 
 // ─── Helpers
+import { _makeEntry } from '../_helpers/classify-test-helpers.ts';
 // types
 import type { ClassifyBuffer, ProjectDicEntry } from '../../types/classify.types.ts';
-
 // constants
 import { CLASSIFY_ACTIONS } from '../../types/classify.types.ts';
 
 // ─── Internal Helpers
-import { _makeEntry } from '../_helpers/classify-test-helpers.ts';
 
 // constants
 /** プロジェクト辞書（AI を呼び出さないテスト用に proj-a のみ定義）。 */

--- a/skills/classify-chatlogs/scripts/classes/ClassifyChatlogEntry.class.ts
+++ b/skills/classify-chatlogs/scripts/classes/ClassifyChatlogEntry.class.ts
@@ -6,6 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// ─── Shared scripts
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -16,27 +16,25 @@
 
 // cspell:words noai
 
-// -- external --
+// ─── Shared scripts
+import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-// classes
-import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
-import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 
-// -- internal --
-import { FALLBACK_PROJECT } from './constants/classify.constants.ts';
+// ─── Local
 import { loadProjectDic } from './libs/load-project-dic.ts';
-// types
-import { CLASSIFY_ACTIONS } from './types/classify.types.ts';
-import type { ClassifyBuffer, ClassifyConfig, ClassifyStats, ProjectDicEntry } from './types/classify.types.ts';
-
-// -- modules --
 import { classifyByAI } from './modules/classify-ai.ts';
 import { buildConfig, parseArgs } from './modules/classify-config.ts';
 import { processPreclassify } from './modules/classify-noai.ts';
 import { moveClassified } from './modules/file-ops.ts';
 import { findBufferEntries } from './modules/find-buffer-entries.ts';
+// types
+import type { ClassifyBuffer, ClassifyConfig, ClassifyStats, ProjectDicEntry } from './types/classify.types.ts';
+// constants
+import { FALLBACK_PROJECT } from './constants/classify.constants.ts';
+import { CLASSIFY_ACTIONS } from './types/classify.types.ts';
 
 // ─────────────────────────────────────────────
 // processClassify

--- a/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
+++ b/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
@@ -6,16 +6,17 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// deno lib
+// ─── External modules
 import { parse as parseYaml } from '@std/yaml';
 
-// utils
+// ─── Shared scripts
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { resolveConfigPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
+
+// ─── Local
 // types
 import type { ProjectDicEntry } from '../types/classify.types.ts';
-// classes
-import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 // constants
 import { DEFAULT_PROJECTS_DIC_PATH, FALLBACK_PROJECT } from '../constants/classify.constants.ts';
 

--- a/skills/classify-chatlogs/scripts/modules/classify-ai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-ai.ts
@@ -9,13 +9,14 @@
 
 // cspell:words MoveByAI
 
-// --- import ---
-// functions
+// ─── Shared scripts
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runChunked } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
 
+// ─── Local
+import { ClassifyChatlogEntry } from '../classes/ClassifyChatlogEntry.class.ts';
 // types
 import type {
   ClassifyBuffer,
@@ -23,10 +24,6 @@ import type {
   ClassifyResult,
   ProjectDicEntry,
 } from '../types/classify.types.ts';
-
-// classes
-import { ClassifyChatlogEntry } from '../classes/ClassifyChatlogEntry.class.ts';
-
 // constants
 import { FALLBACK_PROJECT } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';

--- a/skills/classify-chatlogs/scripts/modules/classify-config.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-config.ts
@@ -7,13 +7,19 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// ─── Shared scripts
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 import { isValidModel } from '../../../_scripts/libs/ai/model-utils.ts';
 import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
+// types
 import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
-import { DEFAULT_CLASSIFY_CONFIG } from '../constants/classify.constants.ts';
+
+// ─── Local
+// types
 import type { ClassifyConfig, ParsedConfig } from '../types/classify.types.ts';
+// constants
+import { DEFAULT_CLASSIFY_CONFIG } from '../constants/classify.constants.ts';
 
 /** classify-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgsSchema = [

--- a/skills/classify-chatlogs/scripts/modules/classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-noai.ts
@@ -9,19 +9,15 @@
 
 // cspell:words noai
 
-// --- shared modules
-// functions
+// ─── Shared scripts
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
-// --- internal modules ---
+// ─── Local
+import { ClassifyChatlogEntry } from '../classes/ClassifyChatlogEntry.class.ts';
 // types
 import type { ClassifyBufferEntry } from '../types/classify.types.ts';
-
-// classes
-import { ClassifyChatlogEntry } from '../classes/ClassifyChatlogEntry.class.ts';
-
 // constants
 import { FALLBACK_PROJECT, MIN_CLASSIFIABLE_LENGTH } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';

--- a/skills/classify-chatlogs/scripts/modules/file-ops.ts
+++ b/skills/classify-chatlogs/scripts/modules/file-ops.ts
@@ -9,18 +9,15 @@
 
 // cspell:words MoveByAI
 
-// --- import ---
-// functions
+// ─── Shared scripts
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 
+// ─── Local
+import { ClassifyChatlogEntry } from '../classes/ClassifyChatlogEntry.class.ts';
 // types
 import type { ClassifyAction, ClassifyBuffer, ClassifyStats } from '../types/classify.types.ts';
-
-// classes
-import { ClassifyChatlogEntry } from '../classes/ClassifyChatlogEntry.class.ts';
-
 // constants
 import { FALLBACK_PROJECT } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';

--- a/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
+++ b/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
@@ -9,10 +9,11 @@
 
 // cspell:word noai
 
-// -- external --
+// ─── Shared scripts
 import { findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
 
-// -- internal --
+// ─── Local
+import { loadClassifyEntry } from './classify-noai.ts';
 // types
 import type {
   ClassifyBuffer,
@@ -20,10 +21,8 @@ import type {
   ClassifyStats,
   FindBufferEntriesOptions,
 } from '../types/classify.types.ts';
+// constants
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
-
-// -- modules --
-import { loadClassifyEntry } from './classify-noai.ts';
 
 /**
  * ディレクトリ配下の `.md` ファイルを収集し、メタデータを読み込んで分類バッファを返す。


### PR DESCRIPTION
## Overview

**Summary**
Standardizes import group separator comments across all source and test files in the `classify-chatlogs` skill.

**Background / Motivation**
Import group headers were inconsistent across files (e.g. `// --- external ---`, `// --- shared modules ---`, `// functions`). This PR unifies them to the `// ─── <GroupName>` format defined in the project testing conventions, improving readability and making import origins immediately visible at a glance. Production source files are now aligned with the conventions already enforced in test files.

## Changes

### Core Changes

- `skills/classify-chatlogs/scripts/classify-chatlogs.ts` — replace legacy headers with `// ─── Shared scripts` / `// ─── Local`; reorder imports to shared → local libs/modules → types → constants
- `skills/classify-chatlogs/scripts/modules/classify-ai.ts` — align headers to `// ─── Shared scripts` / `// ─── Local`; move `ClassifyChatlogEntry` import into Local group
- `skills/classify-chatlogs/scripts/modules/classify-config.ts` — split into Shared scripts / Local groups; add `types` and `constants` sub-block comments
- `skills/classify-chatlogs/scripts/modules/classify-noai.ts` — replace legacy headers; move `ClassifyChatlogEntry` to Local group head; remove redundant blank line
- `skills/classify-chatlogs/scripts/modules/file-ops.ts` — replace `// --- import ---` / `// functions` with standard headers; move `ClassifyChatlogEntry` to Local group; integrate types/constants sub-blocks
- `skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts` — align headers; move `loadClassifyEntry` to Local group; add `// constants` sub-comment for `CLASSIFY_ACTIONS`
- `skills/classify-chatlogs/scripts/classes/ClassifyChatlogEntry.class.ts` — add `// ─── Shared scripts` group header above shared-script imports
- `skills/classify-chatlogs/scripts/libs/load-project-dic.ts` — rename headers to `// ─── External modules` / `// ─── Shared scripts` / `// ─── Local`; move `ChatlogError` to Shared scripts group

### Test Updates

- `skills/classify-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts` — unify import group separator comments to `// ─── <Name>` format; move `ChatlogError` from Test target to Helpers group; add `// ─── Tests` header before describe block
- `skills/classify-chatlogs/scripts/__tests__/unit/process-classify.unit.spec.ts` — move `_makeEntry` import from Internal Helpers to Helpers group; remove redundant blank line between type import and constants sub-block

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

All 10 commits in this branch are pure style/test reorganization with no functional changes. The diff is net -5 lines across 10 files, reflecting removal of redundant separators and blank lines. No runtime behavior is affected.
