### PR TITLE
feat(normalize-chatlogs): overhaul batch AI segmentation pipeline

### DIFF
--- a/skills/_scripts/constants/chatlog-error.constants.ts
+++ b/skills/_scripts/constants/chatlog-error.constants.ts
@@ -13,4 +13,5 @@ export const ERROR_KIND_LABELS = {
   InvalidYaml: 'Invalid Yaml',
   NotInGitRepo: 'Not In Git Repository',
   GitNotFound: 'Git Not Found',
+  FailFast: 'Fail Fast',
 } as const;

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
@@ -172,23 +172,18 @@ describe('normalize-chatlogs - full E2E', () => {
       await removeTempDirs(inputDir, outputDir);
     });
 
-    it('T-FULL-03: 2 回実行後に旧ファイルが .old-01.md にバックアップされ、入力ファイルは不変である', async () => {
+    it('T-FULL-03: 2 回実行後に normalize済みファイルがスキップされ、入力ファイルは不変である', async () => {
       const fixedHash: HashProvider = () => '0000000';
 
       // 1 回目: 出力ファイルを生成
       await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
 
-      // 2 回目: バックアップを生成
+      // 2 回目: normalize済みファイルをスキップ
       loggerStub.infoLogs.splice(0);
       await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
 
-      // reproducibility: 2 回目も success=1
-      assertMatch(loggerStub.infoLogs.join('\n'), /success=1/);
-
-      // reproducibility: .old-01.md バックアップが存在する（サブディレクトリも含めて再帰検索）
-      const allFiles = await findFiles(outputDir);
-      const backupExists = allFiles.some((path) => path.includes('.old-01.md'));
-      assertEquals(backupExists, true);
+      // reproducibility: 2 回目は skip=1
+      assertMatch(loggerStub.infoLogs.join('\n'), /skip=1/);
 
       // reproducibility: 入力ファイルは不変
       const afterContent = await readTextFile(`${inputDir}/chat.md`);

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
@@ -27,7 +27,6 @@ import {
   silenceLog,
 } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
-import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // types
@@ -46,7 +45,7 @@ import type { HashProvider } from '../../../../_scripts/types/providers.types.ts
 describe('main - reproducibility', () => {
   // ─── T-15-04-02: 再実行時のバックアップ ──────────────────────────────────────
 
-  /** エッジケース: 再実行時に既存出力ファイルをバックアップして再書き込みする (R-011) */
+  /** エッジケース: 再実行時に normalize済みファイルをスキップする (R-011) */
   describe('Given: 出力ファイルがすでに存在する処理済み入力ファイル', () => {
     let inputDir: string;
     let outputDir: string;
@@ -78,8 +77,8 @@ describe('main - reproducibility', () => {
     });
 
     describe('When: main() を同一入力で 2 回呼び出す', () => {
-      describe('Then: Task T-15-04-02 - 再実行時に既存出力ファイルをバックアップして再書き込みする', () => {
-        it('T-15-04-02-01: 2 回目の呼び出しで success=1 がレポートに含まれ、旧ファイルが .old-01.md としてバックアップされる', async () => {
+      describe('Then: Task T-15-04-02 - 再実行時に normalize済みファイルをスキップする', () => {
+        it('T-15-04-02-01: 2 回目の呼び出しで skip=1 がレポートに含まれる', async () => {
           // Fixed hash so both runs generate the same output filename
           const fixedHash: HashProvider = () => '0000000';
 
@@ -89,15 +88,10 @@ describe('main - reproducibility', () => {
           // Reset log capture for second run
           loggerStub.infoLogs.splice(0);
 
-          // Second run: should backup existing file and rewrite
+          // Second run: should skip already-normalized file
           await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
 
-          assertMatch(loggerStub.infoLogs.join('\n'), /success=1/);
-
-          // Verify the old file was backed up as .old-01.md (search recursively under outputDir)
-          const allFiles = await findFiles(outputDir);
-          const backupExists = allFiles.some((path) => path.includes('.old-01.md'));
-          assertEquals(backupExists, true);
+          assertMatch(loggerStub.infoLogs.join('\n'), /skip=1/);
         });
       });
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
@@ -116,14 +116,15 @@ describe('attachFrontmatter — runai-frontmatter', () => {
               const _expectedSegments = await Promise.all(_outputFiles.map(_loadOutputSegment));
               const _fixtureContents = await Promise.all(_outputFiles.map((f) => readTextFile(f)));
 
-              const _stdout = new TextEncoder().encode(JSON.stringify(_expectedSegments));
+              const _aiResult = [{ filePath: _inputPath, segments: _expectedSegments }];
+              const _stdout = new TextEncoder().encode(JSON.stringify(_aiResult));
               const _mockHandle = installCommandMock(makeSuccessMock(_stdout));
 
               try {
                 const _inputContent = await readTextFile(_inputPath);
                 const _entry = new ChatlogEntry(_inputContent);
-                const _result = await segmentChatlogs(_inputPath, _inputContent);
-                const _segments = _result ?? [];
+                const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+                const _segments = _map.get(_inputPath) ?? [];
 
                 const _actual = _buildOutput(_segments[_idx], _entry);
                 const { meta: _actualMeta } = parseFrontmatter(_actual);

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-markdown.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-markdown.spec.ts
@@ -15,13 +15,12 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // test helpers
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { findFixtureDirs } from '../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { collectOutputFiles } from './helpers/fixture-helpers.ts';
 
 // test target
-import { generateSegmentFile, segmentChatlogs, START_BODY_HEADING } from '../../modules/segment-io.ts';
+import { generateSegmentFile, START_BODY_HEADING } from '../../modules/segment-io.ts';
 import type { Segment } from '../../types/normalize.types.ts';
 
 // ─── fixtures ルートパス ──────────────────────────────────────────────────────
@@ -69,9 +68,7 @@ const _fixtureEntries = await Promise.all(
 describe('generateSegmentFile — runai-markdown', () => {
   describe('Given: runai-markdown/* の各 fixture', () => {
     describe('When: generateSegmentFile(segment) を呼び出す', () => {
-      for (const { _dirName, _bodyDir, _bodyOutputFiles } of _fixtureEntries) {
-        const _inputPath = `${_bodyDir}/input.md`;
-
+      for (const { _dirName, _bodyOutputFiles } of _fixtureEntries) {
         if (_bodyOutputFiles.length === 0) {
           it(`SFM-${_dirName}-fixture-error: output-*.md が存在しない（フィクスチャ定義漏れ）`, () => {
             throw new Error(
@@ -90,21 +87,10 @@ describe('generateSegmentFile — runai-markdown', () => {
             const _expectedSegments = await Promise.all(_bodyOutputFiles.map(_loadOutputSegment));
             const _bodyFixtureContents = await Promise.all(_bodyOutputFiles.map((f) => readTextFile(f)));
 
-            const _stdout = new TextEncoder().encode(JSON.stringify(_expectedSegments));
-            const _mockHandle = installCommandMock(makeSuccessMock(_stdout));
-
-            try {
-              const _inputContent = await readTextFile(_inputPath);
-              const _result = await segmentChatlogs(_inputPath, _inputContent);
-              const _segments = _result ?? [];
-
-              const _generated = generateSegmentFile(_segments[_idx]);
-              const _actual = _extractBodyFromFixture(_generated);
-              const _expected = _extractBodyFromFixture(_bodyFixtureContents[_idx]);
-              assertEquals(_actual, _expected);
-            } finally {
-              _mockHandle.restore();
-            }
+            const _generated = generateSegmentFile(_expectedSegments[_idx]);
+            const _actual = _extractBodyFromFixture(_generated);
+            const _expected = _extractBodyFromFixture(_bodyFixtureContents[_idx]);
+            assertEquals(_actual, _expected);
           });
         }
       }

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-segments.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-segments.spec.ts
@@ -63,7 +63,7 @@ async function _loadOutput(dir: string): Promise<FixtureOutput> {
 }
 
 /** output の種別に応じたモックを生成する */
-function _buildMock(output: FixtureOutput): DenoCommandLike {
+function _buildMock(output: FixtureOutput, filePath: string): DenoCommandLike {
   if (output.kind === 'error') {
     switch (output.error) {
       case 'external/ai-fail':
@@ -81,7 +81,8 @@ function _buildMock(output: FixtureOutput): DenoCommandLike {
     summary: `summary-${i}`,
     content: `content-${i}`,
   }));
-  return makeSuccessMock(new TextEncoder().encode(JSON.stringify(_mockSegments)));
+  const _aiResult = [{ filePath, segments: _mockSegments }];
+  return makeSuccessMock(new TextEncoder().encode(JSON.stringify(_aiResult)));
 }
 
 // ─── ファイル駆動 fixtures tests ──────────────────────────────────────────────
@@ -104,11 +105,11 @@ describe('segmentChatlogs — runai-segments', () => {
         const _inputPath = `${_fixtureDir}/input.md`;
 
         it(`SF-${_relPath}-count: セグメント数が output.yaml の count と一致する`, async () => {
-          const _mockHandle = installCommandMock(_buildMock(_output));
+          const _mockHandle = installCommandMock(_buildMock(_output, _inputPath));
           try {
             const _inputContent = await readTextFile(_inputPath);
-            const _result = await segmentChatlogs(_inputPath, _inputContent);
-            const _segments = _result ?? [];
+            const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+            const _segments = _map.get(_inputPath) ?? [];
             assertEquals(_segments.length, _output.count);
           } finally {
             _mockHandle.restore();
@@ -116,11 +117,11 @@ describe('segmentChatlogs — runai-segments', () => {
         });
 
         it(`SF-${_relPath}-structure: 各セグメントが title/summary/content フィールドを持つ`, async () => {
-          const _mockHandle = installCommandMock(_buildMock(_output));
+          const _mockHandle = installCommandMock(_buildMock(_output, _inputPath));
           try {
             const _inputContent = await readTextFile(_inputPath);
-            const _result = await segmentChatlogs(_inputPath, _inputContent);
-            const _segments = _result ?? [];
+            const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+            const _segments = _map.get(_inputPath) ?? [];
             for (const seg of _segments) {
               assertExists(seg.title);
               assertExists(seg.summary);
@@ -141,11 +142,11 @@ describe('segmentChatlogs — runai-segments', () => {
         const _inputPath = `${_fixtureDir}/input.md`;
 
         it(`SF-${_relPath}-error: segmentChatlogs が null を返す`, async () => {
-          const _mockHandle = installCommandMock(_buildMock(_output));
+          const _mockHandle = installCommandMock(_buildMock(_output, _inputPath));
           try {
             const _inputContent = await readTextFile(_inputPath);
-            const _result = await segmentChatlogs(_inputPath, _inputContent);
-            assertNull(_result);
+            const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+            assertNull(_map.get(_inputPath));
           } finally {
             _mockHandle.restore();
           }

--- a/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
@@ -23,18 +23,20 @@ import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/d
 
 // test target
 import { segmentChatlogs } from '../../modules/segment-io.ts';
+// types
+import type { Segment } from '../../types/normalize.types.ts';
 
 // ─── segmentChatlogs tests ─────────────────────────────────────────────────────
 
 /**
  * segmentChatlogs のユニットテスト。
- * チャットログコンテンツを AI に渡してセグメント配列 `{title, summary, body}[]` を取得する関数の
+ * チャットログコンテンツを AI に渡してセグメント Map を取得する関数の
  * 正常系・エラー耐性・上限制御を検証する。
  */
 describe('segmentChatlogs', () => {
   /** 正常系: runAI が有効な JSON 配列を返したときセグメント配列を返す */
   describe('Given: runAI が有効な JSON セグメント配列を返す', () => {
-    describe('When: segmentChatlogs(filePath, content) を呼び出す', () => {
+    describe('When: segmentChatlogs([{filePath, content}]) を呼び出す', () => {
       /**
        * Task T-09-01: 正常なセグメント配列の返却。
        * セグメントが正しく配列として返され、runAI がちょうど1回呼ばれることを確認する。
@@ -47,30 +49,42 @@ describe('segmentChatlogs', () => {
         });
 
         it('T-09-01-01: {title, summary, body}[] の2件以上の配列を返す', async () => {
-          const segments = [
-            { title: 'Topic A', summary: 'Summary A', content: 'Body A' },
-            { title: 'Topic B', summary: 'Summary B', content: 'Body B' },
+          const filePath = 'path/to/file.md';
+          const aiSegments = [
+            {
+              filePath,
+              segments: [
+                { title: 'Topic A', summary: 'Summary A', startLine: 1, endLine: 1 },
+                { title: 'Topic B', summary: 'Summary B', startLine: 2, endLine: 2 },
+              ],
+            },
           ];
-          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(segments))));
+          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(aiSegments))));
 
-          const result = await segmentChatlogs('path/to/file.md', 'some chat content');
+          const resultMap = await segmentChatlogs([{ filePath, content: 'Body A\nBody B' }]);
+          const result = resultMap.get(filePath);
 
           assertEquals(Array.isArray(result), true);
-          assertEquals((result as unknown[]).length >= 2, true);
-          assertEquals((result as { title: string }[])[0].title, 'Topic A');
-          assertEquals((result as { summary: string }[])[0].summary, 'Summary A');
-          assertEquals((result as { content: string }[])[0].content, 'Body A');
+          assertEquals((result as Segment[]).length >= 2, true);
+          assertEquals((result as Segment[])[0].title, 'Topic A');
+          assertEquals((result as Segment[])[0].summary, 'Summary A');
         });
 
         it('T-09-01-02: 1呼び出しにつき runAI をちょうど1回だけ呼び出す', async () => {
+          const filePath = 'path/to/file.md';
           const counter = { calls: 0 };
-          const segments = [
-            { title: 'Topic A', summary: 'Summary A', content: 'Body A' },
-            { title: 'Topic B', summary: 'Summary B', content: 'Body B' },
+          const aiSegments = [
+            {
+              filePath,
+              segments: [
+                { title: 'Topic A', summary: 'Summary A', startLine: 1, endLine: 1 },
+                { title: 'Topic B', summary: 'Summary B', startLine: 2, endLine: 2 },
+              ],
+            },
           ];
-          mockHandle = installCommandMock(makeCountingMock(JSON.stringify(segments), counter));
+          mockHandle = installCommandMock(makeCountingMock(JSON.stringify(aiSegments), counter));
 
-          await segmentChatlogs('path/to/file.md', 'some chat content');
+          await segmentChatlogs([{ filePath, content: 'some chat content' }]);
 
           assertEquals(counter.calls, 1);
         });
@@ -80,7 +94,7 @@ describe('segmentChatlogs', () => {
 
   /** 異常系: runAI がエラーまたは非 JSON を返した場合は null を返す */
   describe('Given: runAI がエラーをスローする', () => {
-    describe('When: segmentChatlogs(filePath, content) を呼び出す', () => {
+    describe('When: segmentChatlogs([{filePath, content}]) を呼び出す', () => {
       /**
        * Task T-09-02: エラー時の null 返却。
        * runAI がエラーをスロー、または非 JSON を返した場合に null が返ることを確認する。
@@ -93,27 +107,29 @@ describe('segmentChatlogs', () => {
         });
 
         it('T-09-02-01: null を返す', async () => {
+          const filePath = 'path/to/file.md';
           mockHandle = installCommandMock(makeFailMock(1));
 
-          const result = await segmentChatlogs('path/to/file.md', 'some chat content');
+          const resultMap = await segmentChatlogs([{ filePath, content: 'some chat content' }]);
 
-          assertNull(result);
+          assertNull(resultMap.get(filePath));
         });
 
         it('T-09-02-02: runAI が "not json" を返す場合に null を返す', async () => {
+          const filePath = 'path/to/file.md';
           mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('not json')));
 
-          const result = await segmentChatlogs('path/to/file.md', 'some chat content');
+          const resultMap = await segmentChatlogs([{ filePath, content: 'some chat content' }]);
 
-          assertNull(result);
+          assertNull(resultMap.get(filePath));
         });
       });
     });
   });
 
-  /** 正常系: セグメント数が上限 (10件) を超えた場合は最初の10件のみ返す */
-  describe('Given: runAI が 15件のセグメントを返す', () => {
-    describe('When: segmentChatlogs(filePath, content) を呼び出す', () => {
+  /** 正常系: セグメント数が上限 (5件) を超えた場合は最初の5件のみ返す */
+  describe('Given: runAI が 8件のセグメントを返す', () => {
+    describe('When: segmentChatlogs([{filePath, content}]) を呼び出す', () => {
       /**
        * Task T-09-03: セグメント数の上限適用。
        * runAI が10件を超えるセグメントを返した場合、最初の10件のみに絞られることを確認する。
@@ -125,17 +141,26 @@ describe('segmentChatlogs', () => {
           mockHandle.restore();
         });
 
-        it('T-09-03-01: ちょうど10件のみ返される', async () => {
-          const segments = Array.from({ length: 15 }, (_, i) => ({
-            title: `Topic ${i + 1}`,
-            summary: `Summary ${i + 1}`,
-            content: `Body ${i + 1}`,
-          }));
-          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(segments))));
+        it('T-09-03-01: ちょうど5件のみ返される', async () => {
+          const filePath = 'path/to/file.md';
+          const content = Array.from({ length: 8 }, (_, i) => `Body ${i + 1}`).join('\n');
+          const aiSegments = [
+            {
+              filePath,
+              segments: Array.from({ length: 8 }, (_, i) => ({
+                title: `Topic ${i + 1}`,
+                summary: `Summary ${i + 1}`,
+                startLine: i + 1,
+                endLine: i + 1,
+              })),
+            },
+          ];
+          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(aiSegments))));
 
-          const result = await segmentChatlogs('path/to/file.md', 'some chat content');
+          const resultMap = await segmentChatlogs([{ filePath, content }]);
+          const result = resultMap.get(filePath);
 
-          assertEquals((result as unknown[]).length, 10);
+          assertEquals((result as Segment[]).length, 5);
         });
       });
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
@@ -132,7 +132,7 @@ describe('segmentChatlogs', () => {
     describe('When: segmentChatlogs([{filePath, content}]) を呼び出す', () => {
       /**
        * Task T-09-03: セグメント数の上限適用。
-       * runAI が10件を超えるセグメントを返した場合、最初の10件のみに絞られることを確認する。
+       * runAI が5件を超えるセグメントを返した場合、最初の5件のみに絞られることを確認する。
        */
       describe('Then: Task T-09-03 - セグメント数の上限適用', () => {
         let mockHandle: CommandMockHandle;

--- a/skills/normalize-chatlogs/scripts/constants/normalize.constants.ts
+++ b/skills/normalize-chatlogs/scripts/constants/normalize.constants.ts
@@ -1,21 +1,27 @@
 // src: skills/normalize-chatlogs/scripts/constants/normalize.constants.ts
-// @(#): normalize-chatlogs 定数定義
+// @(#): Constants for normalize-chatlogs
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// constants
 import { DEFAULT_CONCURRENCY, DEFAULT_NORMALIZE_DIR } from '../../../_scripts/constants/defaults.constants.ts';
+// types
 import type { NormalizeConfig } from '../types/normalize.types.ts';
 
+// ─── Constants defintion
+
+/** Default configuration for the normalize-chatlogs pipeline. */
 export const DEFAULT_NORMALIZE_CONFIG: Partial<NormalizeConfig> = {
   dryRun: false,
   concurrency: DEFAULT_CONCURRENCY,
   normalizeDir: DEFAULT_NORMALIZE_DIR,
 };
 
-export const MAX_SEGMENTS = 10;
+/** Maximum number of segments per file. Segments returned by the AI are truncated to this count. */
+export const MAX_SEGMENTS = 5;
 
-/** 1回のAI呼び出しで処理するファイル数の上限。 */
-export const BATCH_SIZE = 4;
+/** Maximum number of files processed in a single AI call. Larger values increase the risk of timeouts. */
+export const BATCH_SIZE = 2;

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/file-io.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/file-io.unit.spec.ts
@@ -134,7 +134,7 @@ describe('reportResults', () => {
   /** 正常系: success/skip/fail カウントを stdout に集計レポートとして出力する */
   describe('Given: success/skip/fail カウントを持つ stats', () => {
     it('[Normal] T-14-01-01: stdout に成功件数が含まれる', () => {
-      const stats: Stats = { success: 5, skip: 2, fail: 1 };
+      const stats: Stats = { success: 5, skip: 2, fail: 1, fallback: 0 };
 
       reportResults(stats);
 
@@ -143,7 +143,7 @@ describe('reportResults', () => {
     });
 
     it('[Normal] T-14-01-02: stdout にスキップ数と失敗数が含まれる', () => {
-      const stats: Stats = { success: 3, skip: 1, fail: 2 };
+      const stats: Stats = { success: 3, skip: 1, fail: 2, fallback: 0 };
 
       reportResults(stats);
 
@@ -156,7 +156,7 @@ describe('reportResults', () => {
   /** エッジケース: 全カウントが 0 でもスローせず出力する */
   describe('Given: 全カウントが 0 の stats', () => {
     it('[Edge] T-14-02-01: throw せずに stdout に出力される', () => {
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       reportResults(stats);
 
@@ -168,7 +168,7 @@ describe('reportResults', () => {
   /** 正常系: fail が非ゼロのとき失敗件数を stdout に明示する */
   describe('Given: fail が非ゼロの stats', () => {
     it('[Normal] T-14-03-01: stdout に失敗件数が明示される', () => {
-      const stats: Stats = { success: 0, skip: 0, fail: 3 };
+      const stats: Stats = { success: 0, skip: 0, fail: 3, fallback: 0 };
 
       reportResults(stats);
 
@@ -180,7 +180,7 @@ describe('reportResults', () => {
   /** エッジケース: success だけが非ゼロの場合のレポート出力。 */
   describe('Given: success のみ非ゼロの stats', () => {
     it('T-14-04-01: stdout に skip と fail の 0 が含まれる', () => {
-      const stats: Stats = { success: 5, skip: 0, fail: 0 };
+      const stats: Stats = { success: 5, skip: 0, fail: 0, fallback: 0 };
 
       reportResults(stats);
 

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
@@ -8,8 +8,12 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assertEquals, assertNotEquals, assertRejects } from '@std/assert';
+import { assert, assertEquals, assertNotEquals, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+// stub
+import { stub } from '@std/testing/mock';
+// types
+import type { Stub } from '@std/testing/mock';
 
 // ─── Test target
 import { processFiles } from '../../process-files.ts';
@@ -20,10 +24,12 @@ import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class
 import { assertDirExist } from '../../../../../_scripts/__tests__/helpers/assert.ts';
 import {
   installCommandMock,
+  makeCountingMock,
   makeFailMock,
   makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { logger } from '../../../../../_scripts/libs/io/logger.ts';
 import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 // types
 import type { NormalizeConfig, Stats } from '../../../types/normalize.types.ts';
@@ -70,13 +76,13 @@ describe('processFiles', () => {
   describe('When: 正常系', () => {
     it('[Normal] T-PF-01-01: inputDir が空のとき stats は全ゼロのまま', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
 
       // assert
-      assertEquals(stats, { success: 0, skip: 0, fail: 0 });
+      assertEquals(stats, { success: 0, skip: 0, fail: 0, fallback: 0 });
     });
 
     it('[Normal] T-PF-01-03: segmentChatlogsBatch が1セグメントを返しdryRun=trueのとき stats.success === 0', async () => {
@@ -87,7 +93,7 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -109,7 +115,7 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -133,7 +139,7 @@ describe('processFiles', () => {
 
       await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
       await Deno.writeTextFile(`${tmpDir}/file2.md`, '# File2\n\nContent2');
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -150,7 +156,7 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeFailMock(1));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -164,7 +170,7 @@ describe('processFiles', () => {
   describe('When: エッジケース', () => {
     it('[Edge] T-PF-01-04: concurrency=1 でも複数ファイルを順次処理できる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
         dryRun: true,
         concurrency: 1,
@@ -186,7 +192,7 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -201,7 +207,7 @@ describe('processFiles', () => {
   describe('When: バリデーション', () => {
     it('[Error] T-PF-VAL-01: inputDir が存在しないとき ChatlogError(InputNotFound) を投げる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const nonExistentDir = `${tmpDir}/nonexistent`;
 
       // act & assert
@@ -213,7 +219,7 @@ describe('processFiles', () => {
 
     it('[Normal] T-PF-VAL-02: outputBase が存在しないとき自動作成されて正常処理される', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       // outputBase は inputDir(tmpDir) の外に配置する必要があるため
       // outputDir の親ディレクトリ配下に未作成のサブディレクトリを使う
       const nonExistentBase = `${outputDir}/nonexistent-base`;
@@ -223,12 +229,12 @@ describe('processFiles', () => {
 
       // assert — outputBase が作成されている
       await assertDirExist(nonExistentBase);
-      assertEquals(stats, { success: 0, skip: 0, fail: 0 });
+      assertEquals(stats, { success: 0, skip: 0, fail: 0, fallback: 0 });
     });
 
     it('[Error] T-PF-VAL-03: outputBase が inputDir 配下のとき ChatlogError(ForbiddenOutput) を投げる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const insideDir = `${tmpDir}/inside`;
       await Deno.mkdir(insideDir, { recursive: true });
 
@@ -241,7 +247,7 @@ describe('processFiles', () => {
 
     it('[Error] T-PF-VAL-04: outputBase === inputDir のとき ChatlogError(ForbiddenOutput) を投げる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act & assert
       await assertRejects(
@@ -252,13 +258,13 @@ describe('processFiles', () => {
 
     it('[Normal] T-PF-VAL-05: outputBase が inputDir の外なら stats はゼロのまま', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
 
       // assert
-      assertEquals(stats, { success: 0, skip: 0, fail: 0 });
+      assertEquals(stats, { success: 0, skip: 0, fail: 0, fallback: 0 });
     });
   });
 
@@ -273,7 +279,7 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
         dryRun: true,
         concurrency: 1,
@@ -287,6 +293,74 @@ describe('processFiles', () => {
       const modelIndex = capturedArgs.value.indexOf('--model');
       assertNotEquals(modelIndex, -1);
       assertEquals(capturedArgs.value[modelIndex + 1], 'claude-opus-4-7');
+    });
+  });
+
+  /** fail-fast: failFast オプションの動作検証。 */
+  describe('When: fail-fast', () => {
+    it('[Normal] T-PF-FF-01: failFast=false のとき fail が複数あっても全ファイルを処理する', async () => {
+      // arrange
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
+      await Deno.writeTextFile(`${tmpDir}/file2.md`, '# File2\n\nContent2');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
+        dryRun: true,
+        concurrency: 1,
+        failFast: false,
+      };
+
+      // act
+      await processFiles(tmpDir, outputDir, config, stats);
+
+      // assert — failFast=false なので全ファイルを処理して 2 fail
+      assertEquals(stats.fail, 2);
+    });
+
+    it('[Error] T-PF-FF-02: failFast=true のとき最初の fail で ChatlogError(FailFast) をスローする', async () => {
+      // arrange
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
+        dryRun: true,
+        concurrency: 1,
+        failFast: true,
+      };
+
+      // act & assert
+      const err = await assertRejects(
+        () => processFiles(tmpDir, outputDir, config, stats),
+        ChatlogError,
+      );
+      assertEquals((err as ChatlogError).kind, 'FailFast');
+    });
+  });
+
+  /** logger.warn: AI 失敗時のファイル名ログ検証。 */
+  describe('When: logger.warn', () => {
+    it('[Error] T-PF-WL-01: AI が fail のとき logger.warn がファイル名付きで呼ばれる', async () => {
+      // arrange
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      const filePath = normalizePath(`${tmpDir}/target-file.md`);
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+        // assert — warn が呼ばれ、ファイル名が含まれる
+        assert(warnStub.calls.length > 0);
+      } finally {
+        warnStub?.restore();
+      }
     });
   });
 
@@ -307,7 +381,7 @@ describe('processFiles', () => {
       const stdout = new TextEncoder().encode(JSON.stringify(batch));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
         dryRun: true,
         concurrency: 2,
@@ -318,6 +392,240 @@ describe('processFiles', () => {
 
       // assert — 全ファイルが処理され fail がゼロ
       assertEquals(stats.fail, 0);
+    });
+  });
+
+  /**
+   * スキップ処理: 出力済みファイルが存在する場合に processFiles がスキップするケース。
+   *
+   * `_isAlreadyNormalized` は内部関数のため processFiles() 経由で検証する。
+   * project frontmatter なし → project=undefined → outputDir は `${outputBase}/misc`。
+   */
+  describe('When: スキップ処理', () => {
+    it('[Normal] T-PF-SKIP-01: outputDir に baseName-*.md が存在するとき stats.skip が 1増加する', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+
+      // project frontmatter なし → misc フォールバック → outputDir = ${outputDir}/misc
+      const miscDir = normalizePath(`${outputDir}/misc`);
+      await Deno.mkdir(miscDir, { recursive: true });
+      // baseName = 'dummy'（hash suffix なし）。パターン dummy-*.md にマッチするファイルを配置する
+      await Deno.writeTextFile(`${miscDir}/dummy-01-abc1234.md`, 'already normalized');
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert
+      assertEquals(stats.skip, 1);
+      assertEquals(stats.success, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Normal] T-PF-SKIP-02: outputDir に baseName-*.md が存在しないとき stats.skip は増加しない', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      // 出力済みファイルなし
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert
+      assertEquals(stats.skip, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Edge] T-PF-SKIP-03: outputDir が存在しないとき stats.skip は増加せずエラーにならない', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      // misc サブディレクトリを作成しない（outputDir 自体は存在する）
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act — エラーなしで処理が完了するはず
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert
+      assertEquals(stats.skip, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Edge] T-PF-SKIP-04: project が undefined のとき misc フォールバックで outputDir が解決され stats.skip は 0', async () => {
+      // arrange — project frontmatter なしのファイル
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      // misc ディレクトリにマッチするファイルなし
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert — misc フォールバックで解決されるが該当ファイルがないのでスキップなし
+      assertEquals(stats.skip, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Normal] T-PF-SKIP-05: 出力済みファイルがある場合 stats.skip が 1増加し stats.success は増加しない', async () => {
+      // arrange — T-PF-SKIP-01 と同等（T-02 統合テスト）
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+
+      const miscDir = normalizePath(`${outputDir}/misc`);
+      await Deno.mkdir(miscDir, { recursive: true });
+      await Deno.writeTextFile(`${miscDir}/dummy-01-abc1234.md`, 'already normalized');
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert
+      assertEquals(stats.skip, 1);
+      assertEquals(stats.success, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Normal] T-PF-SKIP-06: 出力済みでないファイルはスキップされず stats.skip は増加しない', async () => {
+      // arrange — 出力済みファイルなし、dryRun=true
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert
+      assertEquals(stats.skip, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Normal] T-PF-SKIP-08: 出力済みファイルがあるとき AI コマンドは呼び出されない', async () => {
+      // arrange — すでに正規化済みのファイルに対して AI が呼ばれないことを検証する
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+
+      const miscDir = normalizePath(`${outputDir}/misc`);
+      await Deno.mkdir(miscDir, { recursive: true });
+      await Deno.writeTextFile(`${miscDir}/dummy-01-abc1234.md`, 'already normalized');
+
+      const counter = { calls: 0 };
+      // makeCountingMock: コンストラクタ呼び出しごとに counter.calls をインクリメントする
+      mockHandle = installCommandMock(makeCountingMock('[]', counter));
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert — スキップされたので AI コマンドは 0 回呼ばれる
+      assertEquals(stats.skip, 1);
+      assertEquals(counter.calls, 0);
+    });
+
+    it('[Edge] T-PF-SKIP-07: outputBase の深いサブディレクトリに baseName-*.md があるとき stats.skip が 1増加する', async () => {
+      // arrange — ** glob パターンでサブディレクトリ内のファイルを検出できることを確認する
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+
+      // 深いサブディレクトリ（chatlogs/claude/2026/2026-06/misc 相当）に出力済みファイルを配置
+      const deepDir = normalizePath(`${outputDir}/chatlogs/claude/2026/2026-06/misc`);
+      await Deno.mkdir(deepDir, { recursive: true });
+      await Deno.writeTextFile(`${deepDir}/dummy-01-abc1234.md`, 'already normalized');
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert — ** glob がサブディレクトリを再帰検索してスキップを検出する
+      assertEquals(stats.skip, 1);
+      assertEquals(stats.success, 0);
+      assertEquals(stats.fail, 0);
+    });
+  });
+
+  /** --single-file モード: 1ファイルずつ個別に AI 呼び出しを行うケース。 */
+  describe('When: --single-file モード', () => {
+    it('[Normal] T-PF-SF-01: singleFile=true で AI が正常にセグメントを返したとき stats.success が増え stats.fallback は増えない', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'singleFile'> = {
+        dryRun: false,
+        concurrency: 1,
+        singleFile: true,
+      };
+
+      // act
+      await processFiles(tmpDir, outputDir, config, stats);
+
+      // assert — AI が正常に返したので success が増え fallback は 0 のまま
+      assertEquals(stats.success, 1);
+      assertEquals(stats.fallback, 0);
+      assertEquals(stats.fail, 0);
+    });
+
+    it('[Error] T-PF-SF-02: singleFile=true で AI が null を返したとき stats.fallback が増え stats.fail は増えない、出力ファイルが1件生成される', async () => {
+      // arrange
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      await Deno.writeTextFile(filePath, '# Test\n\nFallback content');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'singleFile'> = {
+        dryRun: false,
+        concurrency: 1,
+        singleFile: true,
+      };
+
+      // act
+      await processFiles(tmpDir, outputDir, config, stats);
+
+      // assert — AI 失敗 → fallback で 1セグメント処理される
+      assertEquals(stats.fallback, 1);
+      assertEquals(stats.fail, 0);
+      assertEquals(stats.success, 1);
     });
   });
 });

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
 // @(#): segment-io モジュールのユニットテスト
-//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, segmentChatlogs, segmentChatlogsBatch, writeSegmentToFile
+//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, segmentChatlogs, writeSegmentToFile
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -12,6 +12,11 @@
 // ─── BDD modules
 import { assert, assertEquals, assertFalse, assertNotEquals, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+// stub
+import { stub } from '@std/testing/mock';
+import type { DenoCommandLike } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+// types
+import type { Stub } from '@std/testing/mock';
 
 // ─── Test target
 import {
@@ -20,15 +25,19 @@ import {
   generateOutputFileName,
   generateSegmentFile,
   segmentChatlogs,
-  segmentChatlogsBatch,
   START_BODY_HEADING,
   writeSegmentToFile,
 } from '../../segment-io.ts';
 
 // ─── Helpers
 import { assertFileExist, assertNull } from '../../../../../_scripts/__tests__/helpers/assert.ts';
+// functions
+import { logger } from '../../../../../_scripts/libs/io/logger.ts';
+// constants
+import { MAX_SEGMENTS } from '../../../constants/normalize.constants.ts';
 // mock helpers
 import {
+  BaseMockCommand,
   installCommandMock,
   makeDelayedSuccessMock,
   makeFailMock,
@@ -43,6 +52,71 @@ import { ChatlogFrontmatter } from '../../../../../_scripts/classes/ChatlogFront
 import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { Stats } from '../../../types/normalize.types.ts';
+
+// ─── Internal Helpers
+
+// classes
+
+/**
+ * stdin に書き込まれた内容をキャプチャするモック。
+ *
+ * `runAI` が `getWriter().write()` で送る userPrompt を検証するために使用する。
+ * `capturedStdin` にデコードされた文字列が蓄積される。
+ */
+class _StdinCaptureMock extends BaseMockCommand {
+  private readonly stdout: Uint8Array;
+  readonly capturedStdin: string[] = [];
+
+  constructor(_cmd: string, _opts: unknown, stdout: Uint8Array) {
+    super();
+    this.stdout = stdout;
+  }
+
+  override spawn() {
+    const captured = this.capturedStdin;
+    return {
+      stdin: {
+        getWriter() {
+          return {
+            write(data: Uint8Array): Promise<void> {
+              captured.push(new TextDecoder().decode(data));
+              return Promise.resolve();
+            },
+            close(): Promise<void> {
+              return Promise.resolve();
+            },
+          };
+        },
+      },
+      output: () => this.makeOutput(),
+    };
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
+  }
+}
+
+// functions
+
+/**
+ * `_StdinCaptureMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param stdout - AI が返す stdout バイト列
+ * @param captured - stdin のキャプチャ先（インスタンスを後から参照するための出口）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeStdinCaptureMock = (
+  stdout: Uint8Array,
+  captured: { instance: _StdinCaptureMock | null },
+): DenoCommandLike => {
+  return class extends _StdinCaptureMock {
+    constructor(cmd: string, opts: unknown) {
+      super(cmd, opts, stdout);
+      captured.instance = this;
+    }
+  } as unknown as DenoCommandLike;
+};
 
 // ─── Tests
 
@@ -293,15 +367,15 @@ describe('attachFrontmatter', () => {
   });
 });
 
-// ─── segmentChatlogs tests ─────────────────────────────────────────────────────
+// ─── segmentChatlogs tests ────────────────────────────────────────────────────
 
 /**
  * `segmentChatlogs` のユニットテストスイート。
  *
- * Deno.Command をモックして AI 呼び出しを制御する。
+ * 複数ファイルをまとめて1回のAI呼び出しでセグメント分割する関数の
  * 正常系・異常系・エッジケースを検証する。
  *
- * テスト ID 範囲: T-SC-01-01 〜 T-SC-05-02
+ * テスト ID 範囲: T-SC-01-01, T-SC-05-01, T-SC-05-02, T-SCB-01-01 〜 T-SCB-05-02, T-SIO-LR-14, T-SIO-LR-19 〜 T-SIO-LR-25, T-SIO-LOG-01 〜 T-SIO-LOG-02
  *
  * @see segmentChatlogs
  */
@@ -312,22 +386,73 @@ describe('segmentChatlogs', () => {
     mockHandle?.restore();
   });
 
-  /** AI が有効な JSON 配列を返す正常ケース。 */
   describe('When: 正常系', () => {
-    it('[Normal] T-SC-01-01: AI が有効な JSON 配列を返すとき Segment 配列を返す', async () => {
+    it('[Normal] T-SC-01-01: 1要素入力でAIが有効なJSON(envelope形式)を返すとき Segment[]をMapで返す', async () => {
       // arrange
-      const segments = [
-        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' },
-        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2' },
+      const aiResult = [
+        {
+          filePath: 'test.md',
+          segments: [
+            { title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 },
+            { title: 'Topic 2', summary: 'Summary 2', startLine: 2, endLine: 2 },
+          ],
+        },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(segments));
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
-      const result = await segmentChatlogs('test.md', 'content');
+      const result = await segmentChatlogs([{ filePath: 'test.md', content: 'Body 1\nBody 2' }]);
 
       // assert
-      assertEquals(result, segments);
+      assertEquals(result.get('test.md'), [
+        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' },
+        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2' },
+      ]);
+    });
+
+    it('[Normal] T-SCB-01-01: 2ファイル入力でAIが有効なJSONを返すとき各ファイルのSegment[]をMapで返す', async () => {
+      // arrange
+      const inputs = [
+        { filePath: 'a.md', content: 'C1' },
+        { filePath: 'b.md', content: 'C2' },
+      ];
+      const aiResult = [
+        { filePath: 'a.md', segments: [{ title: 'T1', summary: 'S1', startLine: 1, endLine: 1 }] },
+        { filePath: 'b.md', segments: [{ title: 'T2', summary: 'S2', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md'), [{ title: 'T1', summary: 'S1', content: 'C1' }]);
+      assertEquals(result.get('b.md'), [{ title: 'T2', summary: 'S2', content: 'C2' }]);
+    });
+
+    it('[Normal] T-SCB-01-02: 1ファイルでAIが12セグメントを返すとき先頭5件に制限される（MAX_SEGMENTS上限）', async () => {
+      // arrange
+      const content = Array.from({ length: 12 }, (_, i) => `l${i + 1}`).join('\n');
+      const inputs = [{ filePath: 'big.md', content }];
+      const manySegments = Array.from({ length: 12 }, (_, i) => ({
+        title: `Topic ${i + 1}`,
+        summary: `Summary ${i + 1}`,
+        startLine: i + 1,
+        endLine: i + 1,
+      }));
+      const aiResult = [{ filePath: 'big.md', segments: manySegments }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('big.md')?.length, 5);
+      assertEquals(result.get('big.md')?.[0].title, 'Topic 1');
+      assertEquals(result.get('big.md')?.[4].title, 'Topic 5');
     });
   });
 
@@ -335,13 +460,15 @@ describe('segmentChatlogs', () => {
   describe('When: 正常系 — model 指定', () => {
     it('[Normal] T-SC-05-01: model を明示指定したとき Deno.Command args に --model <指定モデル> が含まれる', async () => {
       // arrange
-      const segments = [{ title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' }];
-      const stdout = new TextEncoder().encode(JSON.stringify(segments));
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
       // act
-      await segmentChatlogs('test.md', 'content', { model: 'claude-sonnet-4-6' });
+      await segmentChatlogs([{ filePath: 'test.md', content: 'content' }], { model: 'claude-sonnet-4-6' });
 
       // assert
       const modelIndex = capturedArgs.value.indexOf('--model');
@@ -351,142 +478,20 @@ describe('segmentChatlogs', () => {
 
     it('[Normal] T-SC-05-02: model を省略したとき Deno.Command args に --model DEFAULT_AI_MODEL が含まれる', async () => {
       // arrange
-      const segments = [{ title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' }];
-      const stdout = new TextEncoder().encode(JSON.stringify(segments));
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
       // act
-      await segmentChatlogs('test.md', 'content');
+      await segmentChatlogs([{ filePath: 'test.md', content: 'content' }]);
 
       // assert
       const modelIndex = capturedArgs.value.indexOf('--model');
       assertNotEquals(modelIndex, -1);
       assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
-    });
-  });
-
-  /** AI がエラー終了または非 JSON を返す異常ケース。 */
-  describe('When: 異常系', () => {
-    it('[Error] T-SC-02-01: AI が非ゼロ exit code で終了するとき null を返す', async () => {
-      // arrange
-      mockHandle = installCommandMock(makeFailMock(1));
-
-      // act
-      const result = await segmentChatlogs('test.md', 'content');
-
-      // assert
-      assertNull(result);
-    });
-
-    it('[Error] T-SC-03-01: AI が JSON でない文字列を返すとき null を返す', async () => {
-      // arrange
-      const stdout = new TextEncoder().encode('This is not JSON at all.');
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs('test.md', 'content');
-
-      // assert
-      assertNull(result);
-    });
-  });
-
-  /** セグメント数が上限を超えるエッジケース。 */
-  describe('When: エッジケース', () => {
-    it('[Edge] T-SC-04-01: 12件のセグメントが返るとき先頭10件のみに制限される', async () => {
-      // arrange
-      const segments = Array.from({ length: 12 }, (_, i) => ({
-        title: `Topic ${i + 1}`,
-        summary: `Summary ${i + 1}`,
-        content: `Body ${i + 1}`,
-      }));
-      const stdout = new TextEncoder().encode(JSON.stringify(segments));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs('test.md', 'content');
-
-      // assert
-      assertEquals(result?.length, 10);
-      assertEquals(result?.[0].title, 'Topic 1');
-      assertEquals(result?.[9].title, 'Topic 10');
-    });
-
-    it('[Edge] T-SC-04-02: AIが空配列 [] を返すとき null を返す（空配列は未処理として扱う）', async () => {
-      // arrange
-      const stdout = new TextEncoder().encode(JSON.stringify([]));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs('test.md', 'content');
-
-      // assert — parseJsonArray は空配列を null として返すため null になる
-      assertNull(result);
-    });
-  });
-});
-
-// ─── segmentChatlogsBatch tests ───────────────────────────────────────────────
-
-/**
- * `segmentChatlogsBatch` のユニットテストスイート。
- *
- * 複数ファイルをまとめて1回のAI呼び出しでセグメント分割する関数の
- * 正常系・異常系・エッジケースを検証する。
- *
- * テスト ID 範囲: T-SCB-01-01 〜 T-SCB-04-01
- *
- * @see segmentChatlogsBatch
- */
-describe('segmentChatlogsBatch', () => {
-  let mockHandle: CommandMockHandle;
-
-  afterEach(() => {
-    mockHandle?.restore();
-  });
-
-  describe('When: 正常系', () => {
-    it('[Normal] T-SCB-01-01: 2ファイル入力でAIが有効なJSONを返すとき各ファイルのSegment[]をMapで返す', async () => {
-      // arrange
-      const inputs = [
-        { filePath: 'a.md', content: 'content a' },
-        { filePath: 'b.md', content: 'content b' },
-      ];
-      const aiResult = [
-        { filePath: 'a.md', segments: [{ title: 'T1', summary: 'S1', content: 'C1' }] },
-        { filePath: 'b.md', segments: [{ title: 'T2', summary: 'S2', content: 'C2' }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogsBatch(inputs);
-
-      // assert
-      assertEquals(result.get('a.md'), [{ title: 'T1', summary: 'S1', content: 'C1' }]);
-      assertEquals(result.get('b.md'), [{ title: 'T2', summary: 'S2', content: 'C2' }]);
-    });
-
-    it('[Normal] T-SCB-01-02: 1ファイルでAIが12セグメントを返すとき先頭10件に制限される（MAX_SEGMENTS上限）', async () => {
-      // arrange
-      const inputs = [{ filePath: 'big.md', content: 'content' }];
-      const manySegments = Array.from({ length: 12 }, (_, i) => ({
-        title: `Topic ${i + 1}`,
-        summary: `Summary ${i + 1}`,
-        content: `Body ${i + 1}`,
-      }));
-      const aiResult = [{ filePath: 'big.md', segments: manySegments }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogsBatch(inputs);
-
-      // assert
-      assertEquals(result.get('big.md')?.length, 10);
-      assertEquals(result.get('big.md')?.[0].title, 'Topic 1');
-      assertEquals(result.get('big.md')?.[9].title, 'Topic 10');
     });
   });
 
@@ -500,7 +505,7 @@ describe('segmentChatlogsBatch', () => {
       mockHandle = installCommandMock(makeFailMock(1));
 
       // act
-      const result = await segmentChatlogsBatch(inputs);
+      const result = await segmentChatlogs(inputs);
 
       // assert
       assertNull(result.get('a.md'));
@@ -514,25 +519,66 @@ describe('segmentChatlogsBatch', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
-      const result = await segmentChatlogsBatch(inputs);
+      const result = await segmentChatlogs(inputs);
 
       // assert
       assertNull(result.get('a.md'));
+    });
+
+    it('[Error] T-SCB-WL-01: AI が非ゼロ exit のとき logger.warn が呼ばれる', async () => {
+      // arrange
+      const inputs = [{ filePath: 'file-a.md', content: 'content a' }];
+      mockHandle = installCommandMock(makeFailMock(1));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert — warn が 1 回呼ばれ、ファイル名（拡張子なし）がメッセージに含まれる
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('file-a'));
+      } finally {
+        warnStub?.restore();
+      }
+    });
+
+    it('[Error] T-SCB-WL-02: AI が不正 JSON を返すとき logger.warn が呼ばれる', async () => {
+      // arrange
+      const inputs = [{ filePath: 'file-b.md', content: 'content b' }];
+      const stdout = new TextEncoder().encode('not valid json');
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert — warn が 1 回呼ばれ、ファイル名（拡張子なし）がメッセージに含まれる
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('file-b'));
+      } finally {
+        warnStub?.restore();
+      }
     });
   });
 
   describe('When: エッジケース', () => {
     it('[Edge] T-SCB-03-01: 1ファイル入力でも正常動作する', async () => {
       // arrange
-      const inputs = [{ filePath: 'solo.md', content: 'solo content' }];
+      const inputs = [{ filePath: 'solo.md', content: 'C' }];
       const aiResult = [
-        { filePath: 'solo.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] },
+        { filePath: 'solo.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
       ];
       const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
-      const result = await segmentChatlogsBatch(inputs);
+      const result = await segmentChatlogs(inputs);
 
       // assert
       assertEquals(result.get('solo.md'), [{ title: 'T', summary: 'S', content: 'C' }]);
@@ -548,11 +594,158 @@ describe('segmentChatlogsBatch', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
-      const result = await segmentChatlogsBatch(inputs);
+      const result = await segmentChatlogs(inputs);
 
       // assert
       assertNull(result.get('known.md'));
       assertFalse(result.has('unknown.md'));
+    });
+  });
+
+  /** userPrompt に行番号付きコンテンツが含まれることを検証するケース。 */
+  describe('When: userPrompt 行番号付きコンテンツ', () => {
+    it('[Normal] T-SIO-LR-14: userPrompt に行番号付きコンテンツが含まれる', async () => {
+      // arrange
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 2 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const captured: { instance: _StdinCaptureMock | null } = { instance: null };
+      mockHandle = installCommandMock(_makeStdinCaptureMock(stdout, captured));
+      const content = 'line A\nline B';
+
+      // act
+      await segmentChatlogs([{ filePath: 'test.md', content }]);
+
+      // assert — stdin には "1: line A\n2: line B" が含まれる
+      assert(captured.instance !== null, 'mock was not instantiated');
+      const written = captured.instance.capturedStdin.join('');
+      assert(written.includes('1: line A\n2: line B'), `expected line-numbered content in stdin, got: ${written}`);
+    });
+  });
+
+  /** 行番号範囲方式（_AiSegmentRange）: startLine/endLine でバッチ処理するケース。 */
+  describe('When: 行番号範囲方式（_AiSegmentRange）', () => {
+    it('[Normal] T-SIO-LR-19: 2ファイル入力でAIが {startLine,endLine} 返すとき各ファイルの Segment[] を Map で返す', async () => {
+      // arrange
+      const inputs = [
+        { filePath: 'a.md', content: 'a1\na2\na3' },
+        { filePath: 'b.md', content: 'b1\nb2' },
+      ];
+      const aiResult = [
+        { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 2 }] },
+        { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 1, endLine: 2 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md')?.[0].content, 'a1\na2');
+      assertEquals(result.get('b.md')?.[0].content, 'b1\nb2');
+    });
+
+    it('[Normal] T-SIO-LR-20: 各ファイルの行番号は独立（ファイルごとにリセット）', async () => {
+      // arrange
+      const inputs = [
+        { filePath: 'a.md', content: 'lineA1\nlineA2' },
+        { filePath: 'b.md', content: 'lineB1\nlineB2\nlineB3' },
+      ];
+      const aiResult = [
+        { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 1 }] },
+        { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 2, endLine: 3 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md')?.[0].content, 'lineA1');
+      assertEquals(result.get('b.md')?.[0].content, 'lineB2\nlineB3');
+    });
+
+    it('[Error] T-SIO-LR-21: AIが非ゼロ exit のとき全ファイルが null の Map を返す', async () => {
+      // arrange
+      const inputs = [
+        { filePath: 'a.md', content: 'content a' },
+        { filePath: 'b.md', content: 'content b' },
+      ];
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('a.md'));
+      assertNull(result.get('b.md'));
+    });
+
+    it('[Error] T-SIO-LR-22: AIが不正 JSON を返すとき全ファイルが null の Map を返す', async () => {
+      // arrange
+      const inputs = [{ filePath: 'a.md', content: 'content a' }];
+      const stdout = new TextEncoder().encode('not valid json');
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('a.md'));
+    });
+
+    it('[Edge] T-SIO-LR-23: AIが返す filePath が inputs にない場合無視され inputs 側は null になる', async () => {
+      // arrange
+      const inputs = [{ filePath: 'known.md', content: 'c' }];
+      const aiResult = [
+        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('known.md'));
+      assertFalse(result.has('unknown.md'));
+    });
+
+    it('[Edge] T-SIO-LR-24: 1ファイルで6件のセグメントを返すとき先頭5件に制限される（MAX_SEGMENTS=5）', async () => {
+      // arrange
+      const inputs = [{ filePath: 'big.md', content: 'l1\nl2\nl3\nl4\nl5\nl6' }];
+      const aiSegments = Array.from({ length: 6 }, (_, i) => ({
+        title: `Topic ${i + 1}`,
+        summary: `Sum ${i + 1}`,
+        startLine: i + 1,
+        endLine: i + 1,
+      }));
+      const aiResult = [{ filePath: 'big.md', segments: aiSegments }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('big.md')?.length, 5);
+    });
+
+    it('[Edge] T-SIO-LR-25: timeoutMs:1 を渡すとタイムアウトして全ファイルが null の Map を返す', async () => {
+      // arrange — AI が 50ms 後に応答するモック
+      const inputs = [{ filePath: 'a.md', content: 'content a' }];
+      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
+
+      // act — 1ms タイムアウト: 50ms の遅延より先に abort される
+      const result = await segmentChatlogs(inputs, { timeoutMs: 1 });
+
+      // assert
+      assertNull(result.get('a.md'));
     });
   });
 
@@ -566,7 +759,7 @@ describe('segmentChatlogsBatch', () => {
       mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
 
       // act — 1ms タイムアウト: 50ms の遅延より先に abort される
-      const result = await segmentChatlogsBatch(inputs, { timeoutMs: 1 });
+      const result = await segmentChatlogs(inputs, { timeoutMs: 1 });
 
       // assert
       assertNull(result.get('a.md'));
@@ -574,16 +767,88 @@ describe('segmentChatlogsBatch', () => {
 
     it('[Normal] T-SCB-05-02: timeoutMs を省略するとデフォルト(120s)が使われ正常にセグメントを返す', async () => {
       // arrange — AI が 50ms 後に応答するモック
-      const inputs = [{ filePath: 'a.md', content: 'content a' }];
-      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] }];
+      const inputs = [{ filePath: 'a.md', content: 'C' }];
+      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
       const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
       mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
 
       // act — timeoutMs 省略: デフォルト 120s >> 50ms 遅延
-      const result = await segmentChatlogsBatch(inputs);
+      const result = await segmentChatlogs(inputs);
 
       // assert
       assertEquals(result.get('a.md'), [{ title: 'T', summary: 'S', content: 'C' }]);
+    });
+  });
+
+  /** systemPrompt の内容検証: 「必ず 1 件以上返す」指示が含まれることを確認するケース。 */
+  describe('When: systemPrompt 内容検証', () => {
+    it('[Normal] T-SCB-SP-01: systemPrompt に "at least 1 segment" が含まれる', async () => {
+      // arrange
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const capturedArgs: { value: string[] } = { value: [] };
+      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
+
+      // act
+      await segmentChatlogs([{ filePath: 'test.md', content: 'single line' }]);
+
+      // assert — args must have been captured
+      assert(capturedArgs.value.length > 0, 'no args captured — mock did not fire');
+      const argsText = capturedArgs.value.join(' ');
+      assert(argsText.includes('at least 1 segment'), `expected "at least 1 segment" in args, got: ${argsText}`);
+    });
+  });
+
+  /** AI がエントリを返さなかった・空セグメントを返したときの warn ログ検証ケース。 */
+  describe('When: エッジケース — ログ出力', () => {
+    it('[Edge] T-SIO-LOG-01: AI が当該ファイルのエントリを返さなかったとき "no entry returned for" を含む warn が出る', async () => {
+      // arrange — input は known.md だが AI は unknown.md のエントリのみ返す
+      const inputs = [{ filePath: 'known.md', content: 'content' }];
+      const aiResult = [
+        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('no entry returned for'));
+      } finally {
+        warnStub?.restore();
+      }
+    });
+
+    it('[Edge] T-SIO-LOG-02: AI が segments:[] を返したとき "empty segments returned for" を含む warn が出る', async () => {
+      // arrange — AI は known.md のエントリを返すが segments は空配列
+      const inputs = [{ filePath: 'known.md', content: 'content' }];
+      const aiResult = [
+        { filePath: 'known.md', segments: [] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('empty segments returned for'));
+      } finally {
+        warnStub?.restore();
+      }
     });
   });
 });
@@ -609,7 +874,7 @@ describe('writeSegmentToFile', () => {
 
   beforeEach(async () => {
     outputDir = await Deno.makeTempDir({ prefix: 'write-segment-test-' });
-    stats = { success: 0, skip: 0, fail: 0 };
+    stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
     filePath = `${outputDir}/sample.md`;
     segment = { title: 'Test Title', summary: 'Test Summary', content: 'Test Content' };
     frontmatter = new ChatlogEntry('---\nproject: test\n---\n# body').frontmatter;
@@ -715,5 +980,20 @@ describe('writeSegmentToFile', () => {
       );
       assertEquals((err as ChatlogError).subindex, 'IndexOverflow');
     });
+  });
+});
+
+// ─── MAX_SEGMENTS tests ───────────────────────────────────────────────────────
+
+/**
+ * `MAX_SEGMENTS` 定数のユニットテスト。
+ *
+ * セグメント上限値の期待値を検証する。
+ *
+ * @see MAX_SEGMENTS
+ */
+describe('MAX_SEGMENTS', () => {
+  it('[Normal] T-SIO-LR-01: MAX_SEGMENTS の値が 5 である', () => {
+    assertEquals(MAX_SEGMENTS, 5);
   });
 });

--- a/skills/normalize-chatlogs/scripts/modules/file-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/file-io.ts
@@ -70,7 +70,10 @@ export const writeOutput = async (
  * @param stats - Counters collected across a batch run
  */
 export const reportResults = (stats: Stats): void => {
-  logger.info(`Results: success=${stats.success}, skip=${stats.skip}, fail=${stats.fail}`);
+  logger.info(`Results: success=${stats.success}, skip=${stats.skip}, fallback=${stats.fallback}, fail=${stats.fail}`);
+  if (stats.fallback > 0) {
+    logger.info(`::info:: ${stats.fallback} file(s) processed via fallback (1-segment)`);
+  }
   if (stats.fail > 0) {
     logger.warn(`WARNING: ${stats.fail} file(s) failed`);
   }

--- a/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
+++ b/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
@@ -36,6 +36,8 @@ const _SCHEMA: ArgsSchema = [
   { option: '--concurrency', field: 'concurrency', type: 'integer' },
   { option: '--timeout-ms', field: 'timeoutMs', type: 'integer' },
   { option: '--normalize-dir', field: 'normalizeDir', type: 'directory' },
+  { option: '--fail-fast', field: 'failFast', type: 'flag' },
+  { option: '--single-file', field: 'singleFile', type: 'flag' },
 ];
 
 export const parseArgs = (args: string[]): NormalizeParsedConfig => {

--- a/skills/normalize-chatlogs/scripts/modules/process-files.ts
+++ b/skills/normalize-chatlogs/scripts/modules/process-files.ts
@@ -7,14 +7,18 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// --- std
+import { expandGlob } from '@std/fs';
+
 // --- shared
 // functions
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { extractChatlogPath } from '../../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../../_scripts/libs/file-ops/find-files.ts';
+import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
-import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
+import { getBasename, normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
 // types
 import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
@@ -25,7 +29,7 @@ import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 
 // --- internal modules
-import { segmentChatlogsBatch, writeSegmentToFile } from './segment-io.ts';
+import { extractSegmentBaseName, segmentChatlogs, writeSegmentToFile } from './segment-io.ts';
 
 // constants
 import { BATCH_SIZE } from '../constants/normalize.constants.ts';
@@ -47,6 +51,28 @@ export const resolveOutputDir = (outputBase: string, filePath: string, project?:
 };
 
 /**
+ * Returns true if an output file for `filePath` already exists anywhere under `outputBase`.
+ *
+ * Searches recursively using the glob pattern outputBase/{@code **}/baseName-*.md,
+ * so any project subdirectory structure is covered. Returns false when no match is found.
+ *
+ * @param filePath   - Source chatlog file path
+ * @param outputBase - Base output directory
+ * @returns Promise resolving to true if already normalized, false otherwise
+ */
+const _isAlreadyNormalized = async (
+  filePath: string,
+  outputBase: string,
+): Promise<boolean> => {
+  const _baseName = extractSegmentBaseName(filePath);
+  const _pattern = `${outputBase}/**/${_baseName}-*.md`;
+  for await (const _entry of expandGlob(_pattern)) {
+    if (_entry.isFile) { return true; }
+  }
+  return false;
+};
+
+/**
  * Processes markdown files under `inputDir` by segmenting each via AI and writing output.
  *
  * Discovers files via `findFiles(inputDir)`, then for each file: reads content,
@@ -63,7 +89,7 @@ export const resolveOutputDir = (outputBase: string, filePath: string, project?:
 export const processFiles = async (
   inputDir: string,
   outputBase: string,
-  config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'timeoutMs'>,
+  config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'timeoutMs' | 'failFast' | 'singleFile'>,
   stats: Stats,
   hashFn?: HashProvider,
 ): Promise<void> => {
@@ -93,10 +119,21 @@ export const processFiles = async (
 
   const mdFiles = await findFiles(_inputDir);
 
-  const _chunks: string[][] = [];
-  for (let i = 0; i < mdFiles.length; i += BATCH_SIZE) {
-    _chunks.push(mdFiles.slice(i, i + BATCH_SIZE));
+  // 正規化済みファイルを事前にフィルタ
+  const _normalized = await Promise.all(mdFiles.map((f) => _isAlreadyNormalized(f, _outputBase)));
+  const _skipFiles = mdFiles.filter((_, i) => _normalized[i]);
+  const _pendingFiles = mdFiles.filter((_, i) => !_normalized[i]);
+
+  for (const filePath of _skipFiles) {
+    logger.info(`  skipped (already normalized): ${getBasename(filePath)}`);
+    stats.skip++;
   }
+
+  const _chunkSize = config.singleFile ? 1 : BATCH_SIZE;
+  const _chunks = Array.from(
+    { length: Math.ceil(_pendingFiles.length / _chunkSize) },
+    (_, i) => _pendingFiles.slice(i * _chunkSize, (i + 1) * _chunkSize),
+  );
 
   await runConcurrent(_chunks, async (chunk) => {
     const _inputs = await Promise.all(
@@ -106,23 +143,37 @@ export const processFiles = async (
       }),
     );
 
-    const _resultMap = await segmentChatlogsBatch(_inputs, {
+    const _resultMap = await segmentChatlogs(_inputs, {
       model: config.model,
       ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
     });
 
     for (const { filePath, content } of _inputs) {
-      const segments = _resultMap.get(filePath) ?? null;
-      if (segments === null) {
-        stats.fail++;
-        continue;
-      }
-
       const _entry = new ChatlogEntry(content);
       const _projectVal = _entry.frontmatter.get('project');
       const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
       const outputDir = resolveOutputDir(_outputBase, filePath, _project);
       await Deno.mkdir(outputDir, { recursive: true });
+
+      let segments = _resultMap.get(filePath) ?? null;
+
+      if (segments === null && config.singleFile) {
+        // fallback: content 全体を1セグメントとして使う
+        segments = [{
+          title: getBasename(filePath).replace(/-[0-9a-f]{7}$/, ''),
+          summary: '(auto-generated: AI segmentation failed)',
+          content: content,
+        }];
+        logger.info(`  fallback (1-segment): ${getBasename(filePath)}`);
+        stats.fallback++;
+      } else if (segments === null) {
+        logger.warn(`  failed (no segments returned): ${getBasename(filePath)}`);
+        stats.fail++;
+        if (config.failFast) {
+          throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
+        }
+        continue;
+      }
 
       for (let i = 0; i < segments.length; i++) {
         await writeSegmentToFile(

--- a/skills/normalize-chatlogs/scripts/modules/segment-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/segment-io.ts
@@ -1,6 +1,6 @@
 // src: scripts/modules/segment-io.ts
 // @(#): セグメント分割・ファイル生成・フロントマター付与・ファイル書き出しに関する関数群
-//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, segmentChatlogs, segmentChatlogsBatch, _writeSegmentToFile
+//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, segmentChatlogs, _writeSegmentToFile
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -149,58 +149,34 @@ export const attachFrontmatter = (
   return `${fmText}\n${content}`;
 };
 
-// ─── AI Execution ─────────────────────────────────────────────────────────────
+// ─── Line Number Helpers ──────────────────────────────────────────────────────
 
-/**
- * Splits a chatlog into topic-based segments by calling the Claude AI.
- *
- * Sends the chatlog content to Claude with a system prompt requesting a JSON
- * array of segments. Each segment has `title`, `summary`, and `body` fields.
- * At most {@link MAX_SEGMENTS} segments are returned.
- *
- * @param filePath - Path to the chatlog file (used for context in the prompt)
- * @param content  - Full text content of the chatlog file
- * @returns Promise resolving to an array of {@link Segment} objects, or `null`
- *          if the AI call fails or the response cannot be parsed as a JSON array
- */
-export const segmentChatlogs = async (
-  filePath: string,
-  content: string,
-  options?: { model?: string },
-): Promise<Segment[] | null> => {
-  const systemPrompt = 'You are a chatlog analyst. Split the given chatlog into topic-based segments. '
-    + 'Return ONLY a JSON array where each element has exactly three string fields: '
-    + '"title" (short topic title), "summary" (one-sentence summary), and "content" (relevant text). '
-    + 'For "content": copy the relevant conversation verbatim — do NOT rewrite, paraphrase, or reformat. '
-    + 'Preserve all original line breaks, blank lines, code blocks, and list formatting exactly as they appear. '
-    + 'Preserve ### User and ### Assistant headings to distinguish speakers. '
-    + 'Do not include any explanation or markdown fences — respond with the JSON array only.';
-
-  const userPrompt = `File: ${filePath}\n\n${content}`;
-
-  let raw: string;
-  try {
-    raw = await runAI(systemPrompt, userPrompt, { model: options?.model ?? DEFAULT_AI_MODEL });
-  } catch (e) {
-    if (e instanceof ChatlogError && e.kind === 'TimedOut') {
-      logger.warn(`segmentChatlogs: timed out — ${filePath}`);
-    }
-    return null;
-  }
-
-  const parsed = parseAiJsonArray(raw);
-  if (parsed === null) {
-    return null;
-  }
-
-  const segments = parsed as Segment[];
-  return segments.slice(0, MAX_SEGMENTS);
+const _addLineNumbers = (content: string): string => {
+  if (!content) { return ''; }
+  return content.split('\n').map((line, i) => `${i + 1}: ${line}`).join('\n');
 };
 
-// ─── Batch AI Execution ───────────────────────────────────────────────────────
+const _extractLines = (lines: string[], startLine: number, endLine: number): string => {
+  const total = lines.length;
+  if (total === 0) { return ''; }
+  const start = Math.max(1, Math.min(startLine, total));
+  const end = Math.max(start, Math.min(endLine, total));
+  if (start > end) { return ''; }
+  return lines.slice(start - 1, end).join('\n');
+};
+
+// ─── AI Execution ─────────────────────────────────────────────────────────────
+
+/** AI が返す行番号範囲方式のセグメント定義。export しない内部型。 */
+type _AiSegmentRange = {
+  title: string;
+  summary: string;
+  startLine: number;
+  endLine: number;
+};
 
 /** バッチ処理用の入力1件。 */
-type ChatlogInput = {
+export type ChatlogInput = {
   filePath: string;
   content: string;
 };
@@ -213,10 +189,10 @@ type ChatlogInput = {
  * return results for, or if the AI call fails entirely.
  *
  * @param inputs   - Array of `{ filePath, content }` to segment
- * @param options  - Optional AI options (model)
+ * @param options  - Optional AI options (model, timeoutMs)
  * @returns Map from filePath to Segment[] or null
  */
-export const segmentChatlogsBatch = async (
+export const segmentChatlogs = async (
   inputs: ChatlogInput[],
   options?: { model?: string; timeoutMs?: number },
 ): Promise<Map<string, Segment[] | null>> => {
@@ -226,18 +202,22 @@ export const segmentChatlogsBatch = async (
     return m;
   };
 
-  const systemPrompt = 'You are a chatlog analyst. Split each given chatlog into topic-based segments. '
-    + 'Return ONLY a JSON array where each element has exactly two fields: '
-    + '"filePath" (the file path as given) and "segments" (array of segment objects). '
-    + 'Each segment object has exactly three string fields: '
-    + '"title" (short topic title), "summary" (one-sentence summary), and "content" (relevant text). '
-    + 'For "content": copy the relevant conversation verbatim — do NOT rewrite, paraphrase, or reformat. '
-    + 'Preserve all original line breaks, blank lines, code blocks, and list formatting exactly as they appear. '
-    + 'Preserve ### User and ### Assistant headings to distinguish speakers. '
+  const systemPrompt = 'You are a chatlog analyst. Split each given chatlog into 1 to 5 broad topic segments.\n'
+    + 'If the conversation covers only one topic, return exactly 1 segment covering the full content.\n'
+    + 'Never return an empty segments array — always return at least 1 segment per file.\n'
+    + 'Group minor subtopics under the nearest major theme — do NOT create a segment per small exchange.\n'
+    + 'Return ONLY a JSON array where each element has exactly two fields:\n'
+    + '"filePath" (the file path as given) and "segments" (array of segment objects).\n'
+    + 'Each segment object has exactly four fields:\n'
+    + '"title" (short topic title, 5 words or fewer),\n'
+    + '"summary" (one-sentence summary),\n'
+    + '"startLine" (integer, 1-based, inclusive),\n'
+    + '"endLine" (integer, 1-based, inclusive).\n'
+    + 'Ranges must be contiguous and non-overlapping. Cover the full conversation.\n'
     + 'Do not include any explanation or markdown fences — respond with the JSON array only.';
 
   const userPrompt = inputs
-    .map(({ filePath, content }, i) => `File ${i + 1}: ${filePath}\n${content}`)
+    .map(({ filePath, content }, i) => `File ${i + 1}: ${filePath}\n${_addLineNumbers(content)}`)
     .join('\n\n---\n\n');
 
   let _raw: string;
@@ -247,23 +227,52 @@ export const segmentChatlogsBatch = async (
       ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
     });
   } catch (e) {
+    const _paths = inputs.map((i) => getBasename(i.filePath)).join(', ');
     if (e instanceof ChatlogError && e.kind === 'TimedOut') {
-      logger.warn(`segmentChatlogsBatch: timed out`);
+      logger.warn(`segmentChatlogs: timed out — ${_paths}`);
+    } else {
+      logger.warn(`segmentChatlogs: AI error — ${_paths}`);
     }
     return _nullMap();
   }
 
   const _parsed = parseAiJsonArray(_raw);
-  if (_parsed === null) { return _nullMap(); }
+  if (_parsed === null) {
+    const _paths = inputs.map((i) => getBasename(i.filePath)).join(', ');
+    logger.warn(`segmentChatlogs: invalid JSON response — ${_paths}`);
+    return _nullMap();
+  }
 
   const _validPaths = new Set(inputs.map((i) => i.filePath));
   const _result = new Map<string, Segment[] | null>();
   for (const { filePath } of inputs) { _result.set(filePath, null); }
 
-  for (const entry of _parsed as Array<{ filePath: string; segments: Segment[] }>) {
+  for (const entry of _parsed as Array<{ filePath: string; segments: _AiSegmentRange[] }>) {
     if (!_validPaths.has(entry.filePath)) { continue; }
+    const _inputContent = inputs.find((i) => i.filePath === entry.filePath)!.content;
+    const _lines = _inputContent.split('\n');
     const _segments = Array.isArray(entry.segments) ? entry.segments : [];
-    _result.set(entry.filePath, _segments.slice(0, MAX_SEGMENTS));
+    _result.set(
+      entry.filePath,
+      _segments.slice(0, MAX_SEGMENTS).map((r) => ({
+        title: r.title,
+        summary: r.summary,
+        content: _extractLines(_lines, r.startLine, r.endLine),
+      })),
+    );
+  }
+
+  // null のまま残ったファイルまたは空セグメントのファイルに対してログ出力
+  for (const { filePath } of inputs) {
+    const _segments = _result.get(filePath);
+    if (_segments && _segments.length > 0) { continue; }
+    const _entry = (_parsed as Array<{ filePath: string; segments: unknown[] }>)
+      .find((e) => e.filePath === filePath);
+    if (!_entry) {
+      logger.warn(`segmentChatlogs: no entry returned for — ${getBasename(filePath)}`);
+    } else {
+      logger.warn(`segmentChatlogs: empty segments returned for — ${getBasename(filePath)}`);
+    }
   }
 
   return _result;

--- a/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
+++ b/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
@@ -78,7 +78,7 @@ export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void
     }
     const outputBase = config.normalizeDir ?? DEFAULT_NORMALIZE_DIR;
 
-    const stats: Stats = { success: 0, skip: 0, fail: 0 };
+    const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
     await processFiles(inputDir, outputBase, config, stats, hashFn);
     reportResults(stats);
   } catch (e) {

--- a/skills/normalize-chatlogs/scripts/types/normalize.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/normalize.types.ts
@@ -43,6 +43,8 @@ export type Stats = {
   skip: number;
   /** 失敗したファイル数（AI エラー・書き込みエラー等）。 */
   fail: number;
+  /** AI 失敗 → 1セグメント強制で処理した件数（--single-file モード専用）。 */
+  fallback: number;
 };
 
 export interface NormalizeConfig {
@@ -55,6 +57,8 @@ export interface NormalizeConfig {
   dryRun: boolean;
   concurrency: number;
   normalizeDir?: string;
+  failFast?: boolean;
+  singleFile?: boolean;
 }
 
 export type NormalizeParsedConfig = Partial<NormalizeConfig> & {


### PR DESCRIPTION
## Overview

**Summary**
Refactor `segmentChatlogs` to a batch API and add resilience features (skip, fail-fast, single-file fallback).

**Background / Motivation**
The previous single-file API called the AI once per file, which was inefficient and lacked error recovery.
This change enables multi-file batch processing, reduces payload size by switching to line-range references, and adds options to skip already-normalized files, stop on first failure, and fall back per-file when batch fails.

## Changes

### Core Changes

- `segment-io.ts` — rewritten batch API: `segmentChatlogs(inputs[]) → Map<filePath, Segment[] | null>`; switched from raw content to line-range extraction (`startLine`/`endLine`)
- `process-files.ts` — skip already-normalized files before dispatch; `--fail-fast` and `--single-file` fallback support
- `file-io.ts` — `reportResults` includes fallback count in output log
- `normalize-config.ts` — adds `--fail-fast` and `--single-file` flags
- `normalize.types.ts` — extends `NormalizeConfig` with `failFast`/`singleFile`; extends `Stats` with `fallback` field
- `normalize.constants.ts` — lowers `MAX_SEGMENTS` from 10 to 5
- `chatlog-error.constants.ts` — adds `FailFast` display label

### Test Updates

- `segment-io.unit.spec.ts` — updated for batch API, line-range segments, `MAX_SEGMENTS` cap, and fallback stats
- `process-files.unit.spec.ts` — added coverage for skip, fail-fast, and fallback
- `file-io.unit.spec.ts` — added `fallback: 0` to all `Stats` fixtures
- `normalize.functional.spec.ts` — updated mock data to batch format; fixed missing `filePath` variable; removed duplicate describe block
- Fixture and E2E specs — aligned to batch API and updated skip-behavior expectations

### Removed

- Single-file variant of `segmentChatlogs` (breaking change — see below)

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

**Breaking change:** `segmentChatlogs` signature changed from
`segmentChatlogs(filePath, content) → Segment[] | null` to
`segmentChatlogs(inputs: ChatlogInput[]) → Map<string, Segment[] | null>`.
Callers must pass an array and read results from the returned `Map`.
