### PR TITLE
feat(hashtag): normalize tag hash handling in frontmatter

### DIFF
--- a/skills/_scripts/classes/ChatlogEntry.class.ts
+++ b/skills/_scripts/classes/ChatlogEntry.class.ts
@@ -92,7 +92,7 @@ export class ChatlogEntry {
    * @returns `---\n...\n---\n\n<content>` 形式の文字列。content が空の場合は frontmatter のみ。
    */
   renderEntry(fieldOrder?: string[]): string {
-    const _fm = this.frontmatter.toFrontmatter(fieldOrder);
+    const _fm = this.frontmatter.toFrontmatter(fieldOrder, { addTagHashes: true });
     return this.content === '' ? _fm : `${_fm}\n${this.content}`;
   }
 }

--- a/skills/_scripts/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_scripts/classes/ChatlogFrontmatter.class.ts
@@ -11,7 +11,12 @@
 import { parse as parseYaml } from '@std/yaml';
 
 // --- shared
-import { divideEntry, hasFrontmatterFields, reorderFrontmatterEntries } from '../libs/text/frontmatter-utils.ts';
+import {
+  divideEntry,
+  hasFrontmatterFields,
+  reorderFrontmatterEntries,
+  stripTagHashes,
+} from '../libs/text/frontmatter-utils.ts';
 import { toStringWithNull } from '../libs/text/string-utils.ts';
 import { stringifyFrontmatter } from '../libs/text/yaml-utils.ts';
 
@@ -23,6 +28,16 @@ import { ChatlogError } from './ChatlogError.class.ts';
 
 // Constants
 import { DEFAULT_ORDERED_FIELDS, FRONTMATTER_DELIMITER } from '../constants/common.constants.ts';
+
+/** `entries.tags` の各要素先頭に `#` を付与した新しい `FrontmatterFields` を返す。`tags` がない場合はそのまま返す。 */
+const _addTagHashes = (entries: FrontmatterFields): FrontmatterFields => {
+  const _tags = entries['tags'];
+  if (_tags === undefined) { return entries; }
+  const _prefixed = Array.isArray(_tags)
+    ? _tags.map((tag) => `#${tag}`)
+    : `#${_tags}`;
+  return { ...entries, tags: _prefixed };
+};
 
 export class ChatlogFrontmatter {
   private _entries: FrontmatterFields;
@@ -81,7 +96,7 @@ export class ChatlogFrontmatter {
     for (const key of Object.keys(parsed)) {
       _result[key] = this._toStringOrArray(parsed[key]);
     }
-    return _result;
+    return stripTagHashes(_result);
   }
 
   get(key: string): string | string[] | undefined {
@@ -106,7 +121,7 @@ export class ChatlogFrontmatter {
     return hasFrontmatterFields(this._entries, ['type', 'category', 'title']);
   }
 
-  toFrontmatter(fieldOrder: string[] = DEFAULT_ORDERED_FIELDS): string {
+  toFrontmatter(fieldOrder: string[] = DEFAULT_ORDERED_FIELDS, opts?: { addTagHashes?: boolean }): string {
     if (fieldOrder.length === 0) {
       throw new ChatlogError('InvalidArgs', 'IsEmpty', 'fieldOrder must not be empty');
     }
@@ -114,7 +129,8 @@ export class ChatlogFrontmatter {
     if (Object.keys(_ordered).length === 0) {
       return `${FRONTMATTER_DELIMITER}\n\n${FRONTMATTER_DELIMITER}\n`;
     }
-    const _yamlBody = stringifyFrontmatter(_ordered);
+    const _entriesForOutput = opts?.addTagHashes ? _addTagHashes(_ordered) : _ordered;
+    const _yamlBody = stringifyFrontmatter(_entriesForOutput);
     return `${FRONTMATTER_DELIMITER}\n${_yamlBody}${FRONTMATTER_DELIMITER}\n`;
   }
 }

--- a/skills/_scripts/classes/__tests__/fixtures/fixtures-data/render-entry/normal/field/normal-array-fields/expected.md
+++ b/skills/_scripts/classes/__tests__/fixtures/fixtures-data/render-entry/normal/field/normal-array-fields/expected.md
@@ -1,9 +1,9 @@
 ---
 title: "Array Fields"
 tags:
-  - "foo"
-  - "bar"
-  - "baz"
+  - "#foo"
+  - "#bar"
+  - "#baz"
 ---
 
 First paragraph.

--- a/skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.toFrontmatter.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.toFrontmatter.unit.spec.ts
@@ -85,10 +85,10 @@ describe('ChatlogFrontmatter', () => {
           label: '配列値は2スペースインデント＋引用符でフォーマットされる',
           init: '',
           setup: (fm) => {
-            fm.set('tags', ['foo', 'bar', 'baz']);
+            fm.set('topics', ['foo', 'bar', 'baz']);
           },
-          fieldOrder: ['tags'],
-          expected: '---\ntags:\n  - "foo"\n  - "bar"\n  - "baz"\n---\n',
+          fieldOrder: ['topics'],
+          expected: '---\ntopics:\n  - "foo"\n  - "bar"\n  - "baz"\n---\n',
         },
       ];
 
@@ -99,6 +99,42 @@ describe('ChatlogFrontmatter', () => {
           assertEquals(fm.toFrontmatter(tc.fieldOrder), tc.expected);
         });
       }
+
+      it('T-CLS-CF-46: addTagHashes:true 指定時、tags の各要素に # が付与されて出力される', () => {
+        const fm = new ChatlogFrontmatter('');
+        fm.set('tags', ['foo', 'bar']);
+        const result = fm.toFrontmatter(['tags'], { addTagHashes: true });
+        assertEquals(result, '---\ntags:\n  - "#foo"\n  - "#bar"\n---\n');
+      });
+
+      it('T-CLS-CF-47: addTagHashes:true 指定時、tags 以外のフィールドには # が付与されない', () => {
+        const fm = new ChatlogFrontmatter('');
+        fm.set('topics', ['foo', 'bar']);
+        fm.set('tags', ['baz']);
+        const result = fm.toFrontmatter(['topics', 'tags'], { addTagHashes: true });
+        assertEquals(result, '---\ntopics:\n  - "foo"\n  - "bar"\ntags:\n  - "#baz"\n---\n');
+      });
+
+      it('T-CLS-CF-48: addTagHashes:true 指定後も get で取得する内部値は # なしのまま', () => {
+        const fm = new ChatlogFrontmatter('');
+        fm.set('tags', ['foo', 'bar']);
+        fm.toFrontmatter(['tags'], { addTagHashes: true });
+        assertEquals(fm.get('tags'), ['foo', 'bar']);
+      });
+
+      it('T-CLS-CF-49: opts 未指定時は tags に # が付与されない（デフォルト false）', () => {
+        const fm = new ChatlogFrontmatter('');
+        fm.set('tags', ['foo', 'bar']);
+        const result = fm.toFrontmatter(['tags']);
+        assertEquals(result, '---\ntags:\n  - "foo"\n  - "bar"\n---\n');
+      });
+
+      it('T-CLS-CF-50: addTagHashes:false 明示指定時も tags に # が付与されない', () => {
+        const fm = new ChatlogFrontmatter('');
+        fm.set('tags', ['foo', 'bar']);
+        const result = fm.toFrontmatter(['tags'], { addTagHashes: false });
+        assertEquals(result, '---\ntags:\n  - "foo"\n  - "bar"\n---\n');
+      });
     });
 
     describe('エッジケース', () => {

--- a/skills/_scripts/classes/__tests__/unit/ChatlogWorks.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogWorks.unit.spec.ts
@@ -703,7 +703,7 @@ describe('ChatlogWorks', () => {
    * outputDir の `.md` ファイルを `isComplete(text)` 述語でフィルタし、true のファイルのみ書き込むことを検証する。
    * デフォルト述語は `hasFrontmatter`。glob プロバイダーは `.md` と `.json` パターンで返値を分岐させる。
    *
-   * テスト ID 範囲: T-CLS-CC-43 〜 T-CLS-CC-56
+   * テスト ID 範囲: T-CLS-CC-43 〜 T-CLS-CC-56, T-CLS-CC-82 〜 T-CLS-CC-83
    */
   describe('initFromOutputDir', () => {
     /** outputDir の .md ファイルをフロントマターありのもののみ書き込むケース。 */
@@ -778,6 +778,80 @@ describe('ChatlogWorks', () => {
         await _cache.ready;
         await _cache.initFromOutputDir('/out');
         assertEquals(_cache.read('full.md'), {
+          title: 'A',
+          type: 'tech',
+          category: 'dev',
+          topics: ['topic1'],
+          tags: ['tag1'],
+          status: 'written',
+        });
+      });
+
+      it("[Normal] T-CLS-CC-82: tags が #付きハッシュタグ形式（['#tag1', '#tag2']）→ 先頭の # が除去され ['tag1', 'tag2'] でキャッシュされる", async () => {
+        const _buf = new Map<string, string>([
+          [
+            '/out/hashtag.md',
+            '---\ntitle: A\ntype: tech\ncategory: dev\ntopics:\n  - topic1\ntags:\n  - "#tag1"\n  - "#tag2"\n---\n',
+          ],
+        ]);
+        const _cache = new ChatlogWorks<{
+          title?: string;
+          type?: string;
+          category?: string;
+          topics?: string[];
+          tags?: string[];
+          status: string;
+        }>(
+          'sub',
+          '/cache',
+          undefined,
+          {
+            cache: {
+              ..._makeBufferProviders(_buf),
+              glob: _makePatternGlob(['/out/hashtag.md']),
+            },
+          },
+        );
+        await _cache.ready;
+        await _cache.initFromOutputDir('/out');
+        assertEquals(_cache.read('hashtag.md'), {
+          title: 'A',
+          type: 'tech',
+          category: 'dev',
+          topics: ['topic1'],
+          tags: ['tag1', 'tag2'],
+          status: 'written',
+        });
+      });
+
+      it("[Normal] T-CLS-CC-83: tags が #なし（['tag1']）→ 変化せず ['tag1'] のままキャッシュされる（回帰確認）", async () => {
+        const _buf = new Map<string, string>([
+          [
+            '/out/no-hashtag.md',
+            '---\ntitle: A\ntype: tech\ncategory: dev\ntopics:\n  - topic1\ntags:\n  - tag1\n---\n',
+          ],
+        ]);
+        const _cache = new ChatlogWorks<{
+          title?: string;
+          type?: string;
+          category?: string;
+          topics?: string[];
+          tags?: string[];
+          status: string;
+        }>(
+          'sub',
+          '/cache',
+          undefined,
+          {
+            cache: {
+              ..._makeBufferProviders(_buf),
+              glob: _makePatternGlob(['/out/no-hashtag.md']),
+            },
+          },
+        );
+        await _cache.ready;
+        await _cache.initFromOutputDir('/out');
+        assertEquals(_cache.read('no-hashtag.md'), {
           title: 'A',
           type: 'tech',
           category: 'dev',

--- a/skills/_scripts/libs/text/__tests__/unit/frontmatter-utils.unit.spec.ts
+++ b/skills/_scripts/libs/text/__tests__/unit/frontmatter-utils.unit.spec.ts
@@ -20,6 +20,7 @@ import {
   parseFrontmatterEntries,
   renderFrontmatter,
   reorderFrontmatterEntries,
+  stripTagHashes,
 } from '../../frontmatter-utils.ts';
 
 // ─── Helpers
@@ -315,6 +316,18 @@ describe('parseFrontmatterEntries', () => {
           const text = '---\ntags:\n  - foo\n  - ~\n  - bar\n---\nbody';
           const result = parseFrontmatterEntries(text);
           assertEquals(result.meta['tags'], ['foo', '', 'bar']);
+        });
+
+        it('T-LIB-FSM-06-05: tags に # が付いていない → そのまま返る（回帰確認）', () => {
+          const text = '---\ntags:\n  - foo\n  - bar\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['tags'], ['foo', 'bar']);
+        });
+
+        it('T-LIB-FSM-06-06: tags に # が付いている → 先頭の # が除去されて返る', () => {
+          const text = '---\ntags:\n  - "#foo"\n  - "#bar"\n---\nbody';
+          const result = parseFrontmatterEntries(text);
+          assertEquals(result.meta['tags'], ['foo', 'bar']);
         });
       });
     });
@@ -890,6 +903,51 @@ describe('extractYaml', () => {
       const _raw = 'null\n';
       const _result = extractYaml(_raw, 'nonexistent');
       assertEquals(_result.ok, false);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// stripTagHashes
+// ─────────────────────────────────────────────
+
+/**
+ * `stripTagHashes` のユニットテストスイート。
+ *
+ * `tags` の各要素から先頭の `#` を除去する動作を検証する。
+ *
+ * テスト ID 範囲: T-FU-STH-01 〜 T-FU-STH-04
+ *
+ * @see stripTagHashes
+ */
+describe('stripTagHashes', () => {
+  /** tags が配列・スカラーのいずれでも先頭の # が除去されることを確認する。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-FU-STH-01: tags が # 付き配列 → 各要素の # が除去される', () => {
+      const _entries = { tags: ['#foo', '#bar'] };
+      const _result = stripTagHashes(_entries);
+      assertEquals(_result['tags'], ['foo', 'bar']);
+    });
+
+    it('[Normal] T-FU-STH-02: tags が # 付きスカラー文字列 → # が除去される', () => {
+      const _entries = { tags: '#foo' };
+      const _result = stripTagHashes(_entries);
+      assertEquals(_result['tags'], 'foo');
+    });
+  });
+
+  /** tags が未定義または # なしのケースを確認する。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-FU-STH-03: tags が undefined → entries をそのまま返す', () => {
+      const _entries = { title: 'Hello' };
+      const _result = stripTagHashes(_entries);
+      assertEquals(_result, _entries);
+    });
+
+    it('[Edge] T-FU-STH-04: tags に # が付いていない → 変化せずそのまま返る', () => {
+      const _entries = { tags: ['foo', 'bar'] };
+      const _result = stripTagHashes(_entries);
+      assertEquals(_result['tags'], ['foo', 'bar']);
     });
   });
 });

--- a/skills/_scripts/libs/text/frontmatter-utils.ts
+++ b/skills/_scripts/libs/text/frontmatter-utils.ts
@@ -152,6 +152,14 @@ export const hasFrontmatterFields = (
   );
 };
 
+/** `entries.tags` の各要素から先頭の `#` を除去した新しい `FrontmatterFields` を返す。`tags` がない場合はそのまま返す。 */
+export const stripTagHashes = (entries: FrontmatterFields): FrontmatterFields => {
+  const _tags = entries['tags'];
+  if (_tags === undefined) { return entries; }
+  const _stripped = Array.isArray(_tags) ? _tags.map((tag) => tag.replace(/^#/, '')) : _tags.replace(/^#/, '');
+  return { ...entries, tags: _stripped };
+};
+
 /** Markdown テキストから frontmatter を抽出し、文字列または文字列配列に変換して返す。 */
 export const parseFrontmatterEntries = (text: string): FrontmatterEntries => {
   const { meta, content } = parseFrontmatter(text);
@@ -159,7 +167,7 @@ export const parseFrontmatterEntries = (text: string): FrontmatterEntries => {
   for (const key of Object.keys(meta)) {
     _typedMeta[key] = _unknownToStringOrArray(meta[key]);
   }
-  return { meta: _typedMeta, content };
+  return { meta: stripTagHashes(_typedMeta), content };
 };
 
 /**

--- a/skills/normalize-chatlogs/scripts/modules/segment-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/segment-io.ts
@@ -145,7 +145,7 @@ export const attachFrontmatter = (
   frontmatter.set('title', segmentMeta.title);
   frontmatter.set('log_id', segmentMeta.log_id);
   frontmatter.set('summary', segmentMeta.summary);
-  const fmText = frontmatter.toFrontmatter(_ATTACH_FIELD_ORDER);
+  const fmText = frontmatter.toFrontmatter(_ATTACH_FIELD_ORDER, { addTagHashes: true });
   return `${fmText}\n${content}`;
 };
 


### PR DESCRIPTION
## Overview

**Summary**
Add hashtag-prefixed tag output for Obsidian while keeping internal tag handling hash-free.

**Background / Motivation**
Obsidian only treats frontmatter tags as clickable hashtags when they are prefixed with `#`. Internal processing (caching and comparisons in `ChatlogWorks`) needs hash-free values instead. This PR adds a strip step on parse and an opt-in add-hash step on serialization, so Obsidian-facing output gets `#` tags while internal state stays consistent.

## Changes

### Core Changes

- `skills/_scripts/libs/text/frontmatter-utils.ts`: add `stripTagHashes`, applied inside `parseFrontmatterEntries` so parsed tags are always hash-free.
- `skills/_scripts/classes/ChatlogFrontmatter.class.ts`: strip tag hashes on parse; add `opts?: { addTagHashes?: boolean }` to `toFrontmatter()` to re-add `#` on serialization when requested.
- `skills/_scripts/classes/ChatlogEntry.class.ts`: `renderEntry()` passes `{ addTagHashes: true }` to `toFrontmatter()`.
- `skills/normalize-chatlogs/scripts/modules/segment-io.ts`: `attachFrontmatter()` likewise passes `{ addTagHashes: true }`.

### Test Updates

- `skills/_scripts/libs/text/__tests__/unit/frontmatter-utils.unit.spec.ts`: cases for `stripTagHashes` and updated `parseFrontmatterEntries` expectations.
- `skills/_scripts/classes/__tests__/unit/ChatlogFrontmatter.toFrontmatter.unit.spec.ts`: cases for the new `addTagHashes` option.
- `skills/_scripts/classes/__tests__/unit/ChatlogWorks.unit.spec.ts`: cache cases confirming hashed tags are stored hash-free.
- `skills/_scripts/classes/__tests__/fixtures/fixtures-data/render-entry/normal/field/normal-array-fields/expected.md`: expected tag values updated to `#`-prefixed form.

### Removed

- None.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #272

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`ChatlogWorks.class.ts` itself is not modified in this branch; its cache stores hash-free tags only as an indirect effect of `stripTagHashes` running inside `parseFrontmatterEntries`.
