### PR TITLE
feat: resolve output path from chatlog base directory

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,7 +26,7 @@ pre-commit:
 prepare-commit-msg:
   commands:
     prepare-message-script:
-      run: bash -c './scripts/prepare-commit-msg.sh --model gpt-5.5 --output "{1}"'
+      run: bash -c './scripts/prepare-commit-msg.sh --model opus --output "{1}"'
 
 # check commit message as Conventional Commit
 commit-msg:

--- a/skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
@@ -14,6 +14,7 @@ import { describe, it } from '@std/testing/bdd';
 // ─── Test target
 import {
   agentPath,
+  extractChatlogBaseDir,
   extractChatlogPath,
   periodToPath,
   resolveChatlogsDir,
@@ -246,11 +247,13 @@ describe('resolveChatlogsDir', () => {
 /**
  * `extractChatlogPath` 関数のユニットテストスイート。
  *
- * ファイルパスから chatlogs/<agent>/<yyyy>/<yyyy-mm> セグメントを抽出する
- * 純粋関数の正常系・エッジケースを検証する。内部で normalizePath を呼ぶため
+ * ファイルパスから <agent>/<yyyy>/<yyyy-mm> セグメントを抽出する
+ * 純粋関数の正常系・エッジケースを検証する。`chatlogs/`・`originalLogs/` の
+ * ような固定リテラルに依存せず、任意の --chatlogs-dir パスや addOnDir名でも
+ * 動作することを確認する。内部で normalizePath を呼ぶため
  * Windows バックスラッシュ区切りパスも正しく処理する。
  *
- * テスト ID 範囲: T-ECP-01-01 〜 T-ECP-03-02
+ * テスト ID 範囲: T-ECP-01-01 〜 T-ECP-03-07
  *
  * @see extractChatlogPath
  */
@@ -271,6 +274,20 @@ describe('extractChatlogPath', () => {
 
     it('[Normal] T-ECP-01-04: バックスラッシュ区切りパスも正規化して claude/2026/2026-04 を返す', () => {
       assertEquals(extractChatlogPath('W:\\chatlogs\\claude\\2026\\2026-04\\chat.md'), 'claude/2026/2026-04');
+    });
+
+    it('[Normal] T-ECP-01-05: chatlogs/originalLogs/codex/2026/2026-04 を含むパスから codex/2026/2026-04 を返す', () => {
+      assertEquals(
+        extractChatlogPath('chatlogs/originalLogs/codex/2026/2026-04/chatlog-exporter/foo.md'),
+        'codex/2026/2026-04',
+      );
+    });
+
+    it('[Normal] T-ECP-01-06: chatlogs/originalLogs/claude/2025/2025-12 を含むパスから claude/2025/2025-12 を返す', () => {
+      assertEquals(
+        extractChatlogPath('chatlogs/originalLogs/claude/2025/2025-12/foo.md'),
+        'claude/2025/2025-12',
+      );
     });
   });
 
@@ -293,6 +310,90 @@ describe('extractChatlogPath', () => {
 
     it('[Edge] T-ECP-03-02: chatlogs直下にファイルがある（agent/yyyy/yyyy-mmなし）とき空文字列を返す', () => {
       assertEquals(extractChatlogPath('/chatlogs/chat.md'), '');
+    });
+
+    it('[Edge] T-ECP-03-03: originalLogs 以外の addOnDir（normalizelogs）でも agent/yyyy/yyyy-mm を返す', () => {
+      assertEquals(
+        extractChatlogPath('chatlogs/normalizelogs/codex/2026/2026-04/proj/f.md'),
+        'codex/2026/2026-04',
+      );
+    });
+
+    it('[Edge] T-ECP-03-04: chatlogs という文字列を含まない --chatlogs-dir 任意パスでも agent/yyyy/yyyy-mm を返す', () => {
+      assertEquals(
+        extractChatlogPath('/data/exports/chatgpt/2025/2025-12/f.md'),
+        'chatgpt/2025/2025-12',
+      );
+    });
+
+    it('[Edge] T-ECP-03-05: Windows ドライブレターパス（chatlogs 文字列なし）でも agent/yyyy/yyyy-mm を返す', () => {
+      assertEquals(
+        extractChatlogPath('W:/data/codex/2026/2026-04/f.md'),
+        'codex/2026/2026-04',
+      );
+    });
+
+    it('[Edge] T-ECP-03-06: yyyy/yyyy-mm 構造がなければ任意ディレクトリ名（normalize）でも空文字列を返す', () => {
+      assertEquals(extractChatlogPath('/tmp/normalize/notes.md'), '');
+    });
+
+    it('[Edge] T-ECP-03-07: yyyy/yyyy-mm 構造があれば直前のディレクトリ名（normalize）を agent として抽出する', () => {
+      assertEquals(
+        extractChatlogPath('/tmp/normalize/2026/2026-04/f.md'),
+        'normalize/2026/2026-04',
+      );
+    });
+  });
+});
+
+/**
+ * `extractChatlogBaseDir` 関数のユニットテストスイート。
+ *
+ * ファイルパスから `<agent>/<yyyy>/<yyyy-mm>` セグメントの手前までを
+ * ベースディレクトリとして抽出する純粋関数の正常系・エッジケースを検証する。
+ * 内部で normalizePath を呼ぶため Windows バックスラッシュ区切りパスも正しく処理する。
+ *
+ * テスト ID 範囲: T-ECB-01-01 〜 T-ECB-02-03
+ *
+ * @see extractChatlogBaseDir
+ */
+describe('extractChatlogBaseDir', () => {
+  /** `<agent>/<yyyy>/<yyyy-mm>` を含む正常ケース。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-ECB-01-01: chatlogs/normalizelogs/codex/2026/2026-04 を含むパスから chatlogs/normalizelogs を返す', () => {
+      assertEquals(
+        extractChatlogBaseDir('chatlogs/normalizelogs/codex/2026/2026-04/chatlog-exporter/2026-04-03-xxx.md'),
+        'chatlogs/normalizelogs',
+      );
+    });
+
+    it('[Normal] T-ECB-01-02: Windows ドライブレターの絶対パスでも正しく解決される', () => {
+      assertEquals(
+        extractChatlogBaseDir('C:/work/chatlogs/normalizelogs/claude/2026/2026-03/proj/f.md'),
+        'C:/work/chatlogs/normalizelogs',
+      );
+    });
+
+    it('[Normal] T-ECB-01-03: バックスラッシュ区切りパスも正規化して解決される', () => {
+      assertEquals(
+        extractChatlogBaseDir('C:\\work\\chatlogs\\normalizelogs\\codex\\2026\\2026-04\\proj\\f.md'),
+        'C:/work/chatlogs/normalizelogs',
+      );
+    });
+  });
+
+  /** エッジケース。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-ECB-02-01: <agent>/<yyyy>/<yyyy-mm> パターンにマッチしないパスは空文字列を返す', () => {
+      assertEquals(extractChatlogBaseDir('/tmp/arbitrary/chat.md'), '');
+    });
+
+    it('[Edge] T-ECB-02-02: パスの先頭が agent セグメントの場合は空文字列を返す', () => {
+      assertEquals(extractChatlogBaseDir('codex/2026/2026-04/proj/f.md'), '');
+    });
+
+    it('[Edge] T-ECB-02-03: <agent>/<yyyy> のみ（月なし）のときは空文字列を返す', () => {
+      assertEquals(extractChatlogBaseDir('/chatlogs/normalizelogs/claude/2026/file.md'), '');
     });
   });
 });

--- a/skills/_scripts/libs/file-io/resolve-directory.ts
+++ b/skills/_scripts/libs/file-io/resolve-directory.ts
@@ -72,17 +72,41 @@ export const resolveChatlogsDir = (
 /**
  * Extracts the `<agent>/<yyyy>/<yyyy-mm>` path segment from a file path.
  *
- * Normalizes the path, then matches the `chatlogs/<agent>/<yyyy>/<yyyy-mm>`
- * pattern and returns `<agent>/<yyyy>/<yyyy-mm>`. Returns `''` if the pattern is not found.
+ * Normalizes the path, then matches the `<segment>/<yyyy>/<yyyy-mm>`
+ * structure (independent of any fixed `chatlogs/`/`originalLogs/` literal,
+ * so it also works with arbitrary `--chatlogs-dir` paths and any add-on
+ * directory name) and returns `<agent>/<yyyy>/<yyyy-mm>`. Returns `''` if
+ * the pattern is not found.
  *
  * @param filePath - Path to the source chatlog file
  * @returns Path segment like `'claude/2026/2026-04'`, or `''`
  */
 export const extractChatlogPath = (filePath: string): string => {
-  const match = normalizePath(filePath).match(/chatlogs\/([^/]+)\/(\d{4})\/(\d{4}-\d{2})/);
+  const match = normalizePath(filePath).match(/([^/]+)\/(\d{4})\/(\d{4}-\d{2})/);
   if (match) {
     const [, agent, year, yearMonth] = match;
     return `${agent}/${year}/${yearMonth}`;
+  }
+  return '';
+};
+
+/**
+ * Extracts the base directory that precedes the `<agent>/<yyyy>/<yyyy-mm>`
+ * path segment in a file path.
+ *
+ * Normalizes the path, then matches the same `<agent>/<yyyy>/<yyyy-mm>`
+ * structure as `extractChatlogPath` and returns everything before that
+ * segment (with the trailing separator stripped). Returns `''` if the
+ * pattern is not found, or if it matches at the start of the path.
+ *
+ * @param filePath - Path to the source chatlog file
+ * @returns Base directory like `'chatlogs/normalizelogs'`, or `''`
+ */
+export const extractChatlogBaseDir = (filePath: string): string => {
+  const _normalized = normalizePath(filePath);
+  const match = _normalized.match(/([^/]+)\/(\d{4})\/(\d{4}-\d{2})/);
+  if (match && match.index) {
+    return _normalized.slice(0, match.index - 1);
   }
   return '';
 };

--- a/skills/export-chatlogs/SKILL.md
+++ b/skills/export-chatlogs/SKILL.md
@@ -44,25 +44,28 @@ Glob ツールで `**/commands/export-chatlogs.md` を検索し、そのディ�
 ```bash
 SKILL_DIR   = <export-chatlogs.md が存在するディレクトリの絶対パス>
 SCRIPT_PATH = $SKILL_DIR/scripts/export-chatlogs.ts
-OUTPUT      = <cwd>/chatlogs
 ```
 
 ## ステップ2: スクリプト実行
 
-解決した `SCRIPT_PATH` と `OUTPUT` を使い、Bash で実行する:
+解決した `SCRIPT_PATH` を使い、Bash で実行する:
 
 ```bash
-deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] --output-dir "$OUTPUT"
+deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period]
 ```
+
+`--output-dir` は明示指定しない。未指定時は `buildConfig()` が
+`<chatlogsDir ?? ./chatlogs>/originalLogs` を出力先として解決する。
 
 ### 引数からオプションを組み立てるルール
 
-- 引数なし → `deno run ... "$SCRIPT_PATH" --output-dir "$OUTPUT"`
-- `agent` のみ → `deno run ... "$SCRIPT_PATH" codex --output-dir "$OUTPUT"`
-- `YYYY-MM` のみ → `deno run ... "$SCRIPT_PATH" 2026-03 --output-dir "$OUTPUT"`
-- `agent YYYY-MM` → `deno run ... "$SCRIPT_PATH" codex 2026-03 --output-dir "$OUTPUT"`
-- `chatlogsDir` 指定時 → `deno run ... "$SCRIPT_PATH" --chatlogs-dir "$CHATLOGS_DIR" --output-dir "$OUTPUT"`
-- dry-run 確認時 → `deno run ... "$SCRIPT_PATH" --dry-run --output-dir "$OUTPUT"`（※現状 `main()` 側で書き込みスキップは未実装のため、実際にはファイルが生成される点に注意）
+- 引数なし → `deno run ... "$SCRIPT_PATH"`
+- `agent` のみ → `deno run ... "$SCRIPT_PATH" codex`
+- `YYYY-MM` のみ → `deno run ... "$SCRIPT_PATH" 2026-03`
+- `agent YYYY-MM` → `deno run ... "$SCRIPT_PATH" codex 2026-03`
+- `chatlogsDir` 指定時 → `deno run ... "$SCRIPT_PATH" --chatlogs-dir "$CHATLOGS_DIR"`
+- dry-run 確認時 → `deno run ... "$SCRIPT_PATH" --dry-run`（※現状 `main()` 側で書き込みスキップは未実装のため、実際にはファイルが生成される点に注意）
+- `--output-dir DIR` を明示指定したい場合のみ追加する（この場合 `originalLogs` は挟まれず、指定パスがそのまま使われる）
 
 #### その他の利用可能なオプション
 
@@ -70,6 +73,7 @@ deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] 
 
 - `--input-dir DIR` — 入力ディレクトリ（chatgpt エージェントの位置引数と同義）
 - `--chatlogs-dir DIR` — チャットログ格納ディレクトリ
+- `--output-dir DIR` — 出力先ディレクトリを明示指定（`originalLogs` を挟まない）
 - `--dry-run` — dry-run モード（**現状未実装**: フラグは解析されるが、書き込みスキップの動作は行われない）
 
 #### chatgpt エージェントの場合
@@ -78,8 +82,8 @@ deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] 
 `\` は `/` に自動正規化されるため Windows パスもそのまま渡せる。
 未指定の場合はエラーを出力して終了する。
 
-- `chatgpt /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt "$INPUT_DIR" --output-dir "$OUTPUT"`
-- `chatgpt 2026-03 /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt 2026-03 "$INPUT_DIR" --output-dir "$OUTPUT"`
+- `chatgpt /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt "$INPUT_DIR"`
+- `chatgpt 2026-03 /path/to/export` → `deno run ... "$SCRIPT_PATH" chatgpt 2026-03 "$INPUT_DIR"`
 - `chatgpt /path/to/export 2026-03` → 順番を逆にしても同様に動作する
 
 フラグ形式（`--input-dir DIR`）も引き続き使用可能。
@@ -105,11 +109,12 @@ deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period] 
 
 ```bash
 chatlogs/
-  └── <agent>/
-       └── YYYY/
-            └── YYYY-MM/
-                 └── <project>/
-                      └── YYYY-MM-DD-{slug}-{sessionid8}.md
+  └── originalLogs/
+       └── <agent>/
+            └── YYYY/
+                 └── YYYY-MM/
+                      └── <project>/
+                           └── YYYY-MM-DD-{slug}-{sessionid8}.md
 ```
 
 ### エージェント別データソース

--- a/skills/set-frontmatter/SKILL.md
+++ b/skills/set-frontmatter/SKILL.md
@@ -46,7 +46,7 @@ allowed-tools: Bash, Glob
    - 2つ: INPUT_DIR=PATH_ARGS[0]、OUTPUT_DIR=PATH_ARGS[1]
 6. PATH_ARGS が0の場合は非パスモードで処理:
    - `YYYY-MM` パターン (`^[0-9]{4}-[0-9]{2}$`) → YEAR_MONTH
-   - 既知のagentリスト (`claude`, `chatgpt`) に一致 → AGENT
+   - 既知のagentリスト (`claude`, `chatgpt`, `codex`) に一致 → AGENT
    - それ以外最初の値 → PROJECT
 
 例:
@@ -96,7 +96,8 @@ PATH_ARGS=()
 # PATH_ARGS が0: 非パスモード（PROJECT/AGENT/YEAR_MONTH で INPUT_DIR を構築）
 
 # 非パスモードの INPUT_DIR 決定:
-#   YEAR_MONTH あり: $CHATLOGS_BASE/normalizelogs/$AGENT/$YEAR_MONTH/$PROJECT
+#   YEAR_MONTH あり: $CHATLOGS_BASE/normalizelogs/$AGENT/$YEAR/$YEAR_MONTH/$PROJECT
+#     （$YEAR は $YEAR_MONTH の先頭4文字）
 #   YEAR_MONTH なし: find で $CHATLOGS_BASE/normalizelogs/$AGENT 配下を列挙
 ```
 
@@ -119,7 +120,7 @@ deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" \
   $REVIEW_FLAG
 
 # 非パスモード・YEAR_MONTH が未指定の場合 (全年月):
-find "$CHATLOGS_BASE/normalizelogs/$AGENT" -mindepth 2 -maxdepth 2 -type d -name "$PROJECT" | sort | while read -r dir; do
+find "$CHATLOGS_BASE/normalizelogs/$AGENT" -mindepth 3 -maxdepth 3 -type d -name "$PROJECT" | sort | while read -r dir; do
   echo "=== Processing: $dir ==="
   deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" \
     --input-dir "$dir" \

--- a/skills/set-frontmatter/scripts/modules/__tests__/functional/write-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/functional/write-frontmatter.functional.spec.ts
@@ -202,6 +202,31 @@ describe('writeFrontmatter', () => {
     });
   });
 
+  // ─── inputDir が normalizelogs ルートより深い絞り込み済みパスの場合 ─────────
+
+  describe('Given: inputDir が normalizelogs ルートより深い絞り込み済みパス', () => {
+    describe('When: writeFrontmatter(entry, cache, outputDir, inputDir) を呼び出す', () => {
+      describe('Then: T-SF-WF-05 - filePath から逆算した agent/yyyy/yyyy-mm 階層で出力される', () => {
+        it('T-SF-WF-05-01: outputDir/agent/yyyy/yyyy-mm/... に出力される', async () => {
+          const inputBaseDir = `${tempDir}/chatlogs/normalizelogs`;
+          const outputBaseDir = `${tempDir}/chatlogs/outputLogs`;
+          const narrowedInputDir = `${inputBaseDir}/codex/2026/2026-04`;
+          const filePath = `${narrowedInputDir}/chatlog-exporter/2026-04-03-xxx.md`;
+
+          await Deno.mkdir(`${narrowedInputDir}/chatlog-exporter`, { recursive: true });
+          await Deno.writeTextFile(filePath, '# テスト\n本文');
+          const entry = _makeChatlogEntry(filePath);
+          _setAllFields(entry);
+
+          await writeFrontmatter(entry, cache, outputBaseDir, narrowedInputDir);
+
+          const expectedOutputPath = `${outputBaseDir}/codex/2026/2026-04/chatlog-exporter/2026-04-03-xxx.md`;
+          assertEquals(await fileOrDirExists(expectedOutputPath), true);
+        });
+      });
+    });
+  });
+
   // ─── 一時ファイルが残らない ───────────────────────────────────────────────
 
   describe('Given: 正常な書き込み完了後', () => {

--- a/skills/set-frontmatter/scripts/modules/setfm-write.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-write.ts
@@ -13,6 +13,7 @@
 import { join, relative } from '@std/path';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogWorks } from '../../../_scripts/classes/ChatlogWorks.class.ts';
+import { extractChatlogBaseDir } from '../../../_scripts/libs/file-io/resolve-directory.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getDirectory, getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
@@ -110,8 +111,14 @@ export const writeFrontmatter = async (
     return false;
   }
 
-  const _relPath = relative(inputDir, _inputPath);
-  const _outputPath = join(outputDir, _relPath);
+  const _baseDir = extractChatlogBaseDir(_inputPath);
+  const _resolvedInputDir = _baseDir || inputDir;
+  const _resolvedOutputDir = _baseDir && _baseDir.endsWith('normalizelogs')
+    ? _baseDir.replace(/normalizelogs$/, 'outputLogs')
+    : outputDir;
+
+  const _relPath = relative(_resolvedInputDir, _inputPath);
+  const _outputPath = join(_resolvedOutputDir, _relPath);
   const _outputSubDir = getDirectory(_outputPath);
   const _tmpFile = _outputPath + '.tmp';
   try {


### PR DESCRIPTION
## Overview

**Summary**
Resolve `set-frontmatter` output paths from the chatlog base directory instead of the raw input directory.

**Background / Motivation**
`writeFrontmatter` used to derive its output path from whatever `inputDir` was passed in. This broke when `inputDir` pointed to a deeper, already-filtered path (e.g. a specific year/month under `normalizelogs`), since the `agent/yyyy/yyyy-mm` hierarchy could no longer be reconstructed correctly. Extracting the base directory from the actual file path fixes this regardless of how deep `inputDir` is.

## Changes

### Core Changes

- `skills/_scripts/libs/file-io/resolve-directory.ts`: generalized `extractChatlogPath` to support agent/date directory structures; added `extractChatlogBaseDir` to extract the directory preceding the chatlog path.
- `skills/set-frontmatter/scripts/modules/setfm-write.ts`: `writeFrontmatter` now derives the output path from `extractChatlogBaseDir`, falling back to `inputDir` when no base directory can be extracted.

### Test Updates

- `skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts`: added cases for chatlog path/base-directory extraction, including Windows paths and invalid structures.
- `skills/set-frontmatter/scripts/modules/__tests__/functional/write-frontmatter.functional.spec.ts`: added a case verifying output path resolution when `inputDir` is narrower than the `normalizelogs` root.

### Documentation

- `skills/set-frontmatter/SKILL.md`: added `codex` to the known agent list; documented the `$YEAR` path segment; corrected the `find` search depth for year-month directories.
- `skills/export-chatlogs/SKILL.md`: documented that `buildConfig()` defaults to `<chatlogsDir ?? ./chatlogs>/originalLogs` when `--output-dir` is unspecified.

### Removed

- `skills/export-chatlogs/SKILL.md`: removed the now-unnecessary `OUTPUT` variable and `--output-dir "$OUTPUT"` from the step 1 example.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This branch also includes an unrelated `lefthook.yml` change switching the `prepare-commit-msg` hook's model to `opus`.
