### PR TITLE
feat(classify-chatlogs): resolve chatlogs under originalLogs dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ node_modules/
 .beads/*
 !**/.gitignore
 !.beads/config.yaml
+!.beads/issues.jsonl
 
 
 # Beads / Dolt files (added by bd init)

--- a/skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
@@ -176,7 +176,7 @@ describe('agentPath', () => {
  * - `chatlogsDir` 指定あり → そのまま返す（agent/period は無視）
  * - `chatlogsDir` 未定義 → `baseDir/agentPath(agent, period)` を返す
  *
- * テスト ID 範囲: T-LIB-RD-03-01 〜 T-LIB-RD-03-04
+ * テスト ID 範囲: T-LIB-RD-03-01 〜 T-LIB-RD-03-06
  *
  * @see resolveChatlogsDir
  */
@@ -208,6 +208,15 @@ describe('resolveChatlogsDir', () => {
       };
       assertEquals(resolveChatlogsDir(_opts), '/custom/chatlogs/claude/2026/2026-03');
     });
+
+    it('[Normal] T-LIB-RD-03-05: chatlogsDir 未定義、addOnDir 指定 → baseDir/addOnDir/agent', () => {
+      const _opts: ResolveChatlogsDirOptions = {
+        baseDir: '/custom/chatlogs',
+        agent: 'claude',
+        addOnDir: 'originalLogs',
+      };
+      assertEquals(resolveChatlogsDir(_opts), '/custom/chatlogs/originalLogs/claude');
+    });
   });
 
   /** エッジケース。 */
@@ -218,6 +227,16 @@ describe('resolveChatlogsDir', () => {
         baseDir: '/custom/chatlogs',
         agent: 'claude',
         period: '2026-03',
+      };
+      assertEquals(resolveChatlogsDir(_opts), '/explicit/chatlogs');
+    });
+
+    it('[Edge] T-LIB-RD-03-06: chatlogsDir 指定あり + addOnDir 指定 → chatlogsDir をそのまま返す（addOnDir 無視）', () => {
+      const _opts: ResolveChatlogsDirOptions = {
+        chatlogsDir: '/explicit/chatlogs',
+        baseDir: '/custom/chatlogs',
+        agent: 'claude',
+        addOnDir: 'originalLogs',
       };
       assertEquals(resolveChatlogsDir(_opts), '/explicit/chatlogs');
     });

--- a/skills/_scripts/libs/file-io/resolve-directory.ts
+++ b/skills/_scripts/libs/file-io/resolve-directory.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // functions
-import { normalizePath } from '../path-utils/path-utils.ts';
+import { joinPath, normalizePath } from '../path-utils/path-utils.ts';
 
 // ─────────────────────────────────────────────
 // チャットログパス構築
@@ -47,16 +47,22 @@ export type ResolveChatlogsDirOptions = {
   baseDir: string;
   agent: string;
   period?: string;
+  addOnDir?: string;
 };
 
 /**
  * チャットログディレクトリを解決する。
  *
- * - `chatlogsDir` が指定済み → そのまま返す（agent/period は無視）
- * - `chatlogsDir` が未定義 → `baseDir/agentPath(agent, period)` を返す
+ * - `chatlogsDir` が指定済み → そのまま返す（agent/period/addOnDir は無視）
+ * - `chatlogsDir` が未定義 → `baseDir` と `agentPath(agent, period)` の間に
+ *   `addOnDir`（指定時のみ）を挟んだパスを返す
  */
-export const resolveChatlogsDir = ({ chatlogsDir, baseDir, agent, period }: ResolveChatlogsDirOptions): string => {
-  return chatlogsDir ?? `${baseDir}/${agentPath(agent, period)}`;
+export const resolveChatlogsDir = (
+  { chatlogsDir, baseDir, agent, period, addOnDir }: ResolveChatlogsDirOptions,
+): string => {
+  if (chatlogsDir) { return chatlogsDir; }
+  const _base = addOnDir ? joinPath(baseDir, addOnDir) : baseDir;
+  return `${_base}/${agentPath(agent, period)}`;
 };
 
 // ─────────────────────────────────────────────

--- a/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -3,8 +3,8 @@
 //       main() 経由でのファイル分類フロー（Deno.Command モック・実 tempdir）
 //
 //       classify-chatlogs の動作:
-//         入力: baseDir/agent/YYYY/YYYY-MM/*.md
-//         出力: ファイルを baseDir/agent/YYYY/YYYY-MM/<project>/ サブディレクトリに移動
+//         入力: baseDir/originalLogs/agent/YYYY/YYYY-MM/*.md
+//         出力: ファイルを baseDir/originalLogs/agent/YYYY/YYYY-MM/<project>/ サブディレクトリに移動
 //               (normalize-chatlog と異なり、別出力ディレクトリはない)
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -48,7 +48,7 @@ import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.t
  * inputDir / configsDir を作成して返す。
  * - configsDir/config.yaml: 空の設定ファイル（GlobalConfig 用）
  * - configsDir/projects.dic: テスト用プロジェクト辞書（YAML 形式）
- * - inputDir/agent/YYYY/YYYY-MM/: 月別ディレクトリ（入れ子形式）
+ * - inputDir/originalLogs/agent/YYYY/YYYY-MM/: 月別ディレクトリ（入れ子形式）
  */
 async function _makeTestDirs(agent = 'claude', period = '2026-03'): Promise<{
   inputDir: string;
@@ -60,7 +60,7 @@ async function _makeTestDirs(agent = 'claude', period = '2026-03'): Promise<{
   const configsDir = normalizePath(await Deno.makeTempDir());
   const configFile = `${configsDir}/config.yaml`;
   const year = period.slice(0, 4);
-  const monthDir = `${inputDir}/${agent}/${year}/${period}`;
+  const monthDir = `${inputDir}/originalLogs/${agent}/${year}/${period}`;
   await Deno.mkdir(monthDir, { recursive: true });
   await Deno.writeTextFile(configFile, `dicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`);
   await Deno.writeTextFile(
@@ -354,7 +354,7 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
         beforeEach(async () => {
           ({ inputDir, configsDir, configFile } = await _makeTestDirs());
           // 既に app1/ サブディレクトリに配置済み
-          const app1Dir = `${inputDir}/claude/2026/2026-03/app1`;
+          const app1Dir = `${inputDir}/originalLogs/claude/2026/2026-03/app1`;
           await Deno.mkdir(app1Dir, { recursive: true });
           await Deno.writeTextFile(
             `${app1Dir}/chat.md`,
@@ -391,7 +391,7 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
         it('T-CL-E2E-09-02: app1/app1/ ディレクトリが作成されない', async () => {
           await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
 
-          assertEquals(await fileOrDirExists(`${inputDir}/claude/2026/2026-03/app1/app1`), false);
+          assertEquals(await fileOrDirExists(`${inputDir}/originalLogs/claude/2026/2026-03/app1/app1`), false);
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -22,6 +22,8 @@ import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
+// constants
+import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 
 // ─── Local
 import { loadProjectDic } from './libs/load-project-dic.ts';
@@ -75,6 +77,7 @@ export const main = async (argv?: string[]): Promise<void> => {
       baseDir: _config.baseDir,
       agent: _config.agent,
       period: _config.period,
+      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
     });
     if (!await dirExists(_agentDir)) {
       throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_agentDir}`);
@@ -98,6 +101,7 @@ export const main = async (argv?: string[]): Promise<void> => {
       baseDir: _config.baseDir,
       agent: _config.agent,
       period: _config.period,
+      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
     });
 
     const stats: ClassifyStats = { moved: 0, movedByAI: 0, skipped: 0, error: 0, remaining: 0 };


### PR DESCRIPTION
## Overview

**Summary**
Resolve classify-chatlogs input/output paths under an `originalLogs/` addon directory.

**Background / Motivation**
`classify-chatlogs` used to resolve chatlog paths directly under `baseDir/agent/...`. This adds a generic `addOnDir` option to `resolveChatlogsDir` and has `classify-chatlogs` pass `DEFAULT_ORIGINAL_LOGS_DIR` (`'originalLogs'`), so paths now resolve under `baseDir/originalLogs/agent/...`.

## Changes

### Core Changes

- `skills/_scripts/libs/file-io/resolve-directory.ts` — add `addOnDir` to `ResolveChatlogsDirOptions`; when `chatlogsDir` is unset, insert `addOnDir` (if given) between `baseDir` and `agentPath(agent, period)`
- `skills/classify-chatlogs/scripts/classify-chatlogs.ts` — import `DEFAULT_ORIGINAL_LOGS_DIR` and pass `addOnDir: DEFAULT_ORIGINAL_LOGS_DIR` to both `resolveChatlogsDir` calls
- `.gitignore` — stop ignoring `.beads/issues.jsonl`

### Test Updates

- `skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts` — add cases for `addOnDir` resolution (T-LIB-RD-03-05) and `addOnDir` being ignored when `chatlogsDir` is set (T-LIB-RD-03-06)
- `skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts` — update fixture paths to `baseDir/originalLogs/agent/YYYY/YYYY-MM/`

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> Related to #276

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This changes the resolved directory layout for classify-chatlogs (adds an `originalLogs/` segment). Existing users relying on the old flat `baseDir/agent/...` layout will need to move their log files accordingly.
