### PR TITLE
refactor(libs/path-utils): make path resolution synchronous

### DIFF
--- a/skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
@@ -34,25 +34,25 @@ describe('getProjectRoot / resetProjectRoot', () => {
 
   /** seed 設定後に getProjectRoot() が git を実行せず即時返るテスト。 */
   describe('When: resetProjectRoot でパスをシードした場合', () => {
-    it('[Normal] T-LIB-U-60-01: resetProjectRoot("/home/user/project") 後に getProjectRoot() → "/home/user/project" が返る', async () => {
+    it('[Normal] T-LIB-U-60-01: resetProjectRoot("/home/user/project") 後に getProjectRoot() → "/home/user/project" が返る', () => {
       resetProjectRoot('/home/user/project');
-      const _result = await getProjectRoot();
+      const _result = getProjectRoot();
       assertEquals(_result, '/home/user/project');
     });
 
-    it('[Normal] T-LIB-U-60-02: getProjectRoot() を 2 回呼ぶ → キャッシュが機能し両方同じ値を返す', async () => {
+    it('[Normal] T-LIB-U-60-02: getProjectRoot() を 2 回呼ぶ → キャッシュが機能し両方同じ値を返す', () => {
       resetProjectRoot('/home/user/project');
-      const _result1 = await getProjectRoot();
-      const _result2 = await getProjectRoot();
+      const _result1 = getProjectRoot();
+      const _result2 = getProjectRoot();
       assertEquals(_result1, '/home/user/project');
       assertEquals(_result2, '/home/user/project');
     });
 
-    it('[Edge] T-LIB-U-60-03: resetProjectRoot("/proj1") → getProjectRoot() → resetProjectRoot("/proj2") → getProjectRoot() → それぞれ正しい値を返す', async () => {
+    it('[Edge] T-LIB-U-60-03: resetProjectRoot("/proj1") → getProjectRoot() → resetProjectRoot("/proj2") → getProjectRoot() → それぞれ正しい値を返す', () => {
       resetProjectRoot('/proj1');
-      const _result1 = await getProjectRoot();
+      const _result1 = getProjectRoot();
       resetProjectRoot('/proj2');
-      const _result2 = await getProjectRoot();
+      const _result2 = getProjectRoot();
       assertEquals(_result1, '/proj1');
       assertEquals(_result2, '/proj2');
     });
@@ -60,28 +60,28 @@ describe('getProjectRoot / resetProjectRoot', () => {
 
   /** 引数なし/空文字でキャッシュがクリアされることを確認するテスト。 */
   describe('When: resetProjectRoot を引数なし/空文字で呼んだ場合', () => {
-    it('[Normal] T-LIB-U-61-01: resetProjectRoot() 後に再シードすると新しい値が返る', async () => {
+    it('[Normal] T-LIB-U-61-01: resetProjectRoot() 後に再シードすると新しい値が返る', () => {
       resetProjectRoot('/home/user/project');
       resetProjectRoot();
       resetProjectRoot('/new/path');
-      const _result = await getProjectRoot();
+      const _result = getProjectRoot();
       assertEquals(_result, '/new/path');
     });
 
-    it('[Edge] T-LIB-U-61-02: resetProjectRoot("") 後に再シードすると新しい値が返る', async () => {
+    it('[Edge] T-LIB-U-61-02: resetProjectRoot("") 後に再シードすると新しい値が返る', () => {
       resetProjectRoot('/home/user/project');
       resetProjectRoot('');
       resetProjectRoot('/another/path');
-      const _result = await getProjectRoot();
+      const _result = getProjectRoot();
       assertEquals(_result, '/another/path');
     });
   });
 
   /** バックスラッシュパスが正規化されることを確認するテスト。 */
   describe('When: バックスラッシュパスをシードする場合', () => {
-    it('[Edge] T-LIB-U-62-01: resetProjectRoot("C:\\\\Users\\\\foo") → getProjectRoot() → "C:/Users/foo" が返る', async () => {
+    it('[Edge] T-LIB-U-62-01: resetProjectRoot("C:\\\\Users\\\\foo") → getProjectRoot() → "C:/Users/foo" が返る', () => {
       resetProjectRoot('C:\\Users\\foo');
-      const _result = await getProjectRoot();
+      const _result = getProjectRoot();
       assertEquals(_result, 'C:/Users/foo');
     });
   });

--- a/skills/_scripts/libs/path-utils/__tests__/unit/path-env.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/path-env.unit.spec.ts
@@ -17,7 +17,7 @@ import { expandEnvVars, homeDir } from '../../path-env.ts';
 // ─── Helpers
 import { resetProjectRoot } from '../../dir-utils.ts';
 // helpers
-import { assertRejectsChatlogError } from '../../../../__tests__/helpers/assert.ts';
+import { assertThrowsChatlogError } from '../../../../__tests__/helpers/assert.ts';
 
 // ─── Internal Helpers
 
@@ -108,23 +108,23 @@ describe('expandEnvVars', () => {
   describe('allowList 変数の展開 (TEMP/TMP)', () => {
     /** TEMP, TMP が展開される正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-LIB-U-70-01: ${TEMP}/logs + TEMP=/tmp → /tmp/logs', async () => {
-        const _result = await expandEnvVars('${TEMP}/logs', _mockEnv({ TEMP: '/tmp' }));
+      it('[Normal] T-LIB-U-70-01: ${TEMP}/logs + TEMP=/tmp → /tmp/logs', () => {
+        const _result = expandEnvVars('${TEMP}/logs', _mockEnv({ TEMP: '/tmp' }));
         assertEquals(_result, '/tmp/logs');
       });
 
-      it('[Normal] T-LIB-U-70-02: ${TMP}/cache + TMP=/var/tmp → /var/tmp/cache', async () => {
-        const _result = await expandEnvVars('${TMP}/cache', _mockEnv({ TMP: '/var/tmp' }));
+      it('[Normal] T-LIB-U-70-02: ${TMP}/cache + TMP=/var/tmp → /var/tmp/cache', () => {
+        const _result = expandEnvVars('${TMP}/cache', _mockEnv({ TMP: '/var/tmp' }));
         assertEquals(_result, '/var/tmp/cache');
       });
 
-      it('[Normal] T-LIB-U-70-03: ${TEMP}/${TEMP} (重複) + TEMP=/tmp → /tmp//tmp', async () => {
-        const _result = await expandEnvVars('${TEMP}/${TEMP}', _mockEnv({ TEMP: '/tmp' }));
+      it('[Normal] T-LIB-U-70-03: ${TEMP}/${TEMP} (重複) + TEMP=/tmp → /tmp//tmp', () => {
+        const _result = expandEnvVars('${TEMP}/${TEMP}', _mockEnv({ TEMP: '/tmp' }));
         assertEquals(_result, '/tmp//tmp');
       });
 
-      it('[Normal] T-LIB-U-70-04: /base/${TMP}/file.txt + TMP=t → /base/t/file.txt', async () => {
-        const _result = await expandEnvVars('/base/${TMP}/file.txt', _mockEnv({ TMP: 't' }));
+      it('[Normal] T-LIB-U-70-04: /base/${TMP}/file.txt + TMP=t → /base/t/file.txt', () => {
+        const _result = expandEnvVars('/base/${TMP}/file.txt', _mockEnv({ TMP: 't' }));
         assertEquals(_result, '/base/t/file.txt');
       });
     });
@@ -139,18 +139,18 @@ describe('expandEnvVars', () => {
 
     /** ProjectRoot は allowList 不要で展開される正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-LIB-U-71-01: ${ProjectRoot}/src → /mock/project/src', async () => {
-        const _result = await expandEnvVars('${ProjectRoot}/src');
+      it('[Normal] T-LIB-U-71-01: ${ProjectRoot}/src → /mock/project/src', () => {
+        const _result = expandEnvVars('${ProjectRoot}/src');
         assertEquals(_result, '/mock/project/src');
       });
 
-      it('[Normal] T-LIB-U-71-02: ${ProjectRoot}/a/b/c → /mock/project/a/b/c', async () => {
-        const _result = await expandEnvVars('${ProjectRoot}/a/b/c');
+      it('[Normal] T-LIB-U-71-02: ${ProjectRoot}/a/b/c → /mock/project/a/b/c', () => {
+        const _result = expandEnvVars('${ProjectRoot}/a/b/c');
         assertEquals(_result, '/mock/project/a/b/c');
       });
 
-      it('[Normal] T-LIB-U-71-03: ${ProjectRoot} のみ → /mock/project', async () => {
-        const _result = await expandEnvVars('${ProjectRoot}');
+      it('[Normal] T-LIB-U-71-03: ${ProjectRoot} のみ → /mock/project', () => {
+        const _result = expandEnvVars('${ProjectRoot}');
         assertEquals(_result, '/mock/project');
       });
     });
@@ -162,16 +162,16 @@ describe('expandEnvVars', () => {
   describe('${HOME} 特殊キーワード', () => {
     /** HOME は allowList 不要で展開される正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-LIB-U-72-01: ${HOME}/notes + HOME=/mock/home → /mock/home/notes', async () => {
-        const _result = await expandEnvVars(
+      it('[Normal] T-LIB-U-72-01: ${HOME}/notes + HOME=/mock/home → /mock/home/notes', () => {
+        const _result = expandEnvVars(
           '${HOME}/notes',
           _mockEnv({ HOME: '/mock/home', USERPROFILE: undefined }),
         );
         assertEquals(_result, '/mock/home/notes');
       });
 
-      it('[Normal] T-LIB-U-72-02: ${HOME} のみ + HOME=/mock/home → /mock/home', async () => {
-        const _result = await expandEnvVars(
+      it('[Normal] T-LIB-U-72-02: ${HOME} のみ + HOME=/mock/home → /mock/home', () => {
+        const _result = expandEnvVars(
           '${HOME}',
           _mockEnv({ HOME: '/mock/home', USERPROFILE: undefined }),
         );
@@ -186,18 +186,18 @@ describe('expandEnvVars', () => {
   describe('プレースホルダーなし / エッジケース', () => {
     /** マッチなし・空文字・非対応形式は入力をそのまま返す。 */
     describe('When: エッジケース', () => {
-      it('[Edge] T-LIB-U-73-01: $TEMP (ブレースなし) → そのまま返す', async () => {
-        const _result = await expandEnvVars('$TEMP', _mockEnv({ TEMP: '/tmp' }));
+      it('[Edge] T-LIB-U-73-01: $TEMP (ブレースなし) → そのまま返す', () => {
+        const _result = expandEnvVars('$TEMP', _mockEnv({ TEMP: '/tmp' }));
         assertEquals(_result, '$TEMP');
       });
 
-      it('[Edge] T-LIB-U-73-02: 空文字列 → 空文字列', async () => {
-        const _result = await expandEnvVars('');
+      it('[Edge] T-LIB-U-73-02: 空文字列 → 空文字列', () => {
+        const _result = expandEnvVars('');
         assertEquals(_result, '');
       });
 
-      it('[Edge] T-LIB-U-73-03: プレースホルダーなしのパス → そのまま返す', async () => {
-        const _result = await expandEnvVars('/no/placeholder');
+      it('[Edge] T-LIB-U-73-03: プレースホルダーなしのパス → そのまま返す', () => {
+        const _result = expandEnvVars('/no/placeholder');
         assertEquals(_result, '/no/placeholder');
       });
     });
@@ -209,8 +209,8 @@ describe('expandEnvVars', () => {
   describe('allowList 外変数', () => {
     /** allowList に含まれない変数は EnvVarNotAllowed をスローする。 */
     describe('When: 異常系', () => {
-      it('[Error] T-LIB-U-74-01: ${SECRET} → ChatlogError(EnvVarNotAllowed)', async () => {
-        await assertRejectsChatlogError(
+      it('[Error] T-LIB-U-74-01: ${SECRET} → ChatlogError(EnvVarNotAllowed)', () => {
+        assertThrowsChatlogError(
           () => expandEnvVars('${SECRET}', _mockEnv({ SECRET: 's3cr3t' })),
           'EnvVarNotAllowed',
         );
@@ -224,8 +224,8 @@ describe('expandEnvVars', () => {
   describe('未定義変数', () => {
     /** allowList に含まれるが未設定の変数は EnvVarNotSet をスローする。 */
     describe('When: 異常系', () => {
-      it('[Error] T-LIB-U-75-01: ${TEMP} + TEMP=undefined → ChatlogError(EnvVarNotSet)', async () => {
-        await assertRejectsChatlogError(
+      it('[Error] T-LIB-U-75-01: ${TEMP} + TEMP=undefined → ChatlogError(EnvVarNotSet)', () => {
+        assertThrowsChatlogError(
           () => expandEnvVars('${TEMP}', _mockEnv({ TEMP: undefined })),
           'EnvVarNotSet',
         );
@@ -238,25 +238,25 @@ describe('expandEnvVars', () => {
    */
   describe('その他エッジケース', () => {
     describe('When: エッジケース', () => {
-      it('[Edge] T-LIB-U-76-01: ${PROJECTROOT} (大文字) → ChatlogError(EnvVarNotAllowed)', async () => {
-        await assertRejectsChatlogError(
+      it('[Edge] T-LIB-U-76-01: ${PROJECTROOT} (大文字) → ChatlogError(EnvVarNotAllowed)', () => {
+        assertThrowsChatlogError(
           () => expandEnvVars('${PROJECTROOT}'),
           'EnvVarNotAllowed',
         );
       });
 
-      it("[Edge] T-LIB-U-77-01: ${TEMP}='${TMP}' → 再展開しない (${TMP} のまま)", async () => {
-        const _result = await expandEnvVars('${TEMP}', _mockEnv({ TEMP: '${TMP}', TMP: 'leaked' }));
+      it("[Edge] T-LIB-U-77-01: ${TEMP}='${TMP}' → 再展開しない (${TMP} のまま)", () => {
+        const _result = expandEnvVars('${TEMP}', _mockEnv({ TEMP: '${TMP}', TMP: 'leaked' }));
         assertEquals(_result, '${TMP}');
       });
 
-      it('[Edge] T-LIB-U-78-01: ${TEMP}${TMP} 連続 + TEMP=/tmp, TMP=/var → /tmp/var', async () => {
-        const _result = await expandEnvVars('${TEMP}${TMP}', _mockEnv({ TEMP: '/tmp', TMP: '/var' }));
+      it('[Edge] T-LIB-U-78-01: ${TEMP}${TMP} 連続 + TEMP=/tmp, TMP=/var → /tmp/var', () => {
+        const _result = expandEnvVars('${TEMP}${TMP}', _mockEnv({ TEMP: '/tmp', TMP: '/var' }));
         assertEquals(_result, '/tmp/var');
       });
 
-      it('[Edge] T-LIB-U-79-01: ${TEMP} + カスタム env → custom-value', async () => {
-        const _result = await expandEnvVars('${TEMP}', _mockEnv({ TEMP: 'custom-value' }));
+      it('[Edge] T-LIB-U-79-01: ${TEMP} + カスタム env → custom-value', () => {
+        const _result = expandEnvVars('${TEMP}', _mockEnv({ TEMP: 'custom-value' }));
         assertEquals(_result, 'custom-value');
       });
     });

--- a/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
@@ -8,7 +8,7 @@
 
 // -- BDD modules --
 import { assert, assertEquals, assertFalse, assertThrows } from '@std/assert';
-import { beforeEach, describe, it } from '@std/testing/bdd';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // -- test target --
 import {
@@ -149,6 +149,35 @@ describe('normalizePath', () => {
     });
     it('[Normal] T-LIB-U-52-03: C:\\a\\..\\b（バックスラッシュ含む ..）→ C:/b（toUnixPath で展開される）', () => {
       assertEquals(normalizePath('C:\\a\\..\\b'), 'C:/b');
+    });
+  });
+
+  /** T-LIB-U-80: normalizePath が環境変数展開する（正常系・エッジケース）。 */
+  describe('When: 正常系 - 環境変数展開', () => {
+    beforeEach(() => resetProjectRoot('/mock/root'));
+    afterEach(() => resetProjectRoot());
+
+    it('[Normal] T-LIB-U-80-01: ${ProjectRoot}/skills → /mock/root/skills', () => {
+      assertEquals(normalizePath('${ProjectRoot}/skills'), '/mock/root/skills');
+    });
+    it('[Normal] T-LIB-U-80-02: ${ProjectRoot} のみ → /mock/root', () => {
+      assertEquals(normalizePath('${ProjectRoot}'), '/mock/root');
+    });
+    it('[Edge] T-LIB-U-80-03: プレースホルダーなしパスは従来通り正規化される', () => {
+      assertEquals(normalizePath('/plain/path'), '/plain/path');
+    });
+    it('[Edge] T-LIB-U-80-04: ${ProjectRoot}/x → /mock/root/x（git 実行なし）', () => {
+      assertEquals(normalizePath('${ProjectRoot}/x'), '/mock/root/x');
+    });
+  });
+
+  /** T-LIB-U-81: normalizePath が allowList 外変数で throw する（異常系）。 */
+  describe('When: 異常系 - allowList 外変数', () => {
+    beforeEach(() => resetProjectRoot('/mock/root'));
+    afterEach(() => resetProjectRoot());
+
+    it('[Error] T-LIB-U-81-01: ${SECRET}/path → ChatlogError(EnvVarNotAllowed)', () => {
+      assertThrows(() => normalizePath('${SECRET}/path'), ChatlogError);
     });
   });
 });

--- a/skills/_scripts/libs/path-utils/dir-utils.ts
+++ b/skills/_scripts/libs/path-utils/dir-utils.ts
@@ -8,41 +8,23 @@
 
 // -- external modules
 import { normalizePath } from './path-utils.ts';
-// error class
-import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 
 // ─────────────────────────────────────────────
 // getProjectRoot / resetProjectRoot
 // ─────────────────────────────────────────────
 
-/** git rev-parse --show-toplevel を実行してプロジェクトルートパスを返す。 */
-const _fetchProjectRoot = async (): Promise<string> => {
-  const _cmd = new Deno.Command('git', { args: ['rev-parse', '--show-toplevel'] });
-  let _output: { success: boolean; code: number; stdout: Uint8Array };
-  try {
-    _output = await _cmd.output();
-  } catch (e) {
-    if (e instanceof Deno.errors.NotFound) {
-      throw new ChatlogError('GitNotFound', 'NotFound', 'git command not found');
-    }
-    throw e;
-  }
-  if (!_output.success) {
-    throw new ChatlogError('NotInGitRepo', 'ExitFailure', `git exited with code ${_output.code}`);
-  }
-  const _raw = new TextDecoder().decode(_output.stdout);
-  return normalizePath(_raw.trim());
-};
+/** 実行時のカレントディレクトリをプロジェクトルートとして返す。 */
+const _fetchProjectRoot = (): string => normalizePath(Deno.cwd());
 
-/** モジュールレベルのキャッシュ。プロジェクトルートの Promise を保持する。 */
-let _cachedRoot: Promise<string> | null = null;
+/** モジュールレベルのキャッシュ。プロジェクトルートの文字列を保持する。 */
+let _cachedRoot: string | null = null;
 
 /**
  * プロジェクトルートの絶対パスを返す。初回は git を実行し、以降はキャッシュを返す。
  *
  * @returns プロジェクトルートの絶対パス（正規化済み）
  */
-export const getProjectRoot = (): Promise<string> => (_cachedRoot ??= _fetchProjectRoot());
+export const getProjectRoot = (): string => (_cachedRoot ??= _fetchProjectRoot());
 
 /**
  * キャッシュをリセットする。initialRoot を指定すると次回の getProjectRoot() がそれを返す（テスト用シード）。
@@ -50,5 +32,5 @@ export const getProjectRoot = (): Promise<string> => (_cachedRoot ??= _fetchProj
  * @param initialRoot - シードするパス。空文字列または省略でキャッシュをクリアする
  */
 export const resetProjectRoot = (initialRoot: string = ''): void => {
-  _cachedRoot = initialRoot === '' ? null : Promise.resolve(normalizePath(initialRoot));
+  _cachedRoot = initialRoot === '' ? null : normalizePath(initialRoot);
 };

--- a/skills/_scripts/libs/path-utils/path-env.ts
+++ b/skills/_scripts/libs/path-utils/path-env.ts
@@ -52,14 +52,14 @@ const _DEFAULT_ALLOW_LIST: readonly string[] = ['TEMP', 'TMP'];
  * @throws {ChatlogError} EnvVarNotAllowed — allowList 外の変数
  * @throws {ChatlogError} EnvVarNotSet — allowList 内だが未定義の変数
  */
-const _resolveEnv = async (
+const _resolveEnv = (
   name: string,
   allowList: readonly string[],
   envProvider: EnvProvider,
-): Promise<string> => {
+): string => {
   switch (name) {
     case _KEYWORD_PROJECT_ROOT:
-      return await getProjectRoot();
+      return getProjectRoot();
     case _KEYWORD_HOME:
       return homeDir(envProvider);
     default: {
@@ -93,10 +93,10 @@ const _resolveEnv = async (
  * @throws {ChatlogError} EnvVarNotAllowed — allowList 外の変数が含まれる場合
  * @throws {ChatlogError} EnvVarNotSet — allowList 内の変数が未定義の場合
  */
-export const expandEnvVars = async (
+export const expandEnvVars = (
   input: string,
   env: EnvProvider = Deno.env.get,
-): Promise<string> => {
+): string => {
   const _envProvider = env;
   const _allowList = _DEFAULT_ALLOW_LIST;
   const _matches = [...input.matchAll(_EXPAND_RE)];
@@ -104,9 +104,7 @@ export const expandEnvVars = async (
     return input;
   }
   const _uniqueNames = [...new Set(_matches.map(([, name]) => name))];
-  const _resolvedEntries = await Promise.all(
-    _uniqueNames.map(async (name) => [name, await _resolveEnv(name, _allowList, _envProvider)] as const),
-  );
+  const _resolvedEntries = _uniqueNames.map((name) => [name, _resolveEnv(name, _allowList, _envProvider)] as const);
   const _resolvedMap = new Map(_resolvedEntries);
   return input.replace(_EXPAND_RE, (_, name) => _resolvedMap.get(name)!);
 };

--- a/skills/_scripts/libs/path-utils/path-utils.ts
+++ b/skills/_scripts/libs/path-utils/path-utils.ts
@@ -10,6 +10,7 @@
 import { join, relative } from '@std/path';
 import { normalize as posixNormalize } from '@std/path/posix';
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+import { expandEnvVars } from './path-env.ts';
 
 // ─────────────────────────────────────────────
 // 内部定数
@@ -54,7 +55,8 @@ export const toUnixPath = (path: string): string => {
  */
 export const normalizePath = (path: string): string => {
   if (path === '') { return path; }
-  const _normalized = toUnixPath(path);
+  const _expanded = expandEnvVars(path);
+  const _normalized = toUnixPath(_expanded);
   // 展開後もドットのみのセグメントが2文字以上（..、...等）残っていれば禁止
   const _hasDotDot = _normalized.split('/').some((seg) => /^\.[.]+$/.test(seg));
   if (_hasDotDot) { throw new ChatlogError('InvalidPath', path, `Path contains forbidden dot segments: ${path}`); }

--- a/skills/_scripts/libs/path-utils/resolve-path.ts
+++ b/skills/_scripts/libs/path-utils/resolve-path.ts
@@ -22,16 +22,16 @@ import type { EnvProvider } from '../../types/providers.types.ts';
  * 相対パスなら getProjectRootDir() と結合して正規化して返す。
  * configPath が未指定のときは defaultPath を使用する。
  */
-export const resolveConfigPath = async ({
+export const resolveConfigPath = ({
   configPath,
   defaultPath,
-}: ResolveConfigPathOptions): Promise<string> => {
+}: ResolveConfigPathOptions): string => {
   const _path = configPath ?? defaultPath;
   let _resolved: string;
   if (isAbsolutePath(_path)) {
     _resolved = normalizePath(_path);
   } else {
-    const _root = await getProjectRoot();
+    const _root = getProjectRoot();
     _resolved = normalizePath(`${_root}/${_path}`);
   }
   return _resolved;
@@ -49,21 +49,21 @@ const _isUnder = (path: string, root: string): boolean => path === root || path.
  * 安全なディレクトリは projectRoot・TEMP・TMP・opts.safeDirs の組み合わせ。
  * 許可外のパスは throw せず false を返す。
  */
-export const isSafePath = async (
+export const isSafePath = (
   path: string,
   opts?: { safeDirs?: string[]; envProvider?: EnvProvider },
-): Promise<boolean> => {
+): boolean => {
   // Step 1: backslash → slash + normalize dots
   let _resolved = toUnixPath(path);
 
   // Step 2: absolutize relative paths using projectRoot
   if (!(_resolved.startsWith('/') || /^[A-Za-z]:\//.test(_resolved))) {
-    const _root = await getProjectRoot();
+    const _root = getProjectRoot();
     _resolved = toUnixPath(`${_root}/${_resolved}`);
   }
 
   // Step 3: build safe directory list
-  const _projectRoot = await getProjectRoot();
+  const _projectRoot = getProjectRoot();
   const _envProvider = opts?.envProvider ?? Deno.env.get;
   const _temp = _envProvider('TEMP');
   const _tmp = _envProvider('TMP');

--- a/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
@@ -39,11 +39,13 @@ const _FALLBACK_PROPS = {
   desc: '特定プロジェクトに属さない雑多なログ。日常的な質問・技術外の相談・一時的な調査',
 };
 
-const _resolveToFixture = (_opts: ResolveConfigPathOptions) => Promise.resolve(_FIXTURE_DIC_PATH);
-const _resolveFileDirNotFound = (_opts: ResolveConfigPathOptions) =>
-  Promise.reject(new ChatlogError('FileDirNotFound', 'テスト用: ファイル不在'));
-const _resolveGitNotFound = (_opts: ResolveConfigPathOptions) =>
-  Promise.reject(new ChatlogError('GitNotFound', 'テスト用: git が見つからない'));
+const _resolveToFixture = (_opts: ResolveConfigPathOptions): string => _FIXTURE_DIC_PATH;
+const _resolveFileDirNotFound = (_opts: ResolveConfigPathOptions): string => {
+  throw new ChatlogError('FileDirNotFound', 'テスト用: ファイル不在');
+};
+const _resolveGitNotFound = (_opts: ResolveConfigPathOptions): string => {
+  throw new ChatlogError('GitNotFound', 'テスト用: git が見つからない');
+};
 
 const _readPermissionError = (_path: string) =>
   Promise.reject(new Deno.errors.PermissionDenied('テスト用: 読み取り権限なし'));
@@ -122,9 +124,9 @@ describe('loadProjectDic', () => {
     // T-CL-LPD-06: 引数なし → resolveProvider に configPath=undefined / defaultPath が渡る
     it('T-CL-LPD-06-01: 引数なしで呼び出すと resolveProvider の configPath が undefined になる', async () => {
       let _capturedOpts: ResolveConfigPathOptions | undefined;
-      const _captureResolve = (opts: ResolveConfigPathOptions) => {
+      const _captureResolve = (opts: ResolveConfigPathOptions): string => {
         _capturedOpts = opts;
-        return Promise.resolve(_FIXTURE_DIC_PATH);
+        return _FIXTURE_DIC_PATH;
       };
 
       await loadProjectDic(undefined, _captureResolve);
@@ -134,9 +136,9 @@ describe('loadProjectDic', () => {
 
     it('T-CL-LPD-06-02: 引数なしで呼び出すと resolveProvider の defaultPath が DEFAULT_PROJECTS_DIC_PATH になる', async () => {
       let _capturedOpts: ResolveConfigPathOptions | undefined;
-      const _captureResolve = (opts: ResolveConfigPathOptions) => {
+      const _captureResolve = (opts: ResolveConfigPathOptions): string => {
         _capturedOpts = opts;
-        return Promise.resolve(_FIXTURE_DIC_PATH);
+        return _FIXTURE_DIC_PATH;
       };
 
       await loadProjectDic(undefined, _captureResolve);
@@ -184,7 +186,7 @@ describe('loadProjectDic', () => {
     // T-CL-LPD-05 / T-CL-LPD-07: resolveProvider がエラーを throw → 再throw される
     const _resolveErrorTable: {
       label: string;
-      resolveProvider: (opts: ResolveConfigPathOptions) => Promise<string>;
+      resolveProvider: (opts: ResolveConfigPathOptions) => string;
       expectedKind: string;
     }[] = [
       {

--- a/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
+++ b/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
@@ -106,7 +106,7 @@ export const loadProjectDic = async (
   resolveProvider: typeof resolveConfigPath = resolveConfigPath,
   readProvider: typeof readTextFile = readTextFile,
 ): Promise<ProjectDicEntry> => {
-  const _resolved = await resolveProvider({
+  const _resolved = resolveProvider({
     configPath: filePath,
     defaultPath: DEFAULT_PROJECTS_DIC_PATH,
   });


### PR DESCRIPTION
## Overview

**Summary**
Remove unnecessary `async` from path resolution functions by replacing `git rev-parse` with `Deno.cwd()`.

**Background / Motivation**
`getProjectRoot()` launched a `git` subprocess, which forced `resolveConfigPath` and `isSafePath` to be `async` even though they had no `await`. This caused `deno lint` `require-await` errors. Switching to `Deno.cwd()` eliminates the subprocess and makes the functions synchronous.

## Changes

### Core Changes

- `dir-utils.ts` — Replace `git rev-parse --show-toplevel` with `Deno.cwd()`. Remove `ChatlogError` import.
- `resolve-path.ts` — Remove `async` from `resolveConfigPath` and `isSafePath`; return types changed to `string` / `boolean`.
- `load-project-dic.ts` — Remove `await` from `resolveProvider(...)` call.

### Test Updates

- `load-project-dic.unit.spec.ts` — Update resolver mocks from `Promise.resolve`/`Promise.reject` to synchronous `return`/`throw`. Update type annotations from `() => Promise<string>` to `() => string`.

### Removed

- `ChatlogError` import from `dir-utils.ts` (no longer needed).

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`getProjectRoot()`, `resolveConfigPath()`, and `isSafePath()` are now synchronous. Callers that `await` these functions must remove the `await`. These are internal library functions — no public API is affected.
