### PR TITLE
refactor(libs/yaml-utils): add custom YAML frontmatter serializer

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,8 +3,7 @@
     "@std/fs": "jsr:@std/fs@^1.0.23",
     "@std/yaml": "jsr:@std/yaml@^1.0.12",
     "@std/assert": "jsr:@std/assert@^1.0.0",
-    "@std/testing": "jsr:@std/testing@^1.0.0",
-    "yaml": "npm:yaml"
+    "@std/testing": "jsr:@std/testing@^1.0.0"
   },
   "lint": {
     "rules": {

--- a/skills/_scripts/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_scripts/classes/ChatlogFrontmatter.class.ts
@@ -9,11 +9,14 @@
 // --─ Imports
 // external
 import { parse as parseYaml } from '@std/yaml';
-import { stringify } from 'yaml';
 
 // --- shared
 import { divideEntry, reorderFrontmatterEntries } from '../libs/text/frontmatter-utils.ts';
 import { toStringWithNull } from '../libs/text/string-utils.ts';
+import { stringifyFrontmatter } from '../libs/text/yaml-utils.ts';
+
+// types
+import type { FrontmatterFields } from '../types/frontmatter.types.ts';
 
 // Error
 import { ChatlogError } from './ChatlogError.class.ts';
@@ -37,13 +40,13 @@ const _DEFAULT_FIELD_ORDER: string[] = [
 ] as const;
 
 export class ChatlogFrontmatter {
-  private _entries: Record<string, string | string[]>;
+  private _entries: FrontmatterFields;
 
   constructor(input: string) {
     this._entries = this._parseFrontmatter(input);
   }
 
-  private _parseFrontmatter(input: string): Record<string, string | string[]> {
+  private _parseFrontmatter(input: string): FrontmatterFields {
     if (input === '') { return {}; }
 
     // divideEntry で frontmatter テキストを取得（DoesNotStart は '' を返す、NotClosed は throw）
@@ -88,8 +91,8 @@ export class ChatlogFrontmatter {
     return toStringWithNull(v);
   }
 
-  private _toEntries(parsed: Record<string, unknown>): Record<string, string | string[]> {
-    const _result: Record<string, string | string[]> = {};
+  private _toEntries(parsed: Record<string, unknown>): FrontmatterFields {
+    const _result: FrontmatterFields = {};
     for (const key of Object.keys(parsed)) {
       _result[key] = this._toStringOrArray(parsed[key]);
     }
@@ -116,7 +119,7 @@ export class ChatlogFrontmatter {
     if (Object.keys(_ordered).length === 0) {
       return `${FRONTMATTER_DELIMITER}\n\n${FRONTMATTER_DELIMITER}\n`;
     }
-    const _yamlBody = stringify(_ordered, { defaultKeyType: 'PLAIN', defaultStringType: 'QUOTE_DOUBLE', lineWidth: 0 });
+    const _yamlBody = stringifyFrontmatter(_ordered);
     return `${FRONTMATTER_DELIMITER}\n${_yamlBody}${FRONTMATTER_DELIMITER}\n`;
   }
 }

--- a/skills/_scripts/libs/text/__tests__/unit/yaml-utils.unit.spec.ts
+++ b/skills/_scripts/libs/text/__tests__/unit/yaml-utils.unit.spec.ts
@@ -1,0 +1,83 @@
+// src: skills/_scripts/libs/text/__tests__/unit/yaml-utils.unit.spec.ts
+// @(#): yaml-utils ユニットテスト
+//       対象: stringifyFrontmatter
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { stringifyFrontmatter } from '../../yaml-utils.ts';
+
+// ─── Tests
+
+/**
+ * `stringifyFrontmatter` のユニットテストスイート。
+ *
+ * `Record<string, string | string[]>` から YAML 文字列を生成する動作を検証する。
+ * `_quoteString` / `_serializeValue` のエスケープ・直列化ロジックも間接的に検証する。
+ *
+ * テスト ID 範囲: T-YU-SF-01 〜 T-YU-SF-08
+ *
+ * @see stringifyFrontmatter
+ */
+describe('stringifyFrontmatter', () => {
+  describe('When: 正常系', () => {
+    it('[Normal] T-YU-SF-01: スカラー文字列1件 → `key: "value"\\n`', () => {
+      assertEquals(stringifyFrontmatter({ title: 'Hello' }), 'title: "Hello"\n');
+    });
+
+    it('[Normal] T-YU-SF-02: 配列1件 → `key:\\n  - "item"\\n` 形式', () => {
+      assertEquals(
+        stringifyFrontmatter({ tags: ['alpha', 'beta'] }),
+        'tags:\n  - "alpha"\n  - "beta"\n',
+      );
+    });
+
+    it('[Normal] T-YU-SF-03: `"` と `\\` を含む文字列 → エスケープされる', () => {
+      assertEquals(
+        stringifyFrontmatter({ title: 'say "hello"', path: 'foo\\bar' }),
+        'title: "say \\"hello\\""\npath: "foo\\\\bar"\n',
+      );
+    });
+
+    it('[Normal] T-YU-SF-06: `"` と `\\` が同一値に混在 → 両方エスケープされる', () => {
+      assertEquals(
+        stringifyFrontmatter({ title: 'a\\"b' }),
+        'title: "a\\\\\\"b"\n',
+      );
+    });
+
+    it('[Normal] T-YU-SF-07: Unicode 文字列 → そのまま出力される', () => {
+      assertEquals(
+        stringifyFrontmatter({ title: 'こんにちは', category: '開発ログ' }),
+        'title: "こんにちは"\ncategory: "開発ログ"\n',
+      );
+    });
+  });
+
+  describe('When: エッジケース', () => {
+    it('[Edge] T-YU-SF-04: 空オブジェクト → 空文字列', () => {
+      assertEquals(stringifyFrontmatter({}), '');
+    });
+
+    it('[Edge] T-YU-SF-05: スカラーと配列の混在 → 挿入順を保持', () => {
+      assertEquals(
+        stringifyFrontmatter({ title: 'My Title', tags: ['ts', 'deno'] }),
+        'title: "My Title"\ntags:\n  - "ts"\n  - "deno"\n',
+      );
+    });
+
+    it('[Edge] T-YU-SF-08: 1要素配列 → `key:\\n  - "item"\\n`', () => {
+      assertEquals(
+        stringifyFrontmatter({ tags: ['only'] }),
+        'tags:\n  - "only"\n',
+      );
+    });
+  });
+});

--- a/skills/_scripts/libs/text/frontmatter-utils.ts
+++ b/skills/_scripts/libs/text/frontmatter-utils.ts
@@ -7,17 +7,16 @@
 // https://opensource.org/licenses/MIT
 
 // --- external
-// YAML テキストを生成する (yaml npm パッケージ)
-import { stringify } from 'yaml';
 // YAML パース (@std/yaml)
 import { parse as parseYaml } from '@std/yaml';
 
 // --- libs
 import { normalizeLine } from './line-utils.ts';
 import { toStringWithNull } from './string-utils.ts';
+import { stringifyFrontmatter } from './yaml-utils.ts';
 
 // types
-import type { FrontmatterEntries, FrontmatterResult } from '../../types/frontmatter.types.ts';
+import type { FrontmatterEntries, FrontmatterFields, FrontmatterResult } from '../../types/frontmatter.types.ts';
 
 // Error
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
@@ -117,7 +116,7 @@ export const parseFrontmatter = (text: string): FrontmatterResult => {
 /** Markdown テキストから frontmatter を抽出し、文字列または文字列配列に変換して返す。 */
 export const parseFrontmatterEntries = (text: string): FrontmatterEntries => {
   const { meta, content } = parseFrontmatter(text);
-  const _typedMeta: Record<string, string | string[]> = {};
+  const _typedMeta: FrontmatterFields = {};
   for (const key of Object.keys(meta)) {
     _typedMeta[key] = _unknownToStringOrArray(meta[key]);
   }
@@ -132,13 +131,13 @@ export const parseFrontmatterEntries = (text: string): FrontmatterEntries => {
  *
  * @param entries - 並べ替え元の Record
  * @param fieldOrder - 出力フィールドの順序
- * @returns `fieldOrder` の順に並んだ `Record<string, string | string[]>`
+ * @returns `fieldOrder` の順に並んだ `FrontmatterFields`
  */
 export const reorderFrontmatterEntries = (
-  entries: Record<string, string | string[]>,
+  entries: FrontmatterFields,
   fieldOrder: string[],
-): Record<string, string | string[]> => {
-  const _result: Record<string, string | string[]> = {};
+): FrontmatterFields => {
+  const _result: FrontmatterFields = {};
   const _seen = new Set<string>();
   for (const field of fieldOrder) {
     if (_seen.has(field)) { continue; }
@@ -162,8 +161,8 @@ export const reorderFrontmatterEntries = (
  * @param fields - frontmatter フィールドの Record
  * @returns frontmatter ブロック文字列（空オブジェクトのとき `""`）
  */
-export const renderFrontmatter = (fields: Record<string, unknown>): string => {
+export const renderFrontmatter = (fields: FrontmatterFields): string => {
   if (Object.keys(fields).length === 0) { return ''; }
-  const _yamlBody = stringify(fields, { defaultKeyType: 'PLAIN', defaultStringType: 'QUOTE_DOUBLE', lineWidth: 0 });
+  const _yamlBody = stringifyFrontmatter(fields);
   return `---\n${_yamlBody}---\n`;
 };

--- a/skills/_scripts/libs/text/yaml-utils.ts
+++ b/skills/_scripts/libs/text/yaml-utils.ts
@@ -1,0 +1,20 @@
+// src: skills/_scripts/libs/text/yaml-utils.ts
+// @(#): YAML シリアライズユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// types
+import type { FrontmatterFields } from '../../types/frontmatter.types.ts';
+
+const _quoteString = (s: string): string => `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+const _serializeValue = (key: string, value: string | string[]): string =>
+  Array.isArray(value)
+    ? `${key}:\n${value.map((item) => `  - ${_quoteString(item)}`).join('\n')}\n`
+    : `${key}: ${_quoteString(value)}\n`;
+
+export const stringifyFrontmatter = (fields: FrontmatterFields): string =>
+  Object.entries(fields).map(([k, v]) => _serializeValue(k, v)).join('');

--- a/skills/_scripts/types/frontmatter.types.ts
+++ b/skills/_scripts/types/frontmatter.types.ts
@@ -7,6 +7,13 @@
 // https://opensource.org/licenses/MIT
 
 // ─────────────────────────────────────────────
+// frontmatter フィールド型
+// ─────────────────────────────────────────────
+
+/** frontmatter フィールドの値型。スカラー文字列または文字列配列。 */
+export type FrontmatterFields = Record<string, string | string[]>;
+
+// ─────────────────────────────────────────────
 // frontmatter 抽出結果系
 // ─────────────────────────────────────────────
 
@@ -21,7 +28,7 @@ export type FrontmatterResult = {
 /** frontmatter フィールドを文字列または文字列配列に変換した抽出結果。 */
 export type FrontmatterEntries = {
   /** 変換されたフロントマターフィールド。配列値は string[] で保持される。 */
-  meta: Record<string, string | string[]>;
+  meta: FrontmatterFields;
   /** フロントマターを除いた本文。 */
   content: string;
 };

--- a/skills/classify-chatlogs/scripts/__tests__/_helpers/classify-test-helpers.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/_helpers/classify-test-helpers.ts
@@ -11,6 +11,8 @@
 import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { renderFrontmatter } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
 import type { ClassifyStats } from '../../types/classify.types.ts';
+// types
+import type { FrontmatterFields } from '../../../../_scripts/types/frontmatter.types.ts';
 
 // ─── Exports
 
@@ -40,7 +42,7 @@ export const _makeClassifyChatlogEntry = (filename: string, entryText?: string):
  */
 export const _makeEntry = (
   filePath: string,
-  frontmatter: Record<string, unknown> = {},
+  frontmatter: FrontmatterFields = {},
   content = '',
 ): ChatlogEntry => {
   const _text = renderFrontmatter(frontmatter) + content;

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
@@ -20,6 +20,7 @@ import { preClassify } from '../../classify-noai.ts';
 // ─── Helpers
 // types
 import type { ClassifyAction, ClassifyBufferEntry } from '../../../types/classify.types.ts';
+import type { FrontmatterFields } from '../../../../../_scripts/types/frontmatter.types.ts';
 // functions
 import {
   findFixtureDirs,
@@ -40,7 +41,7 @@ const FIXTURES_DIR = new URL('./fixtures-data/pre-classify', import.meta.url)
 // types
 interface _FixtureInput {
   filePath: string;
-  frontmatter: Record<string, unknown>;
+  frontmatter: FrontmatterFields;
   content: string;
   action?: string;
   reason?: string;

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-ai.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-ai.unit.spec.ts
@@ -22,6 +22,8 @@ import {
 
 // ─── Helpers
 import { renderFrontmatter } from '../../../../../_scripts/libs/text/frontmatter-utils.ts';
+// types
+import type { FrontmatterFields } from '../../../../../_scripts/types/frontmatter.types.ts';
 
 // ─── Internal Helpers
 
@@ -62,7 +64,7 @@ const _makeChatlogEntry = (opts: MakeMetaOptions = {}): ChatlogEntry => {
   const tags = opts.tags ?? [];
   const content = opts.content ?? '';
 
-  const _fields: Record<string, unknown> = {};
+  const _fields: FrontmatterFields = {};
   if (title) { _fields['title'] = title; }
   if (category) { _fields['category'] = category; }
   if (topics.length > 0) { _fields['topics'] = topics; }

--- a/skills/set-frontmatter/scripts/modules/setfm-write.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-write.ts
@@ -16,6 +16,8 @@ import { parse as parseYaml } from '@std/yaml';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { renderFrontmatter } from '../../../_scripts/libs/text/frontmatter-utils.ts';
+// types
+import type { FrontmatterFields } from '../../../_scripts/types/frontmatter.types.ts';
 
 // ─── Local
 // types
@@ -39,7 +41,7 @@ export const writeFrontmatter = async (
     return;
   }
 
-  const _fields: Record<string, unknown> = {
+  const _fields: FrontmatterFields = {
     session_id: entry.frontmatter.get('session_id') as string ?? '',
     date: entry.frontmatter.get('date') as string ?? '',
     project: entry.frontmatter.get('project') as string ?? '',
@@ -47,8 +49,8 @@ export const writeFrontmatter = async (
     type: result.type,
     category: result.category,
   };
-  const _parsedYaml = parseYaml(result.yaml) as Record<string, unknown>;
-  const _allFields = { ..._fields, ..._parsedYaml };
+  const _parsedYaml = parseYaml(result.yaml) as FrontmatterFields;
+  const _allFields: FrontmatterFields = { ..._fields, ..._parsedYaml };
   const newFrontmatter = renderFrontmatter(_allFields).trimEnd();
 
   if (dryRun) {


### PR DESCRIPTION
## Overview

**Summary**
Add a dedicated YAML frontmatter serializer and extract a shared `FrontmatterFields` type.

**Background / Motivation**
The project used `npm:yaml` only for serializing frontmatter values. This PR replaces that dependency with a purpose-built `stringifyFrontmatter` function, giving full control over quoting and list formatting while removing an external runtime dependency.

## Changes

### Core Changes

- `skills/_scripts/libs/text/yaml-utils.ts` — new file; exports `stringifyFrontmatter`
- `skills/_scripts/types/frontmatter.types.ts` — exports new `FrontmatterFields` type (`Record<string, string | string[]>`)
- `skills/_scripts/libs/text/frontmatter-utils.ts` — migrates from `npm:yaml` to `stringifyFrontmatter`; adopts `FrontmatterFields`
- `skills/_scripts/classes/ChatlogFrontmatter.class.ts` — removes `npm:yaml` import; uses `stringifyFrontmatter`
- `skills/set-frontmatter/scripts/modules/setfm-write.ts` — adopts `FrontmatterFields` type
- `deno.json` — removes `"yaml": "npm:yaml"` import

### Test Updates

- `skills/_scripts/libs/text/__tests__/unit/yaml-utils.unit.spec.ts` — new file; 8 unit test cases covering scalar strings, arrays, escape sequences, Unicode, and edge cases

### Removed

- Unused `npm:yaml` dependency

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Related to #224

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`stringifyFrontmatter` handles only `string` and `string[]` values, matching the `FrontmatterFields` contract. The serialization output is functionally equivalent to the previous `npm:yaml` output for this project's value shapes. No breaking changes.
