### PR TITLE
test(set-frontmatter): expand unit test coverage for edge cases

### DIFF
--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
@@ -143,6 +143,29 @@ describe('buildConfig', () => {
       });
     });
 
+    /**
+     * `dicsDir` の優先順位テスト。
+     *
+     * 優先順位: parsed.dicsDir > GlobalConfig.dicsDir > DEFAULT_DICS_DIR
+     */
+    describe('When: dicsDir の優先順位', () => {
+      it('[Edge] T-SF-BC-08-01: GlobalConfig に dicsDir 設定済み → GlobalConfig の値が使われる', async () => {
+        const gc = await _makeGlobalConfig('dicsDir: ./gc/dics');
+
+        const result = buildConfig({ outputDir: '/target' }, gc);
+
+        assertEquals(result.dicsDir, './gc/dics');
+      });
+
+      it('[Edge] T-SF-BC-08-02: parsed.dicsDir が GlobalConfig より優先される', async () => {
+        const gc = await _makeGlobalConfig('dicsDir: ./gc/dics');
+
+        const result = buildConfig({ outputDir: '/target', dicsDir: './parsed/dics' }, gc);
+
+        assertEquals(result.dicsDir, './parsed/dics');
+      });
+    });
+
     /** 各フィールドを明示的に指定したケース。 */
     describe('When: 各フィールドを指定', () => {
       it('[Normal] T-SF-BC-03-01: parsed.dicsDir が使用される', () => {

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -269,8 +269,54 @@ describe('judgeTypeAndCategory', () => {
 
   /**
    * AI 出力の type や category が無効キーのとき、フォールバック値がセットされることを検証する。
+   * type のみ・category のみ・逆順の返却パターンも含む。
    */
   describe('When: エッジケース', () => {
+    it(
+      '[Edge] T-SF-TC-16: AI が "type: research" のみ（category なし）を返す → type=research, category=development（デフォルト）',
+      async () => {
+        commandHandle = installCommandMock(
+          makeSuccessMock(_enc.encode('type: research')),
+        );
+
+        const _entry = _makeChatlogEntry('# テスト\n本文');
+        await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts());
+
+        assertEquals(_entry.frontmatter.get('type') as string, 'research');
+        assertEquals(_entry.frontmatter.get('category') as string, 'development'); // DEFAULT_FALLBACK_CATEGORY
+      },
+    );
+
+    it(
+      '[Edge] T-SF-TC-17: AI が "category: development" のみ（type なし）を返す → type=research（デフォルト）, category=development',
+      async () => {
+        commandHandle = installCommandMock(
+          makeSuccessMock(_enc.encode('category: development')),
+        );
+
+        const _entry = _makeChatlogEntry('# テスト\n本文');
+        await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts());
+
+        assertEquals(_entry.frontmatter.get('type') as string, 'research'); // DEFAULT_FALLBACK_TYPE
+        assertEquals(_entry.frontmatter.get('category') as string, 'development');
+      },
+    );
+
+    it(
+      '[Edge] T-SF-TC-18: AI が逆順 "category: development\\ntype: research" を返す → 両方正しくセットされる',
+      async () => {
+        commandHandle = installCommandMock(
+          makeSuccessMock(_enc.encode('category: development\ntype: research')),
+        );
+
+        const _entry = _makeChatlogEntry('# テスト\n本文');
+        await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts());
+
+        assertEquals(_entry.frontmatter.get('type') as string, 'research');
+        assertEquals(_entry.frontmatter.get('category') as string, 'development');
+      },
+    );
+
     it(
       '[Edge] T-SF-TC-12: 不正な type キー → フォールバック type がセットされる',
       async () => {

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -140,8 +140,33 @@ describe('reviewFrontmatter', () => {
 
   /**
    * `runAI` が `fail` かつ corrected フィールドを含むとき entry.frontmatter が更新されることを検証する。
+   * また validity キーなし・errors 複数件のエッジケースも検証する。
    */
   describe('When: エッジケース', () => {
+    it('[Edge] T-SF-RV-05-01: runAI が validity: キーなしの YAML を返す → デフォルト pass → { validity: pass, errors: [] }', async () => {
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('type: research\ncategory: ai\n')),
+      );
+
+      const _entry = _makeChatlogEntry();
+      const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts);
+
+      assertEquals(result, { validity: 'pass', errors: [] });
+    });
+
+    it('[Edge] T-SF-RV-06-01: runAI が validity: fail + errors 2件を返す → errors に2件が含まれる', async () => {
+      commandHandle = installCommandMock(
+        makeSuccessMock(
+          _enc.encode('validity: fail\nerrors:\n  - wrong type\n  - wrong category\n'),
+        ),
+      );
+
+      const _entry = _makeChatlogEntry();
+      const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts);
+
+      assertEquals(result, { validity: 'fail', errors: ['wrong type', 'wrong category'] });
+    });
+
     it('[Edge] T-SF-RV-04-01: runAI が fail かつ corrected type: tech を含む → entry.frontmatter.get(type) が tech に更新される', async () => {
       commandHandle = installCommandMock(
         makeSuccessMock(


### PR DESCRIPTION
## Overview

**Summary**
Adds unit tests for edge cases in `build-config`, `judge-type-category`, and `setfm-review`.

**Background / Motivation**
The `set-frontmatter` module lacked tests for partial AI output and config priority ordering.
These gaps left real-world failure modes unverified — AI responses can be incomplete or out of order.

## Changes

### Core Changes

None. Test-only additions.

### Test Updates

- `build-config.unit.spec.ts` — Verifies that `parsed.dicsDir` takes priority over `GlobalConfig.dicsDir`.
- `judge-type-category.unit.spec.ts` — Covers partial AI classification: type-only, category-only, and reverse-order category+type.
- `setfm-review.unit.spec.ts` — Covers missing `validity` key (defaults to `pass`) and `validity: fail` with multiple errors.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [x] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

All new tests follow the project's BDD conventions (`describe`/`it` hierarchy, `[Normal]`/`[Error]`/`[Edge]` prefixes, `_` prefix for internal helpers).
