### PR TITLE
ci(config): update reusable workflow refs and clean up config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -101,6 +101,7 @@ indent_style = space
 indent_size = 2
 tab_width = 2
 
+
 # ─────────────────────────────
 # Git Config Files
 # ─────────────────────────────

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -28,4 +28,4 @@ jobs:
     name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-scan-betterleaks.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+    uses: aglabo/ci-platform/.github/workflows/ru-scan-betterleaks.yml@3b3ba7602e8588aefbd08babedb8364da5b73c27 # v0.3.2

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-qa-actionlint.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-actionlint.yml@3b3ba7602e8588aefbd08babedb8364da5b73c27 # v0.3.2
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-qa-ghalint.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-ghalint.yml@3b3ba7602e8588aefbd08babedb8364da5b73c27 # v0.3.2

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 # https://opensource.org/licenses/MIT
 
 
-
 ##  General
 #   OS specific files
 .DS_Store
@@ -101,15 +100,8 @@ tmp/
 ## Node
 node_modules/
 
-## Beads
-.beads/*
+## beads
+.beads/+
+!.beads/**/.gitignore
 !.beads/config.yaml
-!.beads/issues.jsonl
-
-
-
-.dolt/
-*.db
-.beads-credential-key
-
 


### PR DESCRIPTION
## Overview

**Summary**
Update CI workflow refs to the new `ru-*` naming convention and clean up stale config entries.

**Background / Motivation**
Reusable workflow files were renamed from `ci-*` to `ru-*`. This PR updates all references and bumps pinned SHAs to v0.3.2. Also removes stale `.gitignore` entries and adds a minor formatting fix to `.editorconfig`.

## Changes

### Core Changes

- `.github/workflows/ci-scan-secrets.yml` — update betterleaks ref to `ru-scan-betterleaks.yml`; bump SHA to v0.3.2
- `.github/workflows/ci-workflows-qa.yml` — update actionlint and ghalint refs to `ru-qa-*`; bump SHAs to v0.3.2
- `.gitignore` — restructure beads section: use `.beads/+` base pattern, add `!.beads/**/.gitignore`

### Test Updates

N/A

### Removed

- Stale `.gitignore` entries: `.dolt/`, `*.db`, `.beads-credential-key`, `!.beads/issues.jsonl`

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Configuration and CI/CD changes only. No functional code changes.
