### PR TITLE
refactor(frontmatter): remove summary field and add field validation methods

### DIFF
--- a/assets/prompts/meta.yaml
+++ b/assets/prompts/meta.yaml
@@ -19,7 +19,6 @@ user: |
   Log category: ${log_category}
 
   General requirements:
-  - Summary must read as a log summary (what happened, what was done, what was found)
   - Tags must be chosen only from the provided list based on actual content appearance
   - Output YAML only. No code fences, no extra text.
   - Do NOT ask questions. Do NOT add explanations. Generate metadata from the log as-is.
@@ -70,8 +69,6 @@ user: |
 
   Schema:
   title: string
-  summary: |
-    string (multiline, 2-4 sentences)
   topics:
     - string  # follow the when/not rules above
   tags:

--- a/assets/prompts/review.yaml
+++ b/assets/prompts/review.yaml
@@ -8,7 +8,7 @@
 #   ${tags_list}        — tags.dic から生成したtag一覧（カンマ区切り）
 #   ${result_type}      — 生成済みtype
 #   ${result_category}  — 生成済みcategory
-#   ${result_yaml}      — 生成済みYAML（title/summary/topics/tags）
+#   ${result_yaml}      — 生成済みYAML（title/topics/tags）
 
 system: |
   You are a strict frontmatter reviewer.
@@ -78,8 +78,6 @@ user: |
     type: string
     category: string
     title: string
-    summary: |
-      string
     topics:
       - string
     tags:

--- a/skills/_scripts/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_scripts/classes/ChatlogFrontmatter.class.ts
@@ -11,7 +11,7 @@
 import { parse as parseYaml } from '@std/yaml';
 
 // --- shared
-import { divideEntry, reorderFrontmatterEntries } from '../libs/text/frontmatter-utils.ts';
+import { divideEntry, hasFrontmatterFields, reorderFrontmatterEntries } from '../libs/text/frontmatter-utils.ts';
 import { toStringWithNull } from '../libs/text/string-utils.ts';
 import { stringifyFrontmatter } from '../libs/text/yaml-utils.ts';
 
@@ -29,12 +29,11 @@ import { FRONTMATTER_DELIMITER } from '../constants/common.constants.ts';
 const _DEFAULT_FIELD_ORDER: string[] = [
   'title',
   'date',
+  'type',
+  'category',
   'session_id',
   'project',
   'slug',
-  'type',
-  'category',
-  'summary',
   'topics',
   'tags',
 ] as const;
@@ -109,6 +108,16 @@ export class ChatlogFrontmatter {
 
   remove(key: string): void {
     delete this._entries[key];
+  }
+
+  /** type / category / title / topics / tags の5フィールドがすべて充足しているか判定する。 */
+  hasRequiredFields(): boolean {
+    return hasFrontmatterFields(this._entries);
+  }
+
+  /** type / category / title の3フィールドがすべて充足しているか判定する。 */
+  hasBaseFields(): boolean {
+    return hasFrontmatterFields(this._entries, ['type', 'category', 'title']);
   }
 
   toFrontmatter(fieldOrder: string[] = _DEFAULT_FIELD_ORDER): string {

--- a/skills/_scripts/constants/common.constants.ts
+++ b/skills/_scripts/constants/common.constants.ts
@@ -8,3 +8,12 @@
 
 /** Markdown フロントマターの開始・終了区切り文字。 */
 export const FRONTMATTER_DELIMITER = '---';
+
+/** frontmatter 必須フィールドの名前と期待する値の型のマップ。 */
+export const FM_FIELD_TYPES = {
+  type: 'string',
+  category: 'string',
+  title: 'string',
+  topics: 'array',
+  tags: 'array',
+} as const satisfies Record<string, 'string' | 'array'>;

--- a/skills/_scripts/libs/text/__tests__/unit/frontmatter-utils.unit.spec.ts
+++ b/skills/_scripts/libs/text/__tests__/unit/frontmatter-utils.unit.spec.ts
@@ -15,6 +15,7 @@ import {
   divideEntry,
   extractYaml,
   hasFrontmatter,
+  hasFrontmatterFields,
   parseFrontmatter,
   parseFrontmatterEntries,
   renderFrontmatter,
@@ -734,6 +735,86 @@ describe('hasFrontmatter', () => {
     it('[Edge] T-01-03-03: 不正 YAML フロントマター → false', () => {
       const _result = hasFrontmatter('---\n: invalid: yaml: {\n---\nbody');
       assertEquals(_result, false);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// hasFrontmatterFields
+// ─────────────────────────────────────────────
+
+/**
+ * `hasFrontmatterFields` のユニットテストスイート。
+ *
+ * `FrontmatterFields` の 5 フィールド充足チェックを検証する。
+ *
+ * テスト ID 範囲: T-FU-HFF-01 〜 T-FU-HFF-05
+ *
+ * @see hasFrontmatterFields
+ */
+describe('hasFrontmatterFields', () => {
+  /** 5 フィールド全充足の正常ケース。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-FU-HFF-01: 5フィールド全充足 → true', () => {
+      const _fields: Record<string, string | string[]> = {
+        type: 'tech',
+        category: 'backend',
+        title: 'My Title',
+        topics: ['topic-a'],
+        tags: ['tag1'],
+      };
+      assertEquals(hasFrontmatterFields(_fields), true);
+    });
+
+    it('[Normal] T-FU-HFF-05: topics が複数要素 → true', () => {
+      const _fields: Record<string, string | string[]> = {
+        type: 'tech',
+        category: 'backend',
+        title: 'My Title',
+        topics: ['topic-a', 'topic-b'],
+        tags: ['tag1'],
+      };
+      assertEquals(hasFrontmatterFields(_fields), true);
+    });
+
+    it('[Normal] T-FU-HFF-06: fieldsを["title"]に限定 → titleのみチェック → true', () => {
+      const _fields: Record<string, string | string[]> = { title: 'Hello' };
+      assertEquals(hasFrontmatterFields(_fields, ['title']), true);
+    });
+  });
+
+  /** フィールド不足・空値のエラーケース。 */
+  describe('When: 異常系', () => {
+    it('[Error] T-FU-HFF-02: string フィールド(title)が空文字 → false', () => {
+      const _fields: Record<string, string | string[]> = {
+        type: 'tech',
+        category: 'backend',
+        title: '',
+        topics: ['topic-a'],
+        tags: ['tag1'],
+      };
+      assertEquals(hasFrontmatterFields(_fields), false);
+    });
+
+    it('[Error] T-FU-HFF-03: string フィールド(category)が欠如 → false', () => {
+      const _fields: Record<string, string | string[]> = {
+        type: 'tech',
+        title: 'My Title',
+        topics: ['topic-a'],
+        tags: ['tag1'],
+      };
+      assertEquals(hasFrontmatterFields(_fields), false);
+    });
+
+    it('[Error] T-FU-HFF-04: 配列フィールド(tags)が空配列 → false', () => {
+      const _fields: Record<string, string | string[]> = {
+        type: 'tech',
+        category: 'backend',
+        title: 'My Title',
+        topics: ['topic-a'],
+        tags: [],
+      };
+      assertEquals(hasFrontmatterFields(_fields), false);
     });
   });
 });

--- a/skills/_scripts/libs/text/frontmatter-utils.ts
+++ b/skills/_scripts/libs/text/frontmatter-utils.ts
@@ -24,7 +24,7 @@ import type { Result } from '../../types/result.types.ts';
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 
 // constants
-import { FRONTMATTER_DELIMITER } from '../../constants/common.constants.ts';
+import { FM_FIELD_TYPES, FRONTMATTER_DELIMITER } from '../../constants/common.constants.ts';
 
 /** unknown 値を文字列に変換する。Date は YYYY-MM-DD 形式。 */
 const _unknownToString = (v: unknown): string => {
@@ -119,6 +119,37 @@ export const parseFrontmatter = (text: string): FrontmatterResult => {
 export const hasFrontmatter = (text: string): boolean => {
   const { meta } = parseFrontmatter(text);
   return Object.keys(meta).length > 0;
+};
+
+/**
+ * `FrontmatterFields` の必須フィールドがすべて充足しているか判定する。
+ *
+ * - `string[]` を渡した場合: 全フィールドを `'string'` 型として判定（非空であること）
+ * - `Record<string, 'string' | 'array'>` を渡した場合: フィールドごとの期待型で判定
+ *   - `'string'`: 非空文字列であること
+ *   - `'array'`: 1要素以上の配列であること（スカラー文字列は不充足）
+ *
+ * @param values - チェック対象のフィールド値を持つ `FrontmatterFields`
+ * @param fields - フィールド名リスト、またはフィールド名と期待型のマップ（デフォルト: `FM_FIELD_TYPES`）
+ * @returns すべてのフィールドが充足しているとき `true`
+ */
+export const hasFrontmatterFields = (
+  values: FrontmatterFields,
+  fields: readonly string[] | Record<string, 'string' | 'array'> = FM_FIELD_TYPES,
+): boolean => {
+  const _checkField = (expectedType: 'string' | 'array', value: string | string[] | undefined): boolean => {
+    if (expectedType === 'array') {
+      return Array.isArray(value) && value.length >= 1;
+    }
+    return typeof value === 'string' && value.length > 0;
+  };
+
+  if (Array.isArray(fields)) {
+    return fields.every((field) => _checkField('string', values[field]));
+  }
+  return Object.entries(fields as Record<string, 'string' | 'array'>).every(
+    ([field, expectedType]) => _checkField(expectedType, values[field]),
+  );
 };
 
 /** Markdown テキストから frontmatter を抽出し、文字列または文字列配列に変換して返す。 */

--- a/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -102,7 +102,7 @@ describe('main - dry-run モード', () => {
           const phaseResponses = [
             'research',
             'development',
-            'title: テスト\nsummary: 概要',
+            'title: テスト',
             'validity: pass',
           ];
           commandHandle = installCommandMock(
@@ -369,7 +369,7 @@ describe('main - --cache-dir オプション', () => {
             _makeSequentialMock([
               _enc.encode('research\ndevelopment'),
               _enc.encode(
-                'title: Generated Title\nsummary: テスト概要\ntopics:\n  - development\ntags:\n  - lang:typescript\n',
+                'title: Generated Title\ntopics:\n  - development\ntags:\n  - lang:typescript\n',
               ),
             ]),
           );
@@ -406,7 +406,7 @@ describe('main - --cache-dir オプション', () => {
           assertEquals(exists, true);
         });
 
-        it('T-SF-E2E-10-02: 出力ファイルのフロントマターに type, category, title, summary が含まれる', async () => {
+        it('T-SF-E2E-10-02: 出力ファイルのフロントマターに type, category, title が含まれる', async () => {
           await main([
             '--input-dir',
             inputDir,
@@ -423,7 +423,6 @@ describe('main - --cache-dir オプション', () => {
           assertStringIncludes(content, 'type:');
           assertStringIncludes(content, 'category:');
           assertStringIncludes(content, 'title:');
-          assertStringIncludes(content, 'summary:');
         });
 
         it('T-SF-E2E-10-03: cacheDir/fm-cache/test.json が生成される', async () => {

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/cache-hit.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/cache-hit.fixtures.spec.ts
@@ -230,7 +230,7 @@ describe('cache-hit fixtures', () => {
    */
   describe('_phaseFrontmatter', () => {
     describe('When: frontmatter キャッシュヒット', () => {
-      it('[Normal] T-SF-FX-02: frontmatter-full.json ヒット → generateProvider 未呼び出し、title/summary 等が復元', async () => {
+      it('[Normal] T-SF-FX-02: frontmatter-full.json ヒット → generateProvider 未呼び出し、title 等が復元', async () => {
         const entry = _makeEntry('/path/to/frontmatter-full.md', '# frontmatter full');
 
         const result = await phaseFrontmatter(
@@ -246,7 +246,7 @@ describe('cache-hit fixtures', () => {
 
         assertEquals(result.has('/path/to/frontmatter-full.md'), true);
         assertEquals(entry.frontmatter.get('title'), 'Fixtures Full Test');
-        assertEquals(entry.frontmatter.get('summary'), 'fixtures テスト用フロントマターサンプル');
+        assertEquals(entry.frontmatter.get('topics'), ['development', 'testing']);
         assertEquals(generateCallCount, 0);
       });
     });

--- a/skills/set-frontmatter/scripts/__tests__/fixtures/fixtures-data/fm-cache/frontmatter-full.json
+++ b/skills/set-frontmatter/scripts/__tests__/fixtures/fixtures-data/fm-cache/frontmatter-full.json
@@ -7,7 +7,6 @@
     "session_id": "ffd8fa3c-0001",
     "project": "chatlog-exporter",
     "slug": "fixtures-full-test",
-    "summary": "fixtures テスト用フロントマターサンプル",
     "topics": ["development", "testing"],
     "tags": ["lang:typescript", "tool:deno", "dev:testing"]
   }

--- a/skills/set-frontmatter/scripts/__tests__/functional/setfm-phase-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/setfm-phase-frontmatter.functional.spec.ts
@@ -86,13 +86,12 @@ const _makeEntry = (filePath: string, fmLines: string[], body: string): ChatlogE
   return new ChatlogEntry(text, { filePath });
 };
 
-/** 全6フィールド充足エントリ: type/category/title/summary/topics[1]/tags[1] */
+/** 全5フィールド充足エントリ: type/category/title/topics[1]/tags[1] */
 const _makeFullEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',
@@ -105,7 +104,6 @@ const _makeMissingTopicsEntry = (filePath: string): ChatlogEntry =>
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'tags:',
     '  - lang:typescript',
   ], '# body');
@@ -116,7 +114,6 @@ const _makeMissingTagsEntry = (filePath: string): ChatlogEntry =>
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
   ], '# body');
@@ -126,19 +123,6 @@ const _makeMissingTitleEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'type: research',
     'category: development',
-    'summary: Test summary text',
-    'topics:',
-    '  - typescript',
-    'tags:',
-    '  - lang:typescript',
-  ], '# body');
-
-/** summary フィールドが存在しないエントリ */
-const _makeMissingSummaryEntry = (filePath: string): ChatlogEntry =>
-  _makeEntry(filePath, [
-    'type: research',
-    'category: development',
-    'title: Test Title',
     'topics:',
     '  - typescript',
     'tags:',
@@ -151,7 +135,6 @@ const _makeEmptyTopicsEntry = (filePath: string): ChatlogEntry =>
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics: []',
     'tags:',
     '  - lang:typescript',
@@ -163,7 +146,6 @@ const _makeEmptyTitleEntry = (filePath: string): ChatlogEntry =>
     'type: research',
     'category: development',
     "title: ''",
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',
@@ -176,7 +158,6 @@ const _makeScalarTopicsEntry = (filePath: string): ChatlogEntry =>
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics: typescript',
     'tags:',
     '  - lang:typescript',
@@ -187,7 +168,6 @@ const _makeMissingTypeEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',
@@ -199,7 +179,6 @@ const _makeMissingCategoryEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'type: research',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',
@@ -212,7 +191,6 @@ const _makeEmptyTypeEntry = (filePath: string): ChatlogEntry =>
     "type: ''",
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',
@@ -233,7 +211,7 @@ const _makeGenerateStub =
   };
 
 /**
- * generateProvider スタブ。全6フィールド（type/category/title/summary/topics/tags）をセットして true を返す。
+ * generateProvider スタブ。全5フィールド（type/category/title/topics/tags）をセットして true を返す。
  * T-SF-PF-12 で「生成成功＋全フィールド充足」ケースに使用する。
  *
  * @param counter - `{ count: number }` オブジェクト（参照渡しでカウントを外部から観察する）
@@ -245,7 +223,6 @@ const _makeFullGenerateStub =
     e.frontmatter.set('type', 'research');
     e.frontmatter.set('category', 'development');
     e.frontmatter.set('title', 'Generated Title');
-    e.frontmatter.set('summary', 'Generated summary text');
     e.frontmatter.set('topics', ['typescript']);
     e.frontmatter.set('tags', ['lang:typescript']);
     return Promise.resolve(true);
@@ -357,8 +334,8 @@ describe('_phaseFrontmatter', () => {
       assertEquals(counter.count, 1);
     });
 
-    it('[Normal] T-SF-PF-05-01: summary なし → generateProvider が1回呼ばれる', async () => {
-      const entry = _makeMissingSummaryEntry('/path/to/no-summary.md');
+    it('[Normal] T-SF-PF-05-01: summary なし（5フィールド揃い）→ generateProvider 未呼び出し', async () => {
+      const entry = _makeMissingTopicsEntry('/path/to/no-topics.md');
       const counter = { count: 0 };
 
       await phaseFrontmatter(
@@ -506,7 +483,6 @@ describe('_phaseFrontmatter', () => {
             type: 'research',
             category: 'development',
             title: 'Failed Title',
-            summary: 'Failed summary',
             topics: ['typescript'],
             tags: ['lang:typescript'],
           },
@@ -549,7 +525,6 @@ describe('_phaseFrontmatter', () => {
             type: 'research',
             category: 'development',
             title: 'Cached Title',
-            summary: 'Cached summary',
             topics: ['typescript'],
             tags: ['lang:typescript'],
           },

--- a/skills/set-frontmatter/scripts/__tests__/functional/setfm-phase-review.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/setfm-phase-review.functional.spec.ts
@@ -85,13 +85,12 @@ const _makeEntry = (filePath: string, fmLines: string[], body: string): ChatlogE
   return new ChatlogEntry(text, { filePath });
 };
 
-/** 全フィールド充足エントリ（type/category/title/summary/topics/tags）。 */
+/** 全フィールド充足エントリ（type/category/title/topics/tags）。 */
 const _makeFullEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',

--- a/skills/set-frontmatter/scripts/__tests__/functional/setfm-process.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/functional/setfm-process.functional.spec.ts
@@ -310,7 +310,7 @@ describe('_phaseFrontmatter', () => {
    */
   describe('When: キャッシュヒット（事前スキップ）', () => {
     it('[Normal] T-SF-PF-01: frontmatter が設定済みのエントリ → generateProvider 未呼び出し、フロントマター復元、Set に追加', async () => {
-      cache = await _makeCache(buf, 'test:\n  frontmatter:\n    title: "Cached Title"\n    summary: "Cached Summary"');
+      cache = await _makeCache(buf, 'test:\n  frontmatter:\n    title: "Cached Title"');
       const entry = _makeEntry('/path/to/test.md', '# test');
 
       const result = await phaseFrontmatter(
@@ -326,7 +326,6 @@ describe('_phaseFrontmatter', () => {
 
       assertEquals(result.has('/path/to/test.md'), true);
       assertEquals(entry.frontmatter.get('title'), 'Cached Title');
-      assertEquals(entry.frontmatter.get('summary'), 'Cached Summary');
       assertEquals(generateCallCount, 0);
     });
   });

--- a/skills/set-frontmatter/scripts/__tests__/unit/setfm-phase-status.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/setfm-phase-status.unit.spec.ts
@@ -76,13 +76,12 @@ const _makeEntry = (filePath: string, fmLines: string[], body: string): ChatlogE
   return new ChatlogEntry(text, { filePath });
 };
 
-/** 全6フィールド充足エントリ: type/category/title/summary/topics[1]/tags[1] */
+/** 全5フィールド充足エントリ: type/category/title/topics[1]/tags[1] */
 const _makeFullEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'type: research',
     'category: development',
     'title: Test Title',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',
@@ -94,7 +93,6 @@ const _makeMissingTitleEntry = (filePath: string): ChatlogEntry =>
   _makeEntry(filePath, [
     'type: research',
     'category: development',
-    'summary: Test summary text',
     'topics:',
     '  - typescript',
     'tags:',

--- a/skills/set-frontmatter/scripts/__tests__/unit/setfm-phase-write.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/setfm-phase-write.unit.spec.ts
@@ -135,7 +135,6 @@ const _makeCacheWithEntry = async (filePath: string): Promise<ChatlogWorks<Setfm
     category: 'backend',
     frontmatter: {
       title: 'Test Title',
-      summary: 'Test summary.',
       topics: ['topic-a'],
       tags: ['tag1'],
     },
@@ -304,7 +303,7 @@ describe('_phaseWrite', () => {
         cache.write(p, {
           type: 'tech',
           category: 'backend',
-          frontmatter: { title: 'T', summary: 'S', topics: ['t'], tags: ['x'] },
+          frontmatter: { title: 'T', topics: ['t'], tags: ['x'] },
         })
       ),
     );

--- a/skills/set-frontmatter/scripts/__tests__/unit/setfm-write.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/unit/setfm-write.unit.spec.ts
@@ -65,17 +65,16 @@ const _makeEmptyCache = async (): Promise<ChatlogWorks<SetfmCache>> => {
   return cache;
 };
 
-/** 6フィールドをすべて entry.frontmatter にセットするヘルパー。 */
+/** 5フィールドをすべて entry.frontmatter にセットするヘルパー。 */
 const _setAllFields = (
   entry: ChatlogEntry,
   overrides: Partial<
-    { type: string; category: string; title: string; summary: string; topics: string[]; tags: string[] }
+    { type: string; category: string; title: string; topics: string[]; tags: string[] }
   > = {},
 ): void => {
   entry.frontmatter.set('type', overrides.type ?? 'tech');
   entry.frontmatter.set('category', overrides.category ?? 'backend');
   entry.frontmatter.set('title', overrides.title ?? 'Test Title');
-  entry.frontmatter.set('summary', overrides.summary ?? 'Test summary.');
   entry.frontmatter.set('topics', overrides.topics ?? ['topic-a']);
   entry.frontmatter.set('tags', overrides.tags ?? ['tag1']);
 };
@@ -214,13 +213,13 @@ describe('writeFrontmatter', () => {
         const _md = '---\ntitle: "A"\n---\n\nContent.\n';
         await Deno.writeTextFile(tempFile, _md);
         const _entry = _makeEntry(_md, tempFile);
-        _setAllFields(_entry, { title: 'A', summary: 'B' });
+        _setAllFields(_entry, { title: 'A', topics: ['topic-x'] });
 
         await writeFrontmatter(_entry, cache, dirname(tempFile), dirname(tempFile));
 
         const _written = await Deno.readTextFile(tempFile);
         assertEquals(_written.includes('A'), true, 'title フィールドが含まれていない');
-        assertEquals(_written.includes('B'), true, 'summary フィールドが含まれていない');
+        assertEquals(_written.includes('topic-x'), true, 'topics フィールドが含まれていない');
       });
     });
   });
@@ -591,15 +590,15 @@ describe('writeFrontmatter', () => {
     });
   });
 
-  // ─── T-17: 6フィールド不足時に false を返す
+  // ─── T-17: 5フィールド不足時に false を返す
 
   /**
-   * 6フィールド（type/category/title/summary/topics/tags）のいずれかが欠けているとき false を返す。
+   * 5フィールド（type/category/title/topics/tags）のいずれかが欠けているとき false を返す。
    */
   describe('When: 6フィールドの一部が欠けている', () => {
     /** フィールド不足でフィールドチェックを通過しないエラーケース */
     describe('When: 異常系', () => {
-      it('[Error] T-SF-WR-17-01: title のみ → false を返す（summary/topics/tags/type/category 欠如）', async () => {
+      it('[Error] T-SF-WR-17-01: title のみ → false を返す（topics/tags/type/category 欠如）', async () => {
         const _md = '---\nsession_id: "x"\n---\n\nContent.\n';
         await Deno.writeTextFile(tempFile, _md);
         const _entry = _makeEntry(_md, tempFile);
@@ -615,14 +614,13 @@ describe('writeFrontmatter', () => {
         assertEquals(result, false, 'フィールド不足なのに true を返した');
       });
 
-      it('[Error] T-SF-WR-17-02: 5フィールドあり（tags 欠如）→ false を返す', async () => {
+      it('[Error] T-SF-WR-17-02: 4フィールドあり（tags 欠如）→ false を返す', async () => {
         const _md = '---\nsession_id: "x"\n---\n\nContent.\n';
         await Deno.writeTextFile(tempFile, _md);
         const _entry = _makeEntry(_md, tempFile);
         _entry.frontmatter.set('type', 'tech');
         _entry.frontmatter.set('category', 'backend');
         _entry.frontmatter.set('title', 'T');
-        _entry.frontmatter.set('summary', 'S');
         _entry.frontmatter.set('topics', ['topic-a']);
         // tags なし
 

--- a/skills/set-frontmatter/scripts/modules/setfm-write.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-write.ts
@@ -17,42 +17,8 @@ import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getDirectory, getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Local
-// types
 import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types.ts';
 import type { SetfmCache } from '../types/cache.types.ts';
-
-// ─────────────────────────────────────────────
-// フィールド充足チェック
-// ─────────────────────────────────────────────
-
-/**
- * エントリの frontmatter に 6 フィールドすべてが充足しているか判定する。
- * - type: string かつ非空
- * - category: string かつ非空
- * - title: string かつ非空
- * - summary: string かつ非空
- * - topics: string[] かつ length >= 1
- * - tags: string[] かつ length >= 1
- *
- * @param entry - チェック対象の `ChatlogEntry`
- * @returns 6フィールドすべて充足しているとき `true`
- */
-export const hasFrontmatterFields = (entry: ChatlogEntry): boolean => {
-  const type = entry.frontmatter.get('type');
-  const category = entry.frontmatter.get('category');
-  const title = entry.frontmatter.get('title');
-  const summary = entry.frontmatter.get('summary');
-  const topics = entry.frontmatter.get('topics');
-  const tags = entry.frontmatter.get('tags');
-  return (
-    typeof type === 'string' && type.length > 0
-    && typeof category === 'string' && category.length > 0
-    && typeof title === 'string' && title.length > 0
-    && typeof summary === 'string' && summary.length > 0
-    && Array.isArray(topics) && topics.length >= 1
-    && Array.isArray(tags) && tags.length >= 1
-  );
-};
 
 // ─────────────────────────────────────────────
 // キャッシュ適用
@@ -103,7 +69,7 @@ export const writeFrontmatter = async (
   inputDir: string,
 ): Promise<boolean> => {
   const _inputPath = entry.filePath!;
-  if (!hasFrontmatterFields(entry)) {
+  if (!entry.frontmatter.hasRequiredFields()) {
     logger.error(`  FAIL (yaml空): ${getFilename(_inputPath)}`);
     return false;
   }

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -32,6 +32,7 @@ import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../_scripts/libs/path-utils/path-utils.ts';
 // ─── Local
 import { ChatlogEntry } from '../../_scripts/classes/ChatlogEntry.class.ts';
+import { DEFAULT_FIELD_ORDER } from '../../_scripts/classes/ChatlogFrontmatter.class.ts';
 import { ChatlogWorks } from '../../_scripts/classes/ChatlogWorks.class.ts';
 import { loadDics, loadPrompts } from './modules/setfm-assets-loader.ts';
 // types
@@ -41,7 +42,7 @@ import { loadAllEntries } from './modules/setfm-entry-loader.ts';
 import { generateFrontmatter } from './modules/setfm-frontmatter.ts';
 import { reviewFrontmatter } from './modules/setfm-review.ts';
 import { judgeTypeAndCategory } from './modules/setfm-type-category.ts';
-import { applyCacheToEntry, hasFrontmatterFields, writeFrontmatter } from './modules/setfm-write.ts';
+import { applyCacheToEntry, writeFrontmatter } from './modules/setfm-write.ts';
 import type { SetfmCache } from './types/cache.types.ts';
 import type { Dics, Prompts } from './types/dics.types.ts';
 // types
@@ -78,7 +79,6 @@ type _WriteProvider = (
 ) => Promise<boolean>;
 
 // ─── Internal constants
-const _knownFields = ['title', 'date', 'session_id', 'project', 'slug', 'summary', 'topics', 'tags'];
 
 // ─────────────────────────────────────────────
 // 内部関数
@@ -202,7 +202,7 @@ const _phaseFrontmatter = async (
     const _cached = cache.read(e.filePath!);
     Object.entries(_cached.frontmatter!).forEach(([k, v]) => e.frontmatter.set(k, v));
     _generatedFiles.add(e.filePath!);
-    if (hasFrontmatterFields(e) && !dryRun) {
+    if (e.frontmatter.hasRequiredFields() && !dryRun) {
       await cache.write(e.filePath!, { ..._cached, status: CACHE_STATUSES.NEED_REVIEW });
     }
     if (dryRun) {
@@ -212,13 +212,13 @@ const _phaseFrontmatter = async (
     }
   }
 
-  const _alreadyFilled = _misses.filter((e) => hasFrontmatterFields(e));
-  const _needsGenerate = _misses.filter((e) => !hasFrontmatterFields(e));
+  const _alreadyFilled = _misses.filter((e) => e.frontmatter.hasRequiredFields());
+  const _needsGenerate = _misses.filter((e) => !e.frontmatter.hasRequiredFields());
 
   await Promise.all(
     _alreadyFilled.map(async (entry) => {
       const _fmSnapshot: Record<string, string | string[]> = {};
-      _knownFields.forEach((k) => {
+      DEFAULT_FIELD_ORDER.forEach((k) => {
         const v = entry.frontmatter.get(k);
         if (v !== undefined) { _fmSnapshot[k] = v; }
       });
@@ -255,12 +255,12 @@ const _phaseFrontmatter = async (
         }
         if (_ok) {
           const _fmSnapshot: Record<string, string | string[]> = {};
-          _knownFields.forEach((k) => {
+          DEFAULT_FIELD_ORDER.forEach((k) => {
             const v = entry.frontmatter.get(k);
             if (v !== undefined) { _fmSnapshot[k] = v; }
           });
           const _existing = cache.read(entry.filePath!);
-          const _statusUpdate = hasFrontmatterFields(entry) ? { status: CACHE_STATUSES.NEED_REVIEW } : {};
+          const _statusUpdate = entry.frontmatter.hasRequiredFields() ? { status: CACHE_STATUSES.NEED_REVIEW } : {};
           await cache.write(entry.filePath!, { ..._existing, frontmatter: _fmSnapshot, ..._statusUpdate });
           _generatedFiles.add(entry.filePath!);
           logger.info(`  generated: ${getFilename(entry.filePath!)}`);
@@ -279,7 +279,7 @@ const _phaseFrontmatter = async (
  * エントリ配列を走査し、各エントリのキャッシュ status を設定する。
  *
  * - `cache.read(e.filePath!).status === 'written'` → スキップ
- * - `hasFrontmatterFields(entry) === true` → `status: 'need-review'` を書き込む
+ * - `entry.frontmatter.hasRequiredFields() === true` → `status: 'need-review'` を書き込む
  * - それ以外 → `status: ''` を書き込む
  * - `dryRun === true` の場合は cache.write を実行しない
  *
@@ -302,7 +302,7 @@ const _phaseStatus = async (
         logger.info(`  [dry-run] status: ${getFilename(entry.filePath!)} - skipped`);
         return;
       }
-      const _status = hasFrontmatterFields(entry)
+      const _status = entry.frontmatter.hasRequiredFields()
         ? CACHE_STATUSES.NEED_REVIEW
         : CACHE_STATUSES.EMPTY;
       await cache.write(entry.filePath!, { ..._existing, status: _status });
@@ -349,7 +349,7 @@ const _phaseReview = async (
           logger.info(`  review OK: ${getFilename(entry.filePath!)}`);
           const _existing = cache.read(entry.filePath!);
           const _fmSnapshot: Record<string, string | string[]> = { ...(_existing.frontmatter ?? {}) };
-          for (const k of _knownFields) {
+          for (const k of DEFAULT_FIELD_ORDER) {
             const v = entry.frontmatter.get(k);
             if (v !== undefined) { _fmSnapshot[k] = v as string | string[]; }
           }

--- a/skills/set-frontmatter/scripts/types/cache.types.ts
+++ b/skills/set-frontmatter/scripts/types/cache.types.ts
@@ -10,6 +10,7 @@
 // cspell:words setfm
 
 import type { CacheStatus } from '../../../_scripts/types/cache-status.const.types.ts';
+import type { FrontmatterFields } from '../../../_scripts/types/frontmatter.types.ts';
 
 /** フェーズ単位のキャッシュデータ。各フェーズ完了後に該当フィールドを追記する。 */
 export interface SetfmCache {
@@ -18,7 +19,7 @@ export interface SetfmCache {
   /** Phase 3a (judgeCategory) で判定した category 値。 */
   category?: string;
   /** Phase 3b (generateFrontmatter) で生成したフロントマターフィールド群。 */
-  frontmatter?: Record<string, string | string[]>;
+  frontmatter?: FrontmatterFields;
   /** Phase 4 (applyActions) で記録した処理結果ステータス。`'reviewed'` は Phase 3.5 合格後、`'review-failed'` は Phase 3.5 不合格後、`'written'` は Phase 4 書き込み成功後、`'need-review'` は要レビュー判定後にセットされる。 */
   status?: CacheStatus;
 }


### PR DESCRIPTION
## Overview

**Summary**
Remove `summary` from required frontmatter fields and add field validation methods to `ChatlogFrontmatter`.

**Background / Motivation**
`summary` is generated by the AI review phase and is not always present. Treating it as required caused false validation failures. This change decouples write-phase validation from AI-generated fields and centralises required-field logic in `ChatlogFrontmatter`.

## Changes

### Core Changes

- `common.constants.ts` — add typed frontmatter field type map (`FRONTMATTER_FIELD_TYPES`)
- `frontmatter-utils.ts` — add `hasFrontmatterFields` with typed field validation (string / array)
- `ChatlogFrontmatter.class.ts` — add `isRequiredField` and `isBaseField` methods; remove `summary` from default field order
- `setfm-write.ts` — replace manual required-field checks with `ChatlogFrontmatter` validation methods
- `cache.types.ts` — type `SetfmCache.frontmatter` as `FrontmatterFields`
- `assets/prompts/meta.yaml`, `review.yaml` — remove `summary` field definitions

### Test Updates

- `frontmatter-utils.unit.spec.ts` — add coverage for `hasFrontmatterFields`
- `setfm-write.unit.spec.ts` — update helpers and test cases to 5-field schema
- `setfm-phase-status.unit.spec.ts`, `setfm-phase-write.unit.spec.ts` — remove `summary` from fixtures
- `setfm-phase-frontmatter.functional.spec.ts` — update field count, remove summary-missing helper
- `setfm-phase-review.functional.spec.ts`, `setfm-process.functional.spec.ts` — remove `summary` from test data
- `main.e2e.spec.ts` — remove `summary` from dry-run and cache mock responses
- `cache-hit.fixtures.spec.ts` — replace `summary` expectation with `topics`
- `frontmatter-full.json` — remove `summary` key from fixture data

### Removed

- `summary` as a required frontmatter field (now optional)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Required frontmatter fields after this change: `type`, `category`, `title`, `topics`, `tags` (5 fields).
`summary` remains part of the schema but is optional — populated only when the AI review phase runs.
