### PR TITLE
refactor(set-frontmatter): inject prompts dependency and support batch type judging

### DIFF
--- a/assets/prompts/review.yaml
+++ b/assets/prompts/review.yaml
@@ -2,7 +2,7 @@
 # @(#) Phase 3.5: フロントマターレビュープロンプトテンプレート
 #
 # 変数:
-#   ${type_list}        — types.dic から生成したtype一覧（when/not付き）
+#   ${type_dics}        — types.dic から生成したtype一覧（when/not付き）
 #   ${topic_list}       — topics.dic から生成したtopic一覧（簡略版）
 #   ${category_list}    — category.dic から生成したcategory一覧（カンマ区切り）
 #   ${tags_list}        — tags.dic から生成したtag一覧（カンマ区切り）
@@ -19,7 +19,7 @@ user: |
 
   ## RULE 0 — type
   Must be one of the following. Choose the best match for the PRIMARY purpose.
-  ${type_list}
+  ${type_dics}
 
   ## RULE 1 — category
   Must match the primary domain (not surface tools).

--- a/assets/prompts/type.yaml
+++ b/assets/prompts/type.yaml
@@ -1,56 +1,21 @@
 # src: ./assets/prompts/type.yaml
-# @(#) Phase 2: type判定プロンプトテンプレート
+# @(#) Phase 2: type判定プロンプトテンプレート（バッチ処理）
 #
 # 変数:
-#   ${type_list} — types.dic から生成したtype一覧
-#   ${body}      — ログ本文
+#   system: ${type_dics} — types.dic から生成したtype一覧
+#   user:   ${entries}   — "=== FILE n: <filename> ===\n<body>" ブロックの連結
 
 system: |
-  You are a log classifier. Output the type name only, nothing else.
-  Choose the single best type based on the PRIMARY purpose of the log.
+  You are a log classifier. Output ONLY a JSON array. No markdown, no explanation.
+
+  Evaluate types in the order listed below. Assign the FIRST matching type. Do not continue after a match.
+
+  ${type_dics}
+
+  Output format: [{"file":"<filename>","type":"<type_key>"},...]
+  One entry per file. Output ONLY the JSON array, nothing else.
 
 user: |
-  Classify the log into one of the following types.
+  Classify each log file listed below.
 
-  Types:
-  ${type_list}
-
-  CLASSIFICATION RULES — evaluate in order. Assign the FIRST matching type. Do not continue after a match.
-
-  [incident]
-    WHEN  the log opens with a problem signal:
-          error message / stack trace / CI failure / "doesn't work" / mismatch / unexpected behavior
-    WHILE the problem signal was an actual event that triggered the conversation (not a hypothetical)
-    NOT DO continue to the next rule — incident dominates all others
-    WHERE any subsequent fix, investigation, or decision in the same log does NOT change the type;
-          the starting point defines the type, not what follows
-
-  [writing]
-    WHEN  the primary outcome is a written artifact: document / article / specification / prompt text
-    WHILE the log was NOT triggered by an error signal
-    NOT DO classify as writing if the document is a side effect of a decision or incident
-
-  [execution]
-    WHEN  code, scripts, or configuration files were modified as the PRIMARY purpose
-    WHILE the log was NOT triggered by an error signal
-    NOT DO classify as execution if changes were made only to fix an incident,
-          or if the primary outcome is a document
-    WHERE "primary purpose" means modification was the goal, not the side effect
-
-  [discussion]
-    WHEN  an explicit, irreversible decision affecting future implementation or operations was stated
-    WHILE no code files were modified as a primary outcome
-    NOT DO classify as discussion for opinions, preferences, or "we might" — must be confirmed ("decided", "we will use X", "adopted", "finalized as Y")
-    WHERE the decision must be forward-looking and binding, not just a conclusion within the log
-
-  [research]
-    WHEN  the primary purpose was understanding, comparison, or learning
-    WHILE no implementation occurred AND no explicit decision was confirmed
-    NOT DO classify as research if the investigation led to a confirmed decision (→ discussion)
-          or if it was triggered by an error (→ incident)
-    WHERE this is the fallback — assign only when no other type fits
-
-  Output the type name only (e.g. "execution"), nothing else.
-
-  ---
-  ${body}
+  ${entries}

--- a/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -54,7 +54,7 @@ async function _makeDicsDir(): Promise<string> {
   await Deno.writeTextFile(`${dicsDir}/tags.dic`, '"lang:typescript":\n  def: TypeScript\n');
 
   // プロンプトファイル
-  await Deno.writeTextFile(`${promptsDir}/type.yaml`, 'system: "type"\nuser: "${type_list} ${body}"\n');
+  await Deno.writeTextFile(`${promptsDir}/type.yaml`, 'system: "type ${type_dics}"\nuser: "${entries}"\n');
   await Deno.writeTextFile(
     `${promptsDir}/category.yaml`,
     'system: "category"\nuser: "${category_list} ${focus_guide} ${body}"\n',
@@ -65,7 +65,7 @@ async function _makeDicsDir(): Promise<string> {
   );
   await Deno.writeTextFile(
     `${promptsDir}/review.yaml`,
-    'system: "review"\nuser: "${type_list} ${topic_list} ${category_list} ${tags_list} ${result_type} ${result_category} ${result_yaml}"\n',
+    'system: "review"\nuser: "${type_dics} ${topic_list} ${category_list} ${tags_list} ${result_type} ${result_category} ${result_yaml}"\n',
   );
 
   return dicsDir;

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts
@@ -20,16 +20,17 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { DEFAULT_PROMPTS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { normalizeLine } from '../../../../_scripts/libs/text/line-utils.ts';
 
 // test target
-import { loadDics } from '../../modules/setfm-ai.ts';
 import { judgeCategory } from '../../modules/setfm-category.ts';
 import { generateFrontmatter } from '../../modules/setfm-frontmatter.ts';
+import { loadDics, loadPrompts } from '../../modules/setfm-loader.ts';
 import { judgeType } from '../../modules/setfm-type.ts';
-import type { Dics } from '../../types/dics.types.ts';
+import type { Dics, Prompts } from '../../types/dics.types.ts';
 import type { EntryMeta } from '../../types/entry-meta.types.ts';
 
 const _enc = new TextEncoder();
@@ -149,9 +150,15 @@ function _makeDicsForFallback(): Dics {
     topicEntries: [
       { key: 'development', def: '開発', desc: '', rules: { when: [], not: [] } },
     ],
+  };
+}
+
+/** フォールバックケース用のインラインプロンプト（実ファイル不要） */
+function _makePromptsForFallback(): Prompts {
+  return {
     categoryPrompts: new Map([['research', '']]),
     prompts: new Map([
-      ['type', { system: '', user: '${type_list} ${body}' }],
+      ['type', { system: '${type_dics}', user: '${entries}' }],
       ['category', { system: '', user: '${category_list} ${focus_guide} ${body}' }],
       ['meta', { system: '', user: '${log_type} ${log_category} ${topic_list} ${tags_list} ${body}' }],
       ['review', { system: '', user: '' }],
@@ -163,10 +170,11 @@ function _makeDicsForFallback(): Dics {
 
 const _fixtureDirs = await _collectFixtureDirs(FIXTURES_DIR);
 
-// 辞書は実際の assets/dics/ を使用
+// 辞書・プロンプトは実際の assets/ を使用
 let _dics: Dics | null = null;
+let _prompts: Prompts | null = null;
 try {
-  _dics = await loadDics(ASSETS_DICS_DIR);
+  [_dics, _prompts] = await Promise.all([loadDics(ASSETS_DICS_DIR), loadPrompts(DEFAULT_PROMPTS_DIR)]);
 } catch {
   // 辞書が読み込めない場合はテストをスキップ
 }
@@ -217,7 +225,9 @@ for (const _relPath of _fixtureDirs) {
           async () => {
             if (_isFallbackCase) {
               const _activeDics = _dics ?? _makeDicsForFallback();
-              const _result = await judgeType(_fileMeta, _activeDics);
+              const _activePrompts = _prompts ?? _makePromptsForFallback();
+              const _typeResults = await judgeType([_fileMeta], _activeDics, _activePrompts);
+              const _result = _typeResults[0];
 
               if (_expectedOutput.fallback?.expected_type) {
                 assertEquals(
@@ -237,12 +247,13 @@ for (const _relPath of _fixtureDirs) {
               return;
             }
 
-            if (!_dics) {
+            if (!_dics || !_prompts) {
               // 辞書ファイルが読み込めないためスキップ
               return;
             }
 
-            const _result = await judgeType(_fileMeta, _dics);
+            const _typeResults = await judgeType([_fileMeta], _dics, _prompts);
+            const _result = _typeResults[0];
 
             assertEquals(
               _expectedOutput.known_types.includes(_result.type),
@@ -262,8 +273,10 @@ for (const _relPath of _fixtureDirs) {
           async () => {
             if (_isFallbackCase) {
               const _activeDics = _dics ?? _makeDicsForFallback();
-              const _typeResult = await judgeType(_fileMeta, _activeDics);
-              const _category = await judgeCategory(_fileMeta, _typeResult.type, _activeDics);
+              const _activePrompts = _prompts ?? _makePromptsForFallback();
+              const _typeResultArr = await judgeType([_fileMeta], _activeDics, _activePrompts);
+              const _typeResult = _typeResultArr[0];
+              const _category = await judgeCategory(_fileMeta, _typeResult.type, _activeDics, _activePrompts);
 
               if (_expectedOutput.fallback?.expected_category) {
                 assertEquals(
@@ -283,14 +296,15 @@ for (const _relPath of _fixtureDirs) {
               return;
             }
 
-            if (!_dics) {
+            if (!_dics || !_prompts) {
               // 辞書ファイルが読み込めないためスキップ
               return;
             }
 
             // まず type を判定してから category を判定する
-            const _typeResult = await judgeType(_fileMeta, _dics);
-            const _category = await judgeCategory(_fileMeta, _typeResult.type, _dics);
+            const _typeResultArr = await judgeType([_fileMeta], _dics, _prompts);
+            const _typeResult = _typeResultArr[0];
+            const _category = await judgeCategory(_fileMeta, _typeResult.type, _dics, _prompts);
 
             assertEquals(
               _expectedOutput.known_categories.includes(_category),
@@ -312,9 +326,17 @@ for (const _relPath of _fixtureDirs) {
           async () => {
             if (_isFallbackCase) {
               const _activeDics = _dics ?? _makeDicsForFallback();
-              const _typeResult = await judgeType(_fileMeta, _activeDics);
-              const _category = await judgeCategory(_fileMeta, _typeResult.type, _activeDics);
-              const _fmResult = await generateFrontmatter(_fileMeta, _typeResult.type, _category, _activeDics);
+              const _activePrompts = _prompts ?? _makePromptsForFallback();
+              const _typeResults = await judgeType([_fileMeta], _activeDics, _activePrompts);
+              const _typeResult = _typeResults[0];
+              const _category = await judgeCategory(_fileMeta, _typeResult.type, _activeDics, _activePrompts);
+              const _fmResult = await generateFrontmatter(
+                _fileMeta,
+                _typeResult.type,
+                _category,
+                _activeDics,
+                _activePrompts,
+              );
 
               if (_expectedOutput.fallback?.expected_yaml_empty === true) {
                 assertEquals(
@@ -334,14 +356,15 @@ for (const _relPath of _fixtureDirs) {
               return;
             }
 
-            if (!_dics) {
+            if (!_dics || !_prompts) {
               // 辞書ファイルが読み込めないためスキップ
               return;
             }
 
-            const _typeResult = await judgeType(_fileMeta, _dics);
-            const _category = await judgeCategory(_fileMeta, _typeResult.type, _dics);
-            const _fmResult = await generateFrontmatter(_fileMeta, _typeResult.type, _category, _dics);
+            const _typeResults = await judgeType([_fileMeta], _dics, _prompts);
+            const _typeResult = _typeResults[0];
+            const _category = await judgeCategory(_fileMeta, _typeResult.type, _dics, _prompts);
+            const _fmResult = await generateFrontmatter(_fileMeta, _typeResult.type, _category, _dics, _prompts);
 
             // yaml が生成されたことを確認（空でないこと）
             if (!_fmResult.yaml) {

--- a/skills/set-frontmatter/scripts/libs/dic-format-utils.ts
+++ b/skills/set-frontmatter/scripts/libs/dic-format-utils.ts
@@ -1,0 +1,33 @@
+// src: scripts/libs/dic-format-utils.ts
+// @(#): set-frontmatter 辞書エントリ整形ユーティリティ
+//       対象: formatEntryWithRules / formatEntryShort
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Local
+// types
+import type { DicEntry } from '../types/dics.types.ts';
+
+// ─────────────────────────────────────────────
+// 辞書エントリをプロンプト文字列に整形するヘルパー
+// ─────────────────────────────────────────────
+
+/** エントリを「- key: def\n  <rule-key>: ...\n  structure: ...」形式に展開 */
+export const formatEntryWithRules = (e: DicEntry): string => {
+  const lines: string[] = [`- ${e.key}: ${e.def}`];
+  Object.entries(e.rules)
+    .filter(([, vals]) => vals.length > 0)
+    .forEach(([k, vals]) => lines.push(`  ${k}: ${vals.join(' / ')}`));
+  if (e.structure) {
+    lines.push(`  structure: ${e.structure}`);
+  }
+  return lines.join('\n');
+};
+
+/** エントリを「- key: def」形式に展開（rules なし・簡略版） */
+export const formatEntryShort = (e: DicEntry): string => {
+  return `- ${e.key}: ${e.def}`;
+};

--- a/skills/set-frontmatter/scripts/libs/template-utils.ts
+++ b/skills/set-frontmatter/scripts/libs/template-utils.ts
@@ -1,0 +1,31 @@
+// src: scripts/libs/template-utils.ts
+// @(#): set-frontmatter テンプレートユーティリティ
+//       対象: renderPrompt
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared scripts
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+
+// ─────────────────────────────────────────────
+// テンプレート変数置換
+// ─────────────────────────────────────────────
+
+/**
+ * テンプレート内の ${varname} を vars で置換する。
+ * varname が [a-z_]+ 以外の場合はエラー終了（インジェクション防止）。
+ */
+export const renderPrompt = (template: string, vars: Record<string, string>): string => {
+  return template.replace(/\$\{([^}]+)\}/g, (_match, name: string) => {
+    if (!/^[a-z_]+$/.test(name)) {
+      throw new ChatlogError('InvalidArgs', 'InvalidSyntax', `不正な変数名 "${name}" — 英小文字と "_" のみ使用可能`);
+    }
+    if (!(name in vars)) {
+      throw new ChatlogError('InvalidArgs', 'NotDefined', `未定義の変数 "${name}"`);
+    }
+    return vars[name];
+  });
+};

--- a/skills/set-frontmatter/scripts/modules/__tests__/functional/load-entry-meta.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/functional/load-entry-meta.functional.spec.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { assertNotNull, assertNull } from '../../../../../_scripts/__tests__/helpers/assert.ts';
 
 // ───  test target
-import { loadEntryMeta } from '../../setfm-ai.ts';
+import { loadEntryMeta } from '../../setfm-loader.ts';
 
 // ─── テスト共通セットアップ ───────────────────────────────────────────────────
 const MAX_BODY_CHARS = 1000; // loadEntryMeta 内の定数と同じ値を使用

--- a/skills/set-frontmatter/scripts/modules/__tests__/integration/judge-pipeline.integration.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/integration/judge-pipeline.integration.spec.ts
@@ -22,7 +22,7 @@ import { generateFrontmatter } from '../../setfm-frontmatter.ts';
 import { reviewFrontmatter } from '../../setfm-review.ts';
 import { judgeType } from '../../setfm-type.ts';
 // types
-import type { Dics } from '../../../types/dics.types.ts';
+import type { Dics, Prompts } from '../../../types/dics.types.ts';
 import type { EntryMeta } from '../../../types/entry-meta.types.ts';
 import type { FrontmatterResult } from '../../../types/phase.types.ts';
 
@@ -52,6 +52,18 @@ function _makeEntryMeta(): EntryMeta {
   };
 }
 
+function _makeEntryMeta2(): EntryMeta {
+  return {
+    file: '/tmp/other.md',
+    sessionId: 'sess-002',
+    date: '2026-03-16',
+    project: 'my-project',
+    slug: 'other-slug',
+    content: '# Other\nOther body',
+    fullBody: '# Other\nOther body',
+  };
+}
+
 function _makeDics(): Dics {
   return {
     category: 'development,tooling,ai',
@@ -64,15 +76,20 @@ function _makeDics(): Dics {
     topicEntries: [
       { key: 'development', def: '開発', desc: '', rules: { when: [], not: [] } },
     ],
+  };
+}
+
+function _makePrompts(): Prompts {
+  return {
     categoryPrompts: new Map([['research', 'focus guide for research']]),
     prompts: new Map([
-      ['type', { system: 'type system', user: 'type ${type_list} ${body}' }],
+      ['type', { system: 'type system ${type_dics}', user: '${entries}' }],
       ['category', { system: 'category system', user: 'category ${category_list} ${focus_guide} ${body}' }],
       ['meta', { system: 'meta system', user: 'meta ${log_type} ${log_category} ${topic_list} ${tags_list} ${body}' }],
       ['review', {
         system: 'review system',
         user:
-          'review ${type_list} ${topic_list} ${category_list} ${tags_list} ${result_type} ${result_category} ${result_yaml}',
+          'review ${type_dics} ${topic_list} ${category_list} ${tags_list} ${result_type} ${result_category} ${result_yaml}',
       }],
     ]),
   };
@@ -95,49 +112,85 @@ afterEach(() => {
 // ─── judgeType のテスト ───────────────────────────────────────────────────────
 
 describe('judgeType', () => {
-  describe('Given: モックが "research" を返す', () => {
-    describe('When: judgeType(fm, dics) を呼び出す', () => {
-      describe('Then: T-SF-JP-01 - type="research" が返る', () => {
+  describe('Given: モックが JSON 配列 [{"file":"test.md","type":"research"}] を返す', () => {
+    describe('When: judgeType([fm], dics, prompts) を呼び出す', () => {
+      describe('Then: T-SF-JP-01 - result[0].type="research" が返る', () => {
         beforeEach(() => {
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          commandHandle = installCommandMock(
+            makeSuccessMock(_enc.encode('[{"file":"test.md","type":"research"}]')),
+          );
         });
 
-        it('T-SF-JP-01-01: type が "research" になる', async () => {
-          const result = await judgeType(_makeEntryMeta(), _makeDics());
+        it('T-SF-JP-01-01: result[0].type が "research" になる', async () => {
+          const result = await judgeType([_makeEntryMeta()], _makeDics(), _makePrompts());
 
-          assertEquals(result.type, 'research');
+          assertEquals(result[0].type, 'research');
         });
       });
     });
   });
 
-  describe('Given: モックが有効キー以外の "unknown" を返す', () => {
-    describe('When: judgeType(fm, dics) を呼び出す', () => {
+  describe('Given: モックが有効キー以外の JSON 配列を返す', () => {
+    describe('When: judgeType([fm], dics, prompts) を呼び出す', () => {
       describe('Then: T-SF-JP-02 - フォールバック "research" が返る', () => {
         beforeEach(() => {
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('unknown')));
+          commandHandle = installCommandMock(
+            makeSuccessMock(_enc.encode('[{"file":"test.md","type":"unknown"}]')),
+          );
         });
 
-        it('T-SF-JP-02-01: type が "research" になる（フォールバック）', async () => {
-          const result = await judgeType(_makeEntryMeta(), _makeDics());
+        it('T-SF-JP-02-01: result[0].type が "research" になる（フォールバック）', async () => {
+          const result = await judgeType([_makeEntryMeta()], _makeDics(), _makePrompts());
 
-          assertEquals(result.type, 'research');
+          assertEquals(result[0].type, 'research');
         });
       });
     });
   });
 
   describe('Given: Claude CLI が失敗する（exit code=1）', () => {
-    describe('When: judgeType(fm, dics) を呼び出す', () => {
+    describe('When: judgeType([fm], dics, prompts) を呼び出す', () => {
       describe('Then: T-SF-JP-03 - フォールバック "research" が返る（例外なし）', () => {
         beforeEach(() => {
           commandHandle = installCommandMock(makeFailMock(1));
         });
 
-        it('T-SF-JP-03-01: type が "research" になる（例外なし）', async () => {
-          const result = await judgeType(_makeEntryMeta(), _makeDics());
+        it('T-SF-JP-03-01: result[0].type が "research" になる（例外なし）', async () => {
+          const result = await judgeType([_makeEntryMeta()], _makeDics(), _makePrompts());
 
-          assertEquals(result.type, 'research');
+          assertEquals(result[0].type, 'research');
+        });
+      });
+    });
+  });
+
+  describe('Given: モックが 2 ファイル分の JSON 配列を返す（1件はファイル名不一致）', () => {
+    describe('When: judgeType([fm1, fm2], dics, prompts) を呼び出す', () => {
+      describe('Then: T-SF-JP-14 - 一致したファイルは採用、不一致は "research" フォールバック', () => {
+        beforeEach(() => {
+          commandHandle = installCommandMock(
+            makeSuccessMock(
+              _enc.encode('[{"file":"test.md","type":"execution"},{"file":"nomatch.md","type":"discussion"}]'),
+            ),
+          );
+        });
+
+        it('T-SF-JP-14-01: result[0].type が "execution" になる（test.md と一致）', async () => {
+          const result = await judgeType([_makeEntryMeta(), _makeEntryMeta2()], _makeDics(), _makePrompts());
+
+          assertEquals(result[0].type, 'execution');
+        });
+
+        it('T-SF-JP-14-02: result[1].type が "research" になる（other.md は不一致 → フォールバック）', async () => {
+          const result = await judgeType([_makeEntryMeta(), _makeEntryMeta2()], _makeDics(), _makePrompts());
+
+          assertEquals(result[1].type, 'research');
+        });
+
+        it('T-SF-JP-14-03: result[0].file がフルパス "/tmp/test.md" になる', async () => {
+          const result = await judgeType([_makeEntryMeta(), _makeEntryMeta2()], _makeDics(), _makePrompts());
+
+          assertEquals(result[0].file, '/tmp/test.md');
         });
       });
     });
@@ -155,7 +208,7 @@ describe('judgeCategory', () => {
         });
 
         it('T-SF-JP-04-01: "development" が返る', async () => {
-          const result = await judgeCategory(_makeEntryMeta(), 'research', _makeDics());
+          const result = await judgeCategory(_makeEntryMeta(), 'research', _makeDics(), _makePrompts());
 
           assertEquals(result, 'development');
         });
@@ -171,7 +224,7 @@ describe('judgeCategory', () => {
         });
 
         it('T-SF-JP-05-01: "development" が返る（フォールバック）', async () => {
-          const result = await judgeCategory(_makeEntryMeta(), 'research', _makeDics());
+          const result = await judgeCategory(_makeEntryMeta(), 'research', _makeDics(), _makePrompts());
 
           assertEquals(result, 'development');
         });
@@ -187,7 +240,7 @@ describe('judgeCategory', () => {
         });
 
         it('T-SF-JP-06-01: "development" が返る（例外なし）', async () => {
-          const result = await judgeCategory(_makeEntryMeta(), 'research', _makeDics());
+          const result = await judgeCategory(_makeEntryMeta(), 'research', _makeDics(), _makePrompts());
 
           assertEquals(result, 'development');
         });
@@ -214,6 +267,7 @@ describe('generateFrontmatter', () => {
             'research',
             'development',
             _makeDics(),
+            _makePrompts(),
           );
 
           assertEquals(result.yaml.length > 0, true);
@@ -225,6 +279,7 @@ describe('generateFrontmatter', () => {
             'research',
             'development',
             _makeDics(),
+            _makePrompts(),
           );
 
           assertEquals(result.type, 'research');
@@ -236,6 +291,7 @@ describe('generateFrontmatter', () => {
             'research',
             'development',
             _makeDics(),
+            _makePrompts(),
           );
 
           assertEquals(result.category, 'development');
@@ -259,6 +315,7 @@ describe('generateFrontmatter', () => {
             'research',
             'development',
             _makeDics(),
+            _makePrompts(),
           );
 
           assertEquals(result.yaml.includes('```'), false);
@@ -280,6 +337,7 @@ describe('generateFrontmatter', () => {
             'research',
             'development',
             _makeDics(),
+            _makePrompts(),
           );
 
           assertEquals(result.yaml, '');
@@ -311,13 +369,13 @@ describe('reviewFrontmatter', () => {
         });
 
         it('T-SF-JP-10-01: validity が "pass" になる', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.validity, 'pass');
         });
 
         it('T-SF-JP-10-02: errors が空配列になる', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.errors, []);
         });
@@ -342,13 +400,13 @@ describe('reviewFrontmatter', () => {
         });
 
         it('T-SF-JP-11-01: validity が "fail" になる', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.validity, 'fail');
         });
 
         it('T-SF-JP-11-02: errors が2件になる', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.errors.length, 2);
         });
@@ -377,13 +435,13 @@ describe('reviewFrontmatter', () => {
         });
 
         it('T-SF-JP-12-01: correctedType が "execution" になる', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.correctedType, 'execution');
         });
 
         it('T-SF-JP-12-02: correctedCategory が "tooling" になる', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.correctedCategory, 'tooling');
         });
@@ -399,7 +457,7 @@ describe('reviewFrontmatter', () => {
         });
 
         it('T-SF-JP-13-01: validity が "pass" になる（例外なし）', async () => {
-          const result = await reviewFrontmatter(_makeFmResult(), _makeDics());
+          const result = await reviewFrontmatter(_makeFmResult(), _makeDics(), _makePrompts());
 
           assertEquals(result.validity, 'pass');
         });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
@@ -19,6 +19,8 @@ import { buildConfig } from '../../setfm-config.ts';
 // ─── Helpers
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_CHUNK_SIZE, DEFAULT_PROMPTS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
 
 // ─── Internal Helpers
 
@@ -107,6 +109,11 @@ describe('buildConfig', () => {
         const result = buildConfig({ targetDir: '/target' }, globalConfig);
         assertEquals(result.concurrency, 4);
       });
+
+      it('[Normal] T-SF-BC-06-01: chunkSize のデフォルトは 10', () => {
+        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        assertEquals(result.chunkSize, DEFAULT_CHUNK_SIZE);
+      });
     });
 
     /** 各フィールドを明示的に指定したケース。 */
@@ -124,6 +131,50 @@ describe('buildConfig', () => {
       it('[Normal] T-SF-BC-03-03: review=false → result.review=false になる', () => {
         const result = buildConfig({ targetDir: '/target', review: false }, globalConfig);
         assertEquals(result.review, false);
+      });
+
+      it('[Normal] T-SF-BC-06-02: parsed.chunkSize=5 → result.chunkSize=5 になる', () => {
+        const result = buildConfig({ targetDir: '/target', chunkSize: 5 }, globalConfig);
+        assertEquals(result.chunkSize, 5);
+      });
+    });
+  });
+
+  /**
+   * `promptsDir` フィールドの優先順位テスト。
+   *
+   * 優先順位: parsed.promptsDir > GlobalConfig.promptsDir > DEFAULT_PROMPTS_DIR
+   */
+  describe('When: promptsDir の優先順位', () => {
+    /** promptsDir 未指定でデフォルト値が使われる正常ケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-SFP-01-01: 引数なし + GlobalConfig 未設定 → DEFAULT_PROMPTS_DIR が使われる', () => {
+        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        assertEquals(result.promptsDir, DEFAULT_PROMPTS_DIR);
+      });
+
+      it('[Normal] T-SFP-02-01: parsed.promptsDir 指定 → その値が使われる', () => {
+        const result = buildConfig({ targetDir: '/target', promptsDir: './custom/prompts' }, globalConfig);
+        assertEquals(result.promptsDir, './custom/prompts');
+      });
+    });
+
+    /** GlobalConfig の値が使われるエッジケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-SFP-03-01: GlobalConfig に promptsDir 設定済み → GlobalConfig の値が使われる', async () => {
+        const gc = await _makeGlobalConfig('promptsDir: ./gc/prompts');
+
+        const result = buildConfig({ targetDir: '/target' }, gc);
+
+        assertEquals(result.promptsDir, './gc/prompts');
+      });
+
+      it('[Edge] T-SFP-03-02: parsed.promptsDir が GlobalConfig より優先される', async () => {
+        const gc = await _makeGlobalConfig('promptsDir: ./gc/prompts');
+
+        const result = buildConfig({ targetDir: '/target', promptsDir: './parsed/prompts' }, gc);
+
+        assertEquals(result.promptsDir, './parsed/prompts');
       });
     });
   });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/format-entry.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/format-entry.unit.spec.ts
@@ -11,15 +11,15 @@ import { assert, assertEquals, assertNotMatch } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { formatEntryShort, formatEntryWithRules } from '../../setfm-ai.ts';
+import { formatEntryShort, formatEntryWithRules } from '../../../libs/dic-format-utils.ts';
 // types
-import type { DicEntry } from '../../../types/dics.types.ts';
+import type { DicEntry, DicRules } from '../../../types/dics.types.ts';
 
 // ─── Internal Helpers
 
 // functions
-function _makeEntry(key: string, def: string, when: string[], not: string[]): DicEntry {
-  return { key, def, desc: '', rules: { when, not } };
+function _makeEntry(key: string, def: string, rules: DicRules, structure?: string): DicEntry {
+  return { key, def, desc: '', rules, structure };
 }
 
 // ─── Tests
@@ -28,7 +28,7 @@ describe('formatEntryWithRules', () => {
   describe('Given: when と not 両方があるエントリ', () => {
     describe('When: formatEntryWithRules を呼び出す', () => {
       describe('Then: T-SF-FE-01 - when/not が含まれる形式に展開される', () => {
-        const entry = _makeEntry('research', '調査・情報収集', ['技術調査'], ['実装作業']);
+        const entry = _makeEntry('research', '調査・情報収集', { when: ['技術調査'], not: ['実装作業'] });
 
         it('T-SF-FE-01-01: "- research: 調査・情報収集" で始まる', () => {
           const result = formatEntryWithRules(entry);
@@ -42,10 +42,10 @@ describe('formatEntryWithRules', () => {
           assert(result.includes('  when: 技術調査'));
         });
 
-        it('T-SF-FE-01-03: "not:  実装作業" 行が含まれる', () => {
+        it('T-SF-FE-01-03: "not: 実装作業" 行が含まれる', () => {
           const result = formatEntryWithRules(entry);
 
-          assert(result.includes('  not:  実装作業'));
+          assert(result.includes('  not: 実装作業'));
         });
       });
     });
@@ -56,7 +56,7 @@ describe('formatEntryWithRules', () => {
   describe('Given: when のみがあるエントリ（not は空配列）', () => {
     describe('When: formatEntryWithRules を呼び出す', () => {
       describe('Then: T-SF-FE-02 - not 行が含まれない', () => {
-        const entry = _makeEntry('execution', '実行・実装', ['実装作業'], []);
+        const entry = _makeEntry('execution', '実行・実装', { when: ['実装作業'], not: [] });
 
         it('T-SF-FE-02-01: "when:" 行が含まれる', () => {
           const result = formatEntryWithRules(entry);
@@ -78,7 +78,7 @@ describe('formatEntryWithRules', () => {
   describe('Given: when も not も空のエントリ', () => {
     describe('When: formatEntryWithRules を呼び出す', () => {
       describe('Then: T-SF-FE-03 - "- key: def" のみになる', () => {
-        const entry = _makeEntry('writing', '文書作成', [], []);
+        const entry = _makeEntry('writing', '文書作成', { when: [], not: [] });
 
         it('T-SF-FE-03-01: "- writing: 文書作成" のみ返る', () => {
           const result = formatEntryWithRules(entry);
@@ -94,12 +94,64 @@ describe('formatEntryWithRules', () => {
   describe('Given: when に複数の値があるエントリ', () => {
     describe('When: formatEntryWithRules を呼び出す', () => {
       describe('Then: T-SF-FE-04 - when の値が " / " で区切られる', () => {
-        const entry = _makeEntry('discussion', '議論・相談', ['設計議論', '方針議論'], []);
+        const entry = _makeEntry('discussion', '議論・相談', { when: ['設計議論', '方針議論'], not: [] });
 
         it('T-SF-FE-04-01: when の値が "設計議論 / 方針議論" で展開される', () => {
           const result = formatEntryWithRules(entry);
 
           assert(result.includes('設計議論 / 方針議論'));
+        });
+      });
+    });
+  });
+
+  // ─── always フィールドを含むエントリ ─────────────────────────────────────
+
+  describe('Given: always フィールドを含むエントリ', () => {
+    describe('When: formatEntryWithRules を呼び出す', () => {
+      describe('Then: T-SF-FE-07 - always 行が展開される', () => {
+        const entry = _makeEntry('incident', 'エラー起点のログ', {
+          when: ['エラーが起点'],
+          always: ['incident は他のタイプより優先'],
+          not: ['エラーなしの実装'],
+        });
+
+        it('T-SF-FE-07-01: "always:" 行が含まれる', () => {
+          const result = formatEntryWithRules(entry);
+
+          assert(result.includes('  always: incident は他のタイプより優先'));
+        });
+
+        it('T-SF-FE-07-02: when / always / not の順序で展開される', () => {
+          const result = formatEntryWithRules(entry);
+          const whenIdx = result.indexOf('  when:');
+          const alwaysIdx = result.indexOf('  always:');
+          const notIdx = result.indexOf('  not:');
+
+          assert(whenIdx < alwaysIdx && alwaysIdx < notIdx);
+        });
+      });
+    });
+  });
+
+  // ─── structure フィールドを含むエントリ ──────────────────────────────────
+
+  describe('Given: structure フィールドを含むエントリ', () => {
+    describe('When: formatEntryWithRules を呼び出す', () => {
+      describe('Then: T-SF-FE-08 - structure が末尾に追加される', () => {
+        const entry = _makeEntry('execution', '実装ログ', { when: ['実装作業'], not: [] }, '指示 → 実装 → 確認');
+
+        it('T-SF-FE-08-01: "structure: 指示 → 実装 → 確認" 行が含まれる', () => {
+          const result = formatEntryWithRules(entry);
+
+          assert(result.includes('  structure: 指示 → 実装 → 確認'));
+        });
+
+        it('T-SF-FE-08-02: structure 行が最終行になる', () => {
+          const result = formatEntryWithRules(entry);
+          const lines = result.split('\n');
+
+          assertEquals(lines.at(-1), '  structure: 指示 → 実装 → 確認');
         });
       });
     });
@@ -110,7 +162,7 @@ describe('formatEntryShort', () => {
   describe('Given: when と not 両方があるエントリ', () => {
     describe('When: formatEntryShort を呼び出す', () => {
       describe('Then: T-SF-FE-05 - rules を無視して "- key: def" のみ返る', () => {
-        const entry = _makeEntry('research', '調査・情報収集', ['技術調査'], ['実装作業']);
+        const entry = _makeEntry('research', '調査・情報収集', { when: ['技術調査'], not: ['実装作業'] });
 
         it('T-SF-FE-05-01: "- research: 調査・情報収集" だけが返る', () => {
           const result = formatEntryShort(entry);
@@ -136,7 +188,7 @@ describe('formatEntryShort', () => {
   describe('Given: rules が空のエントリ', () => {
     describe('When: formatEntryShort を呼び出す', () => {
       describe('Then: T-SF-FE-06 - "- key: def" が返る', () => {
-        const entry = _makeEntry('writing', '文書作成', [], []);
+        const entry = _makeEntry('writing', '文書作成', { when: [], not: [] });
 
         it('T-SF-FE-06-01: "- writing: 文書作成" が返る', () => {
           const result = formatEntryShort(entry);

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/render-prompt.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/render-prompt.unit.spec.ts
@@ -11,7 +11,7 @@ import { assertEquals, assertThrows } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { renderPrompt } from '../../setfm-ai.ts';
+import { renderPrompt } from '../../../libs/template-utils.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';

--- a/skills/set-frontmatter/scripts/modules/setfm-ai.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-ai.ts
@@ -22,107 +22,108 @@ import { toStringArrayWithNull } from '../../../_scripts/libs/text/string-utils.
 
 // ─── Local
 // types
-import type { DicEntry, Dics, PromptTemplate } from '../types/dics.types.ts';
+import type { DicEntry, Dics, Prompts, PromptTemplate } from '../types/dics.types.ts';
 import type { EntryMeta } from '../types/entry-meta.types.ts';
 
 // ─────────────────────────────────────────────
 // 辞書読み込み
 // ─────────────────────────────────────────────
 
+const _readFileSilent = async (path: string): Promise<string> => {
+  try {
+    return await readTextFile(path);
+  } catch {
+    logger.warn(`辞書ファイルが見つかりません: ${path}`);
+    return '';
+  }
+};
+
+const _parseYamlDic = (raw: string): Record<string, unknown> => {
+  if (!raw) { return {}; }
+  const result = parseYaml(raw);
+  return (result && typeof result === 'object') ? (result as Record<string, unknown>) : {};
+};
+
+const _extractEntries = (raw: string): DicEntry[] => {
+  const parsed = _parseYamlDic(raw);
+  return Object.entries(parsed)
+    .filter(([, v]) => v !== null && typeof v === 'object')
+    .map(([k, v]) => {
+      const entry = v as Record<string, unknown>;
+      const rulesRaw = entry['rules'] as Record<string, unknown> | undefined;
+      return {
+        key: k,
+        def: (entry['def'] as string | undefined)?.trim() ?? '',
+        desc: (entry['desc'] as string | undefined)?.trim() ?? '',
+        rules: {
+          when: toStringArrayWithNull(rulesRaw?.['when']),
+          not: toStringArrayWithNull(rulesRaw?.['not']),
+        },
+      };
+    });
+};
+
+const _loadPromptTemplate = (raw: string, name: string): PromptTemplate => {
+  const obj = _parseYamlDic(raw);
+  const system = typeof obj['system'] === 'string' ? (obj['system'] as string).trim() : '';
+  const user = typeof obj['user'] === 'string' ? (obj['user'] as string).trim() : '';
+  if (!system || !user) {
+    logger.warn(`プロンプトテンプレート "${name}" に system/user キーがありません`);
+  }
+  return { system, user };
+};
+
 export const loadDics = async (dicsDir: string): Promise<Dics> => {
-  const readFile = async (path: string): Promise<string> => {
-    try {
-      return await readTextFile(path);
-    } catch {
-      logger.warn(`辞書ファイルが見つかりません: ${path}`);
-      return '';
-    }
+  const [categoryRaw, topicsRaw, tagsRaw, typesRaw] = await Promise.all([
+    _readFileSilent(`${dicsDir}/category.dic`),
+    _readFileSilent(`${dicsDir}/topics.dic`),
+    _readFileSilent(`${dicsDir}/tags.dic`),
+    _readFileSilent(`${dicsDir}/types.dic`),
+  ]);
+
+  const _category = Object.keys(_parseYamlDic(categoryRaw)).join(',');
+  const _tags = Object.keys(_parseYamlDic(tagsRaw)).join(',');
+
+  return {
+    category: _category,
+    tags: _tags,
+    typeEntries: _extractEntries(typesRaw),
+    topicEntries: _extractEntries(topicsRaw),
   };
+};
 
-  const promptsDir = dicsDir.replace(/[/\\]dics$/, '/prompts');
-
+export const loadPrompts = async (promptsDir: string): Promise<Prompts> => {
   const [
-    categoryRaw,
-    topicsRaw,
-    tagsRaw,
-    typesRaw,
     categoryRulesRaw,
     typePromptRaw,
     categoryPromptRaw,
     metaPromptRaw,
     reviewPromptRaw,
   ] = await Promise.all([
-    readFile(`${dicsDir}/category.dic`),
-    readFile(`${dicsDir}/topics.dic`),
-    readFile(`${dicsDir}/tags.dic`),
-    readFile(`${dicsDir}/types.dic`),
-    readFile(`${promptsDir}/category-rules.yaml`),
-    readFile(`${promptsDir}/type.yaml`),
-    readFile(`${promptsDir}/category.yaml`),
-    readFile(`${promptsDir}/meta.yaml`),
-    readFile(`${promptsDir}/review.yaml`),
+    _readFileSilent(`${promptsDir}/category-rules.yaml`),
+    _readFileSilent(`${promptsDir}/type.yaml`),
+    _readFileSilent(`${promptsDir}/category.yaml`),
+    _readFileSilent(`${promptsDir}/meta.yaml`),
+    _readFileSilent(`${promptsDir}/review.yaml`),
   ]);
 
-  const parseYamlDic = (raw: string): Record<string, unknown> => {
-    if (!raw) { return {}; }
-    const result = parseYaml(raw);
-    return (result && typeof result === 'object') ? (result as Record<string, unknown>) : {};
-  };
-
-  const extractEntries = (raw: string): DicEntry[] => {
-    const parsed = parseYamlDic(raw);
-    return Object.entries(parsed)
-      .filter(([, v]) => v !== null && typeof v === 'object')
-      .map(([k, v]) => {
-        const entry = v as Record<string, unknown>;
-        const rulesRaw = entry['rules'] as Record<string, unknown> | undefined;
-        return {
-          key: k,
-          def: (entry['def'] as string | undefined)?.trim() ?? '',
-          desc: (entry['desc'] as string | undefined)?.trim() ?? '',
-          rules: {
-            when: toStringArrayWithNull(rulesRaw?.['when']),
-            not: toStringArrayWithNull(rulesRaw?.['not']),
-          },
-        };
-      });
-  };
-
-  const _category = Object.keys(parseYamlDic(categoryRaw)).join(',');
-  const _tags = Object.keys(parseYamlDic(tagsRaw)).join(',');
-
-  const categoryRulesObj = parseYamlDic(categoryRulesRaw);
+  const categoryRulesObj = _parseYamlDic(categoryRulesRaw);
   const _categoryPrompts = new Map<string, string>(
     Object.entries(categoryRulesObj)
       .filter(([, v]) => typeof v === 'string')
       .map(([k, v]) => [k, (v as string).trim()]),
   );
 
-  // プロンプトテンプレート読み込み
-  const loadPromptTemplate = (raw: string, name: string): PromptTemplate => {
-    const obj = parseYamlDic(raw);
-    const system = typeof obj['system'] === 'string' ? (obj['system'] as string).trim() : '';
-    const user = typeof obj['user'] === 'string' ? (obj['user'] as string).trim() : '';
-    if (!system || !user) {
-      logger.warn(`プロンプトテンプレート "${name}" に system/user キーがありません`);
-    }
-    return { system, user };
-  };
-
-  const prompts = new Map<string, PromptTemplate>([
-    ['type', loadPromptTemplate(typePromptRaw, 'type')],
-    ['category', loadPromptTemplate(categoryPromptRaw, 'category')],
-    ['meta', loadPromptTemplate(metaPromptRaw, 'meta')],
-    ['review', loadPromptTemplate(reviewPromptRaw, 'review')],
+  const _prompts = new Map<string, PromptTemplate>([
+    ['type', _loadPromptTemplate(typePromptRaw, 'type')],
+    ['category', _loadPromptTemplate(categoryPromptRaw, 'category')],
+    ['meta', _loadPromptTemplate(metaPromptRaw, 'meta')],
+    ['review', _loadPromptTemplate(reviewPromptRaw, 'review')],
   ]);
 
   return {
-    category: _category,
-    tags: _tags,
-    typeEntries: extractEntries(typesRaw),
-    topicEntries: extractEntries(topicsRaw),
     categoryPrompts: _categoryPrompts,
-    prompts,
+    prompts: _prompts,
   };
 };
 

--- a/skills/set-frontmatter/scripts/modules/setfm-category.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-category.ts
@@ -13,9 +13,9 @@
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 
 // ─── Local
-import { renderPrompt } from './setfm-ai.ts';
+import { renderPrompt } from '../libs/template-utils.ts';
 // types
-import type { Dics } from '../types/dics.types.ts';
+import type { Dics, Prompts } from '../types/dics.types.ts';
 import type { EntryMeta } from '../types/entry-meta.types.ts';
 import type { LogType } from '../types/phase.types.ts';
 
@@ -23,9 +23,9 @@ import type { LogType } from '../types/phase.types.ts';
 // Phase 3a: category判定（並列）
 // ─────────────────────────────────────────────
 
-export const judgeCategory = async (fm: EntryMeta, type: LogType, dics: Dics): Promise<string> => {
-  const tmpl = dics.prompts.get('category') ?? { system: '', user: '' };
-  const focusGuide = dics.categoryPrompts.get(type) ?? '';
+export const judgeCategory = async (fm: EntryMeta, type: LogType, dics: Dics, prompts: Prompts): Promise<string> => {
+  const tmpl = prompts.prompts.get('category') ?? { system: '', user: '' };
+  const focusGuide = prompts.categoryPrompts.get(type) ?? '';
   const system = renderPrompt(tmpl.system, {});
   const user = renderPrompt(tmpl.user, {
     category_list: dics.category,

--- a/skills/set-frontmatter/scripts/modules/setfm-config.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-config.ts
@@ -14,7 +14,11 @@ import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 // constants
-import { DEFAULT_DICS_DIR } from '../../../_scripts/constants/defaults.constants.ts';
+import {
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_DICS_DIR,
+  DEFAULT_PROMPTS_DIR,
+} from '../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
 
@@ -26,8 +30,10 @@ import type { ParsedConfig, SetfmConfig } from '../types/args.types.ts';
 const _SCHEMA: ArgsSchema = [
   { option: '--target-dir', field: 'targetDir', type: 'directory' },
   { option: '--dics', field: 'dicsDir', type: 'directory' },
+  { option: '--prompts', field: 'promptsDir', type: 'directory' },
   { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--review', field: 'review', type: 'flag' },
+  { option: '--chunk-size', field: 'chunkSize', type: 'number' },
   { option: '--config', field: 'configFile', type: 'string' },
 ];
 
@@ -39,6 +45,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
  * ParsedConfig・GlobalConfig・デフォルト値から完全な SetfmConfig を構築する。
  * - targetDir: `parsed.targetDir` が未指定なら `ChatlogError('InvalidArgs')` をスロー
  * - dicsDir 優先順位: `parsed.dicsDir` > `globalConfig.get('dicsDir')` > `DEFAULT_DICS_DIR`
+ * - promptsDir 優先順位: `parsed.promptsDir` > `globalConfig.get('promptsDir')` > `DEFAULT_PROMPTS_DIR`
  * - dryRun: `parsed.dryRun ?? false`
  * - review: `parsed.review ?? true` — デフォルト true
  * - concurrency: `globalConfig.get('concurrency') as number`
@@ -55,14 +62,19 @@ export const buildConfig = (
     );
   }
   const _dicsDir = parsed.dicsDir ?? (globalConfig.get('dicsDir') as string | undefined) ?? DEFAULT_DICS_DIR;
+  const _promptsDir = parsed.promptsDir ?? (globalConfig.get('promptsDir') as string | undefined)
+    ?? DEFAULT_PROMPTS_DIR;
   const _dryRun = parsed.dryRun ?? false;
   const _review = parsed.review ?? true;
   const _concurrency = globalConfig.get('concurrency') as number;
+  const _chunkSize = parsed.chunkSize ?? DEFAULT_CHUNK_SIZE;
   return {
     targetDir: parsed.targetDir,
     dicsDir: _dicsDir,
+    promptsDir: _promptsDir,
     dryRun: _dryRun,
     review: _review,
     concurrency: _concurrency,
+    chunkSize: _chunkSize,
   };
 };

--- a/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
@@ -14,9 +14,10 @@ import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { cleanYaml } from '../../../_scripts/libs/text/markdown-utils.ts';
 
 // ─── Local
-import { formatEntryWithRules, renderPrompt } from './setfm-ai.ts';
+import { formatEntryWithRules } from '../libs/dic-format-utils.ts';
+import { renderPrompt } from '../libs/template-utils.ts';
 // types
-import type { Dics } from '../types/dics.types.ts';
+import type { Dics, Prompts } from '../types/dics.types.ts';
 import type { EntryMeta } from '../types/entry-meta.types.ts';
 import type { FrontmatterResult, LogType } from '../types/phase.types.ts';
 
@@ -29,8 +30,9 @@ export const generateFrontmatter = async (
   type: LogType,
   category: string,
   dics: Dics,
+  prompts: Prompts,
 ): Promise<FrontmatterResult> => {
-  const tmpl = dics.prompts.get('meta') ?? { system: '', user: '' };
+  const tmpl = prompts.prompts.get('meta') ?? { system: '', user: '' };
   const topicList = dics.topicEntries.map(formatEntryWithRules).join('\n');
   const system = renderPrompt(tmpl.system, {});
   const user = renderPrompt(tmpl.user, {

--- a/skills/set-frontmatter/scripts/modules/setfm-loader.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-loader.ts
@@ -1,7 +1,6 @@
-// src: scripts/modules/setfm-ai.ts
-// @(#): set-frontmatter AI/辞書操作モジュール
-//       対象: loadDics / renderPrompt / formatEntryWithRules / formatEntryShort /
-//             loadEntryMeta
+// src: scripts/modules/setfm-loader.ts
+// @(#): set-frontmatter データ読み込みモジュール
+//       対象: loadDics / loadPrompts / loadEntryMeta
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -180,7 +179,7 @@ export const loadEntryMeta = async (filePath: string, maxContentLength: number):
     return null;
   }
 
-  const entry = new ChatlogEntry(text);
+  const entry = new ChatlogEntry(text, { filePath });
   const fullBody = entry.content;
 
   if (!/^#/m.test(fullBody)) { return null; }

--- a/skills/set-frontmatter/scripts/modules/setfm-review.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-review.ts
@@ -13,9 +13,10 @@
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 
 // ─── Local
-import { formatEntryShort, formatEntryWithRules, renderPrompt } from './setfm-ai.ts';
+import { formatEntryShort, formatEntryWithRules } from '../libs/dic-format-utils.ts';
+import { renderPrompt } from '../libs/template-utils.ts';
 // types
-import type { Dics } from '../types/dics.types.ts';
+import type { Dics, Prompts } from '../types/dics.types.ts';
 import type { FrontmatterResult, ReviewResult } from '../types/phase.types.ts';
 
 // ─────────────────────────────────────────────
@@ -25,13 +26,14 @@ import type { FrontmatterResult, ReviewResult } from '../types/phase.types.ts';
 export const reviewFrontmatter = async (
   result: FrontmatterResult,
   dics: Dics,
+  prompts: Prompts,
 ): Promise<ReviewResult> => {
-  const tmpl = dics.prompts.get('review') ?? { system: '', user: '' };
+  const tmpl = prompts.prompts.get('review') ?? { system: '', user: '' };
   const typeList = dics.typeEntries.map(formatEntryWithRules).join('\n');
   const topicList = dics.topicEntries.map(formatEntryShort).join('\n');
   const system = renderPrompt(tmpl.system, {});
   const user = renderPrompt(tmpl.user, {
-    type_list: typeList,
+    type_dics: typeList,
     topic_list: topicList,
     category_list: dics.category,
     tags_list: dics.tags,

--- a/skills/set-frontmatter/scripts/modules/setfm-type.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-type.ts
@@ -1,5 +1,5 @@
 // src: scripts/modules/setfm-type.ts
-// @(#): set-frontmatter Phase 2 type判定モジュール
+// @(#): set-frontmatter Phase 2 type判定モジュール（バッチ処理）
 //       対象: judgeType
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -11,30 +11,43 @@
 
 // ─── Shared scripts
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
+import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
+import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
 
 // ─── Local
-import { formatEntryWithRules, renderPrompt } from './setfm-ai.ts';
+import { formatEntryWithRules } from '../libs/dic-format-utils.ts';
+import { renderPrompt } from '../libs/template-utils.ts';
 // types
-import type { Dics } from '../types/dics.types.ts';
+import type { Dics, Prompts } from '../types/dics.types.ts';
 import type { EntryMeta } from '../types/entry-meta.types.ts';
 import type { TypeResult } from '../types/phase.types.ts';
 
 // ─────────────────────────────────────────────
-// Phase 2: type判定（並列）
+// Phase 2: type判定（バッチ）
 // ─────────────────────────────────────────────
 
-export const judgeType = async (fm: EntryMeta, dics: Dics): Promise<TypeResult> => {
-  const tmpl = dics.prompts.get('type') ?? { system: '', user: '' };
+export const judgeType = async (fmList: EntryMeta[], dics: Dics, prompts: Prompts): Promise<TypeResult[]> => {
+  const tmpl = prompts.prompts.get('type') ?? { system: '', user: '' };
   const typeList = dics.typeEntries.map(formatEntryWithRules).join('\n');
-  const system = renderPrompt(tmpl.system, {});
-  const user = renderPrompt(tmpl.user, { type_list: typeList, body: fm.content });
-  let raw: string;
-  try {
-    raw = await runAI(system, user);
-  } catch {
-    return { file: fm.file, type: 'research' };
-  }
-  const normalized = raw.replace(/\s/g, '').toLowerCase();
+  const entries = fmList
+    .map((fm, i) => `=== FILE ${i + 1}: ${getFilename(fm.file)} ===\n${fm.content}`)
+    .join('\n\n');
+  const system = renderPrompt(tmpl.system, { type_dics: typeList });
+  const user = renderPrompt(tmpl.user, { entries });
   const validKeys = new Set(dics.typeEntries.map((e) => e.key));
-  return { file: fm.file, type: validKeys.has(normalized) ? normalized : 'research' };
+
+  let parsed: { file: string; type: string }[] | null = null;
+  try {
+    const raw = await runAI(system, user);
+    parsed = parseAiJsonArray<{ file: string; type: string }>(raw);
+  } catch {
+    // fall through to fallback
+  }
+
+  return fmList.map((fm) => {
+    const filename = getFilename(fm.file);
+    const match = parsed?.find((r) => r.file === filename);
+    const normalized = match?.type.replace(/\s/g, '').toLowerCase() ?? '';
+    return { file: fm.file, type: validKeys.has(normalized) ? normalized : 'research' };
+  });
 };

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -30,13 +30,13 @@ import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
+import { runChunked, runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
 
 // ─── Local
-import { loadDics, loadEntryMeta } from './modules/setfm-ai.ts';
 import { judgeCategory } from './modules/setfm-category.ts';
 import { buildConfig, parseArgs } from './modules/setfm-config.ts';
 import { generateFrontmatter } from './modules/setfm-frontmatter.ts';
+import { loadDics, loadEntryMeta, loadPrompts } from './modules/setfm-loader.ts';
 import { reviewFrontmatter } from './modules/setfm-review.ts';
 import { judgeType } from './modules/setfm-type.ts';
 import { writeFrontmatter } from './modules/setfm-write.ts';
@@ -52,23 +52,23 @@ export const main = async (args: string[]): Promise<void> => {
   try {
     const _parsed = parseArgs(args);
     const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
-    const { targetDir, dicsDir, dryRun, review, concurrency } = buildConfig(_parsed, _globalConfig);
+    const _config = buildConfig(_parsed, _globalConfig);
 
-    if (!await dirExists(targetDir)) {
-      throw new ChatlogError('InputNotFound', 'NotFound', `ディレクトリが見つかりません: ${targetDir}`);
+    if (!await dirExists(_config.targetDir)) {
+      throw new ChatlogError('InputNotFound', 'NotFound', `ディレクトリが見つかりません: ${_config.targetDir}`);
     }
 
-    const dics = await loadDics(dicsDir);
+    const [dics, prompts] = await Promise.all([loadDics(_config.dicsDir), loadPrompts(_config.promptsDir)]);
     logger.info(
       `辞書読み込み完了: category=${dics.category.split(',').length}件 `
         + `topics=${dics.topicEntries.length}件 tags=${dics.tags.split(',').length}件 `
         + `types=${dics.typeEntries.length}件`,
     );
 
-    const allFiles = await findFiles(targetDir);
+    const allFiles = await findFiles(_config.targetDir);
     logger.info(`対象ファイル数: ${allFiles.length}`);
-    if (dryRun) { logger.info('dry-run モード: ファイルは更新しません'); }
-    if (!review) { logger.info('--no-review モード: Phase 3.5 をスキップします'); }
+    if (_config.dryRun) { logger.info('dry-run モード: ファイルは更新しません'); }
+    if (!_config.review) { logger.info('--no-review モード: Phase 3.5 をスキップします'); }
     if (allFiles.length === 0) {
       logger.info('対象ファイルなし');
       return;
@@ -86,48 +86,58 @@ export const main = async (args: string[]): Promise<void> => {
     }
     logger.info(`メタ読み込み: ${fileMetaList.length}件（スキップ: ${stats.skip}件）`);
 
-    // Phase 2: type判定（並列）
-    logger.info(`\nPhase 2: type判定開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
-    const typeResults = await runConcurrent(fileMetaList, (fm) => judgeType(fm, dics), concurrency);
+    // Phase 2: type判定（バッチ並列）
+    logger.info(
+      `\nPhase 2: type判定開始 (${fileMetaList.length}件 × チャンク${_config.chunkSize} × 並列度${_config.concurrency})`,
+    );
+    const typeChunks = await runChunked(
+      fileMetaList,
+      _config.chunkSize,
+      (chunk) => judgeType(chunk, dics, prompts),
+      _config.concurrency,
+    );
+    const typeResults = typeChunks.flat();
     const typeMap = new Map(typeResults.map((r) => [r.file, r]));
     for (const r of typeResults) { logger.info(`  type [${r.type}]: ${r.file.split(/[/\\]/).pop()}`); }
 
     // Phase 3a: category判定（並列）
-    logger.info(`\nPhase 3a: category判定開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+    logger.info(`\nPhase 3a: category判定開始 (${fileMetaList.length}件 × 並列度${_config.concurrency})`);
     const categoryResults = await runConcurrent(
       fileMetaList,
       async (fm) => {
         const type = typeMap.get(fm.file)?.type ?? 'research';
-        const category = await judgeCategory(fm, type, dics);
+        const category = await judgeCategory(fm, type, dics, prompts);
         logger.info(`  category [${category}]: ${fm.file.split(/[/\\]/).pop()}`);
         return { file: fm.file, type, category };
       },
-      concurrency,
+      _config.concurrency,
     );
     const categoryMap = new Map(categoryResults.map((r) => [r.file, r]));
 
     // Phase 3b: フロントマター生成（並列）
-    logger.info(`\nPhase 3b: フロントマター生成開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+    logger.info(`\nPhase 3b: フロントマター生成開始 (${fileMetaList.length}件 × 並列度${_config.concurrency})`);
     const fmResults = await runConcurrent(
       fileMetaList,
       (fm) => {
         const cr = categoryMap.get(fm.file);
         const type = cr?.type ?? 'research';
         const category = cr?.category ?? 'development';
-        return generateFrontmatter(fm, type, category, dics);
+        return generateFrontmatter(fm, type, category, dics, prompts);
       },
-      concurrency,
+      _config.concurrency,
     );
     const fmResultMap = new Map(fmResults.map((r) => [r.file, r]));
     for (const r of fmResults) { logger.info(`  generated: ${r.file.split(/[/\\]/).pop()}`); }
 
     // Phase 3.5: レビュー（並列）
-    if (review) {
-      logger.info(`\nPhase 3.5: フロントマターレビュー開始 (${fileMetaList.length}件 × 並列度${concurrency})`);
+    if (_config.review) {
+      logger.info(
+        `\nPhase 3.5: フロントマターレビュー開始 (${fileMetaList.length}件 × 並列度${_config.concurrency})`,
+      );
       const reviewResults = await runConcurrent(
         fmResults.filter((r) => r.yaml),
-        (r) => reviewFrontmatter(r, dics),
-        concurrency,
+        (r) => reviewFrontmatter(r, dics, prompts),
+        _config.concurrency,
       );
       for (const r of reviewResults) {
         if (r.validity === 'fail') {
@@ -157,10 +167,10 @@ export const main = async (args: string[]): Promise<void> => {
         stats.fail++;
         continue;
       }
-      await writeFrontmatter(fm, result, dryRun, stats);
+      await writeFrontmatter(fm, result, _config.dryRun, stats);
     }
 
-    const drySuffix = dryRun ? ' (dry-run)' : '';
+    const drySuffix = _config.dryRun ? ' (dry-run)' : '';
     logger.info(
       `\n完了${drySuffix}: total=${stats.total} success=${stats.success} fail=${stats.fail} skip=${stats.skip}`,
     );

--- a/skills/set-frontmatter/scripts/types/args.types.ts
+++ b/skills/set-frontmatter/scripts/types/args.types.ts
@@ -18,12 +18,16 @@ export interface SetfmConfig {
   targetDir: string;
   /** 辞書ファイルが置かれたディレクトリのパス。 */
   dicsDir: string;
+  /** プロンプトファイルが置かれたディレクトリのパス。 */
+  promptsDir: string;
   /** `true` のときファイルを書き換えずに処理結果のみ表示する。 */
   dryRun: boolean;
   /** `true` のときレビューフェーズ（Phase 3）を実行する。 */
   review: boolean;
   /** 同時実行する並列タスク数の上限。 */
   concurrency: number;
+  /** バッチリクエスト1回あたりの最大ファイル数。 */
+  chunkSize: number;
 }
 
 /** `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。`concurrency` は GlobalConfig で管理するため除外。 */

--- a/skills/set-frontmatter/scripts/types/dics.types.ts
+++ b/skills/set-frontmatter/scripts/types/dics.types.ts
@@ -10,13 +10,8 @@
 // 辞書エントリ型
 // ─────────────────────────────────────────────
 
-/** 辞書エントリの適用・除外ルール。AI プロンプト生成時の制約条件として使用する。 */
-export interface DicRules {
-  /** このエントリを選択する条件キーワード一覧。 */
-  when: string[];
-  /** このエントリを除外する条件キーワード一覧。 */
-  not: string[];
-}
+/** 辞書エントリの適用・除外ルール。各フィールドはキーワード配列。when / not / always 等、辞書ファイルに実在するフィールドをすべて保持する。 */
+export type DicRules = Record<string, string[]>;
 
 /** category / topic / tag 辞書の1エントリ。`assets/dics/` 配下の YAML から読み込む。 */
 export interface DicEntry {
@@ -28,6 +23,8 @@ export interface DicEntry {
   desc: string;
   /** 適用・除外ルール。 */
   rules: DicRules;
+  /** 会話の構造パターン（スカラー文字列、types.dic の structure フィールド）。 */
+  structure?: string;
 }
 
 // ─────────────────────────────────────────────
@@ -46,7 +43,7 @@ export interface PromptTemplate {
 // 辞書集約型
 // ─────────────────────────────────────────────
 
-/** `loadDics` が返す辞書データ集約。全フェーズで共有される。 */
+/** `loadDics` が返す辞書データ集約（プロンプトを含まない）。全フェーズで共有される。 */
 export interface Dics {
   /** category キー一覧（カンマ区切り、AI スキーマ制約用）。 */
   category: string;
@@ -56,6 +53,10 @@ export interface Dics {
   typeEntries: DicEntry[];
   /** topic 辞書のエントリ配列。 */
   topicEntries: DicEntry[];
+}
+
+/** `loadPrompts` が返すプロンプトデータ集約。 */
+export interface Prompts {
   /** type ごとの category 判定プロンプト。キーは type 名。 */
   categoryPrompts: Map<string, string>;
   /** フェーズ別プロンプトテンプレート。キーはフェーズ名。 */


### PR DESCRIPTION
## Overview

**Summary**
Refactors `set-frontmatter` skill to inject prompts as dependencies and adds batch type judging support.

**Background / Motivation**
The `set-frontmatter` skill previously mixed prompt loading and AI invocation logic within individual classification modules (`setfm-category`, `setfm-review`, `setfm-type`). This tight coupling made it difficult to test each module in isolation and prevented reuse of prompts across modules.

Additionally, the type classification pipeline called the AI model once per entry, which was inefficient for large batches. Introducing batch JSON output reduces API round-trips and improves throughput when processing many chatlog entries at once.

This refactoring establishes a clean boundary: the top-level `set-frontmatter.ts` loads and passes prompts explicitly, while the subordinate modules remain pure transformation functions that accept prompts as parameters.

## Changes

### Core Changes

- `setfm-category.ts`, `setfm-frontmatter.ts`, `setfm-review.ts`: converted to accept prompts as injected parameters instead of loading them internally
- `setfm-type.ts`: extended to support prompt injection and batch type judging with JSON output parsing
- `set-frontmatter.ts`: updated entry point to load prompts once and distribute them to all modules
- `scripts/libs/template-utils.ts` (new): renders prompt template variables (e.g. `${type_dics}`) with runtime values
- `scripts/libs/dic-format-utils.ts` (new): formats dictionary entries for use in prompt context strings
- `scripts/types/dics.types.ts`: separated prompt-related types from dictionary rule types; added flexible dictionary rules support
- `scripts/types/args.types.ts`: extended `SetfmConfig` with `promptsDir` and `chunkSize` options
- `scripts/modules/setfm-config.ts`: added `promptsDir` and `chunkSize` fields to configuration building
- `scripts/modules/setfm-loader.ts` (renamed from `setfm-ai.ts`): clarified module responsibility as a loader
- `assets/prompts/type.yaml`: converted to batch JSON output format
- `assets/prompts/review.yaml`: renamed template variable `${type_list}` to `${type_dics}`

### Test Updates

- Updated unit, functional, integration, and e2e tests to match new module signatures and prompt injection patterns
- Added `build-config.unit.spec.ts` cases covering `promptsDir` and `chunkSize` configuration
- Adapted fixtures and pipeline tests to the batch judging interface

### Removed

- `setfm-ai.ts` (renamed to `setfm-loader.ts`)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #48

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- `chunkSize` defaults should be validated downstream; callers must ensure `chunkSize >= 1` to avoid empty batch requests.
- `${type_dics}` replaces `${type_list}` in `review.yaml`; any external prompts or scripts referencing the old variable name will need to be updated.
