### PR TITLE
refactor(test): use normalizePath for fixture path normalization across test files

### DIFF
--- a/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/divide-entry.fixtures.spec.ts
@@ -18,6 +18,7 @@ import { ChatlogError } from '../../ChatlogError.class.ts';
 
 // -- helpers --
 import { findFixtureDirs, type IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../libs/path-utils/path-utils.ts';
 // exists
 import { readTextFile } from '../../../libs/file-io/read-utils.ts';
 import { fileExists } from '../../../libs/file-ops/exists-utils.ts';
@@ -33,9 +34,7 @@ type _FixtureExpected =
   | { frontmatterText: string; content: string; error?: never }
   | { error: string; frontmatterText?: never; content?: never };
 
-const FIXTURES_DIR = new URL('./fixtures-data/divide-entry', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data/divide-entry', import.meta.url).pathname);
 
 const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
   return await fileExists(`${dir}/input.md`);

--- a/skills/_scripts/classes/__tests__/fixtures/render-entry.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/render-entry.fixtures.spec.ts
@@ -19,6 +19,7 @@ import { ChatlogEntry } from '../../ChatlogEntry.class.ts';
 
 // -- helpers --
 import { findFixtureDirs } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../libs/path-utils/path-utils.ts';
 // type
 import type { IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // file libs
@@ -39,9 +40,7 @@ type _FixtureExpected =
   | { expected: string; error?: never }
   | { error: string; expected?: never };
 
-const FIXTURES_DIR = new URL('./fixtures-data/render-entry', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data/render-entry', import.meta.url).pathname);
 
 async function _loadFixture(
   dir: string,

--- a/skills/_scripts/classes/__tests__/fixtures/to-frontmatter.fixtures.spec.ts
+++ b/skills/_scripts/classes/__tests__/fixtures/to-frontmatter.fixtures.spec.ts
@@ -15,6 +15,7 @@ import { parse as parseYaml } from '@std/yaml';
 
 // -- helpers --
 import { findFixtureDirs } from '../../../__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../libs/path-utils/path-utils.ts';
 // types
 import type { IsFixtureDirProvider } from '../../../__tests__/helpers/find-fixture-dirs.ts';
 // file libs
@@ -39,9 +40,7 @@ type _FixtureExpected =
   | { expected: string; error?: never }
   | { error: string; expected?: never };
 
-const FIXTURES_DIR = new URL('./fixtures-data/to-frontmatter', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data/to-frontmatter', import.meta.url).pathname);
 
 const _isFixtureDir: IsFixtureDirProvider = async (dir) => {
   return await fileExists(`${dir}/input.md`) && await fileExists(`${dir}/config.yaml`);

--- a/skills/classify-chatlogs/scripts/__tests__/system/main.system.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/system/main.system.spec.ts
@@ -8,7 +8,9 @@
 import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
-const SCRIPT_PATH = new URL('../../classify-chatlogs.ts', import.meta.url).pathname;
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
+
+const SCRIPT_PATH = normalizePath(new URL('../../classify-chatlogs.ts', import.meta.url).pathname);
 
 async function runClassify(args: string[]): Promise<number> {
   const _cmd = new Deno.Command(Deno.execPath(), {

--- a/skills/classify-chatlogs/scripts/__tests__/system/short.system.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/system/short.system.spec.ts
@@ -19,13 +19,13 @@ import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.t
 
 // constants
 /** テスト対象スクリプト `classify-chatlogs.ts` の絶対パス。サブプロセス起動時に使用する。 */
-const SCRIPT_PATH = new URL('../../classify-chatlogs.ts', import.meta.url).pathname;
+const SCRIPT_PATH = normalizePath(new URL('../../classify-chatlogs.ts', import.meta.url).pathname);
 
-/** システムテスト用フィクスチャディレクトリの絶対パス。Windows ドライブレター正規化済み。 */
-const FIXTURE_SYSTEM_DATA = new URL('./fixtures', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+/** システムテスト用フィクスチャディレクトリの絶対パス。 */
+const FIXTURE_SYSTEM_DATA = normalizePath(new URL('./fixtures', import.meta.url).pathname);
 
 /** システムテスト用辞書フィクスチャの絶対パス。GlobalConfig の dicsDir として使用する。 */
-const FIXTURE_DICS_DIR = new URL('./fixtures/assets/dics', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const FIXTURE_DICS_DIR = normalizePath(new URL('./fixtures/assets/dics', import.meta.url).pathname);
 
 /** `RUN_AI=1` 環境変数が設定されている場合に `true`。AI 呼び出しを伴うテストの実行制御に使用する。 */
 const _shouldRunAI = Deno.env.get('RUN_AI') === '1';

--- a/skills/classify-chatlogs/scripts/libs/__tests__/integration/load-project-dic.integration.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/integration/load-project-dic.integration.spec.ts
@@ -14,15 +14,15 @@ import { loadProjectDic } from '../../load-project-dic.ts';
 // classes
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 
+// ─── Helpers
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
+
 // ─── フィクスチャパス ──────────────────────────────────────────────────────────
 
 /**
  * 統合テスト用フィクスチャアセットのディレクトリパス。
- * Windows 環境で `/C:/...` → `C:/...` に正規化する。
  */
-const ASSETS_DIR = new URL('../../../modules/__tests__/integration/assets', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1'); // Windows: /C:/... → C:/...
+const ASSETS_DIR = normalizePath(new URL('../../../modules/__tests__/integration/assets', import.meta.url).pathname);
 
 // ─── loadProjectDic ───────────────────────────────────────────────────────────
 

--- a/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
@@ -20,11 +20,12 @@ import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class
 // constants
 import { DEFAULT_PROJECTS_DIC_PATH } from '../../../../../_scripts/constants/defaults.constants.ts';
 
+// ─── Helpers
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
+
 // ─── テスト用フィクスチャ ──────────────────────────────────────────────────────
 
-const _FIXTURE_DIC_PATH = new URL('../../../modules/__tests__/integration/assets/projects.dic', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const _FIXTURE_DIC_PATH = normalizePath(new URL('../../../modules/__tests__/integration/assets/projects.dic', import.meta.url).pathname);
 
 const _FIXTURE_TEXT_NO_MISC = `app1:\n  def: Test project 1\napp2:\n  def: Test project 2\n`;
 const _FIXTURE_TEXT_NON_STRING_PROP = `app1:\n  def: Test project 1\n  count: 5\n`;

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-classify-prompt.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-classify-prompt.fixtures.spec.ts
@@ -24,6 +24,7 @@ import {
   findFixtureDirs,
   type IsFixtureDirProvider,
 } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../../../../_scripts/libs/file-ops/find-files.ts';
@@ -32,9 +33,7 @@ import { loadProjectDic } from '../../../libs/load-project-dic.ts';
 // ─── Internal Helpers
 
 // constants
-const FIXTURES_DIR = new URL('./fixtures-data/build-classify-prompt', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data/build-classify-prompt', import.meta.url).pathname);
 
 // functions
 

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-system-prompt.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-system-prompt.fixtures.spec.ts
@@ -20,6 +20,7 @@ import {
   findFixtureDirs,
   type IsFixtureDirProvider,
 } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { loadProjectDic } from '../../../libs/load-project-dic.ts';
@@ -27,9 +28,7 @@ import { loadProjectDic } from '../../../libs/load-project-dic.ts';
 // ─── Internal Helpers
 
 // constants
-const FIXTURES_DIR = new URL('./fixtures-data/build-system-prompt', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data/build-system-prompt', import.meta.url).pathname);
 
 // functions
 

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
@@ -26,6 +26,7 @@ import {
   findFixtureDirs,
   type IsFixtureDirProvider,
 } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 // helpers
@@ -34,9 +35,7 @@ import { _makeEntry } from '../../../__tests__/_helpers/classify-test-helpers.ts
 // ─── Internal Helpers
 
 // constants
-const FIXTURES_DIR = new URL('./fixtures-data/pre-classify', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data/pre-classify', import.meta.url).pathname);
 
 // types
 interface _FixtureInput {

--- a/skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts
@@ -18,7 +18,8 @@ import { writeSession } from '../../libs/session-writer.ts';
 // ─── Helpers
 // types
 import type { ExportedSession } from '../../types/session.types.ts';
-// exists
+// functions
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 
@@ -97,7 +98,7 @@ describe('writeSession', () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
           // Windows パス対応
-          const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
+          const normalizedPath = normalizePath(outPath);
           assertEquals(await fileExists(normalizedPath), true);
         });
       });
@@ -159,7 +160,7 @@ describe('writeSession', () => {
         it('T-EC-WS-03-01: frontmatter の "session_id:" が含まれる', async () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
-          const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
+          const normalizedPath = normalizePath(outPath);
           const content = await readTextFile(normalizedPath);
           assertStringIncludes(content, 'session_id:');
         });
@@ -167,7 +168,7 @@ describe('writeSession', () => {
         it('T-EC-WS-03-02: "# What is TDD?" タイトル行が含まれる', async () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
-          const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
+          const normalizedPath = normalizePath(outPath);
           const content = await readTextFile(normalizedPath);
           assertStringIncludes(content, '# What is TDD?');
         });
@@ -175,7 +176,7 @@ describe('writeSession', () => {
         it('T-EC-WS-03-03: "### User" セクションが含まれる', async () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
-          const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
+          const normalizedPath = normalizePath(outPath);
           const content = await readTextFile(normalizedPath);
           assertStringIncludes(content, '### User');
         });
@@ -183,7 +184,7 @@ describe('writeSession', () => {
         it('T-EC-WS-03-04: "### Assistant" セクションが含まれる', async () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
-          const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
+          const normalizedPath = normalizePath(outPath);
           const content = await readTextFile(normalizedPath);
           assertStringIncludes(content, '### Assistant');
         });
@@ -213,7 +214,7 @@ describe('writeSession', () => {
           const session = _makeSession();
           const nestedBase = `${tempDir}/deep/nested/dir`;
           const outPath = await writeSession(nestedBase, 'codex', session);
-          const normalizedPath = outPath.replace(/^\/([A-Z]:)/, '$1');
+          const normalizedPath = normalizePath(outPath);
           assertEquals(await fileExists(normalizedPath), true);
         });
       });

--- a/skills/export-chatlogs/scripts/exporter/__tests__/fixtures/export.fixtures.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/fixtures/export.fixtures.spec.ts
@@ -22,6 +22,7 @@ import { parseCodexSession } from '../../codex-exporter.ts';
 
 // ─── Helpers
 import { findFixtureDirs } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 // types
 import type { IsFixtureDirProvider } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
 import type { PeriodRange } from '../../../types/filter.types.ts';
@@ -50,9 +51,7 @@ interface FixtureData {
 // constants
 const ALL_PERIOD: PeriodRange = parsePeriod(undefined);
 
-const FIXTURES_DIR = new URL('../fixtures-data', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const FIXTURES_DIR = normalizePath(new URL('../fixtures-data', import.meta.url).pathname);
 
 // functions
 /**  fixture ディレクトリチェック */

--- a/skills/filter-chatlogs/scripts/__tests__/fixtures/filter/fixtures.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/fixtures/filter/fixtures.spec.ts
@@ -20,6 +20,7 @@ import { parseAiJsonArray } from '../../../../../_scripts/libs/text/json-utils.t
 
 // ─── Helpers
 import { findFixtureDirs } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 
 // ─── Internal Helpers
@@ -32,15 +33,11 @@ const _SYSTEM_PROMPT = `Output ONLY a JSON array. No markdown, no explanation, n
 KEEP: design decisions, reusable patterns, new concepts, architecture discussion
 DISCARD: execution-only, trivial Q&A, no reusable insight, context-dependent`;
 
-/** fixtures-data/fixtures/mock の絶対パス（Windows パス正規化済み）。 */
-const MOCK_FIXTURES_DIR = new URL('./fixtures-data/fixtures/mock', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+/** fixtures-data/fixtures/mock の絶対パス。 */
+const MOCK_FIXTURES_DIR = normalizePath(new URL('./fixtures-data/fixtures/mock', import.meta.url).pathname);
 
-/** fixtures-data/fixtures/real の絶対パス（Windows パス正規化済み）。 */
-const REAL_FIXTURES_DIR = new URL('./fixtures-data/fixtures/real', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+/** fixtures-data/fixtures/real の絶対パス。 */
+const REAL_FIXTURES_DIR = normalizePath(new URL('./fixtures-data/fixtures/real', import.meta.url).pathname);
 
 /** `RUN_AI=1`: test with exec run AI */
 const _shouldRunAI = Deno.env.get('RUN_AI') === '1';

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
@@ -18,6 +18,7 @@ import { describe, it } from '@std/testing/bdd';
 // test helpers
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { findFixtureDirs } from '../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { collectOutputFiles } from './helpers/fixture-helpers.ts';
 
@@ -38,8 +39,7 @@ const FRONTMATTER_KEYS = ['title', 'summary'] as const;
 
 // ─── fixtures ルートパス ──────────────────────────────────────────────────────
 
-const RUNAI_FRONTMATTER_DIR = new URL('./fixtures-data/runai-frontmatter', import.meta.url).pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const RUNAI_FRONTMATTER_DIR = normalizePath(new URL('./fixtures-data/runai-frontmatter', import.meta.url).pathname);
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts
@@ -34,6 +34,7 @@ import {
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { DEFAULT_PROMPTS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import type { Dics, Prompts } from '../../types/dics.types.ts';
@@ -43,13 +44,9 @@ const _MAX_CONTENT_LENGTH = 4000;
 
 // ─── フィクスチャパス・辞書パス ───────────────────────────────────────────────
 
-const FIXTURES_DIR = new URL('./fixtures-data', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1'); // Windows: /C:/... → C:/...
+const FIXTURES_DIR = normalizePath(new URL('./fixtures-data', import.meta.url).pathname);
 
-const ASSETS_DICS_DIR = new URL('../../../../../../assets/dics', import.meta.url)
-  .pathname
-  .replace(/^\/([A-Z]:)/, '$1');
+const ASSETS_DICS_DIR = normalizePath(new URL('../../../../../../assets/dics', import.meta.url).pathname);
 
 // ─── 型定義 ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Overview

**Summary**
Replace inline URL pathname regex normalization with the shared `normalizePath` utility across test fixture files.

**Background / Motivation**
Several test files used an inline regex pattern to normalize paths from `URL.pathname`, which is error-prone on Windows (leading slash, backslashes). The shared utility `normalizePath` already handles this correctly. Using it consistently removes duplicated logic and aligns with the project rule against inline logic when an existing function exists.

## Changes

### Core Changes

None. This is a test-only refactor — no production code is modified.

### Test Updates

Replace the following pattern in 15 test/fixture spec files across 6 skill modules:

```typescript
// Before
const FIXTURES_DIR = new URL('../../fixtures', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');

// After
import { normalizePath } from '../../../../_scripts/libs/file-io/path-utils.ts';
const FIXTURES_DIR = normalizePath(new URL('../../fixtures', import.meta.url));
```

Affected modules: `_scripts/classes`, `classify-chatlogs`, `export-chatlogs`, `filter-chatlogs`, `normalize-chatlogs`, `set-frontmatter`

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes) — not applicable, test-only change
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

All 15 changed files are test or fixture spec files. No behavior change in production code.
