### PR TITLE
chore(config): add obsidian-vault-mcp server, bump dprint json plugin

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -22,6 +22,13 @@
         "serve",
         "--mcp"
       ]
+    },
+    "obsidian-vault-mcp": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp",
+      "headers": {
+        "Authorization": "Bearer ${OBSIDIAN_API_KEY}"
+      }
     }
   }
 }

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -43,7 +43,7 @@
   // Plugins
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.96.1.wasm",
-    "https://plugins.dprint.dev/json-0.22.0.wasm",
+    "https://plugins.dprint.dev/json-0.23.0.wasm",
     "https://plugins.dprint.dev/markdown-0.22.1.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",


### PR DESCRIPTION
## Overview

**Summary**
Add the obsidian-vault-mcp server and update the dprint json plugin.

**Background / Motivation**
Registers a new MCP server for Obsidian vault access and keeps the dprint json plugin up to date.

## Changes

### Core Changes

- Add `obsidian-vault-mcp` as an HTTP MCP server in `.mcp.json` (`http://localhost:3001/mcp`, Bearer auth via `OBSIDIAN_API_KEY`)
- Bump the dprint `json` plugin from 0.22.0 to 0.23.0 in `dprint.jsonc`

### Test Updates

None

### Removed

None

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None
