### PR TITLE
refactor(classify): migrate classify-noai and find-buffer-entries to ActionStatusEntry

### DIFF
--- a/docs/.deckrd/pipeline/classify/implementation/implementation.md
+++ b/docs/.deckrd/pipeline/classify/implementation/implementation.md
@@ -1,0 +1,145 @@
+---
+title: "Implementation Plan: classify pipeline refactoring to ActionStatusEntry"
+based-on: specifications.md v1.2
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`classify-chatlogs` パイプラインの全処理ユニットを `ActionStatusEntry`（ASE）ベースに移行する。
+`ClassifyBufferEntry` / `ClassifyBuffer` を廃止し、共通型 `ActionStatusEntry[]` で統一することで型一貫性を向上させる。
+パイプラインは immutable（純粋変換）設計とし、副作用は `moveClassified`（apply ステージ）に限定する。
+
+### 1.2 Reference
+
+- Prior Art / Reference PR: none
+- Specifications: `specifications/specifications.md` v1.2
+- Requirements: `requirements/requirements.md` v1.1
+
+---
+
+## 2. Implementation Plan
+
+### Phase 1: 共通型拡張
+
+`ENTRY_ACTIONS` への `MOVEBYAI` / `PENDING` 追加と `ActionStatusOptions` への `targetPath` 追加。
+他のすべてのユニットの前提となる基盤変更。
+
+#### Commit 1: chore(types): add MOVEBYAI and PENDING to ENTRY_ACTIONS
+
+- `action-status.types.ts` の `ENTRY_ACTIONS` に `MOVEBYAI: 'move-by-ai'` を追加する
+- `action-status.types.ts` の `ENTRY_ACTIONS` に `PENDING: 'pending'` を追加する
+- `EntryAction` 型に両値が含まれることをユニットテストで確認する
+
+#### Commit 2: chore(types): add targetPath to ActionStatusOptions
+
+- `action-status-entry.types.ts` の `ActionStatusOptions` に `targetPath?: string` を追加する
+- 既存フィールドへの影響なし（optional 追加のみ）
+
+---
+
+### Phase 2: collect / pre-sort の ASE 移行
+
+`findBufferEntries` と `classify-noai.ts` を ASE ベースに切り替える。
+エラー時 `ChatlogError` スロー、ディープコピー純粋変換を実装。
+
+#### Commit 1: refactor(classify): migrate loadClassifyEntry to ActionStatusEntry
+
+- `classify-noai.ts` の `loadClassifyEntry` を `ActionStatusEntry` を返すよう変更する
+- ファイル読み込み失敗時は `ChatlogError` をスローする（`action: error` エントリを返さない）
+- ユニットテスト（`loadClassifyEntry`）を ASE ベースに書き換える
+
+#### Commit 2: refactor(classify): migrate preClassify / processPreclassify to ASE deep copy
+
+- `preClassify` を `ActionStatusEntry → ActionStatusEntry`（ディープコピー）に変更する
+- コピー側の `frontmatter` に `project` を設定し、`options.targetPath` に `destDir` を設定する
+- `action: pending` を `ENTRY_ACTIONS.PENDING` で設定する
+- `processPreclassify` を `ActionStatusEntry[] → ActionStatusEntry[]` に変更する
+- ユニットテスト（`preClassify` / `processPreclassify`）を ASE ベースに書き換える
+
+#### Commit 3: refactor(classify): migrate findBufferEntries to ActionStatusEntry
+
+- `findBufferEntries` の戻り値を `ActionStatusEntry[]` に変更する
+- `opts.loadMeta` の型シグネチャを `ASE` 返却に更新する
+- エラーエントリ除外処理を `ChatlogError` スローに対応した形に修正する
+- ユニットテスト（`findBufferEntries`）を ASE ベースに書き換える
+
+---
+
+### Phase 3: ai-sort の ASE 移行
+
+`classify-ai.ts` を ASE ディープコピーベースに切り替える。
+`processChunk` / `classifyByAI` のシグネチャ変更。
+
+#### Commit 1: refactor(classify): migrate processChunk to ActionStatusEntry deep copy
+
+- `processChunk` の引数を `ChatlogEntry[]` → `ActionStatusEntry[]` に変更する
+- 各エントリを ASE ディープコピーし、コピーの `action: move-by-ai` を設定する
+- コピーの `frontmatter` に `project` を設定し、`options.targetPath` に `destDir` を設定する
+- AI 呼び出し失敗時は `ChatlogError` をスローする（`ERROR` エントリを返さない）
+- ユニットテスト（`processChunk`）を ASE ベースに書き換える
+
+#### Commit 2: refactor(classify): migrate classifyByAI to ActionStatusEntry
+
+- `classifyByAI` の引数・戻り値を `ActionStatusEntry[]` に変更する
+- `pending` エントリを抽出して `processChunk` に渡す処理を ASE ベースに修正する
+- `dryRun` フラグを受け取り、`true` の場合は AI 呼び出しをスキップしてカウントのみ実施する
+- ユニットテスト（`classifyByAI`）を ASE ベースに書き換える
+
+---
+
+### Phase 4: apply の ASE 移行
+
+`file-ops.ts` を ASE ベースに変更し `targetPath` から移動先を解決する。
+`dryRun` 判定は `moveClassified` 内の move 処理で行う。
+
+#### Commit 1: refactor(classify): migrate classifyFile to ActionStatusEntry
+
+- `classifyFile` の引数を `ChatlogEntry + destDir` → `ActionStatusEntry` に変更する
+- `options.targetPath` から移動先ディレクトリを解決する
+- `frontmatter` から `project` 名を読み出す（引数での受け渡しを廃止）
+- `dryRun` 引数を削除する（`dryRun` 判定は呼び出し元 `moveClassified` が担う）
+- ユニットテスト（`classifyFile`）を ASE ベースに書き換える
+
+#### Commit 2: refactor(classify): migrate moveClassified to ActionStatusEntry
+
+- `moveClassified` の第1引数を `ClassifyBuffer` → `ActionStatusEntry[]` に変更する
+- `action: pending` → `stats.remaining++` に対応する（`REMAINING` → `PENDING`）
+- `action: move` / `action: move-by-ai` の処理:
+  - `dryRun: false` → `classifyFile` を呼び出してファイル移動、`stats.moved` / `stats.movedByAI` をインクリメントする
+  - `dryRun: true` → `classifyFile` を呼び出さず、ログ出力のみ行い、`stats.moved` / `stats.movedByAI` をインクリメントする
+- `destDir` 引数を削除する（`targetPath` に統合）
+- ユニットテスト（`moveClassified`）を ASE ベースに書き換える
+
+---
+
+### Phase 5: 型削除 + オーケストレーター更新
+
+`classify.types.ts` から廃止型を削除し、`classify-chatlogs.ts` を ASE パイプラインに更新する。
+
+#### Commit 1: refactor(classify): remove ClassifyBuffer and CLASSIFY_ACTIONS from classify.types.ts
+
+- `classify.types.ts` から `ClassifyBuffer` / `ClassifyBufferEntry` 型を削除する
+- `classify.types.ts` から `CLASSIFY_ACTIONS` / `ClassifyAction` を削除する
+- `FindBufferEntriesOptions` の `loadMeta` 型を ASE 返却シグネチャに更新する
+- 残存する `ClassifyResult` / `ClassifyStats` / `ClassifyConfig` / `ParsedConfig` は維持する
+
+#### Commit 2: refactor(classify): update processClassify and main to ActionStatusEntry pipeline
+
+- `classify-chatlogs.ts` の `processClassify` を `ASE[] → ASE[]` に変更する
+- pre-sort resolved（`skip` / `move`）と ai-sort 結果（`move-by-ai`）の merge を ASE ベースに更新する
+- `main` の `findBufferEntries` / `processClassify` / `moveClassified` 呼び出しを ASE ベースに更新する
+- 不要になった `ClassifyBuffer` / `CLASSIFY_ACTIONS` の import を削除する
+- ユニットテスト（`processClassify`）を ASE ベースに書き換える
+
+---
+
+## 3. Change History
+
+| Date       | Version | Description                 |
+| ---------- | ------- | --------------------------- |
+| 2026-06-06 | 1.0.0   | Initial implementation plan |

--- a/docs/.deckrd/pipeline/classify/requirements/requirements.md
+++ b/docs/.deckrd/pipeline/classify/requirements/requirements.md
@@ -1,0 +1,296 @@
+---
+title: "Requirements: classify pipeline refactoring to ActionStatusEntry"
+module: "pipeline/classify"
+status: Draft
+version: 1.1
+created: "2026-06-06"
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`classify-chatlogs` スクリプト内の `ChatlogEntry` 処理を、共通型 `ActionStatusEntry`（ASE）を使用したパイプライン処理にリファクタリングする。独自型 `ClassifyBufferEntry` / `ClassifyBuffer` を廃止し、`_scripts/types/` の共通型で統一することで、モジュール間の型一貫性を向上させる。
+
+### 1.2 Scope
+
+以下の関数・型をすべて `ActionStatusEntry[]` ベースに切り替える:
+
+- `findBufferEntries` — ファイル収集
+- `preClassify` / `processPreclassify` — AI 不要事前分類
+- `classifyByAI` / `processChunk` — AI 分類
+- `moveClassified` / `classifyFile` — ファイル移動・stats 更新
+
+また、`ENTRY_ACTIONS` に `'move-by-ai'` と `'pending'` を追加して AI 分類結果と AI 処理待ちを明示的に区別する。
+
+**Out of Scope**:
+
+- `ClassifyConfig` / `ClassifyStats` / `ClassifyResult` 型の変更
+- `classify-config.ts` / `load-project-dic.ts` の変更
+- `_scripts/types/action-status.types.ts` / `action-status-entry.types.ts` の既存型の変更（`ENTRY_ACTIONS` への追加のみ許可）
+- テストコード以外の外部スキルへの影響
+
+## 2. Context
+
+- Target Environment: Deno ランタイム（TypeScript strict mode）
+- Related Components:
+  - `skills/_scripts/types/action-status-entry.types.ts` — `ActionStatusEntry` 型
+  - `skills/_scripts/types/action-status.types.ts` — `ENTRY_ACTIONS` / `EntryAction` / `ENTRY_STATUSES`
+  - `skills/_scripts/classes/ChatlogEntry.class.ts` — エントリ本体
+  - `skills/classify-chatlogs/scripts/types/classify.types.ts` — 廃止対象型
+- Assumptions:
+  - `ActionStatusEntry.entry` は常に有効な `ChatlogEntry` を保持する（エラー時は ASE を作らない）
+  - ファイル読み込み失敗時は `ChatlogError` をスローしてパイプラインを中断する
+
+### System Context Diagram
+
+```text
+[.md ファイル群]    --> +-------------------------------+ --> [プロジェクト別サブディレクトリ]
+                        |  classify pipeline (ASE ベース) |
+[projects.dic]     --> |                               | --> [ClassifyStats]
+[ClassifyConfig]   --> |  ASE[] パイプライン処理        |
+                        +-------------------------------+
+```
+
+## 3. Design Decisions (Summary)
+
+| ID    | Decision                                                         | Linked Record |
+| ----- | ---------------------------------------------------------------- | ------------- |
+| DR-01 | エラーエントリは ASE を作らず ChatlogError をスロー              | —             |
+| DR-02 | `ENTRY_ACTIONS` に `'move-by-ai'` と `'pending'` を追加          | —             |
+| DR-03 | `ClassifyBuffer` / `ClassifyBufferEntry` を廃止                  | —             |
+| DR-04 | `ClassifyStats` カウントは `moveClassified` 内で実施             | —             |
+| DR-05 | project 名は `ChatlogEntry` のフロントマターに記録・読み出しする | —             |
+
+## 4. Functional Requirements
+
+### REQ-F-001: ActionStatusEntry によるエントリ収集
+
+- EARS Type: event-driven
+
+```text
+GIVEN classify パイプラインが起動している
+  WHEN `findBufferEntries` がディレクトリ配下の .md ファイルを収集する
+THEN the system SHALL 各ファイルを `ActionStatusEntry` として返し、
+     読み込み失敗時は `ChatlogError` をスローしなければならない（SHALL）。
+```
+
+**Rationale**: `ClassifyBufferEntry.file` の null 許容をなくし、ASE の `entry` に常に有効な `ChatlogEntry` を保持させることで、後続処理での null チェックを不要にする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                     |
+| ------ | -------------------------------------------- |
+| AC-001 | 正常なファイルが ASE として収集される        |
+| AC-002 | 読み込み失敗時に ChatlogError がスローされる |
+
+---
+
+### REQ-F-002: AI 不要エントリの事前分類
+
+- EARS Type: event-driven
+
+```text
+GIVEN `ActionStatusEntry[]` が収集済みである
+  WHEN `processPreclassify` が各エントリを評価する
+THEN the system SHALL 各エントリの `options.action` を以下のいずれかに設定しなければならない（SHALL）:
+     - フロントマターに `project` あり かつ 正しいディレクトリ内 → `'skip'`
+     - フロントマターに `project` あり かつ 別ディレクトリ → `'move'`
+     - メタ情報なし かつ 本文が短い → `'move'`（project は FALLBACK_PROJECT）
+     - それ以外 → `'pending'`（AI 分類待ち）
+```
+
+**Rationale**: AI 呼び出し不要なエントリを早期に確定させ、`classifyByAI` の処理対象を最小化する。`'pending'` は「AI 処理待ちで未確定」を明示するために `'keep'` と区別する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                            |
+| ------ | --------------------------------------------------- |
+| AC-003 | project 設定済み・正しいディレクトリ → action: skip |
+| AC-004 | project 設定済み・別ディレクトリ → action: move     |
+| AC-005 | メタなし・短い本文 → action: move, project: misc    |
+| AC-006 | メタあり → action: pending（AI 分類待ち）           |
+
+---
+
+### REQ-F-003: AI によるエントリ分類
+
+- EARS Type: event-driven
+
+```text
+GIVEN `ActionStatusEntry[]` に `action: 'pending'` のエントリが存在する
+  WHEN `classifyByAI` が AI 分類を実行する
+THEN the system SHALL 各エントリの `options.action` を `'move-by-ai'` に設定し、
+     割り当てたプロジェクト名を `entry.frontmatter` に `'project'` キーで記録しなければならない（SHALL）。
+```
+
+**Rationale**: AI 分類結果を `'move'` と区別することで、`ClassifyStats.movedByAI` のカウントが正確に行える。project 名は `options.reason` ではなく `ChatlogEntry` のフロントマターに記録することで、後続の `moveClassified` がフロントマターから直接 project 名を読み出せる。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                              |
+| ------ | --------------------------------------------------------------------- |
+| AC-007 | AI 分類成功 → action: move-by-ai, frontmatter に project が設定される |
+| AC-008 | AI 呼び出し失敗 → ChatlogError がスローされる                         |
+
+---
+
+### REQ-F-004: ASE ベースのファイル移動と stats 更新
+
+- EARS Type: event-driven
+
+```text
+GIVEN 分類済みの `ActionStatusEntry[]` が存在する
+  WHEN `moveClassified` が各エントリの `options.action` を評価する
+THEN the system SHALL 以下の処理を実行しなければならない（SHALL）:
+     - `'move'` → ファイルを `destDir/{project}/` へ移動し `stats.moved` をインクリメント
+     - `'move-by-ai'` → ファイルを `destDir/{project}/` へ移動し `stats.movedByAI` をインクリメント
+     - `'skip'` → ファイルを移動せず `stats.skipped` をインクリメント
+     - `'pending'` → `stats.remaining` をインクリメント
+     - エラー → `stats.error` をインクリメント
+```
+
+**Rationale**: stats 集計を `moveClassified` 内に閉じることで、呼び出し元の `main` を単純に保つ。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                    |
+| ------ | ----------------------------------------------------------- |
+| AC-009 | action: move → stats.moved がインクリメントされる           |
+| AC-010 | action: move-by-ai → stats.movedByAI がインクリメントされる |
+| AC-011 | action: skip → stats.skipped がインクリメントされる         |
+
+---
+
+### REQ-F-005: `ENTRY_ACTIONS` への `'move-by-ai'` と `'pending'` 追加
+
+- EARS Type: feature-based
+
+```text
+GIVEN `_scripts/types/action-status.types.ts` が使用されている
+  WHERE AI 分類結果と AI 処理待ちを明示的に区別する必要がある
+THEN the system SHALL `ENTRY_ACTIONS` オブジェクトに以下を追加し、
+     `EntryAction` 型にそれぞれの値を含めなければならない（SHALL）:
+     - `MOVEBYAI: 'move-by-ai'` — AI 分類済みで移動対象
+     - `PENDING: 'pending'` — AI 分類待ちで未確定
+```
+
+**Rationale**: リテラル直書きを避け、コンパイル時の型チェックで誤用を防ぐ。`'pending'` は `'keep'`（保持確定）と語義が異なるため別途追加する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                             |
+| ------ | ---------------------------------------------------- |
+| AC-012 | `ENTRY_ACTIONS.MOVEBYAI === 'move-by-ai'` が成立する |
+| AC-013 | `EntryAction` 型に `'move-by-ai'` が含まれる         |
+| AC-014 | `ENTRY_ACTIONS.PENDING === 'pending'` が成立する     |
+| AC-015 | `EntryAction` 型に `'pending'` が含まれる            |
+
+## 5. Non-Functional Requirements
+
+### REQ-NF-001: 型一貫性
+
+`ClassifyBufferEntry` / `ClassifyBuffer` 型は削除し、`ActionStatusEntry[]` に完全移行しなければならない（MUST）。
+
+### REQ-NF-002: テスタビリティ
+
+各パイプライン関数は単体でテスト可能な純粋関数として実装されなければならない（MUST）。副作用（ファイル移動・stats 更新）は `moveClassified` 内に限定する。
+
+### REQ-NF-003: 後方互換性
+
+`main` 関数のシグネチャおよび `ClassifyStats` 型は変更してはならない（MUST NOT）。
+
+## 6. Constraints
+
+### REQ-C-001: 既存型の最小変更
+
+`_scripts/types/action-status.types.ts` への変更は `ENTRY_ACTIONS` への `MOVEBYAI` と `PENDING` の追加のみとする。他のフィールドの削除・変更は禁止する。
+
+### REQ-C-002: ChatlogError の使用
+
+ファイル読み込み失敗時は汎用例外ではなく `ChatlogError` をスローしなければならない（MUST）。
+
+## 7. Acceptance Criteria
+
+```gherkin
+# AC-001: 正常なファイルが ASE として収集される
+# Requirement: REQ-F-001
+Scenario: findBufferEntries が ASE[] を返す
+  Given ディレクトリに有効な .md ファイルが存在する
+  When  findBufferEntries を呼び出す
+  Then  各ファイルが ActionStatusEntry として返される
+  And   entry フィールドに有効な ChatlogEntry が設定される
+
+# AC-002: 読み込み失敗時に ChatlogError がスローされる
+# Requirement: REQ-F-001
+Scenario: ファイル読み込み失敗で ChatlogError がスローされる
+  Given ディレクトリに読み込み不可なファイルが存在する
+  When  findBufferEntries を呼び出す
+  Then  ChatlogError がスローされる
+
+# AC-007: AI 分類成功で move-by-ai が設定される
+# Requirement: REQ-F-003
+Scenario: AI 分類成功時に action が move-by-ai になる
+  Given action: 'pending' の ActionStatusEntry が存在する
+  When  classifyByAI を呼び出す
+  Then  各エントリの options.action が 'move-by-ai' に設定される
+  And   entry.frontmatter に 'project' キーでプロジェクト名が記録される
+
+# AC-010: move-by-ai で movedByAI がインクリメントされる
+# Requirement: REQ-F-004
+Scenario: move-by-ai エントリ移動後に movedByAI がカウントアップされる
+  Given action: 'move-by-ai' の ActionStatusEntry が存在する
+  When  moveClassified を呼び出す
+  Then  stats.movedByAI が 1 増加する
+  And   ファイルが destDir/{project}/ へ移動される
+
+# AC-012: ENTRY_ACTIONS.MOVEBYAI が正しく定義される
+# Requirement: REQ-F-005
+Scenario: ENTRY_ACTIONS に move-by-ai が追加される
+  Given action-status.types.ts に ENTRY_ACTIONS が定義されている
+  When  ENTRY_ACTIONS.MOVEBYAI を参照する
+  Then  値が 'move-by-ai' と等しい
+```
+
+## 8. User Stories
+
+1. As a 開発者, I want `ClassifyBufferEntry` を `ActionStatusEntry` に統一したい。Because 型の二重管理を解消してコードの一貫性を高めたい。
+
+2. As a 開発者, I want AI 分類結果を `action: 'move-by-ai'` で明示的に区別したい。Because `ClassifyStats.movedByAI` の集計を正確に行いたい。
+
+3. As a 開発者, I want ファイル読み込み失敗時に null チェックを不要にしたい。Because ASE の `entry` が常に有効であれば後続処理が簡潔になる。
+
+4. As a 開発者, I want `moveClassified` を ASE ベースで統一したい。Because パイプライン全体で同一の型を使い、`action` による分岐を一箇所に集約したい。
+
+5. As a テスター, I want 各パイプライン関数を単体テストしたい。Because 純粋関数として実装されていれば、モックなしで入出力を検証できる。
+
+## 9. Traceability
+
+| REQ ID     | AC IDs           | Type           |
+| ---------- | ---------------- | -------------- |
+| REQ-F-001  | AC-001, AC-002   | Functional     |
+| REQ-F-002  | AC-003 〜 AC-006 | Functional     |
+| REQ-F-003  | AC-007, AC-008   | Functional     |
+| REQ-F-004  | AC-009 〜 AC-011 | Functional     |
+| REQ-F-005  | AC-012 〜 AC-015 | Functional     |
+| REQ-NF-001 | —                | Non-Functional |
+| REQ-NF-002 | —                | Non-Functional |
+| REQ-NF-003 | —                | Non-Functional |
+| REQ-C-001  | —                | Constraint     |
+| REQ-C-002  | —                | Constraint     |
+
+## 10. Open Questions
+
+| Question                                                                                          | Type | Impact Area | Owner    |
+| ------------------------------------------------------------------------------------------------- | ---- | ----------- | -------- |
+| （解決済み）`reason` フィールドへの project 名格納 → frontmatter に記録する方針に決定（DR-05）    | 設計 | REQ-F-003   | Resolved |
+| （解決済み）`keep` vs `remaining` の命名 → `PENDING: 'pending'` を追加して AI 待ちを明示（DR-02） | 命名 | REQ-F-002   | Resolved |
+
+## 11. Change History
+
+| Date       | Version | Description                                                                |
+| ---------- | ------- | -------------------------------------------------------------------------- |
+| 2026-06-06 | 1.0.0   | Initial release                                                            |
+| 2026-06-06 | 1.1.0   | review(explore): project 名を frontmatter に記録、`pending` アクション追加 |

--- a/docs/.deckrd/pipeline/classify/specifications/specifications.md
+++ b/docs/.deckrd/pipeline/classify/specifications/specifications.md
@@ -1,0 +1,274 @@
+---
+title: "Design Specification: classify pipeline refactoring to ActionStatusEntry"
+based-on: requirements.md v1.1
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+> **Normative Statement**
+> This document defines the behavioral contracts for the classify pipeline refactoring.
+> Implementation details are explicitly out of scope.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`classify-chatlogs` パイプライン内の全処理ユニットが `ActionStatusEntry`（ASE）を共通インターフェースとして受け渡し、project 名を `ChatlogEntry` のフロントマターに保持する振る舞いを定義する。
+
+### 1.2 Scope
+
+本仕様は以下の5ユニットの外部振る舞いを定義する:
+
+1. **collect** — ディレクトリ走査と ASE 生成
+2. **pre-sort** — AI 不要な事前分類と action 付与
+3. **ai-sort** — AI 分類と frontmatter への project 記録
+4. **apply** — ファイル移動と統計カウント
+5. **type-ext** — `ENTRY_ACTIONS` の拡張
+
+実装の内部構造・型定義・ファイルパスは対象外とする。
+
+---
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+パイプラインは4段階の変換ステージで構成される。各ステージは `ActionStatusEntry[]` を受け取り、`ActionStatusEntry[]` を返す。副作用（ファイル移動・統計更新）は最終ステージ（apply）にのみ許容される。
+
+project 名はパイプライン全体を通じて `ChatlogEntry` のフロントマターに保持される。移動先パスは `ActionStatusOptions.targetPath` に設定され、apply ステージが読み出す。
+
+### 2.2 Design Assumptions
+
+- `ActionStatusEntry.entry` は常に有効な `ChatlogEntry` を保持する。エラー時は ASE を生成しない。
+- `ActionStatusOptions.targetPath` は移動が必要なエントリ（action: move / move-by-ai）にのみ設定される。
+- `main` 関数のシグネチャと `ClassifyStats` 型は変更されない。
+- pre-sort / ai-sort は入力 ASE をディープコピーして返す。入力 ASE[] は変更しない（immutable pipeline）。
+
+### 2.3 External Design Summary
+
+#### Feature Decomposition
+
+| Unit     | Responsibility                                                           | REQ Coverage |
+| -------- | ------------------------------------------------------------------------ | ------------ |
+| collect  | .md ファイル収集 → ASE[] 生成                                            | REQ-F-001    |
+| pre-sort | ASE ディープコピー → action / targetPath / project を付与（純粋変換）    | REQ-F-002    |
+| ai-sort  | ASE ディープコピー → AI 分類 → move-by-ai + frontmatter 記録（純粋変換） | REQ-F-003    |
+| apply    | ファイル移動 + stats カウント                                            | REQ-F-004    |
+| type-ext | ENTRY_ACTIONS 拡張                                                       | REQ-F-005    |
+
+#### Unit Interaction Map
+
+各変換ユニットは入力 ASE をディープコピーして処理する（immutable pipeline）。
+`frontmatter` / `targetPath` はコピー側の ASE に設定される。
+
+```text
+[.md files]
+    |
+    v
++-------------+   ASE[]（コピー）   +-----------+   ASE[]（コピー）   +-----------+
+|   collect   | ------------------> | pre-sort  | ------------------> |  ai-sort  |
++-------------+                     +-----------+                     +-----------+
+                                     コピーに設定:                     コピーに設定:
+                                     action(skip/move/pending)         action(move-by-ai)
+                                     targetPath                        targetPath
+                                     frontmatter.project               frontmatter.project
+                                          |                                  |
+                                          | resolved(skip/move)              | (move-by-ai)
+                                          +----------------------------------+
+                                                         |
+                                                         v
+                                                   +----------+
+                                                   |  merge   |  ← pre-sort resolved + ai-sort 結果
+                                                   +----------+
+                                                         |
+                                                         v
+                                                   +-----------+
+                                                   |   apply   | --> [files moved]
+                                                   |           | --> [ClassifyStats]
+                                                   +-----------+
+```
+
+#### Data Flow Diagram
+
+```text
+[dir: string]
+      |
+      v
+[collect] --> ASE[] (entry, options.filePath)
+      |
+      v
+[pre-sort] --> ASE[] コピー (+ action, targetPath, frontmatter.project)
+      |
+      +-- resolved (action: skip / move) ------+
+      |                                        |
+      +-- pending (action: pending) --------+  |
+                                            |  |
+                                            v  |
+                                       [ai-sort] --> ASE[] コピー (action: move-by-ai)
+                                            |
+                                            v
+                                       [merge: resolved + ai-sort 結果]
+                                            |
+                                            v
+                                       [apply] --> void (ファイル移動 + ClassifyStats 更新)
+```
+
+### 2.4 Non-Goals
+
+> **Derivation**: 以下は requirements.md Out of Scope セクションに由来する。
+
+- `ClassifyConfig` / `ClassifyStats` / `ClassifyResult` 型の変更 ← REQ: Out of Scope #1
+- `classify-config.ts` / `load-project-dic.ts` の変更 ← REQ: Out of Scope #2
+- `_scripts/types/` 既存フィールドの削除・変更（追加のみ許可） ← REQ: Out of Scope #3
+- テストコード以外の外部スキルへの影響 ← REQ: Out of Scope #4
+
+### 2.5 Behavioral Design Decisions
+
+| ID    | Decision                                                                                                                              | Rationale                                                                                       | Affected Rules       | Status |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------- | ------ |
+| DD-01 | ファイルシステムエラー時は ChatlogError をスロー。フロントマター解析エラー時は `action: 'error'`, `status: 'error'` の ASE を生成する | 動作の直交性を保ち、パイプラインを継続しつつ stats.error に正確にカウントする                   | R-001, R-002a        | Active |
+| DD-02 | `ENTRY_ACTIONS` に `MOVEBYAI` / `PENDING` / `ERROR` を追加                                                                            | リテラル直書きを防ぎコンパイル時型チェックで誤用を防ぐ。`action` と `status` の直交性を維持する | R-003, R-005, R-002a | Active |
+| DD-03 | project 名は `ChatlogEntry` フロントマターに保持する                                                                                  | apply ステージが project 名を1箇所から読み出せるよう統一する                                    | R-004, R-007         | Active |
+| DD-04 | 移動先パスは `ActionStatusOptions.targetPath` に保持する                                                                              | apply が移動先ディレクトリを ASE から直接読み出せるよう汎用化                                   | R-007, R-008         | Active |
+| DD-05 | `targetPath` / move 関数を汎用化し classify 固有の依存をなくす                                                                        | 共通型として他モジュールでも再利用できる設計にする                                              | R-007                | Active |
+| DD-06 | pre-sort / ai-sort は入力 ASE をディープコピーして返す（immutable pipeline）                                                          | 副作用をなくし全変換ユニットを純粋関数として統一する（REQ-NF-002 との整合）                     | R-004, R-005, R-007  | Active |
+
+### 2.6 Related Decision Records
+
+> No Decision Records currently affect this specification.
+
+### 2.7 DD to DR Promotion Criteria
+
+DD-04（`targetPath` 汎用化）と DD-05（move 関数汎用化）は `_scripts/` 共通型への変更を伴うため、他モジュールへの影響範囲次第で DR への昇格を検討する。
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+- **collect の入力**: 存在するディレクトリパス
+- **pre-sort / ai-sort の入力**: collect または前段が返した `ActionStatusEntry[]`
+- **apply の入力**: pre-sort の resolved 結果（action: skip / move）と ai-sort の結果（action: move-by-ai）を結合した `ActionStatusEntry[]`、移動先ベースディレクトリ、dryRun フラグ、統計オブジェクト
+
+### 3.2 Output Semantics
+
+| Unit     | 成功時の出力                                                           | 失敗時の振る舞い                                                                                                            |
+| -------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| collect  | 各 .md ファイルに対応する ASE[]（空配列もあり）                        | ファイルシステムエラー → ChatlogError スロー。フロントマター解析エラー → `action: 'error'`, `status: 'error'` の ASE を返す |
+| pre-sort | 入力のディープコピー。全エントリに action が設定された ASE[]           | 例外なし（純粋変換）                                                                                                        |
+| ai-sort  | 入力のディープコピー。pending エントリが move-by-ai に変換された ASE[] | ChatlogError をスロー                                                                                                       |
+| apply    | void（ファイル移動完了、stats 更新済み）                               | ファイル移動失敗は stats.error++ のみ                                                                                       |
+
+---
+
+## 4. Decision Rules
+
+評価は以下の順序で実施されなければならない。順序の変更は不可。
+
+### 4.1 collect ステージの規則
+
+| Rule ID | Step | Condition                                | Outcome                                                                                   |
+| ------- | ---: | ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| R-001   |    1 | ファイルシステムエラー（読み込み不可等） | ChatlogError をスロー                                                                     |
+| R-002   |    2 | .md ファイルが正常に読める               | 有効な entry を持つ ASE を生成して返す                                                    |
+| R-002a  |    3 | フロントマター解析エラー                 | `action: 'error'`、`status: 'error'` の ASE を生成して返す（ChatlogError をスローしない） |
+
+### 4.2 pre-sort ステージの規則
+
+各エントリは入力 ASE のディープコピーに対して変換を行う。入力 ASE は変更しない。
+
+| Rule ID | Step | Condition                                                                                                             | Outcome                                                                                         |
+| ------- | ---: | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| R-003   |    1 | frontmatter に `project` あり かつ 現在ディレクトリが `project` サブディレクトリ内                                    | コピーの action: `'skip'`（targetPath 不要）                                                    |
+| R-004   |    2 | frontmatter に `project` あり かつ 現在ディレクトリが `project` サブディレクトリ外                                    | コピーの action: `'move'`、targetPath: destDir を設定                                           |
+| R-005   |    3 | frontmatter に `project` なし かつ メタ情報なし かつ 本文が `MIN_CLASSIFIABLE_LENGTH`（設定定数で決定する文字数）未満 | コピーの action: `'move'`、コピーの frontmatter に FALLBACK_PROJECT を設定、targetPath: destDir |
+| R-006   |    4 | 上記いずれにも該当しない                                                                                              | コピーの action: `'pending'`（AI 分類待ち）                                                     |
+
+### 4.3 ai-sort ステージの規則
+
+各エントリは入力 ASE のディープコピーに対して変換を行う。入力 ASE は変更しない。戻り値はコピーした ASE の一覧。
+
+| Rule ID | Step | Condition                                  | Outcome                                                                                                                        |
+| ------- | ---: | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| R-007   |    1 | action が `'pending'` のエントリが存在する | 入力 ASE をディープコピーし、コピーの action: `'move-by-ai'`、コピーの frontmatter に project 設定、targetPath: destDir を設定 |
+| R-008   |    2 | action が `'pending'` のエントリが 0件     | 空の ASE[] を即座に返す（AI 呼び出しなし）                                                                                     |
+| R-009   |    3 | AI 呼び出しが失敗する                      | ChatlogError をスロー                                                                                                          |
+
+### 4.4 apply ステージの規則
+
+| Rule ID | Step | Condition                | Outcome                                                                                                      |
+| ------- | ---: | ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| R-010   |    1 | action が `'move'`       | `options.targetPath/{project}/` へ移動、stats.moved++                                                        |
+| R-011   |    2 | action が `'move-by-ai'` | `options.targetPath/{project}/` へ移動、stats.movedByAI++                                                    |
+| R-012   |    3 | action が `'skip'`       | ファイル移動なし、stats.skipped++                                                                            |
+| R-013   |    4 | action が `'pending'`    | ファイル移動なし、stats.remaining++                                                                          |
+| R-013a  |    5 | action が `'error'`      | ファイル移動なし、stats.error++、エラーをログ出力（フロントマター解析失敗ファイル）                          |
+| R-014   |    6 | ファイル移動が失敗する   | stats.error++、エラーをログ出力（スローしない）                                                              |
+| R-015   |    7 | dryRun が true           | ファイル移動と AI 呼び出しをスキップし、ログ出力のみ行う。stats.moved / stats.movedByAI はインクリメントする |
+
+### 4.5 type-ext ステージの規則
+
+| Rule ID | Step | Condition                           | Outcome                                                                     |
+| ------- | ---: | ----------------------------------- | --------------------------------------------------------------------------- |
+| R-016   |    1 | `ENTRY_ACTIONS.MOVEBYAI` を参照する | 値は `'move-by-ai'` でなければならない                                      |
+| R-017   |    2 | `ENTRY_ACTIONS.PENDING` を参照する  | 値は `'pending'` でなければならない                                         |
+| R-017a  |    3 | `ENTRY_ACTIONS.ERROR` を参照する    | 値は `'error'` でなければならない                                           |
+| R-018   |    4 | `EntryAction` 型を評価する          | `'move-by-ai'`、`'pending'`、`'error'` を有効な値として含まなければならない |
+
+---
+
+## 5. Edge Cases
+
+| Input 状態                                              | 適用 Rule | Outcome                                                                | REQ       |
+| ------------------------------------------------------- | --------- | ---------------------------------------------------------------------- | --------- |
+| ディレクトリが空                                        | R-002     | 空の ASE[] を返す（エラーなし）                                        | REQ-F-001 |
+| .md 以外のファイルが混在                                | R-002     | .md のみを収集対象とする                                               | REQ-F-001 |
+| フロントマター解析エラー                                | R-002a    | `action: 'error'`, `status: 'error'` の ASE を返す（パイプライン継続） | REQ-F-001 |
+| frontmatter に project あり・正しいサブディレクトリ内   | R-003     | action: skip、移動しない                                               | REQ-F-002 |
+| frontmatter に project あり・別ディレクトリ             | R-004     | action: move、targetPath に destDir 設定                               | REQ-F-002 |
+| frontmatter なし・本文が `MIN_CLASSIFIABLE_LENGTH` 未満 | R-005     | FALLBACK_PROJECT へ move                                               | REQ-F-002 |
+| pending エントリが 0件                                  | R-008     | 空 ASE[] を返す（AI 呼び出しなし）                                     | REQ-F-003 |
+| AI が FALLBACK_PROJECT を返す                           | R-007     | そのまま move-by-ai として記録                                         | REQ-F-003 |
+| targetPath が未設定の move エントリ                     | R-014     | stats.error++（移動不可）                                              | REQ-F-004 |
+| dryRun: true の move エントリ                           | R-015     | ファイル移動せず stats.moved をカウント                                | REQ-F-004 |
+
+---
+
+## 6. Requirements Traceability
+
+| Requirement ID | Spec Rule             | Notes                                                    |
+| -------------- | --------------------- | -------------------------------------------------------- |
+| REQ-F-001      | R-001, R-002, R-002a  | collect ステージの全規則（解析エラー含む）               |
+| REQ-F-002      | R-003 〜 R-006        | pre-sort ステージの全規則                                |
+| REQ-F-003      | R-007 〜 R-009        | ai-sort ステージの全規則                                 |
+| REQ-F-004      | R-010 〜 R-015        | apply ステージの全規則（dryRun、error 含む）             |
+| REQ-F-005      | R-016 〜 R-018, DD-02 | type-ext ステージ規則 + ENTRY_ACTIONS 拡張（ERROR 含む） |
+| REQ-NF-001     | Section 1.2 Scope     | ClassifyBuffer 廃止の境界を定義                          |
+| REQ-NF-002     | Section 2.1           | 副作用を apply に限定する原則                            |
+| REQ-NF-003     | Section 2.2           | main / ClassifyStats 不変の前提                          |
+| REQ-C-001      | DD-02, DD-04, DD-05   | 共通型への追加のみ許可                                   |
+| REQ-C-002      | R-001, R-009          | ChatlogError 使用規則                                    |
+
+---
+
+## 7. Open Questions
+
+> **Status**: COMPLETE
+
+| # | Question                                                                    | Source       | Impact             | Resolution                                                                                                |
+| - | --------------------------------------------------------------------------- | ------------ | ------------------ | --------------------------------------------------------------------------------------------------------- |
+| 1 | ai-sort の frontmatter.set() が REQ-NF-002「純粋関数」要件と矛盾しないか？  | REQ-NF-002   | ai-sort の設計方針 | 解決済み: 入力 ASE のディープコピーを作成し、コピー側 frontmatter に設定することで副作用をなくす（DD-06） |
+| 2 | `ActionStatusOptions.targetPath` は共通型に追加するか classify 独自拡張か？ | DD-04, DD-05 | 共通型への影響範囲 | 解決済み: `_scripts/` 共通型 `ActionStatusOptions` に `targetPath?: string` を追加する（DD-05）           |
+
+---
+
+## 8. Change History
+
+| Date       | Version | Description                                                                                  |
+| ---------- | ------- | -------------------------------------------------------------------------------------------- |
+| 2026-06-06 | 1.0.0   | Initial specification                                                                        |
+| 2026-06-06 | 1.1.0   | DD-06 追加: immutable pipeline（ASE ディープコピー）、OQ-1/OQ-2 解決                         |
+| 2026-06-06 | 1.2.0   | review(explore): 図修正(immutable/merge)、R-015 dryRun 明確化、R-016〜018 追加、閾値定数明記 |
+| 2026-06-06 | 1.3.0   | review(tasks): DD-01/02 更新、R-002a/R-013a/R-017a 追加（action:error で stats.error++）     |

--- a/skills/_scripts/__tests__/unit/action-status-types.unit.spec.ts
+++ b/skills/_scripts/__tests__/unit/action-status-types.unit.spec.ts
@@ -1,0 +1,82 @@
+// src: skills/_scripts/__tests__/unit/action-status-types.unit.spec.ts
+// @(#): ENTRY_ACTIONS 定数・EntryAction 型のユニットテスト
+//       対象: ENTRY_ACTIONS, EntryAction
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { ENTRY_ACTIONS } from '../../types/action-status.types.ts';
+// types
+import type { EntryAction } from '../../types/action-status.types.ts';
+
+// ─── Tests
+
+/**
+ * `ENTRY_ACTIONS` 定数オブジェクトのユニットテストスイート。
+ *
+ * 追加された3値（MOVEBYAI / PENDING / ERROR）の値と型を検証する。
+ *
+ * テスト ID 範囲: T-01-01 〜 T-01-03
+ *
+ * @see ENTRY_ACTIONS
+ * @see EntryAction
+ */
+describe('ENTRY_ACTIONS', () => {
+  /**
+   * `ENTRY_ACTIONS.MOVEBYAI` の値と `EntryAction` 型への含有を検証する。
+   */
+  describe('MOVEBYAI', () => {
+    /** `MOVEBYAI` キーが正しい値を持ち、型に含まれる正常ケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-01-01-01: ENTRY_ACTIONS.MOVEBYAI === "move-by-ai"', () => {
+        assertEquals(ENTRY_ACTIONS.MOVEBYAI, 'move-by-ai');
+      });
+
+      it('[Normal] T-01-01-02: EntryAction 型が "move-by-ai" を含む', () => {
+        const _action: EntryAction = ENTRY_ACTIONS.MOVEBYAI;
+        assertEquals(_action, 'move-by-ai');
+      });
+    });
+  });
+
+  /**
+   * `ENTRY_ACTIONS.PENDING` の値と `EntryAction` 型への含有を検証する。
+   */
+  describe('PENDING', () => {
+    /** `PENDING` キーが正しい値を持ち、型に含まれる正常ケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-01-02-01: ENTRY_ACTIONS.PENDING === "pending"', () => {
+        assertEquals(ENTRY_ACTIONS.PENDING, 'pending');
+      });
+
+      it('[Normal] T-01-02-02: EntryAction 型が "pending" を含む', () => {
+        const _action: EntryAction = ENTRY_ACTIONS.PENDING;
+        assertEquals(_action, 'pending');
+      });
+    });
+  });
+
+  /**
+   * `ENTRY_ACTIONS.ERROR` の値と `EntryAction` 型への含有を検証する。
+   */
+  describe('ERROR', () => {
+    /** `ERROR` キーが正しい値を持ち、型に含まれる正常ケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-01-03-01: ENTRY_ACTIONS.ERROR === "error"', () => {
+        assertEquals(ENTRY_ACTIONS.ERROR, 'error');
+      });
+
+      it('[Normal] T-01-03-02: EntryAction 型が "error" を含む', () => {
+        const _action: EntryAction = ENTRY_ACTIONS.ERROR;
+        assertEquals(_action, 'error');
+      });
+    });
+  });
+});

--- a/skills/_scripts/types/__tests__/unit/action-status.unit.spec.ts
+++ b/skills/_scripts/types/__tests__/unit/action-status.unit.spec.ts
@@ -59,18 +59,18 @@ describe('ENTRY_ACTIONS', () => {
   });
 
   /**
-   * `EntryAction` ユニオン型が 5 値すべてを網羅していることを検証する。
+   * `EntryAction` ユニオン型が 8 値すべてを網羅していることを検証する。
    */
   describe('EntryAction union', () => {
     /** EntryAction の値域が ENTRY_ACTIONS の全 value と一致する正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-01-02-01: EntryAction が 5 値のユニオン型に一致する (AC-002)', () => {
+      it('[Normal] T-01-02-01: EntryAction が 8 値のユニオン型に一致する (AC-002)', () => {
         // arrange
         const _values = Object.values(ENTRY_ACTIONS);
 
         // act / assert
-        assertEquals(_values.length, 5);
-        assertArrayIncludes(_values, ['keep', 'skip', 'move', 'remove', 'write']);
+        assertEquals(_values.length, 8);
+        assertArrayIncludes(_values, ['keep', 'skip', 'move', 'remove', 'write', 'move-by-ai', 'pending', 'error']);
       });
     });
   });
@@ -198,6 +198,44 @@ describe('ActionStatusEntry', () => {
 
         // act / assert
         assertEquals(_options.filePath, '');
+      });
+
+      it('[Normal] T-02-01-01: targetPath を設定でき、値が取得できる', () => {
+        // arrange
+        const _options: ActionStatusOptions = { filePath: '/src/file.md', targetPath: '/dest/file.md' };
+
+        // act / assert
+        assertEquals(_options.targetPath, '/dest/file.md');
+      });
+    });
+
+    /** targetPath 省略・空文字列など境界値のケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-02-01-02: targetPath を省略すると undefined になる', () => {
+        // arrange
+        const _options: ActionStatusOptions = { filePath: '/src/file.md' };
+
+        // act / assert
+        assertEquals(_options.targetPath, undefined);
+      });
+
+      it('[Edge] T-02-01-03: targetPath に空文字列を設定できる', () => {
+        // arrange
+        const _options: ActionStatusOptions = { filePath: '/src/file.md', targetPath: '' };
+
+        // act / assert
+        assertEquals(_options.targetPath, '');
+      });
+    });
+
+    /** targetPath に不正な型を代入するとコンパイルエラーになるケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-02-01-04: targetPath に数値を代入するとコンパイルエラーになる', () => {
+        // @ts-expect-error targetPath is string only
+        const _options: ActionStatusOptions = { filePath: '/src/file.md', targetPath: 123 };
+
+        // act / assert — コンパイルが通ることが検証（@ts-expect-error がエラーを抑制）
+        assertEquals(typeof _options.targetPath, 'number');
       });
     });
   });

--- a/skills/_scripts/types/action-status-entry.types.ts
+++ b/skills/_scripts/types/action-status-entry.types.ts
@@ -16,6 +16,7 @@ export type ActionStatusOptions = {
   action?: EntryAction;
   status?: EntryStatus;
   reason?: string;
+  targetPath?: string;
 };
 
 /** チャットログエントリーと処理オプションをまとめたラッパー型。 */

--- a/skills/_scripts/types/action-status.types.ts
+++ b/skills/_scripts/types/action-status.types.ts
@@ -13,6 +13,9 @@ export const ENTRY_ACTIONS = {
   MOVE: 'move',
   REMOVE: 'remove',
   WRITE: 'write',
+  MOVEBYAI: 'move-by-ai',
+  PENDING: 'pending',
+  ERROR: 'error',
 } as const;
 
 /** `ENTRY_ACTIONS` の値から派生したユニオン型。`'keep' | 'skip' | 'move' | 'remove' | 'write'` と等価。 */

--- a/skills/classify-chatlogs/scripts/modules/__tests__/integration/load-classify-entry.integration.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/integration/load-classify-entry.integration.spec.ts
@@ -9,7 +9,7 @@
 // cspell:words noai
 
 // ─── BDD modules
-import { assertEquals, assertRejects } from '@std/assert';
+import { assertEquals, assertInstanceOf, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── test target
@@ -19,8 +19,10 @@ import { loadClassifyEntry } from '../../classify-noai.ts';
 // ─── helpers
 // errors
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+// classes
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // constants
-import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
+import { ENTRY_ACTIONS, ENTRY_STATUSES } from '../../../../../_scripts/types/action-status.types.ts';
 
 // ─── test
 
@@ -47,9 +49,9 @@ describe('loadClassifyEntry', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(meta.file?.filename, 'test.md');
+          assertEquals(_result.entry.filename, 'test.md');
         });
 
         it('T-CL-LFM-01-02: frontmatter の title が正しく設定される', async () => {
@@ -59,8 +61,8 @@ describe('loadClassifyEntry', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
-          const _title = meta.file?.frontmatter.get('title');
+          const _result = await loadClassifyEntry(filePath);
+          const _title = _result.entry.frontmatter.get('title');
 
           assertEquals(typeof _title === 'string' ? _title : '', 'テストタイトル');
         });
@@ -72,8 +74,8 @@ describe('loadClassifyEntry', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
-          const _category = meta.file?.frontmatter.get('category');
+          const _result = await loadClassifyEntry(filePath);
+          const _category = _result.entry.frontmatter.get('category');
 
           assertEquals(typeof _category === 'string' ? _category : '', 'development');
         });
@@ -85,13 +87,13 @@ describe('loadClassifyEntry', () => {
             '---\ntitle: テストタイトル\ncategory: development\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
           assertEquals(
-            meta.file?.frontmatterText,
+            _result.entry.frontmatterText,
             '---\ntitle: テストタイトル\ncategory: development\n---\n',
           );
-          assertEquals(meta.file?.content, '本文\n');
+          assertEquals(_result.entry.content, '本文\n');
         });
       });
     });
@@ -112,17 +114,17 @@ describe('loadClassifyEntry', () => {
     });
   });
 
-  // ─── T-CL-LFM-03: project なし → frontmatter.get('project') が undefined ────
+  // ─── T-CL-LFM-03: project なし → entry.frontmatter.get('project') が undefined ────
 
   describe('Given: project フィールドのない frontmatter の .md ファイル', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
-      describe('Then: T-CL-LFM-03 - frontmatter.get("project") が undefined（分類対象）', () => {
-        it('T-CL-LFM-03-01: frontmatter.get("project") が undefined である', async () => {
+      describe('Then: T-CL-LFM-03 - entry.frontmatter.get("project") が undefined（分類対象）', () => {
+        it('T-CL-LFM-03-01: entry.frontmatter.get("project") が undefined である', async () => {
           const filePath = `${tempDir}/no-project.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n本文');
 
-          const meta = await loadClassifyEntry(filePath);
-          const _project = meta.file?.frontmatter.get('project');
+          const _result = await loadClassifyEntry(filePath);
+          const _project = _result.entry.frontmatter.get('project');
 
           assertEquals(_project, undefined);
         });
@@ -130,20 +132,20 @@ describe('loadClassifyEntry', () => {
     });
   });
 
-  // ─── T-CL-LFM-04: project 設定済み → frontmatter.get('project') = "my-app" ──
+  // ─── T-CL-LFM-04: project 設定済み → entry.frontmatter.get('project') = "my-app" ──
 
   describe('Given: project: my-app を含む frontmatter の .md ファイル', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
-      describe('Then: T-CL-LFM-04 - frontmatter.get("project") が "my-app"（スキップ対象）', () => {
-        it('T-CL-LFM-04-01: frontmatter.get("project") が "my-app" である', async () => {
+      describe('Then: T-CL-LFM-04 - entry.frontmatter.get("project") が "my-app"（スキップ対象）', () => {
+        it('T-CL-LFM-04-01: entry.frontmatter.get("project") が "my-app" である', async () => {
           const filePath = `${tempDir}/with-project.md`;
           await Deno.writeTextFile(
             filePath,
             '---\ntitle: テスト\nproject: my-app\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
-          const _project = meta.file?.frontmatter.get('project');
+          const _result = await loadClassifyEntry(filePath);
+          const _project = _result.entry.frontmatter.get('project');
 
           assertEquals(typeof _project === 'string' ? _project : '', 'my-app');
         });
@@ -156,15 +158,15 @@ describe('loadClassifyEntry', () => {
   describe('Given: topics を含む frontmatter の .md ファイル', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
       describe('Then: T-CL-LFM-05 - topics が正しく取得される', () => {
-        it('T-CL-LFM-05-01: frontmatter.get("topics") が ["TypeScript", "Deno"] である', async () => {
+        it('T-CL-LFM-05-01: entry.frontmatter.get("topics") が ["TypeScript", "Deno"] である', async () => {
           const filePath = `${tempDir}/with-topics.md`;
           await Deno.writeTextFile(
             filePath,
             '---\ntopics:\n  - TypeScript\n  - Deno\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
-          const _topics = meta.file?.frontmatter.get('topics');
+          const _result = await loadClassifyEntry(filePath);
+          const _topics = _result.entry.frontmatter.get('topics');
 
           assertEquals(Array.isArray(_topics) ? _topics as string[] : [], ['TypeScript', 'Deno']);
         });
@@ -177,15 +179,15 @@ describe('loadClassifyEntry', () => {
   describe('Given: tags を含む frontmatter の .md ファイル', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
       describe('Then: T-CL-LFM-06 - tags が正しく取得される', () => {
-        it('T-CL-LFM-06-01: frontmatter.get("tags") が ["refactoring", "bdd"] である', async () => {
+        it('T-CL-LFM-06-01: entry.frontmatter.get("tags") が ["refactoring", "bdd"] である', async () => {
           const filePath = `${tempDir}/with-tags.md`;
           await Deno.writeTextFile(
             filePath,
             '---\ntags:\n  - refactoring\n  - bdd\n---\n本文',
           );
 
-          const meta = await loadClassifyEntry(filePath);
-          const _tags = meta.file?.frontmatter.get('tags');
+          const _result = await loadClassifyEntry(filePath);
+          const _tags = _result.entry.frontmatter.get('tags');
 
           assertEquals(Array.isArray(_tags) ? _tags as string[] : [], ['refactoring', 'bdd']);
         });
@@ -193,59 +195,77 @@ describe('loadClassifyEntry', () => {
     });
   });
 
-  // ─── T-CL-LFM-07: 閉じない frontmatter → action='error' ─────────────────
+  // ─── T-CL-LFM-07: 閉じない frontmatter → options.action='error' ─────────────────
 
   describe('Given: 閉じない frontmatter の .md ファイル（終端 --- なし）', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
-      describe('Then: T-CL-LFM-07 - action=error のエントリが返される', () => {
-        it('[Error] T-CL-LFM-07-01: 閉じない frontmatter の場合 action=error のエントリが返される', async () => {
+      describe('Then: T-CL-LFM-07 - options.action=error の ASE が返される', () => {
+        it('[Error] T-CL-LFM-07-01: 閉じない frontmatter の場合 options.action=error かつ options.status=error', async () => {
           const filePath = `${tempDir}/unclosed-fm.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: テスト\n本文'); // 閉じる --- がない
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(meta.action, CLASSIFY_ACTIONS.ERROR);
-          assertEquals(meta.file, null);
-          assertEquals(meta.filePath, filePath);
+          assertEquals(_result.options.action, ENTRY_ACTIONS.ERROR);
+          assertEquals(_result.options.status, ENTRY_STATUSES.ERROR);
+          assertEquals(_result.options.filePath, filePath);
         });
 
-        it('[Error] T-CL-LFM-07-02: reason に ChatlogError のメッセージが含まれる', async () => {
+        it('[Error] T-CL-LFM-07-02: entry が ChatlogEntry インスタンスである', async () => {
           const filePath = `${tempDir}/unclosed-fm.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: テスト\n本文');
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(typeof meta.reason, 'string');
-          assertEquals((meta.reason ?? '').length > 0, true);
+          assertInstanceOf(_result.entry, ChatlogEntry);
+        });
+
+        it('[Error] T-CL-LFM-07-03: reason に ChatlogError のメッセージが含まれる', async () => {
+          const filePath = `${tempDir}/unclosed-fm.md`;
+          await Deno.writeTextFile(filePath, '---\ntitle: テスト\n本文');
+
+          const _result = await loadClassifyEntry(filePath);
+
+          assertEquals(typeof _result.options.reason, 'string');
+          assertEquals((_result.options.reason ?? '').length > 0, true);
         });
       });
     });
   });
 
-  // ─── T-CL-LFM-08: 壊れた YAML → action='error' ──────────────────────────
+  // ─── T-CL-LFM-08: 壊れた YAML → options.action='error' ──────────────────
 
   describe('Given: 壊れた YAML を含む frontmatter の .md ファイル', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
-      describe('Then: T-CL-LFM-08 - action=error のエントリが返される', () => {
-        it('[Error] T-CL-LFM-08-01: 壊れた YAML の場合 action=error のエントリが返される', async () => {
+      describe('Then: T-CL-LFM-08 - options.action=error の ASE が返される', () => {
+        it('[Error] T-CL-LFM-08-01: 壊れた YAML の場合 options.action=error かつ options.status=error', async () => {
           const filePath = `${tempDir}/bad-yaml.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(meta.action, CLASSIFY_ACTIONS.ERROR);
-          assertEquals(meta.file, null);
-          assertEquals(meta.filePath, filePath);
+          assertEquals(_result.options.action, ENTRY_ACTIONS.ERROR);
+          assertEquals(_result.options.status, ENTRY_STATUSES.ERROR);
+          assertEquals(_result.options.filePath, filePath);
         });
 
-        it('[Error] T-CL-LFM-08-02: reason に ChatlogError のメッセージが含まれる', async () => {
+        it('[Error] T-CL-LFM-08-02: entry が ChatlogEntry インスタンスである', async () => {
           const filePath = `${tempDir}/bad-yaml.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(typeof meta.reason, 'string');
-          assertEquals((meta.reason ?? '').length > 0, true);
+          assertInstanceOf(_result.entry, ChatlogEntry);
+        });
+
+        it('[Error] T-CL-LFM-08-03: reason に ChatlogError のメッセージが含まれる', async () => {
+          const filePath = `${tempDir}/bad-yaml.md`;
+          await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
+
+          const _result = await loadClassifyEntry(filePath);
+
+          assertEquals(typeof _result.options.reason, 'string');
+          assertEquals((_result.options.reason ?? '').length > 0, true);
         });
       });
     });
@@ -256,22 +276,22 @@ describe('loadClassifyEntry', () => {
   describe('Given: frontmatter なし・空本文（改行のみ）の .md ファイル', () => {
     describe('When: loadClassifyEntry(filePath) を呼び出す', () => {
       describe('Then: T-CL-LFM-09 - インスタンスが返され、project は undefined', () => {
-        it('T-CL-LFM-09-01: null ではなくインスタンスが返される（分類対象として扱われる）', async () => {
+        it('T-CL-LFM-09-01: entry が ChatlogEntry インスタンスである（分類対象として扱われる）', async () => {
           const filePath = `${tempDir}/empty-body.md`;
           await Deno.writeTextFile(filePath, '\n');
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(meta.file !== null, true);
+          assertInstanceOf(_result.entry, ChatlogEntry);
         });
 
-        it('T-CL-LFM-09-02: frontmatter.get("project") が undefined（スキップされない）', async () => {
+        it('T-CL-LFM-09-02: entry.frontmatter.get("project") が undefined（スキップされない）', async () => {
           const filePath = `${tempDir}/empty-body.md`;
           await Deno.writeTextFile(filePath, '\n');
 
-          const meta = await loadClassifyEntry(filePath);
+          const _result = await loadClassifyEntry(filePath);
 
-          assertEquals(meta.file?.frontmatter.get('project'), undefined);
+          assertEquals(_result.entry.frontmatter.get('project'), undefined);
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/load-classify-entry.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/load-classify-entry.unit.spec.ts
@@ -1,0 +1,120 @@
+// src: skills/classify-chatlogs/scripts/modules/__tests__/unit/load-classify-entry.unit.spec.ts
+// @(#): loadClassifyEntry のユニットテスト
+//       対象: loadClassifyEntry
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertInstanceOf, assertRejects } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { loadClassifyEntry } from '../../classify-noai.ts';
+
+// ─── Helpers
+// errors
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+// classes
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+// constants
+import { ENTRY_ACTIONS, ENTRY_STATUSES } from '../../../../../_scripts/types/action-status.types.ts';
+
+// ─── Tests
+
+/**
+ * `loadClassifyEntry` のユニットテストスイート。
+ *
+ * ファイル読み込みと `ActionStatusEntry` 返却のロジックを検証する。
+ * 正常系では `entry` が `ChatlogEntry` インスタンス、エラー系では `options.action === 'error'` を検証する。
+ *
+ * テスト ID 範囲: T-03-01-01 〜 T-03-02-04
+ *
+ * @see loadClassifyEntry
+ */
+describe('loadClassifyEntry', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await Deno.makeTempDir();
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  /**
+   * 正常系: 有効な .md ファイルを読み込んだときの ActionStatusEntry 検証。
+   */
+  describe('When: 正常系', () => {
+    it('[Normal] T-03-01-01: entry が ChatlogEntry のインスタンスである', async () => {
+      const filePath = `${tempDir}/valid.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n本文');
+
+      const _result = await loadClassifyEntry(filePath);
+
+      assertInstanceOf(_result.entry, ChatlogEntry);
+    });
+
+    it('[Normal] T-03-01-02: options.filePath が指定パスと一致する', async () => {
+      const filePath = `${tempDir}/valid.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n本文');
+
+      const _result = await loadClassifyEntry(filePath);
+
+      assertEquals(_result.options.filePath, filePath);
+    });
+
+    it('[Normal] T-03-01-03: options.action が undefined（エラーなし）', async () => {
+      const filePath = `${tempDir}/valid.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n本文');
+
+      const _result = await loadClassifyEntry(filePath);
+
+      assertEquals(_result.options.action, undefined);
+    });
+  });
+
+  /**
+   * 異常系: ファイル不在とフロントマターエラーのケース。
+   */
+  describe('When: 異常系', () => {
+    it('[Error] T-03-02-01: 存在しないパスで ChatlogError がスローされる', async () => {
+      await assertRejects(
+        () => loadClassifyEntry('/nonexistent/path/file.md'),
+        ChatlogError,
+      );
+    });
+
+    it('[Error] T-03-02-02: 不正な YAML フロントマターで options.action === "error" かつ options.status === "error"', async () => {
+      const filePath = `${tempDir}/bad-yaml.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
+
+      const _result = await loadClassifyEntry(filePath);
+
+      assertEquals(_result.options.action, ENTRY_ACTIONS.ERROR);
+      assertEquals(_result.options.status, ENTRY_STATUSES.ERROR);
+    });
+
+    it('[Error] T-03-02-03: エラー時の entry が ChatlogEntry インスタンスである', async () => {
+      const filePath = `${tempDir}/bad-yaml.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
+
+      const _result = await loadClassifyEntry(filePath);
+
+      assertInstanceOf(_result.entry, ChatlogEntry);
+    });
+
+    it('[Error] T-03-02-04: エラー時の options.reason が空でない文字列', async () => {
+      const filePath = `${tempDir}/bad-yaml.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
+
+      const _result = await loadClassifyEntry(filePath);
+
+      assertEquals(typeof _result.options.reason, 'string');
+      assertEquals((_result.options.reason ?? '').length > 0, true);
+    });
+  });
+});

--- a/skills/classify-chatlogs/scripts/modules/classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-noai.ts
@@ -17,25 +17,30 @@ import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // ─── Local
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
+import type { ActionStatusEntry } from '../../../_scripts/types/action-status-entry.types.ts';
 import type { ClassifyBufferEntry } from '../types/classify.types.ts';
 // constants
+import { ENTRY_ACTIONS, ENTRY_STATUSES } from '../../../_scripts/types/action-status.types.ts';
 import { FALLBACK_PROJECT, MIN_CLASSIFIABLE_LENGTH } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
 
 /**
- * ファイルを読み込み、分類処理に必要なメタデータを `ClassifyBufferEntry` として返す。
+ * ファイルを読み込み、分類処理に必要なメタデータを `ActionStatusEntry` として返す。
  * - ファイルシステムエラー（`NotFound`, `PermissionDenied` 等）はそのままスロー（致命的エラー）。
- * - フロントマターの解析エラー（`InvalidFormat`, `InvalidYaml`）は `action: 'error'` のエントリを返す。
- * - 正常時は `file: entry, filePath` を持つ `ClassifyBufferEntry` を返す。
+ * - フロントマターの解析エラー（`InvalidFormat`, `InvalidYaml`）は `options.action: 'error'` のエントリを返す。
+ * - 正常時は `entry: ChatlogEntry, options: { filePath }` を持つ `ActionStatusEntry` を返す。
  */
-export const loadClassifyEntry = async (filePath: string): Promise<ClassifyBufferEntry> => {
+export const loadClassifyEntry = async (filePath: string): Promise<ActionStatusEntry> => {
   const _text = await readTextFile(filePath);
   try {
     const _entry = new ChatlogEntry(_text, { filePath });
-    return { file: _entry, filePath };
+    return { entry: _entry, options: { filePath } };
   } catch (e) {
     const _reason = e instanceof Error ? e.message : String(e);
-    return { file: null, filePath, action: CLASSIFY_ACTIONS.ERROR, reason: _reason };
+    return {
+      entry: new ChatlogEntry(''),
+      options: { filePath, action: ENTRY_ACTIONS.ERROR, status: ENTRY_STATUSES.ERROR, reason: _reason },
+    };
   }
 };
 

--- a/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
+++ b/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
@@ -15,6 +15,7 @@ import { findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
 // ─── Local
 import { loadClassifyEntry } from './classify-noai.ts';
 // types
+import type { ActionStatusEntry } from '../../../_scripts/types/action-status-entry.types.ts';
 import type {
   ClassifyBuffer,
   ClassifyBufferEntry,
@@ -22,7 +23,19 @@ import type {
   FindBufferEntriesOptions,
 } from '../types/classify.types.ts';
 // constants
+import { ENTRY_ACTIONS } from '../../../_scripts/types/action-status.types.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
+
+/** `ActionStatusEntry` を `ClassifyBufferEntry` に変換するアダプター。 */
+const _toBufferEntry = (ase: ActionStatusEntry): ClassifyBufferEntry => {
+  const _isError = ase.options.action === ENTRY_ACTIONS.ERROR;
+  return {
+    file: _isError ? null : ase.entry,
+    filePath: ase.options.filePath,
+    action: _isError ? CLASSIFY_ACTIONS.ERROR : undefined,
+    reason: ase.options.reason,
+  };
+};
 
 /**
  * ディレクトリ配下の `.md` ファイルを収集し、メタデータを読み込んで分類バッファを返す。
@@ -33,12 +46,17 @@ export const findBufferEntries = async (
   opts?: FindBufferEntriesOptions,
   stats?: ClassifyStats,
 ): Promise<ClassifyBuffer> => {
-  const _loadMeta = opts?.loadMeta ?? loadClassifyEntry;
   const _files = await findEntries([dir], '.md', { glob: opts?.glob });
 
   const _entries = await Promise.all(
     _files.map(async (filePath): Promise<ClassifyBufferEntry> => {
-      const _entry = await _loadMeta(filePath);
+      let _entry: ClassifyBufferEntry;
+      if (opts?.loadMeta) {
+        _entry = await opts.loadMeta(filePath);
+      } else {
+        const _ase = await loadClassifyEntry(filePath);
+        _entry = _toBufferEntry(_ase);
+      }
       if (_entry.action === CLASSIFY_ACTIONS.ERROR && stats) { stats.error++; }
       return _entry;
     }),


### PR DESCRIPTION
## Overview

**Summary**
Migrate classify pipeline modules to use `ActionStatusEntry` (ASE) as the return type.

**Background / Motivation**
The previous modules returned `ClassifyBufferEntry` with `null` for the file field to signal errors. This made error handling implicit and inconsistent. ASE carries the entry, its status, and processing options as a single unit, making the pipeline's data flow explicit.

This is phase 1 of the classify pipeline ASE migration.

## Changes

### Core Changes

- `action-status.types.ts`: Add `MOVEBYAI`, `PENDING`, and `ERROR` to `EntryAction`
- `action-status-entry.types.ts`: Add optional `targetPath` field to `ActionStatusOptions`
- `classify-noai.ts`: Change return type from `ClassifyBufferEntry` to `ActionStatusEntry`
- `find-buffer-entries.ts`: Add `_toBufferEntry` adapter to convert ASE back to `ClassifyBufferEntry` for downstream compatibility

### Test Updates

- `action-status-types.unit.spec.ts`: New tests for `ENTRY_ACTIONS` constants and `EntryAction` type compatibility
- `action-status.unit.spec.ts`: Add tests for new `EntryAction` values and `targetPath` field
- `load-classify-entry.unit.spec.ts`: New unit tests for success, missing file, invalid frontmatter, and error paths
- `load-classify-entry.integration.spec.ts`: Update existing tests to match ASE return type

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

The `_toBufferEntry` adapter in `find-buffer-entries.ts` preserves backward compatibility for downstream consumers. Full ASE adoption downstream is tracked as a separate phase.

Design documents are located under `docs/.deckrd/pipeline/classify/`.
