### PR TITLE
fix(filter-chatlogs): default base dir to original logs

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
@@ -24,6 +24,7 @@ import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts
 // types
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants
+import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
 import { PREFILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // e2e helpers
 import { assertFileExist, assertFileNotExist } from '../../../../_scripts/__tests__/helpers/assert.ts';
@@ -359,11 +360,19 @@ describe('main (prefilter) - period 絞り込み', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          ({ tempDir, periodDir1: chatlogsDir03, periodDir2: chatlogsDir04 } = await makePeriodDir(
+          let periodDir1: string;
+          let periodDir2: string;
+          ({ tempDir, periodDir1, periodDir2 } = await makePeriodDir(
             'claude',
             '2026-03',
             '2026-04',
           ));
+          // baseDir は GlobalConfig.chatlogsDir + originalLogs から解決されるため、
+          // ノイズファイルは originalLogs 配下に作成する。
+          chatlogsDir03 = periodDir1.replace(`${tempDir}/`, `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/`);
+          chatlogsDir04 = periodDir2.replace(`${tempDir}/`, `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/`);
+          await Deno.mkdir(chatlogsDir03, { recursive: true });
+          await Deno.mkdir(chatlogsDir04, { recursive: true });
           await _makeGlobalConfig(`chatlogsDir: '${tempDir}'`);
           loggerStub = makeLoggerStub();
         });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -18,11 +18,16 @@ import type { FilterConfig, FilterParsedConfig } from '../../../types/filter.typ
 
 // ─── Helpers
 // constants
+import {
+  DEFAULT_CHATLOGS_DIR,
+  DEFAULT_ORIGINAL_LOGS_DIR,
+} from '../../../../../_scripts/constants/defaults.constants.ts';
 import { DEFAULT_FILTER_CONFIG } from '../../../constants/common.constants.ts';
 // classes
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 // helpers
 import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
+import { joinPath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Internal Helpers
 
@@ -63,7 +68,7 @@ const _CUSTOM_DEFAULTS: FilterConfig = {
  *
  * ## 優先順位ルール
  * - `agent`    : parsed > globalConfig > defaults
- * - `baseDir`  : parsed > globalConfig.chatlogsDir
+ * - `baseDir`  : parsed > joinPath(globalConfig.chatlogsDir, 'originalLogs')
  * - `dryRun`   : parsed > defaults (false)
  * - `period`   : parsed のみ（GlobalConfig 連携なし）
  * - `configFile` は FilterConfig に存在しないため結果に含まれない
@@ -71,7 +76,7 @@ const _CUSTOM_DEFAULTS: FilterConfig = {
  * - `chunkSize`   : parsed > globalConfig.chunkSize > defaults
  * - `concurrency` : parsed > globalConfig.concurrency > defaults
  *
- * テスト ID 範囲: T-FL-BC-01 〜 T-FL-BC-31
+ * テスト ID 範囲: T-FL-BC-01 〜 T-FL-BC-32
  *
  * @see buildConfig
  */
@@ -166,19 +171,33 @@ describe('buildConfig', () => {
   /**
    * `parsed.baseDir` が未指定の前提条件グループ。
    *
-   * GlobalConfig.chatlogsDir がある場合はその値が使われることを検証する。
+   * GlobalConfig.chatlogsDir に `originalLogs` を付加した値が使われることを検証する。
    */
   describe('Given: parsed.baseDir が未指定', () => {
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
-      /** GlobalConfig.chatlogsDir が baseDir に使われることを検証する。 */
-      describe('Then: T-FL-BC-31 - GlobalConfig の chatlogsDir が baseDir に使われる', () => {
+      /** GlobalConfig.chatlogsDir + originalLogs が baseDir に使われることを検証する。 */
+      describe('Then: T-FL-BC-31 - GlobalConfig の chatlogsDir + originalLogs が baseDir に使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-FL-BC-31: globalConfig.chatlogsDir=/global → result.baseDir === /global', () => {
+        it('T-FL-BC-31: globalConfig.chatlogsDir=/global → result.baseDir === /global/originalLogs', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, '/global');
+          assertEquals(result.baseDir, joinPath('/global', DEFAULT_ORIGINAL_LOGS_DIR));
+        });
+      });
+    });
+
+    describe('When: GlobalConfig にもデフォルトの chatlogsDir のみ設定されている', () => {
+      /** DEFAULT_CHATLOGS_DIR + originalLogs が baseDir に使われることを検証する。 */
+      describe('Then: T-FL-BC-32 - DEFAULT_CHATLOGS_DIR + originalLogs が baseDir に使われる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await GlobalConfig.getInstance();
+        });
+        it('T-FL-BC-32: chatlogsDir 未設定 → result.baseDir === DEFAULT_CHATLOGS_DIR/originalLogs', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.baseDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/prefilter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/prefilter/build-config.functional.spec.ts
@@ -18,11 +18,16 @@ import type { PrefilterConfig, PrefilterParsedConfig } from '../../../types/pref
 
 // ─── Helpers
 // constants
+import {
+  DEFAULT_CHATLOGS_DIR,
+  DEFAULT_ORIGINAL_LOGS_DIR,
+} from '../../../../../_scripts/constants/defaults.constants.ts';
 import { DEFAULT_PREFILTER_CONFIG } from '../../../constants/common.constants.ts';
 // classes
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 // helpers
 import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
+import { joinPath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Internal Helpers
 
@@ -65,6 +70,7 @@ const _CUSTOM_DEFAULTS: PrefilterConfig = {
  * ## 優先順位ルール
  * - `agent`      : parsed > globalConfig > defaults
  * - `chatlogsDir`: parsed > globalConfig.chatlogsDir > defaults.chatlogsDir
+ * - `baseDir`    : parsed.baseDir > joinPath(globalConfig.chatlogsDir, 'originalLogs')
  * - `period`     : parsed のみ（GlobalConfig 連携なし）
  * - `dryRun`     : parsed > defaults (false)
  * - `report`     : parsed > defaults (false)
@@ -223,19 +229,33 @@ describe('buildConfig (prefilter functional)', () => {
   /**
    * `parsed.baseDir` が未指定の前提条件グループ。
    *
-   * GlobalConfig.chatlogsDir が baseDir にフォールバックすることを検証する。
+   * GlobalConfig.chatlogsDir に `originalLogs` を付加した値が baseDir にフォールバックすることを検証する。
    */
   describe('Given: parsed.baseDir が未指定', () => {
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
-      /** GlobalConfig.chatlogsDir が baseDir になることを検証する。 */
-      describe('Then: T-PF-BC-16-02 - GlobalConfig の chatlogsDir が baseDir になる', () => {
+      /** GlobalConfig.chatlogsDir + originalLogs が baseDir になることを検証する。 */
+      describe('Then: T-PF-BC-16-02 - GlobalConfig の chatlogsDir + originalLogs が baseDir になる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-PF-BC-16-02: globalConfig.chatlogsDir=/global → result.baseDir === /global', () => {
+        it('T-PF-BC-16-02: globalConfig.chatlogsDir=/global → result.baseDir === /global/originalLogs', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, '/global');
+          assertEquals(result.baseDir, joinPath('/global', DEFAULT_ORIGINAL_LOGS_DIR));
+        });
+      });
+    });
+
+    describe('When: GlobalConfig にもデフォルトの chatlogsDir のみ設定されている', () => {
+      /** DEFAULT_CHATLOGS_DIR + originalLogs が baseDir になることを検証する。 */
+      describe('Then: T-PF-BC-16-03 - DEFAULT_CHATLOGS_DIR + originalLogs が baseDir になる', () => {
+        let globalConfig: GlobalConfig;
+        beforeEach(async () => {
+          globalConfig = await _makeGlobalConfig('agent: claude');
+        });
+        it('T-PF-BC-16-03: chatlogsDir 未設定 → result.baseDir === DEFAULT_CHATLOGS_DIR/originalLogs', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.baseDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
@@ -9,6 +9,7 @@
 // ─── shared ───
 // functions
 import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
+import { joinPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // types
 import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
 // classes
@@ -16,6 +17,7 @@ import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── internal ───
 // constants
+import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../_scripts/constants/defaults.constants.ts';
 import { DEFAULT_PREFILTER_CONFIG } from '../constants/common.constants.ts';
 // types
 import type { PrefilterConfig, PrefilterParsedConfig } from '../types/prefilter.types.ts';
@@ -45,8 +47,8 @@ export const parseArgs = (args: string[]): PrefilterParsedConfig => {
 /**
  * PrefilterParsedConfig・GlobalConfig・デフォルト値から完全な PrefilterConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - baseDir 優先順位: `parsed.baseDir` > `globalConfig.get('chatlogsDir')`
- * - chatlogsDir 優先順位: `parsed.chatlogsDir` > `baseDir`
+ * - baseDir 優先順位: `parsed.baseDir` > `joinPath(globalConfig.get('chatlogsDir'), DEFAULT_ORIGINAL_LOGS_DIR)`
+ * - chatlogsDir 優先順位: `parsed.chatlogsDir` > `globalConfig.get('chatlogsDir')`
  * - `configFile` は PrefilterConfig に存在しないため結果に含まれない。
  */
 export const buildConfig = (
@@ -56,8 +58,8 @@ export const buildConfig = (
 ): PrefilterConfig => {
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _globalChatlogDir = globalConfig.get('chatlogsDir') as string;
-  const _baseDir = parsed.baseDir ?? _globalChatlogDir;
-  const _chatlogsDir = parsed.chatlogsDir ?? _baseDir;
+  const _baseDir = parsed.baseDir ?? joinPath(_globalChatlogDir, DEFAULT_ORIGINAL_LOGS_DIR);
+  const _chatlogsDir = parsed.chatlogsDir ?? _globalChatlogDir;
   const { configFile: _configFile, ...rest } = parsed;
   return {
     ...defaults,

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -28,7 +28,9 @@ import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
+import { joinPath } from '../../_scripts/libs/path-utils/path-utils.ts';
 // constants
+import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.ts';
 // types
 import type { ArgsSchema } from '../../_scripts/types/args-schema.types.ts';
@@ -60,7 +62,7 @@ export const parseArgs = (args: string[]): FilterParsedConfig => {
 /**
  * FilterParsedConfig・GlobalConfig・デフォルト値から完全な FilterConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - baseDir 優先順位: `parsed.baseDir` > `globalConfig.get('chatlogsDir')`
+ * - baseDir 優先順位: `parsed.baseDir` > `joinPath(globalConfig.get('chatlogsDir'), DEFAULT_ORIGINAL_LOGS_DIR)`
  * - chatlogsDir 優先順位: `parsed.chatlogsDir`（直接指定のみ、未指定なら `undefined`）
  * - dryRun: `parsed.dryRun` > `defaults.dryRun`（false）
  * - period: `parsed` のみ（GlobalConfig 連携なし）
@@ -74,7 +76,7 @@ export const buildConfig = (
 ): FilterConfig => {
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _globalChatlogDir = globalConfig.get('chatlogsDir') as string;
-  const _baseDir = parsed.baseDir ?? _globalChatlogDir;
+  const _baseDir = parsed.baseDir ?? joinPath(_globalChatlogDir, DEFAULT_ORIGINAL_LOGS_DIR);
   const _chatlogsDir = parsed.chatlogsDir;
   const _chunkSize = parsed.chunkSize ?? globalConfig.get('chunkSize') as number;
   const _concurrency = parsed.concurrency ?? globalConfig.get('concurrency') as number;


### PR DESCRIPTION
## Overview

**Summary**
Default `baseDir` for filter-chatlogs now points to `chatlogsDir/originalLogs`.

**Background / Motivation**
`classify-chatlogs` (#277) now writes logs under `originalLogs/`. filter-chatlogs still defaulted to the old path, so it looked in the wrong place unless `baseDir`/`chatlogsDir` were set manually. This PR updates the defaults to match, and fixes a bug where `prefilter-config`'s `chatlogsDir` default doubled the `originalLogs` segment.

## Changes

### Core Changes

- `skills/filter-chatlogs/scripts/filter-chatlogs.ts` — default `baseDir` to `chatlogsDir/originalLogs`
- `skills/filter-chatlogs/scripts/configs/prefilter-config.ts` — same `baseDir` fix; also fix `chatlogsDir` default to use the global `chatlogsDir` instead of the joined `baseDir`

### Test Updates

- `skills/filter-chatlogs/__tests__/functional/filter/build-config.functional.spec.ts` — cover the new default `baseDir`
- `skills/filter-chatlogs/__tests__/functional/prefilter/build-config.functional.spec.ts` — cover the new default `baseDir` and fixed `chatlogsDir`
- `skills/filter-chatlogs/__tests__/e2e/prefilter.main.e2e.spec.ts` — update fixture paths

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> Related to #277

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Default paths change for users who don't pass `baseDir`/`chatlogsDir` explicitly. If your logs are still in the old location, pass `--baseDir` explicitly or move them under `originalLogs/`.
