### PR TITLE
refactor(set-frontmatter): replace cache utils with CleCache class

### DIFF
--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-cache.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-cache.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/modules/__tests__/unit/setfm-cache.unit.spec.ts
-// @(#): readCache / writeCache / getCacheSlug のユニットテスト
-//       対象: readCache, writeCache, getCacheSlug
+// @(#): CleCache<SetfmCache> を使ったキャッシュ操作パターンのユニットテスト
+//       対象: CleCache (set-frontmatter 固有のキャッシュパターン)
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -14,78 +14,132 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { getCacheSlug, readCache, writeCache } from '../../../../../_scripts/libs/cache/cache-utils.ts';
+import { CleCache } from '../../../../../_scripts/classes/CleCache.class.ts';
+// types
+import type { SetfmCache } from '../../../types/cache.types.ts';
 
 // ─── Internal Helpers
 
 // constants
-/** テスト用キャッシュ識別子。`getCacheSlug` を使わず固定値でラウンドトリップを検証する。 */
-const _SLUG = 'test-entry.md';
+/** テスト用エントリファイルパス。CleCache がベース名をキーとして使う動作を確認する。 */
+const _ENTRY_PATH = '/some/dir/test-entry.md';
+
+// functions
+/**
+ * バッファプロバイダーを使った `CleCache<SetfmCache>` インスタンスを生成する。
+ *
+ * ファイルシステムに依存しないテストのため、`Map<string, string>` をバッファとして使用する。
+ *
+ * @param buf - 読み書きを受け持つバッファ
+ * @param cacheRoot - テスト用キャッシュルートパス
+ * @returns 初期化済みの `CleCache<SetfmCache>` インスタンス
+ */
+const _makeCache = async (buf: Map<string, string>, cacheRoot: string): Promise<CleCache<SetfmCache>> => {
+  const cache = new CleCache<SetfmCache>('fm-cache', cacheRoot, {
+    cache: {
+      readTextFile: (path) => {
+        const data = buf.get(path);
+        if (data === undefined) { return Promise.reject(new Error('not found')); }
+        return Promise.resolve(data);
+      },
+      writeTextFile: (path, data) => {
+        buf.set(path, data);
+        return Promise.resolve();
+      },
+      mkdir: () => Promise.resolve(),
+    },
+  });
+  await cache.ready;
+  return cache;
+};
 
 // ─── Tests
 
 /**
- * `readCache` / `writeCache` / `getCacheSlug` のユニットテストスイート。
+ * `CleCache<SetfmCache>` を使った set-frontmatter 固有キャッシュパターンのテストスイート。
  *
- * 実ファイルシステムを使ったラウンドトリップと re-export の確認を行う。
+ * Phase 2+3a（type/category の書き込み）と Phase 3b（frontmatter のマージ書き込み）の
+ * 動作を検証する。CleCache 自体のユニットテストは別ファイルで実施済みのため、
+ * ここでは set-frontmatter 固有の使用パターンに集中する。
  *
- * テスト ID 範囲: T-SF-CA-01-01 〜 T-SF-CA-03-01
+ * テスト ID 範囲: T-SF-CA-01 〜 T-SF-CA-03
  *
- * @see readCache
- * @see writeCache
- * @see getCacheSlug
+ * @see CleCache
+ * @see SetfmCache
  */
 describe('setfm-cache', () => {
+  let buf: Map<string, string>;
+  let cacheRoot: string;
+
+  beforeEach(async () => {
+    buf = new Map<string, string>();
+    cacheRoot = await Deno.makeTempDir();
+  });
+
+  afterEach(async () => {
+    await Deno.remove(cacheRoot, { recursive: true });
+  });
+
   /**
-   * `readCache` / `writeCache` のラウンドトリップテスト。
+   * Phase 2+3a パターン: `{ type, category }` を write して read で返るケース。
    *
-   * 実ディレクトリを使い書き込み・読み込み・マージ動作を検証する。
+   * CleCache のインメモリキャッシュにより、同一インスタンス内での read はディスクを読まない。
    */
-  describe('readCache / writeCache', () => {
-    let tempDir: string;
-
-    beforeEach(async () => {
-      tempDir = await Deno.makeTempDir();
-    });
-
-    afterEach(async () => {
-      await Deno.remove(tempDir, { recursive: true });
-    });
-
-    /** 書き込んだ値がそのまま読み返せる正常ケース。 */
+  describe('When: Phase 2+3a - type と category の書き込み', () => {
+    /** write して同一インスタンスで read できる正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-SF-CA-01-01: writeCache で { type: "tech" } を書き、readCache で同じ値が返る', async () => {
-        await writeCache(tempDir, _SLUG, { type: 'tech' });
-        const result = await readCache(tempDir, _SLUG);
-        assertEquals(result, { type: 'tech' });
-      });
+      it('[Normal] T-SF-CA-01-01: write({type, category}) → read で同じ値が返る', async () => {
+        const cache = await _makeCache(buf, cacheRoot);
 
-      it('[Normal] T-SF-CA-01-02: writeCache を2回呼ぶと値がマージされる', async () => {
-        await writeCache(tempDir, _SLUG, { type: 'tech' });
-        await writeCache(tempDir, _SLUG, { category: 'life' });
-        const result = await readCache(tempDir, _SLUG);
-        assertEquals(result, { type: 'tech', category: 'life' });
-      });
-    });
+        await cache.write(_ENTRY_PATH, { type: 'tech', category: 'development' });
+        const result = await cache.read(_ENTRY_PATH);
 
-    /** キャッシュファイルが存在しない境界値ケース。 */
-    describe('When: エッジケース', () => {
-      it('[Edge] T-SF-CA-02-01: 存在しない slug を readCache すると {} が返る', async () => {
-        const result = await readCache(tempDir, 'nonexistent.md');
-        assertEquals(result, {});
+        assertEquals(result, { type: 'tech', category: 'development' });
       });
     });
   });
 
   /**
-   * `getCacheSlug` の re-export 確認テスト。
+   * Phase 3b パターン: 既存の `{ type, category }` に `frontmatter` をマージして write するケース。
    *
-   * cache-utils から正しく re-export されていることを検証する。
+   * `CleCache.write` は上書きのため、Phase 3b では read → spread merge → write の手順が必要。
    */
-  describe('getCacheSlug', () => {
-    it('[Normal] T-SF-CA-03-01: getCacheSlug がファイルパスから文字列を返す', () => {
-      const result = getCacheSlug('/foo/bar.md');
-      assertEquals(typeof result, 'string');
+  describe('When: Phase 3b - frontmatter のマージ書き込み', () => {
+    /** Phase 2+3a 後に Phase 3b でマージして write するケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-SF-CA-02-01: Phase 3b マージパターン → {type, category, frontmatter} が全て返る', async () => {
+        const cache = await _makeCache(buf, cacheRoot);
+        const _fmSnapshot = { title: 'テスト', summary: '概要', topics: ['tech'], tags: ['lang:typescript'] };
+
+        // Phase 2+3a: type, category を書き込む
+        await cache.write(_ENTRY_PATH, { type: 'tech', category: 'development' });
+
+        // Phase 3b: 既存値を read してマージ後に write する
+        const _existing = await cache.read(_ENTRY_PATH);
+        await cache.write(_ENTRY_PATH, { ..._existing, frontmatter: _fmSnapshot });
+
+        const result = await cache.read(_ENTRY_PATH);
+        assertEquals(result, {
+          type: 'tech',
+          category: 'development',
+          frontmatter: { title: 'テスト', summary: '概要', topics: ['tech'], tags: ['lang:typescript'] },
+        });
+      });
+    });
+  });
+
+  /**
+   * キャッシュミスのエッジケース。
+   *
+   * Phase 2+3a でキャッシュヒットしない場合、read は `{}` を返す。
+   */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-SF-CA-03-01: 存在しないエントリの read → {} が返る', async () => {
+      const cache = await _makeCache(buf, cacheRoot);
+
+      const result = await cache.read('/nonexistent/path.md');
+
+      assertEquals(result, {});
     });
   });
 });

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -32,16 +32,16 @@ import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Local
+import { CleCache } from '../../_scripts/classes/CleCache.class.ts';
 import { loadDics, loadPrompts } from './modules/setfm-assets-loader.ts';
-import { getCacheSlug, readCache, writeCache } from '../../_scripts/libs/cache/cache-utils.ts';
 // types
-import type { SetfmCache } from './types/cache.types.ts';
 import { buildConfig, parseArgs } from './modules/setfm-config.ts';
 import { loadAllEntries } from './modules/setfm-entry-loader.ts';
 import { generateFrontmatter } from './modules/setfm-frontmatter.ts';
 import { reviewFrontmatter } from './modules/setfm-review.ts';
 import { judgeTypeAndCategory } from './modules/setfm-type-category.ts';
 import { writeFrontmatter } from './modules/setfm-write.ts';
+import type { SetfmCache } from './types/cache.types.ts';
 // types
 import type { Stats } from './types/phase.types.ts';
 
@@ -58,6 +58,9 @@ export const main = async (args: string[]): Promise<void> => {
     if (!await dirExists(_config.inputDir)) {
       throw new ChatlogError('InputNotFound', 'NotFound', `ディレクトリが見つかりません: ${_config.inputDir}`);
     }
+
+    const _cache = new CleCache<SetfmCache>('fm-cache');
+    await _cache.ready;
 
     const [dics, prompts] = await Promise.all([loadDics(_config.dicsDir), loadPrompts(_config.promptsDir)]);
     logger.info(
@@ -92,15 +95,14 @@ export const main = async (args: string[]): Promise<void> => {
     await runConcurrent(
       entries,
       async (entry) => {
-        const _slug = getCacheSlug(entry.filePath!);
-        const _cache = await readCache<SetfmCache>(_config.cacheDir, _slug);
-        if (_cache.type && _cache.category) {
-          entry.frontmatter.set('type', _cache.type);
-          entry.frontmatter.set('category', _cache.category);
+        const _cached = await _cache.read(entry.filePath!);
+        if (_cached.type && _cached.category) {
+          entry.frontmatter.set('type', _cached.type);
+          entry.frontmatter.set('category', _cached.category);
           logger.info(`  type+category (cached): ${getFilename(entry.filePath!)}`);
         } else {
           await judgeTypeAndCategory(entry, maxContentLength, dics, prompts);
-          await writeCache(_config.cacheDir, _slug, {
+          await _cache.write(entry.filePath!, {
             type: entry.frontmatter.get('type') as string,
             category: entry.frontmatter.get('category') as string,
           });
@@ -120,10 +122,9 @@ export const main = async (args: string[]): Promise<void> => {
     await runConcurrent(
       entries,
       async (entry) => {
-        const _slug = getCacheSlug(entry.filePath!);
-        const _cache = await readCache<SetfmCache>(_config.cacheDir, _slug);
-        if (_cache.frontmatter) {
-          Object.entries(_cache.frontmatter).forEach(([k, v]) => entry.frontmatter.set(k, v));
+        const _cached = await _cache.read(entry.filePath!);
+        if (_cached.frontmatter) {
+          Object.entries(_cached.frontmatter).forEach(([k, v]) => entry.frontmatter.set(k, v));
           _generatedFiles.add(entry.filePath!);
           logger.info(`  generated (cached): ${getFilename(entry.filePath!)}`);
         } else {
@@ -135,7 +136,8 @@ export const main = async (args: string[]): Promise<void> => {
               const v = entry.frontmatter.get(k);
               if (v !== undefined) { _fmSnapshot[k] = v; }
             });
-            await writeCache(_config.cacheDir, _slug, { frontmatter: _fmSnapshot });
+            const _existing = await _cache.read(entry.filePath!);
+            await _cache.write(entry.filePath!, { ..._existing, frontmatter: _fmSnapshot });
             _generatedFiles.add(entry.filePath!);
             logger.info(`  generated: ${getFilename(entry.filePath!)}`);
           } else {


### PR DESCRIPTION
## Overview

**Summary**
Replace low-level cache utility functions with the `CleCache` class in the `set-frontmatter` skill.

**Background / Motivation**
The `set-frontmatter` skill used raw `getCacheSlug`/`readCache`/`writeCache` calls, requiring callers to manage `cacheDir` and slug on every read/write. `CleCache` (introduced in #253) encapsulates this into a single typed instance, reducing boilerplate and ensuring consistent cache behavior across skills.

## Changes

### Core Changes

- `skills/set-frontmatter/scripts/set-frontmatter.ts`
  - Removed imports: `getCacheSlug`, `readCache`, `writeCache` from `cache-utils`
  - Added import: `CleCache` from `_scripts/classes/CleCache.class.ts`
  - Instantiates `CleCache<SetfmCache>('fm-cache')` once in `main`; awaits `_cache.ready` before processing
  - Replaced all `readCache`/`writeCache` call sites with `_cache.read()` / `_cache.write()`
  - Frontmatter write now merges the existing cache entry with the new snapshot before writing

### Test Updates

- `skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-cache.unit.spec.ts`
  - Rewrote tests to use `CleCache<SetfmCache>` directly
  - Covers: `type`/`category` write/read-back, frontmatter merge write/read-back, missing-entry read returns `{}`

### Removed

- Direct usage of `getCacheSlug`, `readCache`, `writeCache` in `set-frontmatter.ts`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This completes the `CleCache` migration for `set-frontmatter`. Prior work in this branch: #253 (CleCache functional tests), #254 (rename target dir to output dir), #255 (expanded unit test coverage).
