### PR TITLE
feat(path-utils): add env provider parameter to normalizePath

### DIFF
--- a/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
@@ -180,6 +180,42 @@ describe('normalizePath', () => {
       assertThrows(() => normalizePath('${SECRET}/path'), ChatlogError);
     });
   });
+
+  /**
+   * `normalizePath` の `env` 引数渡しテスト。
+   *
+   * カスタム `env` を渡すことで環境変数の展開をテスト可能にする。
+   */
+  describe('When: env 引数あり', () => {
+    it('[Normal] T-LIB-U-82-01: カスタム env で ${TEMP} が展開される', () => {
+      const _mockEnv = (key: string): string | undefined => key === 'TEMP' ? '/custom/tmp' : undefined;
+      assertEquals(normalizePath('${TEMP}/foo', _mockEnv), '/custom/tmp/foo');
+    });
+
+    it('[Normal] T-LIB-U-82-02: カスタム env で ${HOME} が展開される', () => {
+      const _mockEnv = (key: string): string | undefined => key === 'HOME' ? '/custom/home' : undefined;
+      assertEquals(normalizePath('${HOME}/notes', _mockEnv), '/custom/home/notes');
+    });
+
+    it('[Error] T-LIB-U-82-03: カスタム env でも allowList 外変数は ChatlogError をスローする', () => {
+      const _mockEnv = (key: string): string | undefined => key === 'SECRET' ? 's3cr3t' : undefined;
+      const _err = assertThrows(() => normalizePath('${SECRET}/path', _mockEnv), ChatlogError);
+      assertEquals(_err.kind, 'EnvVarNotAllowed');
+    });
+
+    it('[Error] T-LIB-U-82-04: カスタム env で TEMP が undefined → ChatlogError(EnvVarNotSet)', () => {
+      const _mockEnv = (_key: string): string | undefined => undefined;
+      const _err = assertThrows(() => normalizePath('${TEMP}/x', _mockEnv), ChatlogError);
+      assertEquals(_err.kind, 'EnvVarNotSet');
+    });
+
+    it('[Edge] T-LIB-U-82-05: カスタム env は ${ProjectRoot} 展開に影響しない', () => {
+      resetProjectRoot('/mock/root');
+      const _mockEnv = (key: string): string | undefined => key === 'ProjectRoot' ? '/injected' : undefined;
+      assertEquals(normalizePath('${ProjectRoot}/x', _mockEnv), '/mock/root/x');
+      resetProjectRoot('');
+    });
+  });
 });
 
 // ─────────────────────────────────────────────

--- a/skills/_scripts/libs/path-utils/path-env.ts
+++ b/skills/_scripts/libs/path-utils/path-env.ts
@@ -95,9 +95,9 @@ const _resolveEnv = (
  */
 export const expandEnvVars = (
   input: string,
-  env: EnvProvider = Deno.env.get,
+  env?: EnvProvider,
 ): string => {
-  const _envProvider = env;
+  const _envProvider = env ?? Deno.env.get;
   const _allowList = _DEFAULT_ALLOW_LIST;
   const _matches = [...input.matchAll(_EXPAND_RE)];
   if (_matches.length === 0) {

--- a/skills/_scripts/libs/path-utils/path-utils.ts
+++ b/skills/_scripts/libs/path-utils/path-utils.ts
@@ -10,6 +10,7 @@
 import { join, relative } from '@std/path';
 import { normalize as posixNormalize } from '@std/path/posix';
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+import type { EnvProvider } from '../../types/providers.types.ts';
 import { expandEnvVars } from './path-env.ts';
 
 // ─────────────────────────────────────────────
@@ -53,9 +54,9 @@ export const toUnixPath = (path: string): string => {
  * `C:\a\..\b` のように展開可能な `..` は `toUnixPath` で `C:/b` に解決されてエラーにならない。
  * `../foo` のような先頭の不可約な `..` は展開後も残るためエラーになる。
  */
-export const normalizePath = (path: string): string => {
+export const normalizePath = (path: string, env?: EnvProvider): string => {
   if (path === '') { return path; }
-  const _expanded = expandEnvVars(path);
+  const _expanded = expandEnvVars(path, env);
   const _normalized = toUnixPath(_expanded);
   // 展開後もドットのみのセグメントが2文字以上（..、...等）残っていれば禁止
   const _hasDotDot = _normalized.split('/').some((seg) => /^\.[.]+$/.test(seg));


### PR DESCRIPTION
## Overview

**Summary**
Adds an optional `env` parameter to `normalizePath` to support dependency injection of environment variables.

**Background / Motivation**
`normalizePath` relied on `Deno.env.get` directly, making it impossible to control environment values in unit tests. Adding an `EnvProvider` parameter enables deterministic testing without touching the real process environment.

## Changes

### Core Changes

- `skills/_scripts/libs/path-utils/path-utils.ts` — add optional `env: EnvProvider` parameter to `normalizePath`; forward it to `expandEnvVars`
- `skills/_scripts/libs/path-utils/path-env.ts` — make `env` argument of `expandEnvVars` optional; fall back to `Deno.env.get` internally

### Test Updates

- `skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts` — add tests for custom env injection (TEMP/HOME expansion, `allowList` rejection, unset variable, `ProjectRoot` unaffected)

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`EnvProvider` was already defined in the project. This PR completes the dependency-injection chain by wiring it through `normalizePath`. The parameter is optional, so all existing call sites remain unaffected.
