### PR TITLE
feat(aplys): add classes test target and flat file finder

### DIFF
--- a/scripts/__tests__/unit/aplys-tester.unit.spec.ts
+++ b/scripts/__tests__/unit/aplys-tester.unit.spec.ts
@@ -276,6 +276,16 @@ describe('buildBaseGlob', () => {
       });
     });
   });
+
+  describe('Given: moduleName が "classes"', () => {
+    describe('When: buildBaseGlob("classes") を呼び出す', () => {
+      describe('Then: T-AT-BG-08 - classes 用の特殊パスを返す', () => {
+        it('T-AT-BG-08-01: 戻り値が "**/_scripts/classes/**/__tests__" である', () => {
+          assertEquals(buildBaseGlob('classes'), '**/_scripts/classes/**/__tests__');
+        });
+      });
+    });
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -309,6 +319,9 @@ describe('MODULE_GLOB_TABLE', () => {
         });
         it('T-AT-GT-08: "set" エントリが "**/set-frontmatter/**/__tests__" である', () => {
           assertEquals(MODULE_GLOB_TABLE['set'], '**/set-frontmatter/**/__tests__');
+        });
+        it('T-AT-GT-09: "classes" エントリが "**/_scripts/classes/**/__tests__" である', () => {
+          assertEquals(MODULE_GLOB_TABLE['classes'], '**/_scripts/classes/**/__tests__');
         });
       });
     });

--- a/scripts/aplys-tester.ts
+++ b/scripts/aplys-tester.ts
@@ -34,6 +34,7 @@ const _SPECIAL_GLOB_TABLE = {
   'all': '**/__tests__',
   'libs': '**/_scripts/**/__tests__',
   'scripts': 'scripts/**/__tests__',
+  'classes': '**/_scripts/classes/**/__tests__',
 } as const;
 
 // スキルモジュール: 短縮名 → フルモジュール名

--- a/skills/_scripts/libs/file-ops/__tests__/unit/find-files.unit.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/unit/find-files.unit.spec.ts
@@ -12,7 +12,7 @@ import { describe, it } from '@std/testing/bdd';
 
 // -- test target --
 import type { GlobProvider } from '../../../../types/providers.types.ts';
-import { findFiles } from '../../find-files.ts';
+import { findFiles, findFilesFlat } from '../../find-files.ts';
 
 // ─────────────────────────────────────────────
 // ヘルパー
@@ -237,6 +237,44 @@ describe('findFiles', () => {
 
           assert(_result.every((p) => p.endsWith('.txt')));
         });
+      });
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // T-LIB-FF-09〜11: findFilesFlat（1段のみ探索）
+  // ─────────────────────────────────────────────
+
+  describe('findFilesFlat', () => {
+    describe('When: 正常系', () => {
+      it('[Normal] T-LIB-FF-09: dir 直下の .json ファイル一覧を返す', async () => {
+        const _glob: GlobProvider = (pattern) =>
+          pattern.endsWith('/*.json')
+            ? Promise.resolve(['/cache/a.json', '/cache/b.json'])
+            : Promise.resolve([]);
+        const _result = await findFilesFlat('/cache', { ext: '.json', glob: _glob });
+        assertEquals(_result, ['/cache/a.json', '/cache/b.json']);
+      });
+
+      it('[Normal] T-LIB-FF-10: ext 省略時はデフォルト ".md" で glob を呼ぶ', async () => {
+        let _called = '';
+        const _glob: GlobProvider = (pattern) => {
+          _called = pattern;
+          return Promise.resolve([]);
+        };
+        await findFilesFlat('/dir', { glob: _glob });
+        assertEquals(_called, '/dir/*.md');
+      });
+    });
+
+    describe('When: エッジケース', () => {
+      it('[Edge] T-LIB-FF-11: サブディレクトリは探索せず dir 直下のみ返す', async () => {
+        const _glob: GlobProvider = (pattern) =>
+          pattern.endsWith('/*.md')
+            ? Promise.resolve(['/root/a.md'])
+            : Promise.resolve(['/root/sub']);
+        const _result = await findFilesFlat('/root', { glob: _glob });
+        assertEquals(_result, ['/root/a.md']);
       });
     });
   });

--- a/skills/_scripts/libs/file-ops/find-files.ts
+++ b/skills/_scripts/libs/file-ops/find-files.ts
@@ -36,9 +36,28 @@ const _defaultGlob: GlobProvider = async (pattern: string): Promise<string[]> =>
   return _results;
 };
 
-/** `dir` 直下の `ext` ファイルパス一覧を返す。 */
+/** `dir` 直下の `ext` ファイルパス一覧を返す（内部実装）。 */
 const _findFileFlats = async (dir: string, ext: string, glob: GlobProvider): Promise<string[]> => {
   return await glob(`${dir}/*${ext}`);
+};
+
+/**
+ * `dir` 直下の `ext` ファイルパス一覧を返す（1段のみ、サブディレクトリ非再帰）。
+ *
+ * @param dir - 探索対象ディレクトリパス
+ * @param options - `ext`（デフォルト `".md"`）、`glob` プロバイダー
+ * @throws Error `ext` がドット始まりでない場合
+ */
+export const findFilesFlat = async (
+  dir: string,
+  options?: FindFilesOptions,
+): Promise<string[]> => {
+  const _ext = options?.ext ?? '.md';
+  if (!_ext.startsWith('.')) {
+    throw new Error(`ext must start with '.': "${_ext}"`);
+  }
+  const _glob = options?.glob ?? _defaultGlob;
+  return await _findFileFlats(dir, _ext, _glob);
 };
 
 /**


### PR DESCRIPTION
## Overview

**Summary**
Adds `classes` as a valid test target to the aplys test runner and introduces `findFilesFlat` as a shared flat file finder utility.

**Background / Motivation**
`deno task test:module unit classes` failed because `classes` was not registered in `_SPECIAL_GLOB_TABLE`. This PR adds the missing entry and introduces `findFilesFlat` — a non-recursive file finder with default-extension handling — to support the new glob resolution.

## Changes

### Core Changes

- `scripts/aplys-tester.ts` — add `classes` entry to `_SPECIAL_GLOB_TABLE` with glob `**/_scripts/classes/**/__tests__`
- `skills/_scripts/libs/file-ops/find-files.ts` — add `findFilesFlat` with default extension handling and injectable glob provider

### Test Updates

- `scripts/__tests__/unit/aplys-tester.unit.spec.ts` — add assertions for `buildBaseGlob('classes')` and `MODULE_GLOB_TABLE['classes']`
- `skills/_scripts/libs/file-ops/__tests__/unit/find-files.unit.spec.ts` — add unit tests for `findFilesFlat` covering matched files, default extensions, and non-recursive behavior

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`findFilesFlat` is placed in the shared `file-ops` library for reuse by other modules that need single-directory file listing.
