### PR TITLE
refactor(set-frontmatter): rename target dir to output dir

### DIFF
--- a/skills/_scripts/constants/defaults.constants.ts
+++ b/skills/_scripts/constants/defaults.constants.ts
@@ -31,8 +31,8 @@ export const DEFAULT_CHATLOGS_DIR = './chatlogs';
 /** normalize-chatlogs が出力するセグメントのデフォルトベースディレクトリ。 */
 export const DEFAULT_NORMALIZE_DIR = './chatlogs/normalizelogs';
 
-/** set-frontmatter が処理対象とするデフォルトのターゲットディレクトリ。 */
-export const DEFAULT_TARGET_DIR = './chatlogs/outputLogs';
+/** set-frontmatter が出力するデフォルトディレクトリ。 */
+export const DEFAULT_OUTPUT_DIR = './outputLogs';
 
 /** 辞書ファイルが置かれたデフォルトディレクトリ。 */
 export const DEFAULT_DICS_DIR = './assets/dics';

--- a/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -83,7 +83,7 @@ async function _makeTargetDir(content?: string): Promise<string> {
 
 describe('main - dry-run モード', () => {
   describe('Given: 1件の .md ファイルと dry-run フラグ', () => {
-    describe('When: main(["--input-dir", dir, "--target-dir", outDir, "--dry-run", ...]) を呼び出す', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--dry-run", ...]) を呼び出す', () => {
       describe('Then: T-SF-E2E-01 - ファイルが変更されない', () => {
         let inputDir: string;
         let outputDir: string;
@@ -127,7 +127,7 @@ describe('main - dry-run モード', () => {
           await main([
             '--input-dir',
             inputDir,
-            '--target-dir',
+            '--output-dir',
             outputDir,
             '--dry-run',
             '--no-review',
@@ -143,7 +143,7 @@ describe('main - dry-run モード', () => {
           await main([
             '--input-dir',
             inputDir,
-            '--target-dir',
+            '--output-dir',
             outputDir,
             '--dry-run',
             '--no-review',
@@ -158,7 +158,7 @@ describe('main - dry-run モード', () => {
           await main([
             '--input-dir',
             inputDir,
-            '--target-dir',
+            '--output-dir',
             outputDir,
             '--dry-run',
             '--no-review',
@@ -177,7 +177,7 @@ describe('main - dry-run モード', () => {
 
 describe('main - --no-review モード', () => {
   describe('Given: 1件の .md ファイルと --no-review フラグ', () => {
-    describe('When: main(["--input-dir", dir, "--target-dir", outDir, "--no-review", ...]) を呼び出す', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", ...]) を呼び出す', () => {
       describe('Then: T-SF-E2E-02 - Phase 3.5 スキップのログが出力される', () => {
         let inputDir: string;
         let outputDir: string;
@@ -208,7 +208,7 @@ describe('main - --no-review モード', () => {
           await main([
             '--input-dir',
             inputDir,
-            '--target-dir',
+            '--output-dir',
             outputDir,
             '--dry-run',
             '--no-review',
@@ -232,7 +232,7 @@ describe('main - --no-review モード', () => {
 
 describe('main - yaml 生成失敗', () => {
   describe('Given: Claude CLI がすべて成功するが yaml が空になるモック', () => {
-    describe('When: main(["--input-dir", dir, "--target-dir", outDir, "--no-review", ...]) を呼び出す', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", ...]) を呼び出す', () => {
       describe('Then: T-SF-E2E-05 - fail=1 のサマリーが出力される', () => {
         let inputDir: string;
         let outputDir: string;
@@ -261,7 +261,7 @@ describe('main - yaml 生成失敗', () => {
         });
 
         it('T-SF-E2E-05-01: "fail=1" がサマリーに出力される', async () => {
-          await main(['--input-dir', inputDir, '--target-dir', outputDir, '--no-review', '--dics', dicsDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir, '--no-review', '--dics', dicsDir]);
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('fail=1')), true);
         });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
@@ -63,82 +63,105 @@ describe('buildConfig', () => {
   });
 
   /**
-   * `targetDir` 未指定のとき `joinPath(chatlogsDir, 'outputLogs')` が使われることを検証する。
+   * `outputDir` 未指定のとき `joinPath(chatlogsDir, 'outputLogs')` が使われることを検証する。
    */
-  describe('When: targetDir が未指定', () => {
-    it('[Normal] T-SF-BC-01-01: targetDir undefined → joinPath(chatlogsDir, outputLogs) が使われる', () => {
+  describe('When: outputDir が未指定', () => {
+    it('[Normal] T-SF-BC-01-01: outputDir undefined → joinPath(chatlogsDir, outputLogs) が使われる', () => {
       const result = buildConfig({}, globalConfig);
-      assertEquals(result.targetDir, joinPath(DEFAULT_CHATLOGS_DIR, 'outputLogs'));
+      assertEquals(result.outputDir, joinPath(DEFAULT_CHATLOGS_DIR, 'outputLogs'));
     });
 
-    it('[Edge] T-SF-BC-01-02: targetDir 空文字列 → joinPath(chatlogsDir, outputLogs) が使われる', () => {
-      const result = buildConfig({ targetDir: '' }, globalConfig);
-      assertEquals(result.targetDir, joinPath(DEFAULT_CHATLOGS_DIR, 'outputLogs'));
+    it('[Edge] T-SF-BC-01-02: outputDir 空文字列 → joinPath(chatlogsDir, outputLogs) が使われる', () => {
+      const result = buildConfig({ outputDir: '' }, globalConfig);
+      assertEquals(result.outputDir, joinPath(DEFAULT_CHATLOGS_DIR, 'outputLogs'));
     });
 
-    it('[Normal] T-SF-BC-01-03: GlobalConfig.chatlogsDir=./custom → targetDir=joinPath(./custom, outputLogs)', async () => {
+    it('[Normal] T-SF-BC-01-03: GlobalConfig.chatlogsDir=./custom → outputDir=joinPath(./custom, outputLogs)', async () => {
       const gc = await _makeGlobalConfig('chatlogsDir: ./custom');
       const result = buildConfig({}, gc);
-      assertEquals(result.targetDir, joinPath('./custom', 'outputLogs'));
+      assertEquals(result.outputDir, joinPath('./custom', 'outputLogs'));
     });
   });
 
   /**
-   * `targetDir` が指定されているとき SetfmConfig が正しく構築されることを検証する。
+   * `outputDir` が指定されているとき SetfmConfig が正しく構築されることを検証する。
    */
-  describe('When: targetDir が指定されている', () => {
+  describe('When: outputDir が指定されている', () => {
     /** デフォルト値が適用される正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-SF-BC-02-01: targetDir が設定される', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
-        assertEquals(result.targetDir, '/target');
+      it('[Normal] T-SF-BC-02-01: outputDir が設定される', () => {
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
+        assertEquals(result.outputDir, '/target');
       });
 
       it('[Normal] T-SF-BC-02-02: dicsDir のデフォルトは ./assets/dics', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
         assertEquals(result.dicsDir, './assets/dics');
       });
 
       it('[Normal] T-SF-BC-02-03: dryRun のデフォルトは false', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
         assertEquals(result.dryRun, false);
       });
 
       it('[Normal] T-SF-BC-02-04: review のデフォルトは true（--review 未指定）', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
         assertEquals(result.review, true);
       });
 
       it('[Normal] T-SF-BC-02-05: concurrency は GlobalConfig から取得される', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
         assertEquals(result.concurrency, 4);
       });
 
       it('[Normal] T-SF-BC-06-01: chunkSize のデフォルトは 10', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
         assertEquals(result.chunkSize, DEFAULT_CHUNK_SIZE);
+      });
+    });
+
+    /**
+     * `outputDir` の絶対パス・相対パス判定テスト。
+     *
+     * 絶対パスはそのまま使用し、相対パスは chatlogsDir と join する。
+     */
+    describe('When: outputDir の絶対パス・相対パス判定', () => {
+      it('[Normal] T-SF-BC-09-01: 絶対パス指定 → そのまま使われる', () => {
+        const result = buildConfig({ outputDir: '/abs/output' }, globalConfig);
+        assertEquals(result.outputDir, '/abs/output');
+      });
+
+      it('[Normal] T-SF-BC-09-02: 相対パス指定 → joinPath(chatlogsDir, outputDir) が使われる', () => {
+        const result = buildConfig({ outputDir: './rel/output' }, globalConfig);
+        assertEquals(result.outputDir, joinPath(DEFAULT_CHATLOGS_DIR, './rel/output'));
+      });
+
+      it('[Normal] T-SF-BC-09-03: 相対パス + GlobalConfig.chatlogsDir=./custom → joinPath(./custom, outputDir)', async () => {
+        const gc = await _makeGlobalConfig('chatlogsDir: ./custom');
+        const result = buildConfig({ outputDir: 'myout' }, gc);
+        assertEquals(result.outputDir, joinPath('./custom', 'myout'));
       });
     });
 
     /** 各フィールドを明示的に指定したケース。 */
     describe('When: 各フィールドを指定', () => {
       it('[Normal] T-SF-BC-03-01: parsed.dicsDir が使用される', () => {
-        const result = buildConfig({ targetDir: '/target', dicsDir: '/custom/dics' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target', dicsDir: '/custom/dics' }, globalConfig);
         assertEquals(result.dicsDir, '/custom/dics');
       });
 
       it('[Normal] T-SF-BC-03-02: dryRun=true が設定される', () => {
-        const result = buildConfig({ targetDir: '/target', dryRun: true }, globalConfig);
+        const result = buildConfig({ outputDir: '/target', dryRun: true }, globalConfig);
         assertEquals(result.dryRun, true);
       });
 
       it('[Normal] T-SF-BC-03-03: review=false → result.review=false になる', () => {
-        const result = buildConfig({ targetDir: '/target', review: false }, globalConfig);
+        const result = buildConfig({ outputDir: '/target', review: false }, globalConfig);
         assertEquals(result.review, false);
       });
 
       it('[Normal] T-SF-BC-06-02: parsed.chunkSize=5 → result.chunkSize=5 になる', () => {
-        const result = buildConfig({ targetDir: '/target', chunkSize: 5 }, globalConfig);
+        const result = buildConfig({ outputDir: '/target', chunkSize: 5 }, globalConfig);
         assertEquals(result.chunkSize, 5);
       });
     });
@@ -185,12 +208,12 @@ describe('buildConfig', () => {
     /** promptsDir 未指定でデフォルト値が使われる正常ケース。 */
     describe('When: 正常系', () => {
       it('[Normal] T-SFP-01-01: 引数なし + GlobalConfig 未設定 → DEFAULT_PROMPTS_DIR が使われる', () => {
-        const result = buildConfig({ targetDir: '/target' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target' }, globalConfig);
         assertEquals(result.promptsDir, DEFAULT_PROMPTS_DIR);
       });
 
       it('[Normal] T-SFP-02-01: parsed.promptsDir 指定 → その値が使われる', () => {
-        const result = buildConfig({ targetDir: '/target', promptsDir: './custom/prompts' }, globalConfig);
+        const result = buildConfig({ outputDir: '/target', promptsDir: './custom/prompts' }, globalConfig);
         assertEquals(result.promptsDir, './custom/prompts');
       });
     });
@@ -200,7 +223,7 @@ describe('buildConfig', () => {
       it('[Edge] T-SFP-03-01: GlobalConfig に promptsDir 設定済み → GlobalConfig の値が使われる', async () => {
         const gc = await _makeGlobalConfig('promptsDir: ./gc/prompts');
 
-        const result = buildConfig({ targetDir: '/target' }, gc);
+        const result = buildConfig({ outputDir: '/target' }, gc);
 
         assertEquals(result.promptsDir, './gc/prompts');
       });
@@ -208,7 +231,7 @@ describe('buildConfig', () => {
       it('[Edge] T-SFP-03-02: parsed.promptsDir が GlobalConfig より優先される', async () => {
         const gc = await _makeGlobalConfig('promptsDir: ./gc/prompts');
 
-        const result = buildConfig({ targetDir: '/target', promptsDir: './parsed/prompts' }, gc);
+        const result = buildConfig({ outputDir: '/target', promptsDir: './parsed/prompts' }, gc);
 
         assertEquals(result.promptsDir, './parsed/prompts');
       });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/parse-args.unit.spec.ts
@@ -24,7 +24,7 @@ import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class
 type ParsedResult = ReturnType<typeof parseArgs>;
 
 // constants
-const _TARGET = '--target-dir';
+const _TARGET = '--output-dir';
 const _PATH = '/path/to/dir';
 
 // ─── Tests
@@ -32,7 +32,7 @@ const _PATH = '/path/to/dir';
 /**
  * `parseArgs` のユニットテストスイート。
  *
- * CLI 引数の解析: `--target-dir`・`--dics`・`--dry-run`・`--review`・`--config` オプション。
+ * CLI 引数の解析: `--output-dir`・`--dics`・`--dry-run`・`--review`・`--config` オプション。
  *
  * テスト ID 範囲: T-SF-PA-01 〜 T-SF-PA-11
  *
@@ -42,16 +42,16 @@ describe('parseArgs', () => {
   // ─── T-SF-PA-01: デフォルト値 ────────────────────────────────────────────────
 
   /**
-   * `--target-dir` のみ指定した場合のデフォルト値テスト。
+   * `--output-dir` のみ指定した場合のデフォルト値テスト。
    *
    * 省略可能なオプションが未指定のとき undefined になることを検証する。
    */
-  describe('Given: 最小引数 ["--target-dir", "/path/to/dir"]', () => {
-    describe('When: parseArgs(["--target-dir", "/path/to/dir"]) を呼び出す', () => {
-      /** `--target-dir` のみ指定した場合の各フィールドのデフォルト値。 */
+  describe('Given: 最小引数 ["--output-dir", "/path/to/dir"]', () => {
+    describe('When: parseArgs(["--output-dir", "/path/to/dir"]) を呼び出す', () => {
+      /** `--output-dir` のみ指定した場合の各フィールドのデフォルト値。 */
       describe('Then: T-SF-PA-01 - デフォルト値が適用される', () => {
         const _defaultCases: { id: string; field: keyof ParsedResult; expected: unknown }[] = [
-          { id: 'T-SF-PA-01-01', field: 'targetDir', expected: _PATH },
+          { id: 'T-SF-PA-01-01', field: 'outputDir', expected: _PATH },
           { id: 'T-SF-PA-01-02', field: 'dicsDir', expected: undefined },
           { id: 'T-SF-PA-01-03', field: 'dryRun', expected: undefined },
           { id: 'T-SF-PA-01-04', field: 'review', expected: undefined },
@@ -93,7 +93,7 @@ describe('parseArgs', () => {
 
   it('T-SF-PA-09-01: 全フィールドが正しく解析される', () => {
     const result = parseArgs([_TARGET, _PATH, '--dry-run', '--review', '--dics', '/dics', '--config', 'cfg.yaml']);
-    assertEquals(result.targetDir, _PATH);
+    assertEquals(result.outputDir, _PATH);
     assertEquals(result.dryRun, true);
     assertEquals(result.review, true);
     assertEquals(result.dicsDir, '/dics');

--- a/skills/set-frontmatter/scripts/modules/setfm-config.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-config.ts
@@ -12,7 +12,7 @@
 // ─── Shared scripts
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
-import { joinPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
+import { isAbsolutePath, joinPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // constants
 import {
   DEFAULT_CHATLOGS_DIR,
@@ -30,7 +30,7 @@ import type { ParsedConfig, SetfmConfig } from '../types/args.types.ts';
 /** set-frontmatter の引数スキーマ。 */
 const _SCHEMA: ArgsSchema = [
   { option: '--input-dir', field: 'inputDir', type: 'directory' },
-  { option: '--target-dir', field: 'targetDir', type: 'directory' },
+  { option: '--output-dir', field: 'outputDir', type: 'directory' },
   { option: '--dics', field: 'dicsDir', type: 'directory' },
   { option: '--prompts', field: 'promptsDir', type: 'directory' },
   { option: '--dry-run', field: 'dryRun', type: 'flag' },
@@ -47,7 +47,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な SetfmConfig を構築する。
  * - inputDir 優先順位: `parsed.inputDir` > `join(chatlogsDir, 'normalizelogs')`
- * - targetDir 優先順位: `parsed.targetDir` > `join(chatlogsDir, 'outputLogs')`
+ * - outputDir: 絶対パスならそのまま使用、相対パスなら `join(chatlogsDir, outputDir)`、未指定なら `join(chatlogsDir, 'outputLogs')`
  * - chatlogsDir: `globalConfig.get('chatlogsDir')` > `DEFAULT_CHATLOGS_DIR`
  * - dicsDir 優先順位: `parsed.dicsDir` > `globalConfig.get('dicsDir')` > `DEFAULT_DICS_DIR`
  * - promptsDir 優先順位: `parsed.promptsDir` > `globalConfig.get('promptsDir')` > `DEFAULT_PROMPTS_DIR`
@@ -61,7 +61,9 @@ export const buildConfig = (
 ): SetfmConfig => {
   const _chatlogsDir = (globalConfig.get('chatlogsDir') as string | undefined) ?? DEFAULT_CHATLOGS_DIR;
   const _inputDir = parsed.inputDir || joinPath(_chatlogsDir, 'normalizelogs');
-  const _targetDir = parsed.targetDir || joinPath(_chatlogsDir, 'outputLogs');
+  const _outputDir = parsed.outputDir
+    ? (isAbsolutePath(parsed.outputDir) ? parsed.outputDir : joinPath(_chatlogsDir, parsed.outputDir))
+    : joinPath(_chatlogsDir, 'outputLogs');
   const _dicsDir = parsed.dicsDir ?? (globalConfig.get('dicsDir') as string | undefined) ?? DEFAULT_DICS_DIR;
   const _promptsDir = parsed.promptsDir ?? (globalConfig.get('promptsDir') as string | undefined)
     ?? DEFAULT_PROMPTS_DIR;
@@ -72,7 +74,7 @@ export const buildConfig = (
   const _cacheDir = parsed.cacheDir ?? joinPath(Deno.env.get('TEMP') ?? '.', 'setfm-cache');
   return {
     inputDir: _inputDir,
-    targetDir: _targetDir,
+    outputDir: _outputDir,
     dicsDir: _dicsDir,
     promptsDir: _promptsDir,
     dryRun: _dryRun,

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -11,7 +11,7 @@
  * set_frontmatter.ts — チャットログMarkdownにAI生成フロントマターを並列付加する
  *
  * 使い方:
- *   deno run --allow-read --allow-run --allow-write set_frontmatter.ts --target-dir <dir> [--dry-run] [--review] [--no-review] [--dics DIR] [--config FILE]
+ *   deno run --allow-read --allow-run --allow-write set_frontmatter.ts --output-dir <dir> [--dry-run] [--review] [--no-review] [--dics DIR] [--config FILE]
  *
  * 処理フロー:
  *   Phase 1: ファイル列挙・メタ読み込み
@@ -176,7 +176,7 @@ export const main = async (args: string[]): Promise<void> => {
         stats.fail++;
         continue;
       }
-      await writeFrontmatter(entry, _config.targetDir, _config.inputDir, _config.dryRun, stats);
+      await writeFrontmatter(entry, _config.outputDir, _config.inputDir, _config.dryRun, stats);
     }
 
     logger.info(

--- a/skills/set-frontmatter/scripts/types/args.types.ts
+++ b/skills/set-frontmatter/scripts/types/args.types.ts
@@ -17,7 +17,7 @@ export interface SetfmConfig {
   /** チャットログを読み込む入力ディレクトリのパス。 */
   inputDir: string;
   /** フロントマター付きファイルの書き込み先ディレクトリのパス。 */
-  targetDir: string;
+  outputDir: string;
   /** 辞書ファイルが置かれたディレクトリのパス。 */
   dicsDir: string;
   /** プロンプトファイルが置かれたディレクトリのパス。 */


### PR DESCRIPTION
## Overview

**Summary**
Renames `--target-dir` CLI option and `targetDir` config field to `--output-dir` / `outputDir` in the `set-frontmatter` skill.

**Background / Motivation**
The name "target dir" was ambiguous. "Output dir" clearly describes what the option does — it specifies where processed files are written. This change also aligns the option name with the shared constant `DEFAULT_OUTPUT_DIR` and simplifies the default path.

## Changes

### Core Changes

- `skills/_scripts/constants/defaults.constants.ts` — rename `DEFAULT_TARGET_DIR` to `DEFAULT_OUTPUT_DIR`; simplify default value from `./chatlogs/outputLogs` to `./outputLogs`
- `skills/set-frontmatter/scripts/types/args.types.ts` — rename `targetDir` to `outputDir`
- `skills/set-frontmatter/scripts/modules/setfm-config.ts` — change CLI option from `--target-dir` to `--output-dir`; add path resolution (relative paths are joined with `chatlogsDir`)
- `skills/set-frontmatter/scripts/set-frontmatter.ts` — update call site from `_config.targetDir` to `_config.outputDir`

### Test Updates

- `parse-args.unit.spec.ts` — update option names and expected field names
- `build-config.unit.spec.ts` — replace `targetDir` with `outputDir`; add absolute/relative path resolution cases
- `main.e2e.spec.ts` — replace `--target-dir` with `--output-dir` in all E2E cases

### Removed

- `--target-dir` CLI option (replaced by `--output-dir`)
- `SetfmArgs.targetDir` field (replaced by `outputDir`)
- `DEFAULT_TARGET_DIR` constant (replaced by `DEFAULT_OUTPUT_DIR`)

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

**Breaking change:** `--target-dir` is removed. Callers must switch to `--output-dir`.

The default output path changed from `./chatlogs/outputLogs` to `./outputLogs`. Workflows relying on the old default should pass `--output-dir chatlogs/outputLogs` explicitly.
