### PR TITLE
fix(normalize-chatlogs): default input to originalLogs directory

### DIFF
--- a/skills/normalize-chatlogs/SKILL.md
+++ b/skills/normalize-chatlogs/SKILL.md
@@ -92,6 +92,11 @@ deno run --allow-read --allow-write --allow-env --allow-run "$SCRIPT_PATH" {変�
 - `fail > 0` の場合は失敗件数を警告として強調表示
 - dry-run モードの場合はその旨を明示する
 
+## 入力ディレクトリ
+
+`--chatlogs-dir` 未指定時、デフォルトの入力元は `chatlogs/originalLogs/<agent>/<year>/<yearMonth>` である
+（`--chatlogs-dir` 明示指定時は `originalLogs` を挟まず指定パスをそのまま使う）。
+
 ## 出力ディレクトリ構造
 
 入力が `chatlogs/<agent>/<year>/<yearMonth>` 形式の場合:

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
@@ -1,0 +1,118 @@
+// src: skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
+// @(#): normalize-chatlogs main() の入力ディレクトリ解決テスト
+//       対象: main
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertMatch } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+// stub
+import { stub } from '@std/testing/mock';
+// types
+import type { Stub } from '@std/testing/mock';
+
+// ─── Test target
+import { main } from '../../normalize-chatlogs.ts';
+
+// ─── Helpers
+import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
+// types
+import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+
+// ─── Tests
+
+/**
+ * `main` の入力ディレクトリ解決テストスイート。
+ *
+ * `--chatlogs-dir` 未指定時に `originalLogs` を挟んだパスから
+ * 入力ファイルを読み込むことを検証する。
+ *
+ * テスト ID 範囲: T-NC-MAIN-01
+ *
+ * @see main
+ */
+describe('main', () => {
+  /** originalLogs を挟んだ入力ディレクトリからファイルを読み込むケース。 */
+  describe('When: 正常系', () => {
+    describe('Given: baseDir 配下の originalLogs/<agent>/<yyyy>/<yyyy-mm> にファイルが存在', () => {
+      describe('When: --chatlogs-dir を指定せず main() を呼び出す', () => {
+        describe('Then: T-NC-MAIN-01 - originalLogs 配下のファイルが読み込まれる', () => {
+          let baseDir: string;
+          let outputDir: string;
+          let commandHandle: CommandMockHandle;
+          let loggerStub: LoggerStub;
+          let exitStub: Stub;
+
+          beforeEach(async () => {
+            baseDir = normalizePath(await Deno.makeTempDir());
+            outputDir = normalizePath(await Deno.makeTempDir());
+            const monthDir = `${baseDir}/originalLogs/claude/2026/2026-03`;
+            await Deno.mkdir(monthDir, { recursive: true });
+            await Deno.writeTextFile(
+              `${monthDir}/chat.md`,
+              '---\nproject: my-project\n---\n### User\nHello\n\n### AI\nHi there.',
+            );
+
+            const chatPath = normalizePath(`${monthDir}/chat.md`);
+            const segmentResponse = JSON.stringify([
+              {
+                filePath: chatPath,
+                segments: [{ title: 'Greeting', summary: 'Say hello', content: '### User\nHello' }],
+              },
+            ]);
+            commandHandle = installCommandMock(
+              makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+            );
+            loggerStub = makeLoggerStub();
+            exitStub = stub(Deno, 'exit');
+          });
+
+          afterEach(async () => {
+            commandHandle.restore();
+            loggerStub.restore();
+            exitStub.restore();
+            await Deno.remove(baseDir, { recursive: true });
+            await Deno.remove(outputDir, { recursive: true });
+          });
+
+          it('T-NC-MAIN-01-01: success=1 がレポートされる', async () => {
+            await main([
+              '--base-dir',
+              baseDir,
+              '--agent',
+              'claude',
+              '--period',
+              '2026-03',
+              '--normalize-dir',
+              outputDir,
+            ]);
+
+            assertMatch(loggerStub.infoLogs.join('\n'), /success=1/);
+          });
+
+          it('T-NC-MAIN-01-02: Deno.exit が呼ばれない（入力ディレクトリが見つかる）', async () => {
+            await main([
+              '--base-dir',
+              baseDir,
+              '--agent',
+              'claude',
+              '--period',
+              '2026-03',
+              '--normalize-dir',
+              outputDir,
+            ]);
+
+            assertEquals(exitStub.calls.length, 0);
+          });
+        });
+      });
+    });
+  });
+});

--- a/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
+++ b/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_AGENT,
   DEFAULT_CHATLOGS_DIR,
   DEFAULT_NORMALIZE_DIR,
+  DEFAULT_ORIGINAL_LOGS_DIR,
   DEFAULT_TIMEOUT_MS,
 } from '../../_scripts/constants/defaults.constants.ts';
 
@@ -72,6 +73,7 @@ export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void
       baseDir: config.baseDir ?? DEFAULT_CHATLOGS_DIR,
       agent: config.agent ?? DEFAULT_AGENT,
       period: config.period,
+      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
     });
     if (!dirExistsSync(inputDir)) {
       throw new ChatlogError('InputNotFound', 'NotFound', `directory not found: ${inputDir}`);


### PR DESCRIPTION
## Overview

**Summary**
Default normalize-chatlogs input to the originalLogs directory.

**Background / Motivation**
classify-chatlogs and filter-chatlogs already default to `originalLogs/` when
`--chatlogs-dir` is omitted. normalize-chatlogs did not follow this convention,
so this change brings it in line with the rest of the pipeline.

## Changes

### Core Changes

- `skills/normalize-chatlogs/scripts/normalize-chatlogs.ts`: resolve the default
  input path under `chatlogs/originalLogs/<agent>/<year>/<yearMonth>` when
  `--chatlogs-dir` is not specified.

### Test Updates

- `skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts`:
  add e2e test covering the default originalLogs input path.

### Removed

None

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

Related to #277, #278 (same originalLogs default-directory pattern).

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None
