### PR TITLE
feat(libs/ai): add multi-backend AI command builder and model parsing

### DIFF
--- a/assets/configs/config.yaml
+++ b/assets/configs/config.yaml
@@ -1,32 +1,32 @@
-# chatlog-exporter グローバルデフォルト設定
-# このファイルを編集することで、全スクリプトのデフォルト値を上書きできます。
-# --config <path> オプションで別ファイルを指定することも可能です。
+# chatlog-exporter global default configuration
+# Edit this file to override default values for all scripts.
+# You can also specify another file with the --config <path> option.
 
-# エージェント
+# Agent
 agent: claude
 
-# AI 実行系
-model: "sonnet"
-timeoutMs: 120_000 # 2分(ms)
+# AI execution
+model: "haiku"
+timeoutMs: 120_000 # 2 min (ms)
 
-# ハッシュ生成系
+# Hash generation
 hashLength: 8
 minRandomLength: 4
 maxRandomLength: 16
 
-# 並列処理・バッチ処理系
-chunkSize: 10
+# Parallel / batch processing
+chunkSize: 5
 concurrency: 4
 
-# 文字数フィルタ系
-minCharCount: 1000 # コンテンツ最小文字数
-minAssistantChars: 300 # Assistant 応答最小文字数（userTurns=1 時）
-maxContentLength: 4000 # コンテンツ最大文字数
+# Character count filters
+minCharCount: 1000 # Minimum content length
+minAssistantChars: 300 # Minimum assistant response length (when userTurns=1)
+maxContentLength: 4000 # Maximum content length
 
-# DISCARD 判定系（filter-chatlog）
-discardThreshold: 0.7 # confidence がこの値以上の DISCARD を削除対象とする
+# DISCARD threshold (filter-chatlog)
+discardThreshold: 0.7 # Remove DISCARD entries with confidence >= this value
 
-# アセットディレクトリ
+# Asset directories
 dicsDir: "./assets/dics"
 promptsDir: "./assets/prompts"
 chatlogsDir: "./chatlogs"

--- a/chatlogs/normalizelogs/.gitignore
+++ b/chatlogs/normalizelogs/.gitignore
@@ -1,0 +1,22 @@
+# src: .gitignore
+# @(#) : ignore outputed chatlogs
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# ignore words for Python files, including pycache and pybuilder
+# cspell:words pycache codz pybuilder
+
+## ignore all directories
+/*
+
+# track git settings
+!.git*
+!**/.git*
+
+# directory keeper
+!**/.keep
+
+

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,7 +26,7 @@ pre-commit:
 prepare-commit-msg:
   commands:
     prepare-message-script:
-      run: bash -c './scripts/prepare-commit-msg.sh --model opus --output "{1}"'
+      run: bash -c './scripts/prepare-commit-msg.sh --model gpt-5.5 --output "{1}"'
 
 # check commit message as Conventional Commit
 commit-msg:

--- a/skills/_scripts/constants/common.constants.ts
+++ b/skills/_scripts/constants/common.constants.ts
@@ -1,4 +1,4 @@
-// src: scripts/constants/common.constants.ts
+// src: skills/_scripts/constants/common.constants.ts
 // @(#): スクリプト共通定数定義
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -8,19 +8,3 @@
 
 /** Markdown フロントマターの開始・終了区切り文字。 */
 export const FRONTMATTER_DELIMITER = '---';
-
-/** Claude Code CLI が受け付けるモデル ID およびエイリアスの集合。 */
-export const VALID_AI_MODELS = new Set([
-  'default',
-  'best',
-  'opus',
-  'sonnet',
-  'haiku',
-  'sonnet[1m]',
-  'opus[1m]',
-  'opusplan',
-  'claude-opus-4-7',
-  'claude-opus-4-6',
-  'claude-sonnet-4-6',
-  'claude-haiku-4-5-20251001',
-]);

--- a/skills/_scripts/libs/ai/__tests__/unit/model-utils.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/model-utils.unit.spec.ts
@@ -6,12 +6,17 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// -- BDD modules --
-import { assert, assertFalse } from '@std/assert';
+// ─── BDD modules
+import { assert, assertEquals, assertFalse } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
-// -- test target --
-import { isValidModel } from '../../model-utils.ts';
+// ─── Test target
+import { getAiBackend, isValidModel, parseModel } from '../../model-utils.ts';
+
+// types
+import type { AiModelSpec } from '../../../../types/ai.const.types.ts';
+
+// ─── Internal Helpers
 
 describe('isValidModel', () => {
   // 有効なショートエイリアス
@@ -72,5 +77,197 @@ describe('isValidModel', () => {
 
   it('T-LIB-AI-14: returns false for "opus-" (partial match)', () => {
     assertFalse(isValidModel('opus-'));
+  });
+});
+
+/**
+ * `getAiBackend` のユニットテストスイート。
+ *
+ * モデル名からバックエンド種別（'claude' | 'codex' | 'copilot' | 'opencode' | null）を返すことを検証する。
+ *
+ * テスト ID 範囲: T-LIB-AI-15 〜 T-LIB-AI-25
+ *
+ * @see getAiBackend
+ */
+describe('getAiBackend', () => {
+  /** VALID_AI_MODELS に含まれるモデル名 → 'claude' を返す正常ケース。 */
+  describe('When: 正常系', () => {
+    it('T-LIB-AI-15: getAiBackend("sonnet") → "claude"', () => {
+      assertEquals(getAiBackend('sonnet'), 'claude');
+    });
+
+    it('T-LIB-AI-16: getAiBackend("opus") → "claude"', () => {
+      assertEquals(getAiBackend('opus'), 'claude');
+    });
+
+    it('T-LIB-AI-17: getAiBackend("haiku") → "claude"', () => {
+      assertEquals(getAiBackend('haiku'), 'claude');
+    });
+
+    it('T-LIB-AI-18: getAiBackend("claude-sonnet-4-6") → "claude"', () => {
+      assertEquals(getAiBackend('claude-sonnet-4-6'), 'claude');
+    });
+
+    it('T-LIB-AI-20: getAiBackend("gpt-5") → "codex"', () => {
+      assertEquals(getAiBackend('gpt-5'), 'codex');
+    });
+
+    it('T-LIB-AI-22: getAiBackend("copilot/gpt-4") → "copilot"', () => {
+      assertEquals(getAiBackend('copilot/gpt-4'), 'copilot');
+    });
+
+    it('T-LIB-AI-23: getAiBackend("openai/gpt-4") → "codex"', () => {
+      assertEquals(getAiBackend('openai/gpt-4'), 'codex');
+    });
+
+    it('T-LIB-AI-24: getAiBackend("unknown") → null', () => {
+      assertEquals(getAiBackend('unknown'), null);
+    });
+
+    it('T-LIB-AI-30: getAiBackend("google/gemini") → "antigravity" (mapped provider)', () => {
+      assertEquals(getAiBackend('google/gemini'), 'antigravity');
+    });
+
+    it('T-LIB-AI-31: getAiBackend("antigravity/foo") → "antigravity" (mapped provider)', () => {
+      assertEquals(getAiBackend('antigravity/foo'), 'antigravity');
+    });
+
+    it('T-LIB-AI-53: getAiBackend("google/gemini") → "antigravity"', () => {
+      assertEquals(getAiBackend('google/gemini'), 'antigravity');
+    });
+
+    it('T-LIB-AI-32: getAiBackend("claude/claude-3") → "claude" (via provider map)', () => {
+      assertEquals(getAiBackend('claude/claude-3'), 'claude');
+    });
+
+    it('T-LIB-AI-33: getAiBackend("codex/gpt-4") → "codex" (via provider map)', () => {
+      assertEquals(getAiBackend('codex/gpt-4'), 'codex');
+    });
+
+    it('T-LIB-AI-54: getAiBackend("foobar/baz") → null (unknown provider)', () => {
+      assertEquals(getAiBackend('foobar/baz'), null);
+    });
+  });
+
+  /** 境界値・特殊エイリアスのエッジケース。 */
+  describe('When: エッジケース', () => {
+    it('T-LIB-AI-19: getAiBackend("sonnet[1m]") → "claude"', () => {
+      assertEquals(getAiBackend('sonnet[1m]'), 'claude');
+    });
+
+    it('T-LIB-AI-25: getAiBackend("") → null', () => {
+      assertEquals(getAiBackend(''), null);
+    });
+  });
+});
+
+/**
+ * `isValidModel` のマルチバックエンド対応ユニットテストスイート。
+ *
+ * getAiBackend が null でないモデルは true を返すことを検証する。
+ *
+ * テスト ID 範囲: T-LIB-AI-26 〜 T-LIB-AI-29
+ *
+ * @see isValidModel
+ */
+describe('isValidModel (multi-backend)', () => {
+  /** getAiBackend が非 null を返すモデル → true の正常ケース。 */
+  describe('When: 正常系', () => {
+    it('T-LIB-AI-26: isValidModel("gpt-5") → true', () => {
+      assert(isValidModel('gpt-5'));
+    });
+
+    it('T-LIB-AI-27: isValidModel("copilot/gpt-4") → true', () => {
+      assert(isValidModel('copilot/gpt-4'));
+    });
+
+    it('T-LIB-AI-28: isValidModel("openai/gpt-4") → true', () => {
+      assert(isValidModel('openai/gpt-4'));
+    });
+  });
+
+  /** getAiBackend が null を返すモデル → false の異常ケース。 */
+  describe('When: 異常系', () => {
+    it('T-LIB-AI-29: isValidModel("unknown") → false', () => {
+      assertFalse(isValidModel('unknown'));
+    });
+
+    it('T-LIB-AI-55: isValidModel("foobar/baz") → false (unknown provider)', () => {
+      assertFalse(isValidModel('foobar/baz'));
+    });
+  });
+});
+
+/**
+ * `parseModel` のユニットテストスイート。
+ *
+ * モデル名から `{ provider, model }` または `null` を返すことを検証する。
+ *
+ * テスト ID 範囲: T-LIB-AI-40 〜 T-LIB-AI-47
+ *
+ * @see parseModel
+ */
+describe('parseModel', () => {
+  /** provider/model 形式・bare モデル・gpt-/o1- プレフィックスの正常ケース。 */
+  describe('When: 正常系', () => {
+    it('T-LIB-AI-40: parseModel("openai/gpt-4") → { provider:"openai", model:"gpt-4" }', () => {
+      const _expected: AiModelSpec = { provider: 'openai', model: 'gpt-4' };
+      assertEquals(parseModel('openai/gpt-4'), _expected);
+    });
+
+    it('T-LIB-AI-41: parseModel("google/gemini") → { provider:"google", model:"gemini" }', () => {
+      const _expected: AiModelSpec = { provider: 'google', model: 'gemini' };
+      assertEquals(parseModel('google/gemini'), _expected);
+    });
+
+    it('T-LIB-AI-50: parseModel("google/gemini") → { provider:"google", model:"gemini" }', () => {
+      const _expected: AiModelSpec = { provider: 'google', model: 'gemini' };
+      assertEquals(parseModel('google/gemini'), _expected);
+    });
+
+    it('T-LIB-AI-51: parseModel("antigravity/foo") → { provider:"antigravity", model:"foo" }', () => {
+      const _expected: AiModelSpec = { provider: 'antigravity', model: 'foo' };
+      assertEquals(parseModel('antigravity/foo'), _expected);
+    });
+
+    it('T-LIB-AI-52: parseModel("anthropic/claude-3") → { provider:"anthropic", model:"claude-3" }', () => {
+      const _expected: AiModelSpec = { provider: 'anthropic', model: 'claude-3' };
+      assertEquals(parseModel('anthropic/claude-3'), _expected);
+    });
+
+    it('T-LIB-AI-42: parseModel("copilot/gpt-4") → { provider:"copilot", model:"gpt-4" }', () => {
+      const _expected: AiModelSpec = { provider: 'copilot', model: 'gpt-4' };
+      assertEquals(parseModel('copilot/gpt-4'), _expected);
+    });
+
+    it('T-LIB-AI-43: parseModel("claude/claude-3") → { provider:"claude", model:"claude-3" }', () => {
+      const _expected: AiModelSpec = { provider: 'claude', model: 'claude-3' };
+      assertEquals(parseModel('claude/claude-3'), _expected);
+    });
+
+    it('T-LIB-AI-44: parseModel("sonnet") → { provider:"claude", model:"sonnet" }', () => {
+      const _expected: AiModelSpec = { provider: 'claude', model: 'sonnet' };
+      assertEquals(parseModel('sonnet'), _expected);
+    });
+
+    it('T-LIB-AI-45: parseModel("gpt-5") → { provider:"codex", model:"gpt-5" }', () => {
+      const _expected: AiModelSpec = { provider: 'codex', model: 'gpt-5' };
+      assertEquals(parseModel('gpt-5'), _expected);
+    });
+  });
+
+  /** バックエンドが特定できないモデル → null のエッジケース。 */
+  describe('When: エッジケース', () => {
+    it('T-LIB-AI-46: parseModel("unknown") → null', () => {
+      assertEquals(parseModel('unknown'), null);
+    });
+
+    it('T-LIB-AI-47: parseModel("") → null', () => {
+      assertEquals(parseModel(''), null);
+    });
+
+    it('T-LIB-AI-56: parseModel("foobar/baz") → null (unknown provider)', () => {
+      assertEquals(parseModel('foobar/baz'), null);
+    });
   });
 });

--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -8,23 +8,157 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assertEquals, assertRejects } from '@std/assert';
+import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { runAI } from '../../run-ai.ts';
+import { _buildCommand, runAI } from '../../run-ai.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
 
+// ─── Internal Helpers
+
+// types
+type CommandSpec = { command: string; args: string[]; hasSystemPromptWithArgs: boolean };
+
+// functions
+/**
+ * `Deno.Command` の代替クラスを返すファクトリ。
+ * spawn() が固定の `CommandOutput` を返すフェイクを生成する。
+ *
+ * @param output - spawn().output() が解決する `Deno.CommandOutput`
+ * @returns `Deno.Command` と互換の偽クラス
+ */
+const _makeCommandStub = (output: Deno.CommandOutput) => {
+  return class {
+    constructor(_cmd: string, _opts: unknown) {}
+    spawn() {
+      return {
+        stdin: { getWriter: () => ({ write: () => Promise.resolve(), close: () => Promise.resolve() }) },
+        output: () => Promise.resolve(output),
+      };
+    }
+  };
+};
+
+// constants
+const _cases: Array<{ model: string; expected: CommandSpec }> = [
+  {
+    model: 'sonnet',
+    expected: {
+      command: 'claude',
+      args: [
+        '-p',
+        '--system-prompt',
+        'sys',
+        '--output-format',
+        'text',
+        '--permission-mode',
+        'acceptEdits',
+        '--strict-mcp-config',
+        '--mcp-config',
+        '{"mcpServers":{}}',
+        '--model',
+        'sonnet',
+      ],
+      hasSystemPromptWithArgs: true,
+    },
+  },
+  {
+    model: 'gpt-5',
+    expected: { command: 'codex', args: ['exec', '--model', 'gpt-5'], hasSystemPromptWithArgs: false },
+  },
+  {
+    model: 'copilot/gpt-4',
+    expected: { command: 'copilot', args: ['--model', 'gpt-4'], hasSystemPromptWithArgs: false },
+  },
+  {
+    model: 'openai/gpt-4',
+    expected: { command: 'opencode', args: ['run', '--model', 'openai/gpt-4'], hasSystemPromptWithArgs: false },
+  },
+];
+
 // ─── Tests
+
+/**
+ * `_buildCommand` 関数のユニットテストスイート。
+ *
+ * モデル名から CLI コマンド・引数・hasSystemPromptWithArgs フラグを正しく生成することを検証する。
+ *
+ * テスト ID 範囲: T-LIB-AI-RA-02 〜 T-LIB-AI-RA-05
+ *
+ * @see _buildCommand
+ */
+describe('_buildCommand', () => {
+  /**
+   * 有効なモデル名ごとに正しい CommandSpec を返す正常ケース。
+   */
+  describe('When: 正常系', () => {
+    it('[Normal] T-LIB-AI-RA-02: model=sonnet → command=claude, hasSystemPromptWithArgs=true', () => {
+      const result = _buildCommand('sonnet', 'sys');
+      assertEquals(result.command, 'claude');
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-03: model=gpt-5 → command=codex, args=[exec,--skip-git-repo-check,--append-system-prompt,sys,--model,gpt-5]', () => {
+      const result = _buildCommand('gpt-5', 'sys');
+      assertEquals(result.command, 'codex');
+      assertEquals(result.args, ['exec', '--skip-git-repo-check', '--append-system-prompt', 'sys', '--model', 'gpt-5']);
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-04: model=copilot/gpt-4 → command=copilot, args=[--disable-builtin-mcps,--model,gpt-4,--prompt,sys]', () => {
+      const result = _buildCommand('copilot/gpt-4', 'sys');
+      assertEquals(result.command, 'copilot');
+      assertEquals(result.args, ['--disable-builtin-mcps', '--model', 'gpt-4', '--prompt', 'sys']);
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-05: model=openai/gpt-4 → command=codex, args=[exec,--skip-git-repo-check,--append-system-prompt,sys,--model,gpt-4]', () => {
+      const result = _buildCommand('openai/gpt-4', 'sys');
+      assertEquals(result.command, 'codex');
+      assertEquals(result.args, ['exec', '--skip-git-repo-check', '--append-system-prompt', 'sys', '--model', 'gpt-4']);
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-07: model=google/gemini → command=agy, args=[--model,gemini,--print,sys]', () => {
+      const result = _buildCommand('google/gemini', 'sys');
+      assertEquals(result.command, 'agy');
+      assertEquals(result.args, ['--model', 'gemini', '--print', 'sys']);
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-09: model=google/gemini → { command:"agy", args:["--model","gemini","--print","sys"], hasSystemPromptWithArgs:true }', () => {
+      const result = _buildCommand('google/gemini', 'sys');
+      assertEquals(result.command, 'agy');
+      assertEquals(result.args, ['--model', 'gemini', '--print', 'sys']);
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-10: model=antigravity/foo → { command:"agy", args:["--model","foo","--print","sys"], hasSystemPromptWithArgs:true }', () => {
+      const result = _buildCommand('antigravity/foo', 'sys');
+      assertEquals(result.command, 'agy');
+      assertEquals(result.args, ['--model', 'foo', '--print', 'sys']);
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+
+    it('[Normal] T-LIB-AI-RA-08: model=claude/claude-3 → command=claude, args include --model claude-3 (stripped)', () => {
+      const result = _buildCommand('claude/claude-3', 'sys');
+      assertEquals(result.command, 'claude');
+      assertEquals(result.args.includes('--model'), true);
+      assertEquals(result.args[result.args.indexOf('--model') + 1], 'claude-3');
+      assertEquals(result.hasSystemPromptWithArgs, true);
+    });
+  });
+});
 
 /**
  * `runAI` 関数のユニットテストスイート。
  *
- * モデルバリデーション（UnknownModel）の subindex 設定を検証する。
+ * モデルバリデーション（UnknownModel）・CLI 終了コード・stderr キャプチャを検証する。
  *
- * テスト ID 範囲: T-LIB-AI-RA-01
+ * テスト ID 範囲: T-LIB-AI-RA-01, T-LIB-AI-RA-11 〜 T-LIB-AI-RA-12
  *
  * @see runAI
  */
@@ -45,6 +179,58 @@ describe('runAI', () => {
         ) as ChatlogError;
         assertEquals(_err.kind, 'UnknownModel');
         assertEquals(_err.subindex, 'InvalidModel');
+      });
+    });
+  });
+
+  /**
+   * CLI 終了コードと stderr キャプチャの検証。
+   *
+   * 非ゼロ終了時に stderr がエラーメッセージに含まれること、
+   * および正常終了時に stdout 文字列が返されることを確認する。
+   */
+  describe('CLI execution', () => {
+    /** CLI 非ゼロ終了時のエラーケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-LIB-AI-RA-11: runAI — CLI が非ゼロ終了 → stderr がエラーメッセージに含まれる', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode('model not found'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'CliError');
+          assertStringIncludes(_err.message, 'model not found');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+    });
+
+    /** CLI 正常終了時の正常ケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-LIB-AI-RA-12: runAI — CLI が正常終了 → stdout 文字列を返す', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode('hello'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _result = await runAI('sys', 'user', { model: 'sonnet' });
+          assertEquals(_result, 'hello');
+        } finally {
+          Deno.Command = _origCommand;
+        }
       });
     });
   });

--- a/skills/_scripts/libs/ai/model-utils.ts
+++ b/skills/_scripts/libs/ai/model-utils.ts
@@ -6,9 +6,57 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { VALID_AI_MODELS } from '../../constants/common.constants.ts';
+import {
+  AI_MODEL_TO_PROVIDER_MAP,
+  AI_PROVIDER_BACKEND_MAP,
+  AI_PROVIDERS,
+} from '../../types/ai.const.types.ts';
+import type { AiBackend, AiModelSpec, AiProvider } from '../../types/ai.const.types.ts';
 
-/** Claude Code CLI が受け付けるモデル名かどうかを返す。 */
-export function isValidModel(model: string): boolean {
-  return VALID_AI_MODELS.has(model);
-}
+const _isKnownProvider = (p: string): p is AiProvider => (AI_PROVIDERS as readonly string[]).includes(p);
+
+const _findProviderByModel = (input: string): AiProvider | null => {
+  for (const p of AI_MODEL_TO_PROVIDER_MAP) {
+    if (p.match === 'regex' && p.pattern.test(input)) { return p.provider; }
+    if (p.match === 'exact' && p.value === input) { return p.provider; }
+  }
+  return null;
+};
+
+/**
+ * モデル名を解析し、プロバイダー・モデル名を返す。
+ *
+ * 優先順位:
+ * 1. `provider/model` 形式 + known provider → `{ provider, model }`
+ * 2. `provider/model` 形式 + unknown provider → `null`
+ * 3. bare string → AI_MODEL_PATTERNS で解決し backend名を provider として返す
+ * 4. それ以外 → `null`
+ */
+export const parseModel = (input: string): AiModelSpec | null => {
+  if (input.includes('/')) {
+    const provider = input.split('/')[0];
+    const model = input.split('/').slice(1).join('/');
+    if (!_isKnownProvider(provider)) { return null; }
+    return { provider, model };
+  }
+  const provider = _findProviderByModel(input);
+  if (provider === null) { return null; }
+  return { provider, model: input };
+};
+
+/**
+ * モデル名から AI バックエンド種別を返す。
+ *
+ * - `provider/model` 形式 + known provider → AI_PROVIDER_BACKEND_MAP の値
+ * - `provider/model` 形式 + unknown provider → `null`
+ * - bare string → AI_MODEL_PATTERNS で解決
+ * - それ以外 → `null`
+ */
+export const getAiBackend = (model: string): AiBackend | null => {
+  const _parsed = parseModel(model);
+  if (_parsed === null || !_isKnownProvider(_parsed.provider)) { return null; }
+  return AI_PROVIDER_BACKEND_MAP[_parsed.provider];
+};
+
+/** AI バックエンドが識別できるモデル名かどうかを返す。 */
+export const isValidModel = (model: string): boolean => parseModel(model) !== null;

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -6,17 +6,114 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { ChatlogError } from '../../classes/ChatlogError.class.ts';
-import { DEFAULT_AI_MODEL, DEFAULT_TIMEOUT_MS } from '../../constants/defaults.constants.ts';
-import { isValidModel } from './model-utils.ts';
+// cspell:words mcps
 
+// ─── Shared libraries
+// functions
+import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+import { getAiBackend, isValidModel, parseModel } from './model-utils.ts';
+
+// types
+import type { AiBackendCommand } from '../../types/ai.const.types.ts';
+
+// constants
+import { DEFAULT_AI_MODEL, DEFAULT_TIMEOUT_MS } from '../../constants/defaults.constants.ts';
+import { AI_BACKEND_COMMAND_MAP } from '../../types/ai.const.types.ts';
+
+// internal types
 export type RunAIOptions = {
   model?: string;
   timeoutMs?: number;
 };
 
+type _CommandSpec = { command: AiBackendCommand; args: string[]; hasSystemPromptWithArgs: boolean };
+
+// ─── Functions
+
 /**
- * Runs a Claude CLI subprocess with the given system prompt and user prompt.
+ * モデル名とシステムプロンプトから CLI コマンド仕様を生成する。
+ *
+ * exported for testing — internal use only (do not rely on outside tests)
+ */
+export const _buildCommand = (model: string, systemPrompt: string): _CommandSpec => {
+  const _parsed = parseModel(model)!;
+  const _backend = getAiBackend(model)!;
+  const _command = AI_BACKEND_COMMAND_MAP[_backend];
+  switch (_backend) {
+    case 'claude':
+      return {
+        command: _command,
+        args: [
+          '--print',
+          '--disable-slash-commands',
+          '--permission-mode',
+          'acceptEdits',
+          '--strict-mcp-config',
+          '--mcp-config',
+          '{"mcpServers":{}}',
+          '--model',
+          _parsed.model,
+          '--system-prompt',
+          systemPrompt,
+        ],
+        hasSystemPromptWithArgs: true,
+      };
+    case 'codex':
+      return {
+        command: _command,
+        args: [
+          'exec',
+          '--skip-git-repo-check',
+          '--append-system-prompt',
+          systemPrompt,
+          '--model',
+          _parsed.model,
+        ],
+        hasSystemPromptWithArgs: true,
+      };
+    case 'copilot':
+      return {
+        command: _command,
+        args: [
+          '--disable-builtin-mcps',
+          '--model',
+          _parsed.model,
+          '--prompt',
+          systemPrompt,
+        ],
+        hasSystemPromptWithArgs: true,
+      };
+    case 'opencode':
+      return {
+        command: _command,
+        args: [
+          'run',
+          '--pure',
+          '--model',
+          `${_parsed.provider}/${_parsed.model}`,
+          '--prompt',
+          systemPrompt,
+        ],
+        hasSystemPromptWithArgs: true,
+      };
+    case 'antigravity':
+      return {
+        command: _command,
+        args: [
+          '--model',
+          _parsed.model,
+          '--print',
+          systemPrompt,
+        ],
+        hasSystemPromptWithArgs: true,
+      };
+    default:
+      throw new ChatlogError('UnknownModel', 'InvalidModel', `"${model}" has no backend`);
+  }
+};
+
+/**
+ * Runs an AI CLI subprocess with the given system prompt and user prompt.
  * Returns the trimmed stdout text on success, or throws on failure.
  */
 export const runAI = async (
@@ -32,43 +129,37 @@ export const runAI = async (
       `"${_options.model}" is not valid. Valid models: opus, sonnet, haiku (or full IDs)`,
     );
   }
+  const _spec = _buildCommand(_options.model, systemPrompt);
   const _controller = new AbortController();
   const _timer = _options.timeoutMs !== 0
     ? setTimeout(() => _controller.abort(), _options.timeoutMs)
     : undefined;
-  const _cmd = new Deno.Command('claude', {
-    args: [
-      '-p',
-      '--system-prompt',
-      systemPrompt,
-      '--output-format',
-      'text',
-      '--permission-mode',
-      'acceptEdits',
-      '--strict-mcp-config',
-      '--mcp-config',
-      '{"mcpServers":{}}',
-      '--model',
-      _options.model,
-    ],
+  const _cmd = new Deno.Command(_spec.command, {
+    args: _spec.args,
     stdin: 'piped',
     stdout: 'piped',
-    stderr: 'null',
+    stderr: 'piped',
     signal: _controller.signal,
   });
   try {
     const _process = _cmd.spawn();
     const _writer = _process.stdin.getWriter();
-    await _writer.write(new TextEncoder().encode(userPrompt));
+    const _input = _spec.hasSystemPromptWithArgs ? userPrompt : `${systemPrompt}\n\n${userPrompt}`;
+    await _writer.write(new TextEncoder().encode(_input));
     await _writer.close();
     const _output = await _process.output();
     if (!_output.success) {
-      throw new ChatlogError('CliError', 'ExitFailure', `claude exited with code ${_output.code}`);
+      const _stderr = new TextDecoder().decode(_output.stderr).trim();
+      throw new ChatlogError(
+        'CliError',
+        'ExitFailure',
+        `${_spec.command} exited with code ${_output.code}: ${_stderr}`,
+      );
     }
     return new TextDecoder().decode(_output.stdout).trim();
   } catch (e) {
     if (_controller.signal.aborted) {
-      throw new ChatlogError('TimedOut', 'Timeout', `claude timed out after ${_options.timeoutMs}ms`);
+      throw new ChatlogError('TimedOut', 'Timeout', `${_spec.command} timed out after ${_options.timeoutMs}ms`);
     }
     throw e;
   } finally {

--- a/skills/_scripts/types/ai.const.types.ts
+++ b/skills/_scripts/types/ai.const.types.ts
@@ -1,0 +1,86 @@
+// src: skills/_scripts/types/ai.const.types.ts
+// @(#): AI バックエンド・プロバイダー・モデルパターン定数と型定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Backend
+
+/** 使用可能な AI バックエンド論理名。 */
+export const AI_BACKENDS = ['claude', 'codex', 'copilot', 'opencode', 'antigravity'] as const;
+export type AiBackend = (typeof AI_BACKENDS)[number];
+
+/** バックエンドが使用する CLI コマンド名（実行バイナリ名）。 */
+export const AI_BACKEND_CLI_COMMANDS = ['claude', 'codex', 'copilot', 'opencode', 'agy'] as const;
+export type AiBackendCommand = (typeof AI_BACKEND_CLI_COMMANDS)[number];
+
+/** バックエンド論理名 → CLI コマンド名のマッピング。 */
+export const AI_BACKEND_COMMAND_MAP = {
+  claude: 'claude',
+  codex: 'codex',
+  copilot: 'copilot',
+  opencode: 'opencode',
+  antigravity: 'agy',
+} as const satisfies Record<AiBackend, AiBackendCommand>;
+
+// ─── Provider
+
+/** 認識可能なプロバイダー名（会社名・サービス名・CLI コマンド名を含む）。 */
+export const AI_PROVIDERS = [
+  'claude',
+  'anthropic',
+  'openai',
+  'opencode',
+  'codex',
+  'copilot',
+  'google',
+  'antigravity',
+] as const;
+export type AiProvider = (typeof AI_PROVIDERS)[number];
+
+/** プロバイダー名 → バックエンド論理名のマッピング。 */
+export const AI_PROVIDER_BACKEND_MAP = {
+  claude: 'claude',
+  anthropic: 'claude',
+  openai: 'codex',
+  opencode: 'opencode',
+  codex: 'codex',
+  copilot: 'copilot',
+  google: 'antigravity',
+  antigravity: 'antigravity',
+} as const satisfies Record<AiProvider, AiBackend>;
+
+// ─── Model patterns
+
+/** モデル名のマッチング方法と対応プロバイダーを定義するパターン。 */
+export type AiModelToProvider =
+  | { match: 'exact'; value: string; provider: AiProvider }
+  | { match: 'regex'; pattern: RegExp; provider: AiProvider };
+
+/** bare string モデル名からプロバイダーを解決するパターンリスト（上から優先）。 */
+export const AI_MODEL_TO_PROVIDER_MAP: AiModelToProvider[] = [
+  // openai codex
+  { match: 'regex', pattern: /^gpt-/, provider: 'codex' },
+  // Anthropic claude
+  { match: 'exact', value: 'default', provider: 'claude' },
+  { match: 'exact', value: 'best', provider: 'claude' },
+  { match: 'exact', value: 'opus', provider: 'claude' },
+  { match: 'exact', value: 'sonnet', provider: 'claude' },
+  { match: 'exact', value: 'haiku', provider: 'claude' },
+  { match: 'exact', value: 'sonnet[1m]', provider: 'claude' },
+  { match: 'exact', value: 'opus[1m]', provider: 'claude' },
+  { match: 'exact', value: 'opusplan', provider: 'claude' },
+  // Anthropic claude / with version
+  { match: 'regex', pattern: /^claude-opus-/, provider: 'claude' },
+  { match: 'regex', pattern: /^claude-sonnet-/, provider: 'claude' },
+  { match: 'regex', pattern: /^claude-haiku-/, provider: 'claude' },
+  // Google Antigravity
+  { match: 'regex', pattern: /^gemini-/, provider: 'antigravity' },
+];
+
+// ─── Model spec
+
+/** `parseModel` の戻り値。プロバイダー・モデル名を保持する。 */
+export type AiModelSpec = { provider: AiProvider; model: string };


### PR DESCRIPTION
## Overview

**Summary**
Extends the AI execution layer to support multiple backends (claude, codex, copilot, opencode, antigravity) with a model-parsing utility and backend-specific command builder.

**Background / Motivation**
The tool previously only supported the Claude CLI. To dispatch commands to other AI backends at runtime, the system needs to resolve a model identifier (e.g. `openai/gpt-4o` or bare `haiku`) to the correct CLI invocation. This PR adds the utilities needed for that resolution and extends `run-ai` to use them.

## Changes

### Core Changes

- `libs/ai/model-utils.ts` — new `parseModel`, `getAiBackend`, and `isValidModel` utilities; resolves both `provider/model` and bare model aliases via `AI_MODEL_TO_PROVIDER_MAP`
- `libs/ai/run-ai.ts` — added `_buildCommand` to generate backend-specific CLI commands; hardened Claude flags for non-interactive use; stderr captured in execution errors
- `types/ai.const.types.ts` — new file consolidating backend/provider constants (`AI_BACKENDS`, `AI_PROVIDERS`, `AI_PROVIDER_BACKEND_MAP`, `AI_BACKEND_COMMAND_MAP`) and model-pattern types

### Test Updates

- `model-utils.unit.spec.ts` — unit tests for `parseModel` and `getAiBackend`
- `run-ai.unit.spec.ts` — unit tests for backend-specific command generation across all supported backends

### Removed

- `VALID_AI_MODELS` constant from `common.constants.ts` — superseded by `isValidModel` from `model-utils.ts`

## Change Type (optional)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Backend dispatch uses a two-level mapping: provider → backend (`AI_PROVIDER_BACKEND_MAP`), then backend → CLI binary (`AI_BACKEND_COMMAND_MAP`). Each backend receives the system prompt differently:

- `claude`: `--system-prompt <text>`
- `codex`: `--append-system-prompt <text>`
- `copilot` / `opencode`: `--prompt <text>`
- `antigravity` (`agy`): positional argument after `--print`
