### PR TITLE
refactor: centralize cli args and default output dir

### DIFF
--- a/skills/_scripts/constants/defaults.constants.ts
+++ b/skills/_scripts/constants/defaults.constants.ts
@@ -31,6 +31,9 @@ export const DEFAULT_CHATLOGS_DIR = './chatlogs';
 /** normalize-chatlogs が出力するセグメントのデフォルトベースディレクトリ。 */
 export const DEFAULT_NORMALIZE_DIR = './chatlogs/normalizelogs';
 
+/** export-chatlogs が出力先に付加するサブディレクトリ名。`chatlogsDir` と `joinPath()` で組み合わせて使用する。 */
+export const DEFAULT_ORIGINAL_LOGS_DIR = 'originalLogs';
+
 /** set-frontmatter が出力するデフォルトディレクトリ。 */
 export const DEFAULT_OUTPUT_DIR = './outputLogs';
 

--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -76,6 +76,10 @@ describe('_initSchemaForTest', () => {
       const _map = _initSchemaForTest([{ option: '--dry-run', field: 'dryRun', type: 'flag' }]);
       assertEquals(_map.get('--dry-run')?.type, 'flag');
     });
+    it('[Normal] T-PA-22-04: 空スキーマ → --config がデフォルトエントリとして含まれる', () => {
+      const _map = _initSchemaForTest([]);
+      assert(_map.has('--config'));
+    });
   });
 });
 

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -33,6 +33,10 @@ const _DEFAULT_SCHEMA: ArgsSchema = [
   { option: 'agent', field: 'agent', type: 'agent' },
   { option: 'chatlogsDir', field: 'chatlogsDir', type: 'directory' },
   { option: 'cacheDir', field: 'cacheDir', type: 'directory' },
+  { option: '--config', field: 'configFile', type: 'string' },
+  { option: '--dry-run', field: 'dryRun', type: 'flag' },
+  { option: '--base-dir', field: 'baseDir', type: 'directory' },
+  { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
 ];
 
 /**

--- a/skills/classify-chatlogs/scripts/modules/classify-config.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-config.ts
@@ -23,12 +23,8 @@ import { DEFAULT_CLASSIFY_CONFIG } from '../constants/classify.constants.ts';
 
 /** classify-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgsSchema = [
-  { option: '--base-dir', field: 'baseDir', type: 'directory' },
-  { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
   { option: '--period', field: 'period', type: 'period' },
   { option: '--model', field: 'model', type: 'string' },
-  { option: '--config', field: 'configFile', type: 'string' },
-  { option: '--dry-run', field: 'dryRun', type: 'flag' },
 ];
 
 export const parseArgs = (args: string[]): ParsedConfig => {

--- a/skills/export-chatlogs/SKILL.md
+++ b/skills/export-chatlogs/SKILL.md
@@ -52,15 +52,25 @@ OUTPUT      = <cwd>/chatlogs
 解決した `SCRIPT_PATH` と `OUTPUT` を使い、Bash で実行する:
 
 ```bash
-deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] --output "$OUTPUT"
+deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] --output-dir "$OUTPUT"
 ```
 
 ### 引数からオプションを組み立てるルール
 
-- 引数なし → `deno run ... "$SCRIPT_PATH" --output "$OUTPUT"`
-- `agent` のみ → `deno run ... "$SCRIPT_PATH" codex --output "$OUTPUT"`
-- `YYYY-MM` のみ → `deno run ... "$SCRIPT_PATH" 2026-03 --output "$OUTPUT"`
-- `agent YYYY-MM` → `deno run ... "$SCRIPT_PATH" codex 2026-03 --output "$OUTPUT"`
+- 引数なし → `deno run ... "$SCRIPT_PATH" --output-dir "$OUTPUT"`
+- `agent` のみ → `deno run ... "$SCRIPT_PATH" codex --output-dir "$OUTPUT"`
+- `YYYY-MM` のみ → `deno run ... "$SCRIPT_PATH" 2026-03 --output-dir "$OUTPUT"`
+- `agent YYYY-MM` → `deno run ... "$SCRIPT_PATH" codex 2026-03 --output-dir "$OUTPUT"`
+- `chatlogsDir` 指定時 → `deno run ... "$SCRIPT_PATH" --chatlogs-dir "$CHATLOGS_DIR" --output-dir "$OUTPUT"`
+- dry-run 確認時 → `deno run ... "$SCRIPT_PATH" --dry-run --output-dir "$OUTPUT"`（※現状 `main()` 側で書き込みスキップは未実装のため、実際にはファイルが生成される点に注意）
+
+#### その他の利用可能なオプション
+
+以下のオプションもそのまま渡せる（`$ARGUMENTS` の位置引数ルールとは独立したフラグ）:
+
+- `--input-dir DIR` — 入力ディレクトリ（chatgpt エージェントの位置引数と同義）
+- `--chatlogs-dir DIR` — チャットログ格納ディレクトリ
+- `--dry-run` — dry-run モード（**現状未実装**: フラグは解析されるが、書き込みスキップの動作は行われない）
 
 #### chatgpt エージェントの場合
 
@@ -68,11 +78,11 @@ deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] 
 `\` は `/` に自動正規化されるため Windows パスもそのまま渡せる。
 未指定の場合はエラーを出力して終了する。
 
-- `chatgpt /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt "$INPUT_DIR" --output "$OUTPUT"`
-- `chatgpt 2026-03 /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt 2026-03 "$INPUT_DIR" --output "$OUTPUT"`
+- `chatgpt /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt "$INPUT_DIR" --output-dir "$OUTPUT"`
+- `chatgpt 2026-03 /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt 2026-03 "$INPUT_DIR" --output-dir "$OUTPUT"`
 - `chatgpt /path/to/export 2026-03` → 順番を逆にしても同様に動作する
 
-フラグ形式（`--input DIR`）も引き続き使用可能。
+フラグ形式（`--input-dir DIR`）も引き続き使用可能。
 
 スクリプトは以下を除外してエクスポート:
 

--- a/skills/export-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -159,8 +159,8 @@ describe('main (export-chatlogs)', () => {
    * エクスポート全フロー（解析→探索→パース→書き出し）が疎通していることの基本確認。
    */
   describe('Given: ~/.claude/projects/ に有効な claude セッションJSONL', () => {
-    /** main(["claude", "--output", outputDir]) を呼び出す */
-    describe('When: main(["claude", "--output", outputDir]) を呼び出す', () => {
+    /** main(["claude", "--output-dir", outputDir]) を呼び出す */
+    describe('When: main(["claude", "--output-dir", outputDir]) を呼び出す', () => {
       beforeEach(async () => {
         const projectsDir = `${tempDir}/.claude/projects/C--home-user-projects-my-app`;
         await Deno.mkdir(projectsDir, { recursive: true });
@@ -173,13 +173,13 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-01: ファイルが outputDir に生成される */
       describe('Then: T-EC-E2E-01 - ファイルが outputDir に生成される', () => {
         it('T-EC-E2E-01-01: outputDir に .md ファイルが生成される', async () => {
-          await main(['claude', '--output', outputDir]);
+          await main(['claude', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.length >= 1, true);
         });
 
         it('T-EC-E2E-01-02: logger.log に生成パスが出力される', async () => {
-          await main(['claude', '--output', outputDir]);
+          await main(['claude', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.some((p) => p.endsWith('.md')), true);
         });
@@ -197,8 +197,8 @@ describe('main (export-chatlogs)', () => {
    * claude と異なるディレクトリ構造・JSONL フォーマットが正しく処理されることの基本確認。
    */
   describe('Given: ~/.codex/sessions/ に有効な codex セッションJSONL', () => {
-    /** main(["codex", "--output", outputDir]) を呼び出す */
-    describe('When: main(["codex", "--output", outputDir]) を呼び出す', () => {
+    /** main(["codex", "--output-dir", outputDir]) を呼び出す */
+    describe('When: main(["codex", "--output-dir", outputDir]) を呼び出す', () => {
       beforeEach(async () => {
         const sessionsDir = `${tempDir}/.codex/sessions/2026/03/15`;
         await Deno.mkdir(sessionsDir, { recursive: true });
@@ -221,7 +221,7 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-02: ファイルが outputDir に生成される */
       describe('Then: T-EC-E2E-02 - ファイルが outputDir に生成される', () => {
         it('T-EC-E2E-02-01: outputDir に .md ファイルが生成される', async () => {
-          await main(['codex', '--output', outputDir]);
+          await main(['codex', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.some((p) => p.endsWith('.md')), true);
         });
@@ -276,7 +276,7 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-03-01: 範囲内セッションのみエクスポートされる */
       describe('Then: T-EC-E2E-03-01 - 範囲内セッションのみエクスポートされる', () => {
         it('T-EC-E2E-03-01: ファイルが1件生成される', async () => {
-          await main(['claude', '2026-03', '--output', outputDir]);
+          await main(['claude', '2026-03', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.length, 1);
         });
@@ -288,7 +288,7 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-03-02: ファイルが生成されない */
       describe('Then: T-EC-E2E-03-02 - ファイルが生成されない', () => {
         it('T-EC-E2E-03-02: ファイルが0件', async () => {
-          await main(['claude', '2026-04', '--output', outputDir]);
+          await main(['claude', '2026-04', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.length, 0);
         });
@@ -306,8 +306,8 @@ describe('main (export-chatlogs)', () => {
    * フォルダ整理に直結するため、形式の正確性が重要。
    */
   describe('Given: claude セッションと outputDir が指定される', () => {
-    /** main(["claude", "--output", outputDir]) を呼び出す */
-    describe('When: main(["claude", "--output", outputDir]) を呼び出す', () => {
+    /** main(["claude", "--output-dir", outputDir]) を呼び出す */
+    describe('When: main(["claude", "--output-dir", outputDir]) を呼び出す', () => {
       beforeEach(async () => {
         const projectsDir = `${tempDir}/.claude/projects/C--home-user-projects-struct-app`;
         await Deno.mkdir(projectsDir, { recursive: true });
@@ -326,7 +326,7 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-06: outputDir/claude/YYYY/YYYY-MM/ 構造が生成される */
       describe('Then: T-EC-E2E-06 - outputDir/claude/YYYY/YYYY-MM/ 構造が生成される', () => {
         it('T-EC-E2E-06-01: 出力パスに "claude/2026/2026-03" が含まれる', async () => {
-          await main(['claude', '--output', outputDir]);
+          await main(['claude', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.length >= 1, true);
           assertStringIncludes(loggerStub.logLogs[0], 'claude');
@@ -347,8 +347,8 @@ describe('main (export-chatlogs)', () => {
    * isSkippable による除外ロジックが E2E 全フローで機能することの統合確認。
    */
   describe('Given: 全ユーザーメッセージがスキップ対象のJSONL', () => {
-    /** main(["claude", "--output", outputDir]) を呼び出す */
-    describe('When: main(["claude", "--output", outputDir]) を呼び出す', () => {
+    /** main(["claude", "--output-dir", outputDir]) を呼び出す */
+    describe('When: main(["claude", "--output-dir", outputDir]) を呼び出す', () => {
       beforeEach(async () => {
         const projectsDir = `${tempDir}/.claude/projects/C--home-user-projects-skip-app`;
         await Deno.mkdir(projectsDir, { recursive: true });
@@ -367,7 +367,7 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-07: ファイルが生成されない */
       describe('Then: T-EC-E2E-07 - ファイルが生成されない', () => {
         it('T-EC-E2E-07-01: ログパスが 0 件（スキップされた）', async () => {
-          await main(['claude', '--output', outputDir]);
+          await main(['claude', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.length, 0);
         });
@@ -421,19 +421,19 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-08: 2つの yyyy-mm サブディレクトリに分散出力される */
       describe('Then: T-EC-E2E-08 - 2つの yyyy-mm サブディレクトリに分散出力される', () => {
         it('T-EC-E2E-08-01: ファイルが 2 件生成される', async () => {
-          await main(['claude', '2026', '--output', outputDir]);
+          await main(['claude', '2026', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.length, 2);
         });
 
         it('T-EC-E2E-08-02: 一方のパスに "2026-01" が含まれる', async () => {
-          await main(['claude', '2026', '--output', outputDir]);
+          await main(['claude', '2026', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.some((p) => p.includes('2026-01')), true);
         });
 
         it('T-EC-E2E-08-03: 他方のパスに "2026-03" が含まれる', async () => {
-          await main(['claude', '2026', '--output', outputDir]);
+          await main(['claude', '2026', '--output-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.some((p) => p.includes('2026-03')), true);
         });

--- a/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
@@ -16,11 +16,16 @@ import { buildConfig } from '../../export-chatlogs.ts';
 // classes
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 // constants
-import { DEFAULT_EXPORT_CONFIG, DEFAULT_OUTPUT_DIR } from '../../constants/defaults.constants.ts';
+import {
+  DEFAULT_CHATLOGS_DIR,
+  DEFAULT_ORIGINAL_LOGS_DIR,
+} from '../../../../_scripts/constants/defaults.constants.ts';
+import { DEFAULT_EXPORT_CONFIG } from '../../constants/defaults.constants.ts';
 // types
 import type { ParsedConfig } from '../../types/export-config.types.ts';
 // helpers
 import { resetProjectRoot } from '../../../../_scripts/libs/path-utils/dir-utils.ts';
+import { joinPath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── ヘルパー ──────────────────────────────────────────────────────────────────
 
@@ -60,12 +65,12 @@ const _EMPTY_PARSED: ParsedConfig = {};
  *
  * ## 優先順位ルール
  * - `agent`     : parsed > globalConfig > defaults
- * - `outputDir` : parsed > globalConfig.chatlogsDir > defaults
+ * - `outputDir` : parsed > (globalConfig.chatlogsDir > defaults) + 'originalLogs'
  * - `baseDir`   : parsed のみ（GlobalConfig 連携なし）
  * - `inputDir`  : parsed のみ（GlobalConfig 連携なし）
  * - `period`    : parsed のみ
  *
- * テスト ID 範囲: T-EC-BC-01 〜 T-EC-BC-14
+ * テスト ID 範囲: T-EC-BC-01 〜 T-EC-BC-16
  */
 describe('buildConfig', () => {
   afterEach(() => {
@@ -164,36 +169,36 @@ describe('buildConfig', () => {
    * `parsed.outputDir` が未設定である前提条件グループ。
    *
    * CLI 引数 `--output` が省略されたケースを表す。
-   * `globalConfig.chatlogsDir` が設定されていればそれを使い、
-   * なければ `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
+   * `globalConfig.chatlogsDir` が設定されていればそれを基準に `originalLogs` を付加し、
+   * なければ `DEFAULT_CHATLOGS_DIR` を基準に `originalLogs` を付加した値にフォールバックすることを検証する。
    */
   describe('Given: parsed.outputDir が未指定', () => {
     /** `globalConfig` に `chatlogsDir` が設定されているとき。 */
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
-      /** `globalConfig.chatlogsDir` が採用されることを検証する。 */
-      describe('Then: T-EC-BC-05 - GlobalConfig の chatlogsDir が使われる', () => {
+      /** `globalConfig.chatlogsDir` + `originalLogs` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-05 - GlobalConfig の chatlogsDir + originalLogs が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global/chatlog');
         });
-        it('T-EC-BC-05-01: globalConfig.chatlogsDir=/global/chatlog → result.outputDir === /global/chatlog', () => {
+        it('T-EC-BC-05-01: globalConfig.chatlogsDir=/global/chatlog → result.outputDir === /global/chatlog/originalLogs', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.outputDir, '/global/chatlog');
+          assertEquals(result.outputDir, joinPath('/global/chatlog', DEFAULT_ORIGINAL_LOGS_DIR));
         });
       });
     });
 
     /** `globalConfig` のスキーマに `chatlogsDir` が登録されていないとき。 */
     describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
-      /** `DEFAULT_OUTPUT_DIR` にフォールバックされることを検証する。 */
-      describe('Then: T-EC-BC-06 - DEFAULT_OUTPUT_DIR が使われる', () => {
+      /** `DEFAULT_CHATLOGS_DIR` + `originalLogs` にフォールバックされることを検証する。 */
+      describe('Then: T-EC-BC-06 - DEFAULT_CHATLOGS_DIR + originalLogs が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it("T-EC-BC-06-01: outputDir 未設定, chatlogsDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
+        it("T-EC-BC-06-01: outputDir 未設定, chatlogsDir 未登録 → result.outputDir === DEFAULT_CHATLOGS_DIR + '/originalLogs'", () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.outputDir, DEFAULT_OUTPUT_DIR);
+          assertEquals(result.outputDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
         });
       });
     });
@@ -349,20 +354,20 @@ describe('buildConfig', () => {
    * `buildConfig` の第 3 引数 `defaults` が省略されている前提条件グループ。
    *
    * 省略時は内部で `DEFAULT_EXPORT_CONFIG` が使われる。
-   * `chatlogsDir` も未登録の場合に `DEFAULT_OUTPUT_DIR` にフォールバックすることを検証する。
+   * `chatlogsDir` も未登録の場合に `DEFAULT_CHATLOGS_DIR` + `originalLogs` にフォールバックすることを検証する。
    */
   describe('Given: defaults 引数が省略されている', () => {
     /** `globalConfig` のスキーマに `chatlogsDir` が登録されていないとき。 */
     describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
-      /** `DEFAULT_OUTPUT_DIR` が採用されることを検証する。 */
-      describe('Then: T-EC-BC-13 - DEFAULT_OUTPUT_DIR が使われる', () => {
+      /** `DEFAULT_CHATLOGS_DIR` + `originalLogs` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-13 - DEFAULT_CHATLOGS_DIR + originalLogs が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it("T-EC-BC-13-01: defaults 省略, chatlogsDir 未登録 → result.outputDir === DEFAULT_OUTPUT_DIR ('./chatlogs')", () => {
+        it("T-EC-BC-13-01: defaults 省略, chatlogsDir 未登録 → result.outputDir === DEFAULT_CHATLOGS_DIR + '/originalLogs'", () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.outputDir, DEFAULT_OUTPUT_DIR);
+          assertEquals(result.outputDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
         });
       });
     });
@@ -389,6 +394,31 @@ describe('buildConfig', () => {
           const _parsed: ParsedConfig = { agent: 'claude', configFile: '/path/to/config.yaml' };
           const result = buildConfig(_parsed, globalConfig);
           assertEquals((result as unknown as Record<string, unknown>).configFile, undefined);
+        });
+      });
+    });
+  });
+
+  // ─── dryRun の引き継ぎ ────────────────────────────────────────────────────────
+
+  /**
+   * `parsed.dryRun` が `result.dryRun` にそのまま引き継がれることを確認する。
+   *
+   * `--dry-run` は `_DEFAULT_SCHEMA` 経由で `parsed.dryRun` にセットされ、
+   * `buildConfig` のスプレッドで `ExportConfig` にそのまま反映される。
+   */
+  describe('Given: ParsedConfig に dryRun が指定されている', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.dryRun` が `parsed.dryRun` と一致することを検証する。 */
+      describe('Then: T-EC-BC-16 - result.dryRun === parsed.dryRun', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance({ schema: {} });
+        });
+        it('T-EC-BC-16-01: parsed.dryRun=true → result.dryRun === true', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, agent: 'claude', dryRun: true }, globalConfig);
+          assertEquals(result.dryRun, true);
         });
       });
     });

--- a/skills/export-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -24,7 +24,7 @@ import type { ParsedConfig } from '../../types/export-config.types.ts';
  * `parseArgs` のユニットテストスイート。
  *
  * CLI 引数配列を受け取り ExportConfig を返す関数の動作を検証する。
- * agent 名・period・--output/--base/--input オプションの各解析パターンと、
+ * agent 名・period・--output-dir/--base/--input-dir オプションの各解析パターンと、
  * 複数フィールドの組み合わせ・未知引数での ChatlogError スローをカバーする。
  *
  * @see parseArgs
@@ -48,25 +48,25 @@ describe('parseArgs', () => {
           { id: 'T-EC-PA-02-01', args: ['codex'], field: 'agent', expected: 'codex' },
           { id: 'T-EC-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
           { id: 'T-EC-PA-03-02', args: ['2026'], field: 'period', expected: '2026' },
-          { id: 'T-EC-PA-04-01', args: ['--output', '/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
-          { id: 'T-EC-PA-04-02', args: ['--output=/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
+          { id: 'T-EC-PA-04-01', args: ['--output-dir', '/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
+          { id: 'T-EC-PA-04-02', args: ['--output-dir=/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
           { id: 'T-EC-PA-08-01', args: ['--base', '/data/logs'], field: 'baseDir', expected: '/data/logs' },
           { id: 'T-EC-PA-08-02', args: ['--base=/data/logs'], field: 'baseDir', expected: '/data/logs' },
           {
             id: 'T-EC-PA-11-01',
-            args: ['--output', '/chatlog/claude'],
+            args: ['--output-dir', '/chatlog/claude'],
             field: 'outputDir',
             expected: '/chatlog/claude',
           },
           {
             id: 'T-EC-PA-12-01',
-            args: ['--input', '/data/chatgpt-export'],
+            args: ['--input-dir', '/data/chatgpt-export'],
             field: 'inputDir',
             expected: '/data/chatgpt-export',
           },
           {
             id: 'T-EC-PA-12-02',
-            args: ['--input=/data/chatgpt-export'],
+            args: ['--input-dir=/data/chatgpt-export'],
             field: 'inputDir',
             expected: '/data/chatgpt-export',
           },
@@ -97,24 +97,24 @@ describe('parseArgs', () => {
 
   /**
    * baseDir と outputDir を同時に指定する組み合わせケース。
-   * --base と --output が互いに干渉せず独立したフィールドに設定されることを確認する。
+   * --base と --output-dir が互いに干渉せず独立したフィールドに設定されることを確認する。
    */
-  describe('Given: ["--base", "/data", "--output", "/data/claude"]', () => {
+  describe('Given: ["--base", "/data", "--output-dir", "/data/claude"]', () => {
     it('T-EC-PA-09: baseDir と outputDir が同時に設定される', () => {
-      const result = parseArgs(['--base', '/data', '--output', '/data/claude']);
+      const result = parseArgs(['--base', '/data', '--output-dir', '/data/claude']);
       assertEquals(result.baseDir, '/data');
       assertEquals(result.outputDir, '/data/claude');
     });
   });
 
   /**
-   * agent・period・--output を同時に指定する3フィールド組み合わせケース。
-   * 位置引数（agent・period）とオプション引数（--output）が混在しても
+   * agent・period・--output-dir を同時に指定する3フィールド組み合わせケース。
+   * 位置引数（agent・period）とオプション引数（--output-dir）が混在しても
    * 正しく解析されることを確認する。
    */
-  describe('Given: ["claude", "2026-03", "--output", "/out"]', () => {
+  describe('Given: ["claude", "2026-03", "--output-dir", "/out"]', () => {
     it('T-EC-PA-07: agent・period・outputDir が同時に設定される', () => {
-      const result = parseArgs(['claude', '2026-03', '--output', '/out']);
+      const result = parseArgs(['claude', '2026-03', '--output-dir', '/out']);
       assertEquals(result.agent, 'claude');
       assertEquals(result.period, '2026-03');
       assertEquals(result.outputDir, '/out');
@@ -135,13 +135,13 @@ describe('parseArgs', () => {
   });
 
   /**
-   * chatgpt agent と --input を組み合わせるケース。
-   * ChatGPT エクスポートでは --input で入力ディレクトリを指定するため、
+   * chatgpt agent と --input-dir を組み合わせるケース。
+   * ChatGPT エクスポートでは --input-dir で入力ディレクトリを指定するため、
    * agent と inputDir が同時に正しく設定されることを確認する。
    */
-  describe('Given: ["chatgpt", "--input", "/data/export"]', () => {
+  describe('Given: ["chatgpt", "--input-dir", "/data/export"]', () => {
     it('T-EC-PA-14: agent と inputDir が同時に設定される', () => {
-      const result = parseArgs(['chatgpt', '--input', '/data/export']);
+      const result = parseArgs(['chatgpt', '--input-dir', '/data/export']);
       assertEquals(result.agent, 'chatgpt');
       assertEquals(result.inputDir, '/data/export');
     });

--- a/skills/export-chatlogs/scripts/export-chatlogs.ts
+++ b/skills/export-chatlogs/scripts/export-chatlogs.ts
@@ -11,7 +11,7 @@
  *
  * 使い方:
  *   deno run --allow-read --allow-write --allow-env export_chatlogs.ts \
- *     [agent] [YYYY-MM|YYYY] [project] --output DIR
+ *     [agent] [YYYY-MM|YYYY] [project] --output-dir DIR
  *
  * 対応エージェント:
  *   claude  — ~/.claude/projects/ 以下のJSONL
@@ -26,7 +26,10 @@ import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 // libs
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { joinPath } from '../../_scripts/libs/path-utils/path-utils.ts';
 import type { ArgsSchema } from '../../_scripts/types/args-schema.types.ts';
+// constants
+import { DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────
 // exporters
@@ -44,10 +47,9 @@ import type { ExportConfig, ParsedConfig } from './types/export-config.types.ts'
 
 /** export-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgsSchema = [
-  { option: '--output', field: 'outputDir', type: 'string' },
+  { option: '--output-dir', field: 'outputDir', type: 'directory' },
   { option: '--base', field: 'baseDir', type: 'directory' },
-  { option: '--input', field: 'inputDir', type: 'string' },
-  { option: '--config', field: 'configFile', type: 'string' },
+  { option: '--input-dir', field: 'inputDir', type: 'directory' },
 ];
 
 /**
@@ -67,7 +69,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な ExportConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - outputDir 優先順位: `parsed.outputDir` > `globalConfig.get('chatlogsDir')` > `defaults.outputDir`
+ * - outputDir 優先順位: `parsed.outputDir` > `join(globalConfig.get('chatlogsDir') ?? DEFAULT_CHATLOGS_DIR, 'originalLogs')`
  * - baseDir 優先順位: `parsed.baseDir` > `defaults.baseDir`
  * - inputDir 優先順位: `parsed.inputDir` > `parsed.chatlogsDir` > `defaults.inputDir`
  * - period: `parsed.period` のみ (GlobalConfig に期間設定なし)
@@ -79,7 +81,8 @@ export function buildConfig(
 ): ExportConfig {
   const _defaults = defaults ?? DEFAULT_EXPORT_CONFIG;
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
-  const _outputDir = parsed.outputDir ?? globalConfig.get('chatlogsDir') as string;
+  const _chatlogsDir = (globalConfig.get('chatlogsDir') as string | undefined) ?? DEFAULT_CHATLOGS_DIR;
+  const _outputDir = parsed.outputDir ?? joinPath(_chatlogsDir, DEFAULT_ORIGINAL_LOGS_DIR);
   const _baseDir = parsed.baseDir ?? _defaults.baseDir;
   const _inputDir = parsed.inputDir ?? parsed.chatlogsDir ?? _defaults.inputDir;
   const { configFile: _configFile, ...parsedRest } = parsed;
@@ -139,7 +142,7 @@ export const main = async (argv?: string[]): Promise<void> => {
           throw new ChatlogError(
             'InvalidArgs',
             'NotSpecified',
-            'chatgpt エージェントには入力ディレクトリを指定してください (位置引数または --input)',
+            'chatgpt エージェントには入力ディレクトリを指定してください (位置引数または --input-dir)',
           );
         }
         result = await exportChatGPT(config);

--- a/skills/export-chatlogs/scripts/types/export-config.types.ts
+++ b/skills/export-chatlogs/scripts/types/export-config.types.ts
@@ -38,6 +38,8 @@ export interface ExportConfig {
   outputDir: string;
   /** チャットログ格納ディレクトリ。位置引数のディレクトリパスが設定される。 */
   chatlogsDir?: string;
+  /** dry-run モード。`--dry-run` オプションの解析結果を保持する（現状 `main()` 側での書き込みスキップは未実装）。 */
+  dryRun?: boolean;
 }
 
 /**

--- a/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
@@ -26,10 +26,6 @@ import type { PrefilterConfig, PrefilterParsedConfig } from '../types/prefilter.
 
 /** prefilter-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgsSchema = [
-  { option: '--base-dir', field: 'baseDir', type: 'directory' },
-  { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
-  { option: '--config', field: 'configFile', type: 'string' },
-  { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--report', field: 'report', type: 'flag' },
 ];
 

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -47,12 +47,7 @@ import type { FilterConfig, FilterParsedConfig } from './types/filter.types.ts';
 // ─────────────────────────────────────────────
 
 /** filter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema = [
-  { option: '--base-dir', field: 'baseDir', type: 'directory' },
-  { option: '--config', field: 'configFile', type: 'string' },
-  { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
-  { option: '--dry-run', field: 'dryRun', type: 'flag' },
-];
+const _SCHEMA: ArgsSchema = [];
 
 export const parseArgs = (args: string[]): FilterParsedConfig => {
   return parseArgsToConfig<FilterParsedConfig>(args, _SCHEMA) as FilterParsedConfig;

--- a/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
+++ b/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
@@ -27,12 +27,8 @@ import { DEFAULT_NORMALIZE_CONFIG } from '../constants/normalize.constants.ts';
 // --- local
 // constants
 const _SCHEMA: ArgsSchema = [
-  { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
-  { option: '--base-dir', field: 'baseDir', type: 'directory' },
   { option: '--agent', field: 'agent', type: 'agent' },
   { option: '--period', field: 'period', type: 'period' },
-  { option: '--config', field: 'configFile', type: 'string' },
-  { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--concurrency', field: 'concurrency', type: 'integer' },
   { option: '--timeout-ms', field: 'timeoutMs', type: 'integer' },
   { option: '--normalize-dir', field: 'normalizeDir', type: 'directory' },

--- a/skills/set-frontmatter/scripts/modules/setfm-config.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-config.ts
@@ -34,11 +34,9 @@ const _SCHEMA: ArgsSchema = [
   { option: '--output-dir', field: 'outputDir', type: 'directory' },
   { option: '--dics', field: 'dicsDir', type: 'directory' },
   { option: '--prompts', field: 'promptsDir', type: 'directory' },
-  { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--review', field: 'review', type: 'flag' },
   { option: '--concurrency', field: 'concurrency', type: 'integer' },
   { option: '--cache-dir', field: 'cacheDir', type: 'string' },
-  { option: '--config', field: 'configFile', type: 'string' },
 ];
 
 export const parseArgs = (args: string[]): ParsedConfig => {


### PR DESCRIPTION
## Overview

**Summary**
Move shared CLI args to a common schema and separate raw exports into their own directory.

**Background / Motivation**
Each skill (`classify-chatlogs`, `normalize-chatlogs`, `filter-chatlogs`, `set-frontmatter`) redefined the same `--config`, `--dry-run`, `--base-dir`, and `--chatlogs-dir` options. This duplication is now removed by adding these options to the shared default schema. `export-chatlogs` also gets clearer flag names and a safer default output path, so raw exports don't mix with downstream processed data.

## Changes

### Core Changes

- Add `--config`, `--dry-run`, `--base-dir`, `--chatlogs-dir` to the shared default schema (`skills/_scripts/libs/io/parse-args.ts`)
- Add `DEFAULT_ORIGINAL_LOGS_DIR` constant (`skills/_scripts/constants/defaults.constants.ts`)
- `export-chatlogs`: rename `--output` → `--output-dir` and `--input` → `--input-dir`, remove unused `--config` option, default output to `<chatlogsDir>/originalLogs`
- `export-chatlogs`: add `dryRun` to `ExportConfig`
- Remove now-duplicated schema options from `classify-chatlogs`, `normalize-chatlogs`, `filter-chatlogs`, and `set-frontmatter`

### Test Updates

- Update `export-chatlogs` unit/functional/e2e tests for the new flag names and default output path
- Add test for `--config` default in the shared schema

### Removed

- Unused `--config` option in `export-chatlogs`
- Duplicated per-module `--base-dir` / `--chatlogs-dir` / `--config` / `--dry-run` schema definitions

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #274

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Breaking change: `export-chatlogs` flags `--output`/`--input` are renamed to `--output-dir`/`--input-dir`, and the default output path is now `<chatlogsDir>/originalLogs` instead of `chatlogsDir` directly. Scripts calling `export-chatlogs` with the old flags or relying on the old default path need to be updated.

Issue #274 is inferred from the branch name (`refactor-274/chatlogs-dir/add-originallogs`); no explicit issue reference was found in commit messages.
