### PR TITLE
style(scripts): fix import formatting across fixture files

### DIFF
--- a/skills/_scripts/libs/cache/cache-utils.ts
+++ b/skills/_scripts/libs/cache/cache-utils.ts
@@ -48,8 +48,7 @@ export interface CacheWriteProviders {
  * @param filePath - エントリファイルの絶対パスまたは相対パス
  * @returns ファイル名部分のみの slug 文字列
  */
-export const getCacheSlug = (filePath: string): string =>
-  getFilename(filePath);
+export const getCacheSlug = (filePath: string): string => getFilename(filePath);
 
 /**
  * キャッシュファイルを読み込んで `T` のパーシャルオブジェクトを返す。

--- a/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
@@ -25,7 +25,9 @@ import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-util
 
 // ─── テスト用フィクスチャ ──────────────────────────────────────────────────────
 
-const _FIXTURE_DIC_PATH = normalizePath(new URL('../../../modules/__tests__/integration/assets/projects.dic', import.meta.url).pathname);
+const _FIXTURE_DIC_PATH = normalizePath(
+  new URL('../../../modules/__tests__/integration/assets/projects.dic', import.meta.url).pathname,
+);
 
 const _FIXTURE_TEXT_NO_MISC = `app1:\n  def: Test project 1\napp2:\n  def: Test project 2\n`;
 const _FIXTURE_TEXT_NON_STRING_PROP = `app1:\n  def: Test project 1\n  count: 5\n`;

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-classify-prompt.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-classify-prompt.fixtures.spec.ts
@@ -24,10 +24,10 @@ import {
   findFixtureDirs,
   type IsFixtureDirProvider,
 } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
-import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../../../../_scripts/libs/file-ops/find-files.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { loadProjectDic } from '../../../libs/load-project-dic.ts';
 
 // ─── Internal Helpers

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-system-prompt.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-system-prompt.fixtures.spec.ts
@@ -20,9 +20,9 @@ import {
   findFixtureDirs,
   type IsFixtureDirProvider,
 } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
-import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { loadProjectDic } from '../../../libs/load-project-dic.ts';
 
 // ─── Internal Helpers

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
@@ -26,9 +26,9 @@ import {
   findFixtureDirs,
   type IsFixtureDirProvider,
 } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
-import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
+import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 // helpers
 import { _makeEntry } from '../../../__tests__/_helpers/classify-test-helpers.ts';
 

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
@@ -18,8 +18,8 @@ import { describe, it } from '@std/testing/bdd';
 // test helpers
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { findFixtureDirs } from '../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
-import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { collectOutputFiles } from './helpers/fixture-helpers.ts';
 
 // test target

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts
@@ -34,9 +34,9 @@ import {
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { DEFAULT_PROMPTS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
-import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 import type { Dics, Prompts } from '../../types/dics.types.ts';
 
 const _enc = new TextEncoder();


### PR DESCRIPTION
## Overview

**Summary**
Reformats import statements and expressions in fixture and utility files to comply with dprint rules.

**Background / Motivation**
Minor formatting drift had accumulated in fixture spec files and a shared cache utility. This change
brings them in line with the project's dprint configuration (120-character line width) with no logic changes.

## Changes

### Core Changes

- `skills/_scripts/libs/cache/cache-utils.ts` — reformat `getCacheSlug` expression to fit within 120 chars.

### Test Updates

- `skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts`
- `skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-classify-prompt.fixtures.spec.ts`
- `skills/classify-chatlogs/scripts/modules/__tests__/fixtures/build-system-prompt.fixtures.spec.ts`
- `skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts`
- `skills/normalize-chatlog/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts`
- `skills/set-frontmatter/scripts/__tests__/fixtures/frontmatter.fixtures.spec.ts`

### Removed

N/A

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [x] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (`dprint fmt --check`)
- [x] Tests pass (`deno task test:unit`)
- [ ] Documentation updated (not applicable — formatting only)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Formatting-only pass. No logic changes. Safe to merge once CI is green.
