### PR TITLE
refactor(config): unify chatlogs directory resolution across skills

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -5,7 +5,7 @@
 
 # Issue prefix for this repository (used by bd init)
 # If not set, bd init will auto-detect from directory name
-# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# Example: issue-prefix: "myProject" creates issues like "myProject-1", "myProject-2", etc.
 # issue-prefix: ""
 issue-prefix: "cle"
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,7 +26,7 @@ pre-commit:
 prepare-commit-msg:
   commands:
     prepare-message-script:
-      run: bash -c './scripts/prepare-commit-msg.sh --model opus --output "{1}"'
+      run: bash -c './scripts/prepare-commit-msg.sh --model gpt-5.5 --output "{1}"'
 
 # check commit message as Conventional Commit
 commit-msg:

--- a/skills/_scripts/classes/ChatlogWorks.class.ts
+++ b/skills/_scripts/classes/ChatlogWorks.class.ts
@@ -152,7 +152,7 @@ export class ChatlogWorks<T extends object> {
 
   /**
    * `_cacheDir` を解決してディレクトリを作成する。
-   * `cacheRoot` が falsy のとき `GlobalConfig.cacheDir` を非同期で取得する。
+   * `cacheRoot` が falsy のとき `GlobalConfig.cacheDir` を取得する。
    */
   private async _initCacheDir(
     subDir: string,
@@ -164,7 +164,7 @@ export class ChatlogWorks<T extends object> {
     if (isAbsolutePath(_expandedSubDir)) {
       this._cacheDir = _expandedSubDir;
     } else {
-      const _root = cacheRoot || String((await GlobalConfig.getInstance()).get('cacheDir'));
+      const _root = cacheRoot || String(GlobalConfig.getInstance().get('cacheDir'));
       this._cacheDir = joinPath(normalizePath(_root, providers?.env), _expandedSubDir);
     }
     await this._mkdir(this._cacheDir, { recursive: true });

--- a/skills/_scripts/classes/GlobalConfig.class.ts
+++ b/skills/_scripts/classes/GlobalConfig.class.ts
@@ -19,7 +19,7 @@ import { DEFAULT_CONFIG_FILE } from '../constants/defaults.constants.ts';
 import { DEFAULT_SCHEMA, DEFAULT_VALUES } from '../constants/schema.constants.ts';
 // types
 import type { ConfigSchema, ConfigValues, DefaultSchemaKey, SchemaValueType } from '../constants/schema.constants.ts';
-import type { ReadTextFileProvider } from '../types/providers.types.ts';
+import type { ReadTextFileSyncProvider } from '../types/providers.types.ts';
 // classes
 import { ChatlogError } from './ChatlogError.class.ts';
 
@@ -27,13 +27,15 @@ import { ChatlogError } from './ChatlogError.class.ts';
  * グローバル設定シングルトン。スキーマ検証付き。
  * - `getInstance(options?)` でシングルトンインスタンスを取得する。既にインスタンスが存在する場合は既存のインスタンスを返す。
  * - `get(key: string): string | number` で値を取得する。すべてのスキーマキーはデフォルト値を持つため `undefined` は返さない。
+ * - `values(): ConfigValues` で全フィールドの値を `{ field: value }` 形式で返す。
  * - `parseYaml(raw: Record<string, unknown>): Partial<ConfigValues>` で YAML パース結果を `Partial<ConfigValues>` に変換する。スキーマにないキーは `ChatlogError('InvalidYaml')` をスローする。
  * - テスト専用の `resetInstance()` メソッドでシングルトンインスタンスをリセットできる。プロダクションコードからは呼び出さないこと。
  */
 export class GlobalConfig {
   private static _instance: GlobalConfig | undefined;
   private static readonly _DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_FILE;
-  private static readonly _DEFAULT_READ_TEXT_FILE: ReadTextFileProvider = (path: string) => Deno.readTextFile(path);
+  private static readonly _DEFAULT_READ_TEXT_FILE: ReadTextFileSyncProvider = (path: string) =>
+    Deno.readTextFileSync(path);
   private _schema: ConfigSchema;
   private _fields: ConfigValues = {} as ConfigValues;
 
@@ -49,12 +51,12 @@ export class GlobalConfig {
    * - ファイルが存在しない場合 (`FileDirNotFound`) はエラーを無視して `DEFAULT_VALUES` のまま返す。
    * - 既にインスタンスが存在する場合は `options` を無視して既存インスタンスを返す。
    */
-  static async getInstance(options?: {
+  static getInstance(options?: {
     schema?: ConfigSchema;
     configFile?: string;
     yaml?: string;
-    readTextFileProvider?: ReadTextFileProvider;
-  }): Promise<GlobalConfig> {
+    readTextFileProvider?: ReadTextFileSyncProvider;
+  }): GlobalConfig {
     if (!GlobalConfig._instance) {
       GlobalConfig._instance = new GlobalConfig(options?.schema);
       if (options?.yaml !== undefined) {
@@ -65,7 +67,7 @@ export class GlobalConfig {
         // 空文字列 → DEFAULT_VALUES のまま継続
       } else if (options?.configFile) {
         try {
-          const _loaded = await GlobalConfig._instance.loadConfigFile({
+          const _loaded = GlobalConfig._instance.loadConfigFile({
             configPath: options.configFile,
             readTextFileProvider: options.readTextFileProvider,
           });
@@ -90,6 +92,11 @@ export class GlobalConfig {
   /** `key` に対応する値を返す。すべてのスキーマキーはデフォルト値を持つため `undefined` は返さない。 */
   get(key: DefaultSchemaKey): string | number {
     return this._fields[key];
+  }
+
+  /** GlobalConfig が保持する全フィールドの値を `{ field: value }` 形式で返す。 */
+  values(): ConfigValues {
+    return { ...this._fields };
   }
 
   /**
@@ -135,18 +142,18 @@ export class GlobalConfig {
    * 設定ファイルを読み込み、`Partial<ConfigValues>` を返す。
    * `_fields` は変更しない（純粋関数）。
    */
-  async loadConfigFile(options?: {
+  loadConfigFile(options?: {
     configPath?: string;
-    readTextFileProvider?: ReadTextFileProvider;
-  }): Promise<Partial<ConfigValues>> {
+    readTextFileProvider?: ReadTextFileSyncProvider;
+  }): Partial<ConfigValues> {
     const _readTextFile = options?.readTextFileProvider ?? GlobalConfig._DEFAULT_READ_TEXT_FILE;
-    const _resolved = await resolveConfigPath({
+    const _resolved = resolveConfigPath({
       configPath: options?.configPath,
       defaultPath: GlobalConfig._DEFAULT_CONFIG_PATH,
     });
     let _text: string;
     try {
-      _text = await _readTextFile(_resolved);
+      _text = _readTextFile(_resolved);
     } catch (e) {
       if (e instanceof Deno.errors.NotFound) {
         throw new ChatlogError('FileDirNotFound', `設定ファイル/ディレクトリが見つかりません: ${_resolved}`);
@@ -158,4 +165,4 @@ export class GlobalConfig {
 }
 
 /** アプリケーション共通の GlobalConfig インスタンス。 */
-// export const globalConfig = await GlobalConfig.getInstance();
+// export const globalConfig = GlobalConfig.getInstance();

--- a/skills/_scripts/classes/__tests__/unit/ChatlogWorks.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogWorks.unit.spec.ts
@@ -238,7 +238,7 @@ describe('ChatlogWorks', () => {
       });
 
       it('[Normal] T-CLS-CC-16: cacheRoot を省略すると GlobalConfig の cacheDir が使われる', async () => {
-        await GlobalConfig.getInstance({ yaml: 'cacheDir: /tmp/gc-cache\n' });
+        GlobalConfig.getInstance({ yaml: 'cacheDir: /tmp/gc-cache\n' });
         let _mkdirPath = '';
         const _cache = new ChatlogWorks('sub', '', undefined, {
           cache: {
@@ -254,7 +254,7 @@ describe('ChatlogWorks', () => {
       });
 
       it('[Normal] T-CLS-CC-17: cacheRoot を明示指定すると GlobalConfig は無視される', async () => {
-        await GlobalConfig.getInstance({ yaml: 'cacheDir: /tmp/gc-cache\n' });
+        GlobalConfig.getInstance({ yaml: 'cacheDir: /tmp/gc-cache\n' });
         let _mkdirPath = '';
         const _cache = new ChatlogWorks('sub', '/tmp/explicit-cache', undefined, {
           cache: {

--- a/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assertEquals, assertFalse, assertRejects, assertStrictEquals, assertThrows } from '@std/assert';
+import { assertEquals, assertFalse, assertStrictEquals, assertThrows } from '@std/assert';
 import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -15,7 +15,7 @@ import { GlobalConfig } from '../../GlobalConfig.class.ts';
 
 // ─── Helpers
 // types
-import type { ReadTextFileProvider } from '../../../types/providers.types.ts';
+import type { ReadTextFileSyncProvider } from '../../../types/providers.types.ts';
 // constants
 import { DEFAULT_CONFIG_FILE } from '../../../constants/defaults.constants.ts';
 import { DEFAULT_SCHEMA, DEFAULT_VALUES } from '../../../constants/schema.constants.ts';
@@ -48,11 +48,13 @@ type EdgeCase = {
 
 // functions
 
-/** ファイル読み込みを成功させる `ReadTextFileProvider` スタブ。指定内容を返す。 */
-const _makeReadOk = (content: string): ReadTextFileProvider => (_path: string) => Promise.resolve(content);
+/** ファイル読み込みを成功させる `ReadTextFileSyncProvider` スタブ。指定内容を返す。 */
+const _makeReadOk = (content: string): ReadTextFileSyncProvider => (_path: string) => content;
 
-/** ファイル未存在を模倣する `ReadTextFileProvider`。`Deno.errors.NotFound` を reject する。 */
-const _notFoundRead: ReadTextFileProvider = () => Promise.reject(new Deno.errors.NotFound('no such file'));
+/** ファイル未存在を模倣する `ReadTextFileSyncProvider`。`Deno.errors.NotFound` を throw する。 */
+const _notFoundRead: ReadTextFileSyncProvider = () => {
+  throw new Deno.errors.NotFound('no such file');
+};
 
 // ─── Tests
 
@@ -61,7 +63,7 @@ const _notFoundRead: ReadTextFileProvider = () => Promise.reject(new Deno.errors
  *
  * シングルトン取得・値参照・YAML パース・ファイル読み込みを検証する。
  *
- * テスト ID 範囲: T-CLS-GC-01 〜 T-CLS-GC-80
+ * テスト ID 範囲: T-CLS-GC-01 〜 T-CLS-GC-86
  *
  * @see GlobalConfig
  */
@@ -80,44 +82,44 @@ describe('GlobalConfig', () => {
   describe('getInstance', () => {
     /** 引数なし・有効な configFile・有効な yaml を渡す正常ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-CLS-GC-01: 2 回の getInstance は同一参照を返す', async () => {
-        const _a = await GlobalConfig.getInstance();
-        const _b = await GlobalConfig.getInstance();
+      it('[Normal] T-CLS-GC-01: 2 回の getInstance は同一参照を返す', () => {
+        const _a = GlobalConfig.getInstance();
+        const _b = GlobalConfig.getInstance();
         assertStrictEquals(_a, _b);
       });
 
-      it('[Normal] T-CLS-GC-02: 異なる変数から取得しても同じ状態を持つ', async () => {
-        const _first = await GlobalConfig.getInstance();
-        const _second = await GlobalConfig.getInstance();
+      it('[Normal] T-CLS-GC-02: 異なる変数から取得しても同じ状態を持つ', () => {
+        const _first = GlobalConfig.getInstance();
+        const _second = GlobalConfig.getInstance();
         assertEquals(_first.get('agent'), _second.get('agent'));
       });
 
-      it('[Normal] T-CLS-GC-40: 引数なしで呼ぶと get("agent") が DEFAULT_VALUES の値を返す', async () => {
-        const _config = await GlobalConfig.getInstance();
+      it('[Normal] T-CLS-GC-40: 引数なしで呼ぶと get("agent") が DEFAULT_VALUES の値を返す', () => {
+        const _config = GlobalConfig.getInstance();
         assertEquals(_config.get('agent'), 'claude');
         assertEquals(_config.get('chatlogsDir'), './chatlogs');
       });
 
-      it('[Normal] T-CLS-GC-41: configFile 指定+存在+valid YAML → get("agent") が YAML 値を返す', async () => {
-        const _config = await GlobalConfig.getInstance({
+      it('[Normal] T-CLS-GC-41: configFile 指定+存在+valid YAML → get("agent") が YAML 値を返す', () => {
+        const _config = GlobalConfig.getInstance({
           configFile: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk('agent: chatgpt\n'),
         });
         assertEquals(_config.get('agent'), 'chatgpt');
       });
 
-      it('[Normal] T-CLS-GC-61: yaml で chatlogsDir が設定される', async () => {
-        const _config = await GlobalConfig.getInstance({ yaml: 'chatlogsDir: /tmp/test-chatlogs\n' });
+      it('[Normal] T-CLS-GC-61: yaml で chatlogsDir が設定される', () => {
+        const _config = GlobalConfig.getInstance({ yaml: 'chatlogsDir: /tmp/test-chatlogs\n' });
         assertEquals(_config.get('chatlogsDir'), '/tmp/test-chatlogs');
       });
 
-      it('[Normal] T-CLS-GC-62: yaml と configFile が両方指定されたとき yaml が優先され readTextFileProvider は呼ばれない', async () => {
+      it('[Normal] T-CLS-GC-62: yaml と configFile が両方指定されたとき yaml が優先され readTextFileProvider は呼ばれない', () => {
         const _called = { flag: false };
-        const _trackingRead: ReadTextFileProvider = (_path: string) => {
+        const _trackingRead: ReadTextFileSyncProvider = (_path: string) => {
           _called.flag = true;
-          return Promise.resolve('agent: chatgpt\n');
+          return 'agent: chatgpt\n';
         };
-        const _config = await GlobalConfig.getInstance({
+        const _config = GlobalConfig.getInstance({
           yaml: 'chatlogsDir: /tmp/yaml-wins\n',
           configFile: '/mock/config.yaml',
           readTextFileProvider: _trackingRead,
@@ -126,19 +128,19 @@ describe('GlobalConfig', () => {
         assertFalse(_called.flag);
       });
 
-      it('[Normal] T-CLS-GC-74: yaml で maxContentLength: 2000 を指定すると get() が 2000 を返す', async () => {
-        const _config = await GlobalConfig.getInstance({ yaml: 'maxContentLength: 2000\n' });
+      it('[Normal] T-CLS-GC-74: yaml で maxContentLength: 2000 を指定すると get() が 2000 を返す', () => {
+        const _config = GlobalConfig.getInstance({ yaml: 'maxContentLength: 2000\n' });
         assertEquals(_config.get('maxContentLength'), 2000);
       });
 
-      it('[Normal] T-CLS-GC-68: yaml で複数フィールドを指定すると get() で反映が確認できる', async () => {
-        const _config = await GlobalConfig.getInstance({ yaml: 'agent: chatgpt\nchatlogsDir: /tmp/logs\n' });
+      it('[Normal] T-CLS-GC-68: yaml で複数フィールドを指定すると get() で反映が確認できる', () => {
+        const _config = GlobalConfig.getInstance({ yaml: 'agent: chatgpt\nchatlogsDir: /tmp/logs\n' });
         assertEquals(_config.get('agent'), 'chatgpt');
         assertEquals(_config.get('chatlogsDir'), '/tmp/logs');
       });
 
-      it('[Normal] T-CLS-GC-69: configFile 経由でフィールドが反映され get() で確認できる', async () => {
-        const _config = await GlobalConfig.getInstance({
+      it('[Normal] T-CLS-GC-69: configFile 経由でフィールドが反映され get() で確認できる', () => {
+        const _config = GlobalConfig.getInstance({
           configFile: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk('agent: chatgpt\ntimeoutMs: 30000\n'),
         });
@@ -146,8 +148,8 @@ describe('GlobalConfig', () => {
         assertEquals(_config.get('timeoutMs'), 30000);
       });
 
-      it('[Normal] T-CLS-GC-70: yaml と configFile 両方指定時、yaml の agent が get() で反映される', async () => {
-        const _config = await GlobalConfig.getInstance({
+      it('[Normal] T-CLS-GC-70: yaml と configFile 両方指定時、yaml の agent が get() で反映される', () => {
+        const _config = GlobalConfig.getInstance({
           yaml: 'agent: chatgpt\n',
           configFile: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk('agent: claude\n'),
@@ -158,8 +160,8 @@ describe('GlobalConfig', () => {
 
     /** 不正な YAML でエラーがスローされるケース。 */
     describe('When: 異常系', () => {
-      it('[Error] T-CLS-GC-43: configFile 指定+不正 YAML → ChatlogError(InvalidYaml) で reject', async () => {
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-43: configFile 指定+不正 YAML → ChatlogError(InvalidYaml) がスローされる', () => {
+        const _err = assertThrows(
           () =>
             GlobalConfig.getInstance({
               configFile: '/mock/config.yaml',
@@ -170,16 +172,16 @@ describe('GlobalConfig', () => {
         assertEquals(_err.kind, 'InvalidYaml');
       });
 
-      it('[Error] T-CLS-GC-64: yaml が不正 YAML 構文のとき ChatlogError(InvalidYaml) で reject される', async () => {
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-64: yaml が不正 YAML 構文のとき ChatlogError(InvalidYaml) がスローされる', () => {
+        const _err = assertThrows(
           () => GlobalConfig.getInstance({ yaml: 'key: [unclosed' }),
           ChatlogError,
         );
         assertEquals(_err.kind, 'InvalidYaml');
       });
 
-      it('[Error] T-CLS-GC-71: yaml に未知キーがあると ChatlogError(InvalidYaml/UnknownKey) で reject される', async () => {
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-71: yaml に未知キーがあると ChatlogError(InvalidYaml/UnknownKey) がスローされる', () => {
+        const _err = assertThrows(
           () => GlobalConfig.getInstance({ yaml: 'unknownKey: value\n' }),
           ChatlogError,
         );
@@ -187,8 +189,8 @@ describe('GlobalConfig', () => {
         assertEquals(_err.subindex, 'UnknownKey');
       });
 
-      it('[Error] T-CLS-GC-72: yaml のルートがスカラー値のとき ChatlogError(InvalidYaml/NotObject) で reject される', async () => {
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-72: yaml のルートがスカラー値のとき ChatlogError(InvalidYaml/NotObject) がスローされる', () => {
+        const _err = assertThrows(
           () => GlobalConfig.getInstance({ yaml: 'just-a-string\n' }),
           ChatlogError,
         );
@@ -199,36 +201,36 @@ describe('GlobalConfig', () => {
 
     /** 境界値・副作用・優先度など特殊なケース。 */
     describe('When: エッジケース', () => {
-      it('[Edge] T-CLS-GC-42: configFile 指定+存在しない → エラーなし、get("agent") が DEFAULT_VALUES の値を返す', async () => {
-        const _config = await GlobalConfig.getInstance({
+      it('[Edge] T-CLS-GC-42: configFile 指定+存在しない → エラーなし、get("agent") が DEFAULT_VALUES の値を返す', () => {
+        const _config = GlobalConfig.getInstance({
           configFile: '/mock/missing.yaml',
           readTextFileProvider: _notFoundRead,
         });
         assertEquals(_config.get('agent'), 'claude');
       });
 
-      it('[Edge] T-CLS-GC-44: getInstance() の戻り値と再取得が同一参照', async () => {
-        const _created = await GlobalConfig.getInstance();
-        const _got = await GlobalConfig.getInstance();
+      it('[Edge] T-CLS-GC-44: getInstance() の戻り値と再取得が同一参照', () => {
+        const _created = GlobalConfig.getInstance();
+        const _got = GlobalConfig.getInstance();
         assertStrictEquals(_created, _got);
       });
 
-      it('[Edge] T-CLS-GC-63: yaml が空文字列のときデフォルト値が使われる', async () => {
-        const _config = await GlobalConfig.getInstance({ yaml: '' });
+      it('[Edge] T-CLS-GC-63: yaml が空文字列のときデフォルト値が使われる', () => {
+        const _config = GlobalConfig.getInstance({ yaml: '' });
         assertEquals(_config.get('agent'), 'claude');
       });
 
-      it('[Edge] T-CLS-GC-65: 既存インスタンスがある場合 yaml オプションは無視される', async () => {
-        const _first = await GlobalConfig.getInstance();
+      it('[Edge] T-CLS-GC-65: 既存インスタンスがある場合 yaml オプションは無視される', () => {
+        const _first = GlobalConfig.getInstance();
         assertEquals(_first.get('agent'), 'claude');
-        const _second = await GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+        const _second = GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
         assertStrictEquals(_first, _second);
         assertEquals(_second.get('agent'), 'claude');
       });
 
-      it('[Edge] T-CLS-GC-66: 既存インスタンスがある場合 configFile オプションは無視される', async () => {
-        const _first = await GlobalConfig.getInstance();
-        const _second = await GlobalConfig.getInstance({
+      it('[Edge] T-CLS-GC-66: 既存インスタンスがある場合 configFile オプションは無視される', () => {
+        const _first = GlobalConfig.getInstance();
+        const _second = GlobalConfig.getInstance({
           configFile: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk('agent: chatgpt\n'),
         });
@@ -236,13 +238,13 @@ describe('GlobalConfig', () => {
         assertEquals(_second.get('agent'), 'claude');
       });
 
-      it('[Edge] T-CLS-GC-78: yaml で cacheDir: /tmp/my-cache を指定すると get("cacheDir") がその値を返す', async () => {
-        const _config = await GlobalConfig.getInstance({ yaml: 'cacheDir: /tmp/my-cache\n' });
+      it('[Edge] T-CLS-GC-78: yaml で cacheDir: /tmp/my-cache を指定すると get("cacheDir") がその値を返す', () => {
+        const _config = GlobalConfig.getInstance({ yaml: 'cacheDir: /tmp/my-cache\n' });
         assertEquals(_config.get('cacheDir'), '/tmp/my-cache');
       });
 
-      it('[Edge] T-CLS-GC-79: yaml に cacheDir キーがない場合は get("cacheDir") がデフォルト値を返す', async () => {
-        const _config = await GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+      it('[Edge] T-CLS-GC-79: yaml に cacheDir キーがない場合は get("cacheDir") がデフォルト値を返す', () => {
+        const _config = GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
         assertEquals(_config.get('cacheDir'), '${TEMP}/cle-cache');
       });
     });
@@ -256,9 +258,31 @@ describe('GlobalConfig', () => {
    * スキーマ登録済みキーの値取得・未登録キーの undefined 返却を検証する。
    */
   describe('get', () => {
-    it('[Normal] T-CLS-GC-03: 設定済みキーの値を返す', async () => {
-      const _config = await GlobalConfig.getInstance();
+    it('[Normal] T-CLS-GC-03: 設定済みキーの値を返す', () => {
+      const _config = GlobalConfig.getInstance();
       assertEquals(_config.get('model'), 'sonnet');
+    });
+  });
+
+  // ─── values ──────────────────────────────────────────────────────────────
+
+  /**
+   * `values` の全フィールド取得テスト。
+   *
+   * DEFAULT_VALUES との一致・YAML 上書き後の反映を検証する。
+   */
+  describe('values', () => {
+    /** getInstance 直後・YAML 上書き後の全フィールド取得ケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-CLS-GC-81: getInstance 直後は DEFAULT_VALUES と一致する全フィールドを返す', () => {
+        const _config = GlobalConfig.getInstance();
+        assertEquals(_config.values(), DEFAULT_VALUES);
+      });
+
+      it('[Normal] T-CLS-GC-82: YAML で agent を上書き後、agent は新しい値・他は DEFAULT_VALUES のままの全フィールドを返す', () => {
+        const _config = GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+        assertEquals(_config.values(), { ...DEFAULT_VALUES, agent: 'chatgpt' });
+      });
     });
   });
 
@@ -356,8 +380,8 @@ describe('GlobalConfig', () => {
     /** string/number フィールドが正しく変換されるケース。 */
     describe('When: 正常系', () => {
       for (const tc of _happyCases) {
-        it(`[Normal] ${tc.id}: ${tc.label}`, async () => {
-          const _config = await GlobalConfig.getInstance();
+        it(`[Normal] ${tc.id}: ${tc.label}`, () => {
+          const _config = GlobalConfig.getInstance();
           assertEquals(_config.parseYaml(tc.input), tc.expected);
         });
       }
@@ -366,8 +390,8 @@ describe('GlobalConfig', () => {
     /** 未知キー・型不一致でエラーがスローされるケース。 */
     describe('When: 異常系', () => {
       for (const tc of _errorCases) {
-        it(`[Error] ${tc.id}: ${tc.label}`, async () => {
-          const _config = await GlobalConfig.getInstance();
+        it(`[Error] ${tc.id}: ${tc.label}`, () => {
+          const _config = GlobalConfig.getInstance();
           assertThrows(() => _config.parseYaml(tc.input), tc.errorType);
         });
       }
@@ -376,8 +400,8 @@ describe('GlobalConfig', () => {
     /** null/undefined 境界値のケース。 */
     describe('When: エッジケース', () => {
       for (const tc of _edgeCases) {
-        it(`[Edge] ${tc.id}: ${tc.label}`, async () => {
-          const _config = await GlobalConfig.getInstance();
+        it(`[Edge] ${tc.id}: ${tc.label}`, () => {
+          const _config = GlobalConfig.getInstance();
           assertEquals(_config.parseYaml(tc.input), tc.expected);
         });
       }
@@ -394,42 +418,42 @@ describe('GlobalConfig', () => {
   describe('loadConfigFile', () => {
     /** YAML を読み込んで Partial<ConfigValues> を返すケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-CLS-GC-30: configPath に絶対パスを渡す → YAML を読み込んで Partial を返す', async () => {
-        const _config = await GlobalConfig.getInstance();
-        const _result = await _config.loadConfigFile({
+      it('[Normal] T-CLS-GC-30: configPath に絶対パスを渡す → YAML を読み込んで Partial を返す', () => {
+        const _config = GlobalConfig.getInstance();
+        const _result = _config.loadConfigFile({
           configPath: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk('agent: chatgpt\n'),
         });
         assertEquals(_result, { agent: 'chatgpt' });
       });
 
-      it('[Normal] T-CLS-GC-31: configPath 絶対パス指定 → そのパスから YAML を読む（readTextFileProvider が呼ばれたパスを検証）', async () => {
-        const _config = await GlobalConfig.getInstance();
+      it('[Normal] T-CLS-GC-31: configPath 絶対パス指定 → そのパスから YAML を読む（readTextFileProvider が呼ばれたパスを検証）', () => {
+        const _config = GlobalConfig.getInstance();
         let _calledPath = '';
-        const _trackingRead: ReadTextFileProvider = (path: string) => {
+        const _trackingRead: ReadTextFileSyncProvider = (path: string) => {
           _calledPath = path;
-          return Promise.resolve('agent: chatgpt\n');
+          return 'agent: chatgpt\n';
         };
-        await _config.loadConfigFile({
+        _config.loadConfigFile({
           configPath: '/mock/config.yaml',
           readTextFileProvider: _trackingRead,
         });
         assertEquals(_calledPath, '/mock/config.yaml');
       });
 
-      it('[Normal] T-CLS-GC-32: loadConfigFile 後も get("agent") は DEFAULT_VALUES の値のまま（純粋関数性）', async () => {
-        const _config = await GlobalConfig.getInstance();
-        await _config.loadConfigFile({
+      it('[Normal] T-CLS-GC-32: loadConfigFile 後も get("agent") は DEFAULT_VALUES の値のまま（純粋関数性）', () => {
+        const _config = GlobalConfig.getInstance();
+        _config.loadConfigFile({
           configPath: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk('agent: chatgpt\n'),
         });
         assertEquals(_config.get('agent'), 'claude');
       });
 
-      it('[Normal] T-CLS-GC-33: 複数フィールドの YAML が全フィールド正しく変換される', async () => {
-        const _config = await GlobalConfig.getInstance();
+      it('[Normal] T-CLS-GC-33: 複数フィールドの YAML が全フィールド正しく変換される', () => {
+        const _config = GlobalConfig.getInstance();
         const _yaml = 'agent: chatgpt\ntimeoutMs: 60000\n';
-        const _result = await _config.loadConfigFile({
+        const _result = _config.loadConfigFile({
           configPath: '/mock/config.yaml',
           readTextFileProvider: _makeReadOk(_yaml),
         });
@@ -439,9 +463,9 @@ describe('GlobalConfig', () => {
 
     /** ファイル不在・不正 YAML でエラーが発生するケース。 */
     describe('When: 異常系', () => {
-      it('[Error] T-CLS-GC-34: readTextFileProvider が NotFound → ChatlogError の kind が FileDirNotFound で reject', async () => {
-        const _config = await GlobalConfig.getInstance();
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-34: readTextFileProvider が NotFound → ChatlogError の kind が FileDirNotFound でスローされる', () => {
+        const _config = GlobalConfig.getInstance();
+        const _err = assertThrows(
           () =>
             _config.loadConfigFile({
               configPath: '/mock/missing.yaml',
@@ -452,9 +476,9 @@ describe('GlobalConfig', () => {
         assertEquals(_err.kind, 'FileDirNotFound');
       });
 
-      it('[Error] T-CLS-GC-35: 不正な YAML 文字列 → ChatlogError の kind が InvalidYaml で reject', async () => {
-        const _config = await GlobalConfig.getInstance();
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-35: 不正な YAML 文字列 → ChatlogError の kind が InvalidYaml でスローされる', () => {
+        const _config = GlobalConfig.getInstance();
+        const _err = assertThrows(
           () =>
             _config.loadConfigFile({
               configPath: '/mock/config.yaml',
@@ -466,9 +490,9 @@ describe('GlobalConfig', () => {
         assertEquals(_err.subindex, 'YamlSyntaxError');
       });
 
-      it('[Error] T-CLS-GC-36: YAML ルートがスカラー（文字列） → ChatlogError の kind が InvalidYaml で reject', async () => {
-        const _config = await GlobalConfig.getInstance();
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-36: YAML ルートがスカラー（文字列） → ChatlogError の kind が InvalidYaml でスローされる', () => {
+        const _config = GlobalConfig.getInstance();
+        const _err = assertThrows(
           () =>
             _config.loadConfigFile({
               configPath: '/mock/config.yaml',
@@ -480,9 +504,9 @@ describe('GlobalConfig', () => {
         assertEquals(_err.subindex, 'NotObject');
       });
 
-      it('[Error] T-CLS-GC-37: スキーマ違反キー → ChatlogError の kind が InvalidYaml で reject', async () => {
-        const _config = await GlobalConfig.getInstance();
-        const _err = await assertRejects(
+      it('[Error] T-CLS-GC-37: スキーマ違反キー → ChatlogError の kind が InvalidYaml でスローされる', () => {
+        const _config = GlobalConfig.getInstance();
+        const _err = assertThrows(
           () =>
             _config.loadConfigFile({
               configPath: '/mock/config.yaml',

--- a/skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
@@ -174,8 +174,8 @@ describe('agentPath', () => {
  * `resolveChatlogsDir` 関数のユニットテストスイート。
  *
  * `resolveChatlogsDir(options)` はチャットログディレクトリを解決する。
- * - `chatlogsDir` 指定あり → そのまま返す（agent/period は無視）
- * - `chatlogsDir` 未定義 → `baseDir/agentPath(agent, period)` を返す
+ * - `override` 指定あり → そのまま返す（agent/period/addOnDir は無視）
+ * - `override` 未指定 → `chatlogsDir/agentPath(agent, period)` を返す
  *
  * テスト ID 範囲: T-LIB-RD-03-01 〜 T-LIB-RD-03-06
  *
@@ -184,35 +184,35 @@ describe('agentPath', () => {
 describe('resolveChatlogsDir', () => {
   /** 正常系ケース。 */
   describe('When: 正常系', () => {
-    it('[Normal] T-LIB-RD-03-01: chatlogsDir 指定あり → chatlogsDir をそのまま返す', () => {
+    it('[Normal] T-LIB-RD-03-01: override 指定あり → override をそのまま返す', () => {
       const _opts: ResolveChatlogsDirOptions = {
-        chatlogsDir: '/explicit/chatlogs',
-        baseDir: '/custom/chatlogs',
+        override: '/explicit/chatlogs',
+        chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
       };
       assertEquals(resolveChatlogsDir(_opts), '/explicit/chatlogs');
     });
 
-    it('[Normal] T-LIB-RD-03-02: chatlogsDir 未定義、period なし → baseDir/agent', () => {
+    it('[Normal] T-LIB-RD-03-02: override 未指定、period なし → chatlogsDir/agent', () => {
       const _opts: ResolveChatlogsDirOptions = {
-        baseDir: '/custom/chatlogs',
+        chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
       };
       assertEquals(resolveChatlogsDir(_opts), '/custom/chatlogs/claude');
     });
 
-    it('[Normal] T-LIB-RD-03-03: chatlogsDir 未定義、period=YYYY-MM → baseDir/agent/YYYY/YYYY-MM', () => {
+    it('[Normal] T-LIB-RD-03-03: override 未指定、period=YYYY-MM → chatlogsDir/agent/YYYY/YYYY-MM', () => {
       const _opts: ResolveChatlogsDirOptions = {
-        baseDir: '/custom/chatlogs',
+        chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
         period: '2026-03',
       };
       assertEquals(resolveChatlogsDir(_opts), '/custom/chatlogs/claude/2026/2026-03');
     });
 
-    it('[Normal] T-LIB-RD-03-05: chatlogsDir 未定義、addOnDir 指定 → baseDir/addOnDir/agent', () => {
+    it('[Normal] T-LIB-RD-03-05: override 未指定、addOnDir 指定 → chatlogsDir/addOnDir/agent', () => {
       const _opts: ResolveChatlogsDirOptions = {
-        baseDir: '/custom/chatlogs',
+        chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
         addOnDir: 'originalLogs',
       };
@@ -222,20 +222,20 @@ describe('resolveChatlogsDir', () => {
 
   /** エッジケース。 */
   describe('When: エッジケース', () => {
-    it('[Edge] T-LIB-RD-03-04: chatlogsDir 指定あり + period 指定 → chatlogsDir をそのまま返す（period 無視）', () => {
+    it('[Edge] T-LIB-RD-03-04: override 指定あり + period 指定 → override をそのまま返す（period 無視）', () => {
       const _opts: ResolveChatlogsDirOptions = {
-        chatlogsDir: '/explicit/chatlogs',
-        baseDir: '/custom/chatlogs',
+        override: '/explicit/chatlogs',
+        chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
         period: '2026-03',
       };
       assertEquals(resolveChatlogsDir(_opts), '/explicit/chatlogs');
     });
 
-    it('[Edge] T-LIB-RD-03-06: chatlogsDir 指定あり + addOnDir 指定 → chatlogsDir をそのまま返す（addOnDir 無視）', () => {
+    it('[Edge] T-LIB-RD-03-06: override 指定あり + addOnDir 指定 → override をそのまま返す（addOnDir 無視）', () => {
       const _opts: ResolveChatlogsDirOptions = {
-        chatlogsDir: '/explicit/chatlogs',
-        baseDir: '/custom/chatlogs',
+        override: '/explicit/chatlogs',
+        chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
         addOnDir: 'originalLogs',
       };

--- a/skills/_scripts/libs/file-io/resolve-directory.ts
+++ b/skills/_scripts/libs/file-io/resolve-directory.ts
@@ -43,25 +43,25 @@ export const agentPath = (agent: string, period?: string): string => {
 // ─────────────────────────────────────────────
 
 export type ResolveChatlogsDirOptions = {
-  chatlogsDir?: string;
-  baseDir: string;
+  chatlogsDir: string;
   agent: string;
   period?: string;
   addOnDir?: string;
+  override?: string;
 };
 
 /**
  * チャットログディレクトリを解決する。
  *
- * - `chatlogsDir` が指定済み → そのまま返す（agent/period/addOnDir は無視）
- * - `chatlogsDir` が未定義 → `baseDir` と `agentPath(agent, period)` の間に
+ * - `override` が指定済み → そのまま返す（agent/period/addOnDir は無視）
+ * - `override` が未定義 → `chatlogsDir` と `agentPath(agent, period)` の間に
  *   `addOnDir`（指定時のみ）を挟んだパスを返す
  */
 export const resolveChatlogsDir = (
-  { chatlogsDir, baseDir, agent, period, addOnDir }: ResolveChatlogsDirOptions,
+  { chatlogsDir, agent, period, addOnDir, override }: ResolveChatlogsDirOptions,
 ): string => {
-  if (chatlogsDir) { return chatlogsDir; }
-  const _base = addOnDir ? joinPath(baseDir, addOnDir) : baseDir;
+  if (override) { return override; }
+  const _base = addOnDir ? joinPath(chatlogsDir, addOnDir) : chatlogsDir;
   return `${_base}/${agentPath(agent, period)}`;
 };
 

--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -9,7 +9,7 @@
 
 // ─── BDD modules
 import { assert, assertEquals, assertFalse, assertThrows } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import {
@@ -17,11 +17,15 @@ import {
   _setByTypeForTest,
   isArgDirectory,
   isArgPeriod,
-  parseArgsToConfig,
+  parseArgs,
+  parseOptions,
 } from '../../parse-args.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_CACHE_ROOT, DEFAULT_CHATLOGS_DIR } from '../../../../constants/defaults.constants.ts';
 // types
 import type { ArgsSchema } from '../../../../types/args-schema.types.ts';
 
@@ -32,13 +36,14 @@ type TestConfig = {
   agent?: string;
   period?: string;
   chatlogsDir?: string;
+  inputDir?: string;
   outputDir?: string;
   dryRun?: boolean;
   verbose?: boolean;
 };
 
 // constants
-const TEST_SCHEMA: ArgsSchema = [
+const TEST_SCHEMA: ArgsSchema<TestConfig> = [
   { option: '--output', field: 'outputDir', type: 'string' },
   { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--verbose', field: 'verbose', type: 'flag' },
@@ -64,13 +69,17 @@ describe('_initSchemaForTest', () => {
       const _map = _initSchemaForTest([]);
       assert(_map.has('period'));
       assert(_map.has('agent'));
-      assert(_map.has('chatlogsDir'));
-      assert(_map.has('cacheDir'));
+      assert(!_map.has('chatlogsDir'));
     });
     it('[Normal] T-PA-22-02: 追加スキーマあり → デフォルト＋追加エントリを含む Map が返る', () => {
       const _map = _initSchemaForTest([{ option: '--output', field: 'outputDir', type: 'string' }]);
       assert(_map.has('--output'));
       assert(_map.has('period'));
+    });
+    it('[Normal] T-PA-22-05: 空スキーマ → --input-dir/--output-dir がデフォルトエントリとして含まれる', () => {
+      const _map = _initSchemaForTest([]);
+      assert(_map.has('--input-dir'));
+      assert(_map.has('--output-dir'));
     });
     it('[Normal] T-PA-22-03: flag 型エントリが正しく含まれる', () => {
       const _map = _initSchemaForTest([{ option: '--dry-run', field: 'dryRun', type: 'flag' }]);
@@ -133,25 +142,95 @@ describe('_setByTypeForTest (negated)', () => {
   });
 });
 
+// ─── T-PA-OPT: parseOptions ──────────────────────────────────────────────────
+
+/**
+ * `parseOptions` のユニットテストスイート。
+ *
+ * `--` オプションの解釈のみを行い、非 `--` 引数は意味付けせず
+ * `positionals` にそのまま積むことを検証する。
+ *
+ * テスト ID 範囲: T-PA-OPT-01 〜 T-PA-OPT-06
+ *
+ * @see parseOptions
+ */
+describe('parseOptions', () => {
+  /** オプション解釈と位置引数のそのままの切り出しを確認する正常系。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-PA-OPT-01: --dry-run --output /out → config にのみ反映される', () => {
+      const result = parseOptions(['--dry-run', '--output', '/out'], TEST_SCHEMA);
+      assertEquals(result.config, { dryRun: true, outputDir: '/out' });
+      assertEquals(result.positionals, []);
+    });
+
+    it('[Normal] T-PA-OPT-02: オプションと位置引数の混在 → positionals は元の順序のまま意味付けされない', () => {
+      const result = parseOptions(['claude', '--dry-run', '2026-03', './dir'], TEST_SCHEMA);
+      assertEquals(result.config, { dryRun: true });
+      assertEquals(result.positionals, ['claude', '2026-03', './dir']);
+    });
+
+    it('[Normal] T-PA-OPT-03: "foo.md" のようなスラッシュなしファイル名 → エラーにならず positionals に含まれる', () => {
+      const result = parseOptions(['foo.md'], TEST_SCHEMA);
+      assertEquals(result.config, {});
+      assertEquals(result.positionals, ['foo.md']);
+    });
+
+    it('[Normal] T-PA-OPT-04: period/agent/directory 形式の位置引数 → 意味付けせず文字列のまま positionals に入る', () => {
+      const result = parseOptions(['2026-03', 'claude', './dir'], TEST_SCHEMA);
+      assertEquals(result.config, {});
+      assertEquals(result.positionals, ['2026-03', 'claude', './dir']);
+    });
+  });
+
+  /** 空配列を渡すエッジケース。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-PA-OPT-05: 空配列 → config が空オブジェクト、positionals が空配列', () => {
+      const result = parseOptions([], TEST_SCHEMA);
+      assertEquals(result.config, {});
+      assertEquals(result.positionals, []);
+    });
+  });
+
+  /** 不明なオプションを渡す異常系（既存の _setByType/_getOptionAndValue ロジックの代表確認）。 */
+  describe('When: 異常系', () => {
+    it('[Error] T-PA-OPT-06: --unknown → ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => parseOptions(['--unknown'], TEST_SCHEMA),
+        ChatlogError,
+        'Invalid Args',
+      );
+    });
+  });
+});
+
 // ─── T-PA-01: 空配列 → 全フィールド undefined ─────────────────────────────
 
 describe('parseArgsToConfig', () => {
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
   describe('Given: 空の引数配列', () => {
-    describe('When: parseArgsToConfig([]) を呼び出す', () => {
-      describe('Then: T-PA-01 - 全フィールドが undefined', () => {
+    describe('When: parseArgs([]) を呼び出す', () => {
+      describe('Then: T-PA-01 - GlobalConfig が管理しないフィールドは undefined', () => {
         const _cases: { id: string; field: keyof TestConfig }[] = [
-          { id: 'T-PA-01-01', field: 'agent' },
           { id: 'T-PA-01-02', field: 'period' },
           { id: 'T-PA-01-04', field: 'outputDir' },
           { id: 'T-PA-01-05', field: 'dryRun' },
           { id: 'T-PA-01-06', field: 'verbose' },
+          { id: 'T-PA-01-07', field: 'inputDir' },
         ];
         for (const { id, field } of _cases) {
           it(`${id}: ${field} が undefined になる`, () => {
-            const result = parseArgsToConfig<TestConfig>([], TEST_SCHEMA);
+            const result = parseArgs<TestConfig>([], TEST_SCHEMA);
             assertEquals(result[field], undefined);
           });
         }
+
+        it('T-PA-01-01: agent が GlobalConfig のデフォルト値 "claude" になる（自動マージ）', () => {
+          const result = parseArgs<TestConfig>([], TEST_SCHEMA);
+          assertEquals(result.agent, 'claude');
+        });
       });
     });
   });
@@ -159,7 +238,7 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-02: フラグオプション ────────────────────────────────────────────
 
   describe('Given: フラグオプション', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-02 - 対応フィールドが true になる', () => {
         const _cases: { id: string; args: string[]; field: keyof TestConfig }[] = [
           { id: 'T-PA-02-01', args: ['--dry-run'], field: 'dryRun' },
@@ -167,7 +246,7 @@ describe('parseArgsToConfig', () => {
         ];
         for (const { id, args, field } of _cases) {
           it(`${id}: ${args[0]} → ${field} が true になる`, () => {
-            const result = parseArgsToConfig<TestConfig>(args, TEST_SCHEMA);
+            const result = parseArgs<TestConfig>(args, TEST_SCHEMA);
             assertEquals(result[field], true);
           });
         }
@@ -178,10 +257,10 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-03: キー付きオプション（スペース区切り） ───────────────────────
 
   describe('Given: キー付きオプション（スペース区切り）', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-03 - 対応フィールドに値が設定される', () => {
         it('T-PA-03-01: --output /out → outputDir が "/out" になる', () => {
-          const result = parseArgsToConfig<TestConfig>(['--output', '/out'], TEST_SCHEMA);
+          const result = parseArgs<TestConfig>(['--output', '/out'], TEST_SCHEMA);
           assertEquals(result.outputDir, '/out');
         });
       });
@@ -191,28 +270,34 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-04: キー付きオプション（= 区切り） ─────────────────────────────
 
   describe('Given: キー付きオプション（= 区切り）', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-04 - 対応フィールドに値が設定される', () => {
         it('T-PA-04-01: --output=/out → outputDir が "/out" になる', () => {
-          const result = parseArgsToConfig<TestConfig>(['--output=/out'], TEST_SCHEMA);
+          const result = parseArgs<TestConfig>(['--output=/out'], TEST_SCHEMA);
           assertEquals(result.outputDir, '/out');
         });
       });
     });
   });
 
-  // ─── T-PA-05: 位置引数 — 期間文字列 ─────────────────────────────────────
+  // ─── T-PA-05: 位置引数 — 期間文字列単独はエラー（インデックスベース方式） ──
 
-  describe('Given: 期間形式の位置引数', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
-      describe('Then: T-PA-05 - period に設定される', () => {
-        it('T-PA-05-01: "2026-03" → period が "2026-03" になる', () => {
-          const result = parseArgsToConfig<TestConfig>(['2026-03'], TEST_SCHEMA);
-          assertEquals(result.period, '2026-03');
+  describe('Given: 期間形式の位置引数のみ（agent なし）', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-PA-05 - idx0 が directory でも agent でもないため ChatlogError(InvalidArgs) がスローされる', () => {
+        it('T-PA-05-01: "2026-03" → ChatlogError(InvalidArgs) がスローされる', () => {
+          assertThrows(
+            () => parseArgs<TestConfig>(['2026-03'], TEST_SCHEMA),
+            ChatlogError,
+            'Invalid Args',
+          );
         });
-        it('T-PA-05-02: "2026" → period が "2026" になる（年のみ指定）', () => {
-          const result = parseArgsToConfig<TestConfig>(['2026'], TEST_SCHEMA);
-          assertEquals(result.period, '2026');
+        it('T-PA-05-02: "2026" → ChatlogError(InvalidArgs) がスローされる（年のみ指定）', () => {
+          assertThrows(
+            () => parseArgs<TestConfig>(['2026'], TEST_SCHEMA),
+            ChatlogError,
+            'Invalid Args',
+          );
         });
       });
     });
@@ -221,7 +306,7 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-06: 位置引数 — 既知エージェント ───────────────────────────────
 
   describe('Given: 既知エージェント名の位置引数', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-06 - agent に設定される', () => {
         const _cases: { id: string; agent: string }[] = [
           { id: 'T-PA-06-01', agent: 'claude' },
@@ -229,7 +314,7 @@ describe('parseArgsToConfig', () => {
         ];
         for (const { id, agent } of _cases) {
           it(`${id}: "${agent}" → agent が "${agent}" になる`, () => {
-            const result = parseArgsToConfig<TestConfig>([agent], TEST_SCHEMA);
+            const result = parseArgs<TestConfig>([agent], TEST_SCHEMA);
             assertEquals(result.agent, agent);
           });
         }
@@ -237,20 +322,20 @@ describe('parseArgsToConfig', () => {
     });
   });
 
-  // ─── T-PA-07: 位置引数 — ディレクトリパス ───────────────────────────────
+  // ─── T-PA-07: 位置引数 — ディレクトリパス（idx0=directory → inputDir） ───
 
   describe('Given: ディレクトリパスの位置引数', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
-      describe('Then: T-PA-07 - chatlogsDir に設定される', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      describe('Then: T-PA-07 - パターンA（idx0=directory）に該当し inputDir にセットされる', () => {
         const _cases: { id: string; input: string; expected: string }[] = [
           { id: 'T-PA-07-01', input: '/absolute/path', expected: '/absolute/path' },
           { id: 'T-PA-07-02', input: './relative/path', expected: 'relative/path' },
           { id: 'T-PA-07-03', input: 'C:\\Windows\\path', expected: 'C:/Windows/path' },
         ];
         for (const { id, input, expected } of _cases) {
-          it(`${id}: "${input}" → chatlogsDir が "${expected}" になる`, () => {
-            const result = parseArgsToConfig<TestConfig>([input], TEST_SCHEMA);
-            assertEquals(result.chatlogsDir, expected);
+          it(`${id}: "${input}" → inputDir が "${expected}" になる`, () => {
+            const result = parseArgs<TestConfig>([input], TEST_SCHEMA);
+            assertEquals(result.inputDir, expected);
           });
         }
       });
@@ -260,10 +345,10 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-08: 複数引数の組み合わせ ──────────────────────────────────────
 
   describe('Given: 複数引数の組み合わせ', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-08 - 全フィールドが正しく解析される', () => {
         it('T-PA-08-01: claude 2026-03 --dry-run --output ./out が全フィールドに設定される', () => {
-          const result = parseArgsToConfig<TestConfig>(
+          const result = parseArgs<TestConfig>(
             ['claude', '2026-03', '--dry-run', '--output', './out'],
             TEST_SCHEMA,
           );
@@ -273,7 +358,7 @@ describe('parseArgsToConfig', () => {
           assertEquals(result.outputDir, './out');
         });
         it('T-PA-08-02: --dry-run --output ./out → dryRun=true かつ outputDir="./out" になる', () => {
-          const result = parseArgsToConfig<TestConfig>(
+          const result = parseArgs<TestConfig>(
             ['--dry-run', '--output', './out'],
             TEST_SCHEMA,
           );
@@ -287,11 +372,11 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-09: 異常系 — 不明なオプション ─────────────────────────────────
 
   describe('Given: 不明な -- オプション', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-09 - ChatlogError(InvalidArgs) がスローされる', () => {
         it('T-PA-09-01: --unknown → ChatlogError がスローされる', () => {
           assertThrows(
-            () => parseArgsToConfig<TestConfig>(['--unknown'], TEST_SCHEMA),
+            () => parseArgs<TestConfig>(['--unknown'], TEST_SCHEMA),
             ChatlogError,
             'Invalid Args',
           );
@@ -303,11 +388,11 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-10: 異常系 — 不明な位置引数 ───────────────────────────────────
 
   describe('Given: 不明な位置引数', () => {
-    describe('When: parseArgsToConfig(args) を呼び出す', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-10 - ChatlogError(InvalidArgs) がスローされる', () => {
         it('T-PA-10-01: "unknown-arg" → ChatlogError がスローされる', () => {
           assertThrows(
-            () => parseArgsToConfig<TestConfig>(['unknown-arg'], TEST_SCHEMA),
+            () => parseArgs<TestConfig>(['unknown-arg'], TEST_SCHEMA),
             ChatlogError,
             'Invalid Args',
           );
@@ -319,11 +404,11 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-11: 異常系 — 値が不足するキー付きオプション ───────────────────
 
   describe('Given: 値なしのキー付きオプション', () => {
-    describe('When: parseArgsToConfig(["--output"]) を呼び出す', () => {
+    describe('When: parseArgs(["--output"]) を呼び出す', () => {
       describe('Then: T-PA-11 - ChatlogError(InvalidArgs) がスローされる', () => {
         it('T-PA-11-01: --output のみ → ChatlogError がスローされる', () => {
           assertThrows(
-            () => parseArgsToConfig<TestConfig>(['--output'], TEST_SCHEMA),
+            () => parseArgs<TestConfig>(['--output'], TEST_SCHEMA),
             ChatlogError,
             'Invalid Args',
           );
@@ -335,11 +420,11 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-12: 異常系 — = の後が空文字列 ─────────────────────────────────
 
   describe('Given: = の後が空文字列のキー付きオプション', () => {
-    describe('When: parseArgsToConfig(["--output="]) を呼び出す', () => {
+    describe('When: parseArgs(["--output="]) を呼び出す', () => {
       describe('Then: T-PA-12 - ChatlogError(InvalidArgs) がスローされる', () => {
         it('T-PA-12-01: --output= → ChatlogError がスローされる', () => {
           assertThrows(
-            () => parseArgsToConfig<TestConfig>(['--output='], TEST_SCHEMA),
+            () => parseArgs<TestConfig>(['--output='], TEST_SCHEMA),
             ChatlogError,
             'Invalid Args',
           );
@@ -351,11 +436,11 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-13: 異常系 — フラグに = 付きで渡された場合 ────────────────────
 
   describe('Given: フラグオプションに = 付きで値を渡す', () => {
-    describe('When: parseArgsToConfig(["--dry-run=true"]) を呼び出す', () => {
+    describe('When: parseArgs(["--dry-run=true"]) を呼び出す', () => {
       describe('Then: T-PA-13 - ChatlogError(InvalidArgs) がスローされる', () => {
         it('T-PA-13-01: --dry-run=true → 不明なオプションとして ChatlogError がスローされる', () => {
           assertThrows(
-            () => parseArgsToConfig<TestConfig>(['--dry-run=true'], TEST_SCHEMA),
+            () => parseArgs<TestConfig>(['--dry-run=true'], TEST_SCHEMA),
             ChatlogError,
             'Invalid Args',
           );
@@ -367,10 +452,10 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-14: 同一フィールドへの後勝ち上書き ────────────────────────────
 
   describe('Given: 同一オプションを2回渡す', () => {
-    describe('When: parseArgsToConfig(["--output", "/a", "--output=/b"]) を呼び出す', () => {
+    describe('When: parseArgs(["--output", "/a", "--output=/b"]) を呼び出す', () => {
       describe('Then: T-PA-14 - 後に指定した値で上書きされる', () => {
         it('T-PA-14-01: outputDir が "/b" になる（後勝ち）', () => {
-          const result = parseArgsToConfig<TestConfig>(
+          const result = parseArgs<TestConfig>(
             ['--output', '/a', '--output=/b'],
             TEST_SCHEMA,
           );
@@ -383,10 +468,10 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-15: 値位置にフラグ風文字列が来た場合 ──────────────────────────
 
   describe('Given: キー付きオプションの値位置に "--" で始まる文字列が来る', () => {
-    describe('When: parseArgsToConfig(["--output", "--dry-run"]) を呼び出す', () => {
+    describe('When: parseArgs(["--output", "--dry-run"]) を呼び出す', () => {
       describe('Then: T-PA-15 - "--dry-run" が outputDir の値として代入される', () => {
         it('T-PA-15-01: outputDir が "--dry-run" になり dryRun は undefined のまま', () => {
-          const result = parseArgsToConfig<TestConfig>(
+          const result = parseArgs<TestConfig>(
             ['--output', '--dry-run'],
             TEST_SCHEMA,
           );
@@ -400,12 +485,11 @@ describe('parseArgsToConfig', () => {
   // ─── T-PA-16: 位置引数の優先順位 ─────────────────────────────────────────
 
   describe('Given: エージェント名を含むディレクトリパスの位置引数', () => {
-    describe('When: parseArgsToConfig(["./claude"]) を呼び出す', () => {
-      describe('Then: T-PA-16 - ディレクトリパスとして chatlogsDir に設定される', () => {
-        it('T-PA-16-01: "./claude" → agent ではなく chatlogsDir が "claude" になる（normalizePath で ./ が除去される）', () => {
-          const result = parseArgsToConfig<TestConfig>(['./claude'], TEST_SCHEMA);
-          assertEquals(result.chatlogsDir, 'claude');
-          assertEquals(result.agent, undefined);
+    describe('When: parseArgs(["./claude"]) を呼び出す', () => {
+      describe('Then: T-PA-16 - isArgDirectory が true となるためパターンA（inputDir）に該当する', () => {
+        it('T-PA-16-01: "./claude" → inputDir が "claude" になる', () => {
+          const result = parseArgs<TestConfig>(['./claude'], TEST_SCHEMA);
+          assertEquals(result.inputDir, 'claude');
         });
       });
     });
@@ -424,14 +508,14 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --period オプションに不正な形式の値', () => {
     /** period 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_PERIOD: ArgsSchema = [
+    const _SCHEMA_WITH_PERIOD: ArgsSchema<TestConfig> = [
       { option: '--period', field: 'period', type: 'period' },
     ];
 
     describe('When: 異常系', () => {
       it('[Error] T-PA-17-01: --period invalid-format → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig>(['--period', 'invalid-format'], _SCHEMA_WITH_PERIOD),
+          () => parseArgs<TestConfig>(['--period', 'invalid-format'], _SCHEMA_WITH_PERIOD),
           ChatlogError,
           'Invalid Args',
         );
@@ -440,52 +524,28 @@ describe('parseArgsToConfig', () => {
 
     describe('When: 正常系', () => {
       it('[Normal] T-PA-17-02: --period 2026-03 → period が "2026-03" になる', () => {
-        const result = parseArgsToConfig<TestConfig>(['--period', '2026-03'], _SCHEMA_WITH_PERIOD);
+        const result = parseArgs<TestConfig>(['--period', '2026-03'], _SCHEMA_WITH_PERIOD);
         assertEquals(result.period, '2026-03');
       });
     });
   });
 
-  // ─── T-PA-18: chatlogsDir 形式バリデーション ──────────────────────────────
+  // ─── T-PA-18: chatlogsDir の GlobalConfig マージ ──────────────────────────
 
   /**
-   * `parseArgsToConfig` の `chatlogsDir` 形式バリデーションテスト。
+   * `parseArgsToConfig` の `chatlogsDir` GlobalConfig マージテスト。
    *
-   * オプション経由で `chatlogsDir` に非ディレクトリ形式の値が設定された場合に
-   * `ChatlogError('InvalidArgs')` をスローすることを検証する。
+   * CLI 側に `chatlogsDir` を設定するオプション・位置引数がなくなった後も、
+   * `chatlogsDir` は GlobalConfig の全量マージ経由で値が供給されることを検証する。
    *
-   * テスト ID 範囲: T-PA-18-01 〜 T-PA-18-02
+   * テスト ID 範囲: T-PA-18-02
    */
-  describe('Given: --chatlogs-dir オプションに非ディレクトリ形式の値', () => {
-    type TestConfigWithChatlogsDir = TestConfig & { chatlogsDir?: string };
-
-    /** 非ディレクトリ形式（スラッシュなし）の値を chatlogsDir に設定するケース。 */
-    const _SCHEMA_WITH_CHATLOGS: ArgsSchema = [
-      { option: '--output', field: 'outputDir', type: 'string' },
-      { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
-      { option: '--dry-run', field: 'dryRun', type: 'flag' },
-      { option: '--verbose', field: 'verbose', type: 'flag' },
-    ];
-
-    describe('When: 異常系', () => {
-      it('[Error] T-PA-18-01: --chatlogs-dir plain-value → ChatlogError(InvalidArgs) がスローされる', () => {
-        assertThrows(
-          () =>
-            parseArgsToConfig<TestConfigWithChatlogsDir>(
-              ['--chatlogs-dir', 'plain-value'],
-              _SCHEMA_WITH_CHATLOGS,
-            ),
-          ChatlogError,
-          'Invalid Args',
-        );
-      });
-    });
-
-    /** chatlogsDir が未設定の場合はスローしない。 */
+  describe('Given: chatlogsDir が CLI 未設定', () => {
+    /** chatlogsDir が CLI 未設定の場合は GlobalConfig のデフォルト値が使われる。 */
     describe('When: エッジケース', () => {
-      it('[Edge] T-PA-18-02: chatlogsDir 未設定 → スローしない', () => {
-        const result = parseArgsToConfig<TestConfig>([], TEST_SCHEMA);
-        assertEquals(result.chatlogsDir, undefined);
+      it('[Edge] T-PA-18-02: chatlogsDir が CLI 未設定 → GlobalConfig のデフォルト値になる（スローしない）', () => {
+        const result = parseArgs<TestConfig>([], TEST_SCHEMA);
+        assertEquals(result.chatlogsDir, DEFAULT_CHATLOGS_DIR);
       });
     });
   });
@@ -502,14 +562,14 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --agent オプションに不明なエージェント名', () => {
     /** agent 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_AGENT: ArgsSchema = [
+    const _SCHEMA_WITH_AGENT: ArgsSchema<TestConfig> = [
       { option: '--agent', field: 'agent', type: 'agent' },
     ];
 
     describe('When: 異常系', () => {
       it('[Error] T-PA-19-01: --agent unknown-bot → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig>(['--agent', 'unknown-bot'], _SCHEMA_WITH_AGENT),
+          () => parseArgs<TestConfig>(['--agent', 'unknown-bot'], _SCHEMA_WITH_AGENT),
           ChatlogError,
           'Invalid Args',
         );
@@ -529,14 +589,14 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --limit オプションに非数値の値', () => {
     /** integer 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_INTEGER: ArgsSchema = [
+    const _SCHEMA_WITH_INTEGER: ArgsSchema<TestConfig & { limit?: string }> = [
       { option: '--limit', field: 'limit', type: 'integer' },
     ];
 
     describe('When: 異常系', () => {
       it('[Error] T-PA-20-01: --limit abc → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig & { limit?: string }>(['--limit', 'abc'], _SCHEMA_WITH_INTEGER),
+          () => parseArgs<TestConfig & { limit?: string }>(['--limit', 'abc'], _SCHEMA_WITH_INTEGER),
           ChatlogError,
           'Invalid Args',
         );
@@ -556,14 +616,14 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --ratio オプションに非数値の値', () => {
     /** number 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_NUMBER: ArgsSchema = [
+    const _SCHEMA_WITH_NUMBER: ArgsSchema<TestConfig & { ratio?: string }> = [
       { option: '--ratio', field: 'ratio', type: 'number' },
     ];
 
     describe('When: 異常系', () => {
       it('[Error] T-PA-21-01: --ratio xyz → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig & { ratio?: string }>(['--ratio', 'xyz'], _SCHEMA_WITH_NUMBER),
+          () => parseArgs<TestConfig & { ratio?: string }>(['--ratio', 'xyz'], _SCHEMA_WITH_NUMBER),
           ChatlogError,
           'Invalid Args',
         );
@@ -582,7 +642,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --chunk-size オプションに整数値', () => {
     /** integer 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_INT: ArgsSchema = [
+    const _SCHEMA_INT: ArgsSchema<TestConfigWithChunkSize> = [
       { option: '--chunk-size', field: 'chunkSize', type: 'integer' },
     ];
 
@@ -590,11 +650,11 @@ describe('parseArgsToConfig', () => {
 
     describe('When: 正常系', () => {
       it('[Normal] T-PA-23-01: --chunk-size 5 → chunkSize が 5 になる', () => {
-        const result = parseArgsToConfig<TestConfigWithChunkSize>(['--chunk-size', '5'], _SCHEMA_INT);
+        const result = parseArgs<TestConfigWithChunkSize>(['--chunk-size', '5'], _SCHEMA_INT);
         assertEquals(result.chunkSize, 5);
       });
       it('[Normal] T-PA-23-02: --chunk-size 0 → chunkSize が 0 になる', () => {
-        const result = parseArgsToConfig<TestConfigWithChunkSize>(['--chunk-size', '0'], _SCHEMA_INT);
+        const result = parseArgs<TestConfigWithChunkSize>(['--chunk-size', '0'], _SCHEMA_INT);
         assertEquals(result.chunkSize, 0);
       });
     });
@@ -611,7 +671,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --threshold オプションに浮動小数点値', () => {
     /** number 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_NUM: ArgsSchema = [
+    const _SCHEMA_NUM: ArgsSchema<TestConfigWithThreshold> = [
       { option: '--threshold', field: 'threshold', type: 'number' },
     ];
 
@@ -619,7 +679,7 @@ describe('parseArgsToConfig', () => {
 
     describe('When: 正常系', () => {
       it('[Normal] T-PA-24-01: --threshold 0.8 → threshold が 0.8 になる', () => {
-        const result = parseArgsToConfig<TestConfigWithThreshold>(['--threshold', '0.8'], _SCHEMA_NUM);
+        const result = parseArgs<TestConfigWithThreshold>(['--threshold', '0.8'], _SCHEMA_NUM);
         assertEquals(result.threshold, 0.8);
       });
     });
@@ -636,17 +696,17 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --agent オプションに既知エージェント名', () => {
     /** agent 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_AGENT: ArgsSchema = [
+    const _SCHEMA_AGENT: ArgsSchema<TestConfig> = [
       { option: '--agent', field: 'agent', type: 'agent' },
     ];
 
     describe('When: 正常系', () => {
       it('[Normal] T-PA-25-01: --agent claude → agent が "claude" になる', () => {
-        const result = parseArgsToConfig<TestConfig>(['--agent', 'claude'], _SCHEMA_AGENT);
+        const result = parseArgs<TestConfig>(['--agent', 'claude'], _SCHEMA_AGENT);
         assertEquals(result.agent, 'claude');
       });
       it('[Normal] T-PA-25-02: --agent chatgpt → agent が "chatgpt" になる', () => {
-        const result = parseArgsToConfig<TestConfig>(['--agent', 'chatgpt'], _SCHEMA_AGENT);
+        const result = parseArgs<TestConfig>(['--agent', 'chatgpt'], _SCHEMA_AGENT);
         assertEquals(result.agent, 'chatgpt');
       });
     });
@@ -666,11 +726,11 @@ describe('parseArgsToConfig', () => {
     /** --no- プレフィックスの正常系ケース。 */
     describe('When: 正常系', () => {
       it('[Normal] T-PA-26-01: --no-dry-run を渡すと dryRun: false がセットされる', () => {
-        const result = parseArgsToConfig<TestConfig>(['--no-dry-run'], TEST_SCHEMA);
+        const result = parseArgs<TestConfig>(['--no-dry-run'], TEST_SCHEMA);
         assertEquals(result.dryRun, false);
       });
       it('[Normal] T-PA-26-02: --no-verbose を渡すと verbose: false がセットされる', () => {
-        const result = parseArgsToConfig<TestConfig>(['--no-verbose'], TEST_SCHEMA);
+        const result = parseArgs<TestConfig>(['--no-verbose'], TEST_SCHEMA);
         assertEquals(result.verbose, false);
       });
     });
@@ -689,11 +749,11 @@ describe('parseArgsToConfig', () => {
     /** 既存フラグ動作が変わっていないことを確認する正常系。 */
     describe('When: 正常系', () => {
       it('[Normal] T-PA-27-01: --dry-run → dryRun: true (既存動作変更なし)', () => {
-        const result = parseArgsToConfig<TestConfig>(['--dry-run'], TEST_SCHEMA);
+        const result = parseArgs<TestConfig>(['--dry-run'], TEST_SCHEMA);
         assertEquals(result.dryRun, true);
       });
       it('[Normal] T-PA-27-02: --no-dry-run と --output の組み合わせ → 両フィールドが正しくセット', () => {
-        const result = parseArgsToConfig<TestConfig>(['--no-dry-run', '--output', '/out'], TEST_SCHEMA);
+        const result = parseArgs<TestConfig>(['--no-dry-run', '--output', '/out'], TEST_SCHEMA);
         assertEquals(result.dryRun, false);
         assertEquals(result.outputDir, '/out');
       });
@@ -713,11 +773,11 @@ describe('parseArgsToConfig', () => {
     /** 後勝ちのエッジケース。 */
     describe('When: エッジケース', () => {
       it('[Edge] T-PA-28-01: --dry-run --no-dry-run → dryRun: false (後が優先)', () => {
-        const result = parseArgsToConfig<TestConfig>(['--dry-run', '--no-dry-run'], TEST_SCHEMA);
+        const result = parseArgs<TestConfig>(['--dry-run', '--no-dry-run'], TEST_SCHEMA);
         assertEquals(result.dryRun, false);
       });
       it('[Edge] T-PA-28-02: --no-dry-run --dry-run → dryRun: true (後が優先)', () => {
-        const result = parseArgsToConfig<TestConfig>(['--no-dry-run', '--dry-run'], TEST_SCHEMA);
+        const result = parseArgs<TestConfig>(['--no-dry-run', '--dry-run'], TEST_SCHEMA);
         assertEquals(result.dryRun, true);
       });
     });
@@ -738,14 +798,14 @@ describe('parseArgsToConfig', () => {
     describe('When: 異常系', () => {
       it('[Error] T-PA-29-01: --no-unknown → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig>(['--no-unknown'], TEST_SCHEMA),
+          () => parseArgs<TestConfig>(['--no-unknown'], TEST_SCHEMA),
           ChatlogError,
           'Invalid Args',
         );
       });
       it('[Error] T-PA-29-02: --no-dry-run=true → ChatlogError(InvalidArgs) がスローされる (=値指定不可)', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig>(['--no-dry-run=true'], TEST_SCHEMA),
+          () => parseArgs<TestConfig>(['--no-dry-run=true'], TEST_SCHEMA),
           ChatlogError,
           'Invalid Args',
         );
@@ -768,7 +828,7 @@ describe('parseArgsToConfig', () => {
     describe('When: 異常系', () => {
       it('[Error] T-PA-30-01: --no-output (string 型) → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfig>(['--no-output'], TEST_SCHEMA),
+          () => parseArgs<TestConfig>(['--no-output'], TEST_SCHEMA),
           ChatlogError,
           'Invalid Args',
         );
@@ -787,7 +847,7 @@ describe('parseArgsToConfig', () => {
    * テスト ID 範囲: T-PA-31-01 〜 T-PA-31-03
    */
   describe('Given: --cache-dir オプションの directory 型バリデーション', () => {
-    const _SCHEMA_WITH_CACHE: ArgsSchema = [
+    const _SCHEMA_WITH_CACHE: ArgsSchema<TestConfigWithCache> = [
       { option: '--cache-dir', field: 'cacheDir', type: 'directory' },
     ];
 
@@ -796,7 +856,7 @@ describe('parseArgsToConfig', () => {
     /** 有効なディレクトリパスを渡す正常系。 */
     describe('When: 正常系', () => {
       it('[Normal] T-PA-31-01: --cache-dir ./tmp/cache → cacheDir が "tmp/cache" になる', () => {
-        const result = parseArgsToConfig<TestConfigWithCache>(
+        const result = parseArgs<TestConfigWithCache>(
           ['--cache-dir', './tmp/cache'],
           _SCHEMA_WITH_CACHE,
         );
@@ -808,7 +868,7 @@ describe('parseArgsToConfig', () => {
     describe('When: 異常系', () => {
       it('[Error] T-PA-31-02: --cache-dir plain-value → ChatlogError(InvalidArgs) がスローされる', () => {
         assertThrows(
-          () => parseArgsToConfig<TestConfigWithCache>(['--cache-dir', 'plain-value'], _SCHEMA_WITH_CACHE),
+          () => parseArgs<TestConfigWithCache>(['--cache-dir', 'plain-value'], _SCHEMA_WITH_CACHE),
           ChatlogError,
           'Invalid Args',
         );
@@ -817,10 +877,262 @@ describe('parseArgsToConfig', () => {
 
     /** 引数を渡さないエッジケース。 */
     describe('When: エッジケース', () => {
-      it('[Edge] T-PA-31-03: 引数なし → cacheDir が undefined になる', () => {
-        const result = parseArgsToConfig<TestConfigWithCache>([], _SCHEMA_WITH_CACHE);
-        assertEquals(result.cacheDir, undefined);
+      it('[Edge] T-PA-31-03: 引数なし → cacheDir が GlobalConfig のデフォルト値になる', () => {
+        const result = parseArgs<TestConfigWithCache>([], _SCHEMA_WITH_CACHE);
+        assertEquals(result.cacheDir, DEFAULT_CACHE_ROOT);
       });
+    });
+  });
+  // ─── T-PA-36: --input-dir/--output-dir オプションの解析 ─────────────────
+
+  /**
+   * `parseArgsToConfig` の `--input-dir`/`--output-dir` オプション解析テスト。
+   *
+   * デフォルトスキーマに追加された `--input-dir`/`--output-dir` オプションが
+   * スペース区切り・`=` 区切りの両方で正しく解析されることを検証する。
+   *
+   * テスト ID 範囲: T-PA-36-01 〜 T-PA-36-04
+   */
+  describe('Given: --input-dir/--output-dir オプション', () => {
+    describe('When: 正常系', () => {
+      it('[Normal] T-PA-36-01: --input-dir ./in → inputDir が "in" になる', () => {
+        const result = parseArgs<TestConfig>(['--input-dir', './in'], TEST_SCHEMA);
+        assertEquals(result.inputDir, 'in');
+      });
+      it('[Normal] T-PA-36-02: --input-dir=./in → inputDir が "in" になる', () => {
+        const result = parseArgs<TestConfig>(['--input-dir=./in'], TEST_SCHEMA);
+        assertEquals(result.inputDir, 'in');
+      });
+      it('[Normal] T-PA-36-03: --output-dir ./out → outputDir が "out" になる', () => {
+        const result = parseArgs<TestConfig>(['--output-dir', './out'], TEST_SCHEMA);
+        assertEquals(result.outputDir, 'out');
+      });
+      it('[Normal] T-PA-36-04: --output-dir=./out → outputDir が "out" になる', () => {
+        const result = parseArgs<TestConfig>(['--output-dir=./out'], TEST_SCHEMA);
+        assertEquals(result.outputDir, 'out');
+      });
+    });
+  });
+
+  // ─── T-PA-33: agent の次に agent 名（period でない）を渡した場合はエラー ──
+
+  /**
+   * `parseArgsToConfig` のパターンB順序違反テスト。
+   *
+   * パターンB（idx0=agent, idx1=period）で idx1 に period 形式でない値
+   * （2つ目の agent 名）を渡すと `ChatlogError('InvalidArgs')` がスローされることを検証する。
+   *
+   * テスト ID 範囲: T-PA-33-01
+   */
+  describe('Given: agent の次に agent 名を渡す（idx1 が period 形式でない）', () => {
+    describe('When: 異常系', () => {
+      it('[Error] T-PA-33-01: "claude" "chatgpt" → idx1 が period 形式でないため ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['claude', 'chatgpt'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+    });
+  });
+
+  // ─── T-PA-34: period 型位置引数のみの指定はいずれにせよエラー ────────────
+
+  /**
+   * `parseArgsToConfig` の period 単独指定テスト。
+   *
+   * idx0 が period 形式の場合、directory でも agent でもないため
+   * `ChatlogError('InvalidArgs')` がスローされることを検証する（インデックスベース方式）。
+   *
+   * テスト ID 範囲: T-PA-34-01
+   */
+  describe('Given: period 型位置引数を2つ連続で渡す（agent なし）', () => {
+    describe('When: 異常系', () => {
+      it('[Error] T-PA-34-01: "2026-01" "2026-02" → idx0 が不明な引数として ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['2026-01', '2026-02'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+    });
+  });
+
+  // ─── T-PA-POS: インデックスベース位置引数解釈（_parsePositionals） ───────
+
+  /**
+   * `parseArgsToConfig` のインデックスベース位置引数解釈テスト。
+   *
+   * パターンA（idx0=directory → inputDir, idx1以降=directory → outputDir）と
+   * パターンB（idx0=agent, idx1=period, idx2以降=directory → outputDir）の
+   * 固定パターンのみを許可し、それ以外の型混在・順序違反は
+   * `ChatlogError('InvalidArgs')` をスローすることを検証する。
+   *
+   * テスト ID 範囲: T-PA-POS-01 〜 T-PA-POS-14
+   */
+  describe('Given: インデックスベースの位置引数パターン', () => {
+    describe('When: パターンA（directory 系）', () => {
+      it('[Normal] T-PA-POS-01: ["./in"] → inputDir のみセットされる', () => {
+        const result = parseArgs<TestConfig>(['./in'], TEST_SCHEMA);
+        assertEquals(result.inputDir, 'in');
+        assertEquals(result.outputDir, undefined);
+      });
+      it('[Normal] T-PA-POS-02: ["./in", "./out"] → inputDir・outputDir がセットされる', () => {
+        const result = parseArgs<TestConfig>(['./in', './out'], TEST_SCHEMA);
+        assertEquals(result.inputDir, 'in');
+        assertEquals(result.outputDir, 'out');
+      });
+      it('[Error] T-PA-POS-03: ["./in", "./out", "./extra"] → 3個目で ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['./in', './out', './extra'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+    });
+
+    describe('When: パターンB（agent/period 系）', () => {
+      it('[Normal] T-PA-POS-04: ["claude"] → agent のみセットされる（period なし、既存回帰）', () => {
+        const result = parseArgs<TestConfig>(['claude'], TEST_SCHEMA);
+        assertEquals(result.agent, 'claude');
+        assertEquals(result.period, undefined);
+      });
+      it('[Normal] T-PA-POS-05: ["claude", "2026-03"] → agent・period がセットされる', () => {
+        const result = parseArgs<TestConfig>(['claude', '2026-03'], TEST_SCHEMA);
+        assertEquals(result.agent, 'claude');
+        assertEquals(result.period, '2026-03');
+      });
+      it('[Normal] T-PA-POS-06: ["claude", "2026"] → agent・period（年のみ形式）がセットされる', () => {
+        const result = parseArgs<TestConfig>(['claude', '2026'], TEST_SCHEMA);
+        assertEquals(result.agent, 'claude');
+        assertEquals(result.period, '2026');
+      });
+      it('[Normal] T-PA-POS-07: ["claude", "2026-03", "./out"] → agent・period・outputDir がセットされる', () => {
+        const result = parseArgs<TestConfig>(['claude', '2026-03', './out'], TEST_SCHEMA);
+        assertEquals(result.agent, 'claude');
+        assertEquals(result.period, '2026-03');
+        assertEquals(result.outputDir, 'out');
+      });
+    });
+
+    describe('When: 異常系（型混在・順序違反）', () => {
+      it('[Error] T-PA-POS-08: ["./dir", "claude"] → パターンA後の directory 検証で ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['./dir', 'claude'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+      it('[Error] T-PA-POS-09: ["claude", "./dir"] → idx1 が period 形式でないため ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['claude', './dir'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+      it('[Error] T-PA-POS-10: ["2026-03", "claude"] → idx0 が不明な引数として ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['2026-03', 'claude'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+      it('[Error] T-PA-POS-11: ["2026-03"] → idx0 が不明な引数として ChatlogError(InvalidArgs)（period のみ、agent なし）', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['2026-03'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+      it('[Error] T-PA-POS-12: ["unknown-agent-name"] → directory でも agent でもないため ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['unknown-agent-name'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+      it('[Error] T-PA-POS-13: ["claude", "2026-03", "2026-04"] → idx2 が directory でないため ChatlogError(InvalidArgs)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['claude', '2026-03', '2026-04'], TEST_SCHEMA),
+          ChatlogError,
+          'Invalid Args',
+        );
+      });
+    });
+
+    describe('When: エッジケース', () => {
+      it('[Edge] T-PA-POS-14: [] → inputDir・outputDir・period は undefined のまま（config 変更なし）', () => {
+        const result = parseArgs<TestConfig>([], TEST_SCHEMA);
+        assertEquals(result.inputDir, undefined);
+        assertEquals(result.outputDir, undefined);
+        assertEquals(result.period, undefined);
+      });
+    });
+  });
+});
+
+// ─── T-PA-35: parseArgs (defaults / globalConfig merge) ────────────────────
+
+/**
+ * `parseArgs` の `defaults`/`globalConfig` マージテストスイート。
+ *
+ * 優先度 CLI 解析値 > GlobalConfig 値 > defaults のマージ順序、
+ * および `defaults`/`globalConfig` 省略時の後方互換性を検証する。
+ *
+ * テスト ID 範囲: T-PA-35-01 〜 T-PA-35-06
+ *
+ * @see parseArgs
+ */
+describe('parseArgs (defaults / globalConfig merge)', () => {
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
+  /** defaults・globalConfig・CLI 値の優先度マージが正しく行われる正常系。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-PA-35-01: defaults のみ指定・globalConfig なし・CLI 未指定 → defaults の値が採用される', () => {
+      const result = parseArgs<TestConfig>([], TEST_SCHEMA, { outputDir: '/default-out' });
+      assertEquals(result.outputDir, '/default-out');
+    });
+
+    it('[Normal] T-PA-35-02: globalConfig 指定・CLI 未指定 → GlobalConfig の値が defaults を上書きする', () => {
+      GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+      const result = parseArgs<TestConfig>([], TEST_SCHEMA, { agent: 'claude' });
+      assertEquals(result.agent, 'chatgpt');
+    });
+
+    it('[Normal] T-PA-35-03: CLI 引数指定あり → CLI 値が defaults・globalConfig 両方より優先される', () => {
+      GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+      const result = parseArgs<TestConfig>(['claude'], TEST_SCHEMA, { agent: 'codex' });
+      assertEquals(result.agent, 'claude');
+    });
+
+    it('[Normal] T-PA-35-04: GlobalConfig が追跡しないフィールド（period）→ defaults の値がそのまま残る', () => {
+      GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+      const result = parseArgs<TestConfig>([], TEST_SCHEMA, { period: '2026-01' });
+      assertEquals(result.period, '2026-01');
+    });
+  });
+
+  /** 後方互換性・境界値の確認を行うエッジケース。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-PA-35-05: defaults/globalConfig 省略の2引数呼び出し → GlobalConfig のデフォルト値が自動マージされる', () => {
+      const result = parseArgs<TestConfig>(['--output', '/out'], TEST_SCHEMA);
+      assertEquals(result.outputDir, '/out');
+      assertEquals(result.agent, 'claude');
+      assertEquals(result.period, undefined);
+    });
+
+    it('[Edge] T-PA-35-06: defaults={} 明示指定・globalConfig なし → GlobalConfig のデフォルト値が自動マージされる', () => {
+      const result = parseArgs<TestConfig>(['--output', '/out'], TEST_SCHEMA, {});
+      assertEquals(result.outputDir, '/out');
+      assertEquals(result.agent, 'claude');
+    });
+
+    it('[Edge] T-PA-35-07: globalConfig が追跡しない outputDir → defaults の値が保持される', () => {
+      GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
+      const result = parseArgs<TestConfig>([], TEST_SCHEMA, { outputDir: '/default-out' });
+      assertEquals(result.outputDir, '/default-out');
     });
   });
 });

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -12,6 +12,7 @@ import { isKnownAgent } from '../../constants/agents.constants.ts';
 import { normalizePath, toSlashPath } from '../path-utils/path-utils.ts';
 // classes
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../classes/GlobalConfig.class.ts';
 // types
 import type { ArgSchemaEntry, ArgsSchema } from '../../types/args-schema.types.ts';
 
@@ -31,12 +32,10 @@ export const isArgDirectory = (arg: string): boolean => {
 const _DEFAULT_SCHEMA: ArgsSchema = [
   { option: 'period', field: 'period', type: 'period' },
   { option: 'agent', field: 'agent', type: 'agent' },
-  { option: 'chatlogsDir', field: 'chatlogsDir', type: 'directory' },
-  { option: 'cacheDir', field: 'cacheDir', type: 'directory' },
   { option: '--config', field: 'configFile', type: 'string' },
   { option: '--dry-run', field: 'dryRun', type: 'flag' },
-  { option: '--base-dir', field: 'baseDir', type: 'directory' },
-  { option: '--chatlogs-dir', field: 'chatlogsDir', type: 'directory' },
+  { option: '--input-dir', field: 'inputDir', type: 'directory' },
+  { option: '--output-dir', field: 'outputDir', type: 'directory' },
 ];
 
 /**
@@ -142,104 +141,197 @@ const _setByType = (
 };
 
 /**
- * `args[i]` を `--key`/`--key=value`/`--key next` 形式で分解して返す。
+ * schemaMap から option キーでエントリを取得し、`_setByType` で `config` にセットする。
+ * 取得失敗時（スキーマに存在しないキー）または `_setByType` がエラーを返した場合は throw する。
  *
- * - `--key` の場合（flag 型）: `_option=--key`, `_rawValue=undefined`, `_nextIndex=i`
- * - `--key=value` の場合（flag 型）: `_option=--key`, `_rawValue=value`, `_nextIndex=i`（エラー判定は呼び出し元）
- * - `--key=value` の場合（非 flag 型）: `_option=--key`, `_rawValue=value`, `_nextIndex=i`（`i` を進めない）
- * - `--key next` の場合: `_option=--key`, `_rawValue=next`, `_nextIndex=i+1`（次トークンを消費）
- * - 次トークンがない場合: `_rawValue=undefined`, `_nextIndex=i`
- *
- * @param args - CLI 引数配列全体
- * @param i - 現在のインデックス。`_nextIndex` を `i` に代入することで消費済みトークンをスキップできる
- * @param schemaMap - オプション名をキーとするスキーマ Map（flag 型の判定に使用）
- * @returns `_option`（`--key` 部分）、`_rawValue`（値、取得不能時 `undefined`）、`_nextIndex`（次に処理すべきインデックス）
+ * @param config - 値をセット対象となる設定オブジェクト（参照渡し、副作用あり）
+ * @param schemaMap - オプション名をキーとするスキーマ Map
+ * @param optionKey - 取得対象のオプションキー（例: `'--input-dir'`, `'agent'`）
+ * @param rawValue - CLI から取得した生文字列
  */
-const _getOptionAndValue = (
-  args: string[],
-  i: number,
+const _assignEntry = (
+  config: Record<string, string | boolean | number>,
   schemaMap: Map<string, ArgSchemaEntry>,
-): { _option: string; _rawValue?: string; _nextIndex: number } => {
-  const arg = args[i];
-  const _eqIdx = arg.indexOf('=');
-
-  // flag 型: = あり・なし両方を処理し、_rawValue に値を含めて返す
-  const _optionName = _eqIdx !== -1 ? arg.slice(0, _eqIdx) : arg;
-  const _exactEntry = schemaMap.get(_optionName);
-  if (_exactEntry?.type === 'flag') {
-    const _rawValue = _eqIdx !== -1 ? arg.slice(_eqIdx + 1) : undefined;
-    return { _option: _optionName, _rawValue, _nextIndex: i };
+  optionKey: string,
+  rawValue: string,
+): void => {
+  const _entry = schemaMap.get(optionKey);
+  if (_entry === undefined) {
+    throw new ChatlogError('InvalidArgs', `スキーマに存在しないエントリです: ${optionKey}`);
   }
-  if (_eqIdx !== -1) {
-    return { _option: arg.slice(0, _eqIdx), _rawValue: arg.slice(_eqIdx + 1), _nextIndex: i };
-  }
-  if (i + 1 < args.length) {
-    return { _option: arg, _rawValue: args[i + 1], _nextIndex: i + 1 };
-  }
-  return { _option: arg, _rawValue: undefined, _nextIndex: i };
+  const err = _setByType(config, _entry, rawValue);
+  if (err) { throw err; }
 };
 
-/** テスト専用エクスポート: `_setByType` の型検証・変換ロジックを直接テストするためのラッパー。 */
-export const _setByTypeForTest = _setByType;
-
-/** テスト専用エクスポート: `_initSchema` を直接テストするためのラッパー。 */
-export const _initSchemaForTest = _initSchema;
+/**
+ * output-dir 用の directory 引数を `config` にセットする。1個のみ許容し、
+ * 既に `outputDir` がセット済みの場合は「位置引数が多すぎます」で throw する。
+ * directory 型でない値は `_assignEntry`（`_setByType` の directory 検証）でエラーになる。
+ *
+ * @param config - 値をセット対象となる設定オブジェクト（参照渡し、副作用あり）
+ * @param schemaMap - オプション名をキーとするスキーマ Map
+ * @param rawValue - CLI から取得した生文字列
+ */
+const _assignOutputDirEntry = (
+  config: Record<string, string | boolean | number>,
+  schemaMap: Map<string, ArgSchemaEntry>,
+  rawValue: string,
+): void => {
+  if ('outputDir' in config) {
+    throw new ChatlogError('InvalidArgs', `位置引数が多すぎます（output-dir は1個のみ指定可能）: ${rawValue}`);
+  }
+  _assignEntry(config, schemaMap, '--output-dir', rawValue);
+};
 
 /**
- * CLI 引数を解析して Partial<T> を返す汎用パーサー。
+ * 位置引数配列をインデックスベースの固定パターンで解釈し、`config` にセットする。
  *
- * 位置引数の解釈は T が `period`/`agent`/`chatlogsDir` を持つことを前提とする。
- * - `YYYY-MM` 形式 → `period`
- * - 既知エージェント名 → `agent`
- * - ディレクトリパス → `chatlogsDir`
+ * 許可パターン（idx0 のみで判定、以降は無条件で output-dir 扱い）:
+ * - パターンA: idx0=directory(input-dir), idx1以降=directory(output-dir, 1個のみ許容)
+ * - パターンB: idx0=agent, idx1=period（存在する場合のみ）, idx2以降=directory(output-dir, 1個のみ許容)
+ * それ以外の型・順序はすべて `ChatlogError('InvalidArgs', ...)` を throw する。
+ *
+ * @param config - 値をセット対象となる設定オブジェクト（参照渡し、副作用あり）
+ * @param positionals - `parseOptions` が返す非 `--` 引数の配列（出現順）
+ * @param schemaMap - `_initSchema` が返すスキーマ Map（`_assignEntry` に渡すエントリ取得用）
  */
-export const parseArgsToConfig = <T extends { period?: string; agent?: string; chatlogsDir?: string }>(
+const _parsePositionals = (
+  config: Record<string, string | boolean | number>,
+  positionals: string[],
+  schemaMap: Map<string, ArgSchemaEntry>,
+): void => {
+  for (let idx = 0; idx < positionals.length; idx++) {
+    const _arg = positionals[idx];
+
+    if (idx === 0 && isArgDirectory(_arg)) {
+      // パターンA: idx0=input-dir
+      _assignEntry(config, schemaMap, '--input-dir', _arg);
+      continue;
+    }
+
+    if (idx === 0 && isKnownAgent(_arg)) {
+      // パターンB: idx0=agent, idx1=period(存在時は period 形式必須)
+      _assignEntry(config, schemaMap, 'agent', _arg);
+
+      if (idx + 1 < positionals.length) {
+        if (!isArgPeriod(positionals[idx + 1])) {
+          throw new ChatlogError(
+            'InvalidArgs',
+            `2番目の引数は期間形式である必要があります（YYYY または YYYY-MM）: ${positionals[idx + 1]}`,
+          );
+        }
+        _assignEntry(config, schemaMap, 'period', positionals[idx + 1]);
+        idx++;
+      }
+      continue;
+    }
+
+    if (idx === 0) {
+      // idx0 が directory でも agent でもない -> 即エラー
+      throw new ChatlogError('InvalidArgs', `不明な引数: ${_arg}`);
+    }
+
+    // idx1以降はすべて output-dir(directory, 1個のみ許容)
+    _assignOutputDirEntry(config, schemaMap, _arg);
+  }
+};
+
+/**
+ * CLI 引数から `--` オプションのみを解釈し、非 `--` 引数は意味付けせずに
+ * `positionals` へそのまま積んで返す。
+ *
+ * @param args - CLI 引数配列全体
+ * @param schema - 呼び出し元が追加するスキーマ
+ * @returns オプション解釈結果の `config`（`Partial<T>`）と、意味付けされていない `positionals`
+ */
+export const parseOptions = <T>(
   args: string[],
-  schema: ArgsSchema,
-): Partial<T> => {
+  schema: ArgsSchema<T>,
+): { config: Partial<T>; positionals: string[] } => {
   const _config: Record<string, string | boolean | number> = {};
+  const _positionals: string[] = [];
   const _schemaMap = _initSchema(schema);
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
     if (arg.startsWith('--')) {
-      const _isNegation = arg.startsWith('--no-') && !_schemaMap.has(arg.split('=')[0]);
-      const _lookupKey = _isNegation ? '--' + arg.slice('--no-'.length) : arg;
+      const _eqIdx = arg.indexOf('=');
+      const _optionName = _eqIdx !== -1 ? arg.slice(0, _eqIdx) : arg;
+      const _isNegation = _optionName.startsWith('--no-') && !_schemaMap.has(_optionName);
+      const _lookupKey = _isNegation ? '--' + _optionName.slice('--no-'.length) : _optionName;
 
-      if (_isNegation && arg.includes('=')) {
+      if (_isNegation && _eqIdx !== -1) {
         throw new ChatlogError('InvalidArgs', `--no- フラグに値は指定できません: ${arg}`);
       }
 
-      const { _option, _rawValue, _nextIndex } = _isNegation
-        ? { _option: arg, _rawValue: undefined, _nextIndex: i }
-        : _getOptionAndValue(args, i, _schemaMap);
-      const _entry = _schemaMap.get(_isNegation ? _lookupKey : _option);
-
+      const _entry = _schemaMap.get(_lookupKey);
       if (_entry === undefined) {
         throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
       }
 
+      let _rawValue: string | undefined;
+      if (_isNegation) {
+        _rawValue = undefined;
+      } else if (_entry.type !== 'flag' && _eqIdx === -1 && i + 1 < args.length) {
+        _rawValue = args[++i];
+      } else if (_eqIdx !== -1) {
+        _rawValue = arg.slice(_eqIdx + 1);
+      }
+
       const err = _setByType(_config, _entry, _rawValue, _isNegation);
       if (err) { throw err; }
-      i = _nextIndex;
       continue;
     }
 
-    // 位置パラメータ解釈
-    if (isArgPeriod(arg)) {
-      const err = _setByType(_config, _schemaMap.get('period')!, arg);
-      if (err) { throw err; }
-    } else if (isKnownAgent(arg)) {
-      const err = _setByType(_config, _schemaMap.get('agent')!, arg);
-      if (err) { throw err; }
-    } else if (isArgDirectory(arg)) {
-      const err = _setByType(_config, _schemaMap.get('chatlogsDir')!, arg);
-      if (err) { throw err; }
-    } else {
-      throw new ChatlogError('InvalidArgs', `不明な引数: ${arg}`);
-    }
+    _positionals.push(arg);
   }
 
-  return _config as Partial<T>;
+  return { config: _config as Partial<T>, positionals: _positionals };
 };
+
+/**
+ * CLI 引数を解析して Partial<T> を返す汎用パーサー。
+ *
+ * 位置引数の解釈はインデックス（出現順序）に基づく固定パターン判定で行う。
+ * - パターンA（directory 系）: `positionals[0]` が directory 型 → `input-dir`。
+ *   `positionals[1]` 以降はすべて directory 型（`output-dir`、1個のみ許容）。
+ * - パターンB（agent/period 系）: `positionals[0]` は agent 型固定、
+ *   `positionals[1]` は period 型固定（存在する場合のみ検査）。
+ *   `positionals[2]` 以降はすべて directory 型（`output-dir`、1個のみ許容）。
+ * - 上記以外の型混在・順序違反はすべて `ChatlogError('InvalidArgs', ...)` を throw する。
+ */
+export const parseArgs = <T extends { period?: string; agent?: string; chatlogsDir?: string }>(
+  args: string[],
+  schema: ArgsSchema<T>,
+  defaults: Partial<T> = {},
+): Partial<T> => {
+  const { config: _config, positionals: _positionals } = parseOptions<T>(args, schema) as unknown as {
+    config: Record<string, string | boolean | number>;
+    positionals: string[];
+  };
+  const _schemaMap = _initSchema(schema);
+
+  _parsePositionals(_config, _positionals, _schemaMap);
+
+  // 優先度: CLI 解析値 > GlobalConfig 値 > defaults
+  const _globalConfig = GlobalConfig.getInstance({ configFile: _config.configFile as string | undefined });
+  const _globalValues = _globalConfig.values();
+  const _merged: Record<string, string | boolean | number> = {
+    ...(defaults as Record<string, string | boolean | number>),
+    ..._globalValues,
+    ..._config,
+  };
+
+  return _merged as Partial<T>;
+};
+
+// --- Test-only exports ---
+/** テスト専用エクスポート: `_parsePositionals` を直接テストするためのラッパー。 */
+export const _parsePositionalsForTest = _parsePositionals;
+
+/** テスト専用エクスポート: `_setByType` の型検証・変換ロジックを直接テストするためのラッパー。 */
+export const _setByTypeForTest = _setByType;
+
+/** テスト専用エクスポート: `_initSchema` を直接テストするためのラッパー。 */
+export const _initSchemaForTest = _initSchema;

--- a/skills/_scripts/types/args-schema.types.ts
+++ b/skills/_scripts/types/args-schema.types.ts
@@ -10,11 +10,11 @@
 export type ArgFieldType = 'string' | 'agent' | 'integer' | 'directory' | 'number' | 'flag' | 'period';
 
 /** 1つのオプション定義。CLIオプション名・フィールド名・フィールド型を持つ。 */
-export interface ArgSchemaEntry {
+export interface ArgSchemaEntry<K extends string = string> {
   option: string; // CLI オプション名。例: '--input', '--dry-run'
-  field: string; // マッピング先フィールド名。例: 'inputDir', 'dryRun'
+  field: K; // マッピング先フィールド名。例: 'inputDir', 'dryRun'
   type: ArgFieldType;
 }
 
 /** parseArgs に渡すスキーマ。オプション定義の配列（複数スキーマを結合してから使う）。 */
-export type ArgsSchema = ArgSchemaEntry[];
+export type ArgsSchema<T = Record<string, unknown>> = ArgSchemaEntry<keyof T & string>[];

--- a/skills/_scripts/types/providers.types.ts
+++ b/skills/_scripts/types/providers.types.ts
@@ -32,6 +32,9 @@ export type StatSyncProvider = (path: string) => Deno.FileInfo;
 /** テキストファイルを読み込む関数の型。テスト用インジェクションに利用する。 */
 export type ReadTextFileProvider = (path: string) => Promise<string>;
 
+/** テキストファイルを同期的に読み込む関数の型。テスト用インジェクションに利用する。 */
+export type ReadTextFileSyncProvider = (path: string) => string;
+
 /** ファイルを削除する関数の型。テスト用インジェクションに利用する。 */
 export type RemoveProvider = (path: string) => Promise<void>;
 

--- a/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -110,13 +110,13 @@ describe('main - dry-run モード', () => {
         });
 
         it('T-CL-E2E-01-01: 元ファイルが移動せず残っている', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(await fileExists(`${monthDir}/chat.md`), true);
         });
 
         it('T-CL-E2E-01-02: "[dry-run]" がログに出力される', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]')), true);
         });
@@ -165,13 +165,13 @@ describe('main - 正常分類', () => {
         });
 
         it('T-CL-E2E-02-01: ファイルが app1/ サブディレクトリに移動している', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(await fileExists(`${monthDir}/app1/chat.md`), true);
         });
 
         it('T-CL-E2E-02-02: 移動先ファイルに "project: \\"app1\\"" が含まれる', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           const content = await readTextFile(`${monthDir}/app1/chat.md`);
           assertStringIncludes(content, 'project: "app1"');
@@ -225,13 +225,13 @@ describe('main - project 設定済みファイルの移動', () => {
         });
 
         it('T-CL-E2E-03-01: 完了ログに moved=1 が含まれる', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('moved=1')), true);
         });
 
         it('T-CL-E2E-03-02: 完了ログに skipped=0 が含まれる', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('skipped=0')), true);
         });
@@ -276,7 +276,7 @@ describe('main - project 設定済みファイルの移動', () => {
         });
 
         it('T-CL-E2E-03-03: Deno.Command が一度も構築されない（counter.calls === 0）', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(counter.calls, 0);
         });
@@ -322,13 +322,13 @@ describe('main - project 設定済みファイルの実移動', () => {
         });
 
         it('T-CL-E2E-08-01: existing-project/ にファイルが移動している', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(await fileExists(`${monthDir}/existing-project/chat.md`), true);
         });
 
         it('T-CL-E2E-08-02: 元のパスにファイルが存在しない', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(await fileOrDirExists(`${monthDir}/chat.md`), false);
         });
@@ -346,13 +346,14 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
         let inputDir: string;
         let configsDir: string;
         let configFile: string;
+        let monthDir: string;
         let commandHandle: CommandMockHandle;
         let errLogs: string[];
         let errStub: Stub;
         let exitStub: Stub;
 
         beforeEach(async () => {
-          ({ inputDir, configsDir, configFile } = await _makeTestDirs());
+          ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
           // 既に app1/ サブディレクトリに配置済み
           const app1Dir = `${inputDir}/originalLogs/claude/2026/2026-03/app1`;
           await Deno.mkdir(app1Dir, { recursive: true });
@@ -383,13 +384,13 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
         });
 
         it('T-CL-E2E-09-01: 完了ログに skipped=1 が含まれる（二重ネストしない）', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('skipped=1')), true);
         });
 
         it('T-CL-E2E-09-02: app1/app1/ ディレクトリが作成されない', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(await fileOrDirExists(`${inputDir}/originalLogs/claude/2026/2026-03/app1/app1`), false);
         });
@@ -407,13 +408,14 @@ describe('main - 対象ファイルなし', () => {
         let inputDir: string;
         let configsDir: string;
         let configFile: string;
+        let monthDir: string;
         let commandHandle: CommandMockHandle;
         let errLogs: string[];
         let errStub: Stub;
         let exitStub: Stub;
 
         beforeEach(async () => {
-          ({ inputDir, configsDir, configFile } = await _makeTestDirs());
+          ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
           // monthDir は _makeTestDirs で作成済み、.md ファイルは置かない
           resetProjectRoot(inputDir);
           commandHandle = installCommandMock(
@@ -438,7 +440,7 @@ describe('main - 対象ファイルなし', () => {
         });
 
         it('T-CL-E2E-04-01: "moved=0 movedByAI=0 skipped=0 error=0" がログに出力される', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(errLogs.some((l) => l.includes('moved=0 movedByAI=0 skipped=0 error=0')), true);
         });
@@ -447,10 +449,10 @@ describe('main - 対象ファイルなし', () => {
   });
 });
 
-// ─── T-CL-E2E-05: 存在しない --base-dir パス → exit(1) ───────────────────────
+// ─── T-CL-E2E-05: 存在しない --input-dir パス → exit(1) ──────────────────────
 
 describe('main - InputNotFound エラー', () => {
-  describe('Given: 存在しない --base-dir パス', () => {
+  describe('Given: 存在しない --input-dir パス', () => {
     describe('When: main([...args]) を呼び出す', () => {
       describe('Then: T-CL-E2E-05 - InputNotFound → exit(1)', () => {
         let configsDir: string;
@@ -484,7 +486,7 @@ describe('main - InputNotFound エラー', () => {
 
         it('T-CL-E2E-05-01: Deno.exit が 1 で呼ばれる', async () => {
           try {
-            await main(['claude', '2026-03', '--base-dir', '/nonexistent/path/xyz', '--config', configFile]);
+            await main(['claude', '2026-03', '--input-dir', '/nonexistent/path/xyz', '--config', configFile]);
           } catch { /* ChatlogError が漏れた場合も継続して検証する */ }
 
           assertEquals(exitStub.calls.length >= 1, true, 'Deno.exit が呼ばれていない');
@@ -493,7 +495,7 @@ describe('main - InputNotFound エラー', () => {
 
         it('T-CL-E2E-05-02: errorLogs に "入力ディレクトリが見つかりません" が含まれる', async () => {
           try {
-            await main(['claude', '2026-03', '--base-dir', '/nonexistent/path/xyz', '--config', configFile]);
+            await main(['claude', '2026-03', '--input-dir', '/nonexistent/path/xyz', '--config', configFile]);
           } catch { /* ChatlogError が漏れた場合も継続して検証する */ }
 
           assertEquals(
@@ -546,13 +548,13 @@ describe('main - AI 失敗フォールバック', () => {
         });
 
         it('T-CL-E2E-06-01: ファイルが元の場所に残っている', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(await fileExists(`${monthDir}/chat.md`), true);
         });
 
         it('T-CL-E2E-06-02: 完了ログに error=1 が含まれる', async () => {
-          await main(['claude', '2026-03', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
           assertEquals(
             errLogs.some((l) => l.includes('error=1')),
@@ -581,15 +583,21 @@ describe('main - 期間フィルタ', () => {
 
         beforeEach(async () => {
           ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs('claude', '2026-03'));
+          // chatlogsDir を GlobalConfig 経由で inputDir に設定し、period による通常解決経路を通す
+          await Deno.writeTextFile(
+            configFile,
+            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`,
+          );
           // 2026-03 の対象ファイル
           await Deno.writeTextFile(
             `${monthDir}/in-scope.md`,
             '---\ntitle: 対象\ncategory: dev\n---\n本文',
           );
-          // 2026-02 の期間外ファイル
-          await Deno.mkdir(`${inputDir}/claude/2026-02`, { recursive: true });
+          // 2026-02 の期間外ファイル（resolveChatlogsDir で解決可能なツリー上に配置）
+          const outOfScopeDir = `${inputDir}/originalLogs/claude/2026/2026-02`;
+          await Deno.mkdir(outOfScopeDir, { recursive: true });
           await Deno.writeTextFile(
-            `${inputDir}/claude/2026-02/out-of-scope.md`,
+            `${outOfScopeDir}/out-of-scope.md`,
             '---\ntitle: 期間外\ncategory: dev\n---\n本文',
           );
           const response = JSON.stringify([
@@ -615,14 +623,14 @@ describe('main - 期間フィルタ', () => {
         });
 
         it('T-CL-E2E-07-01: 期間外ファイル（out-of-scope.md）がログに出力されない', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--config', configFile]);
 
           const allInfoLogs = loggerStub.infoLogs.join('\n');
           assertEquals(allInfoLogs.includes('out-of-scope.md'), false);
         });
 
         it('T-CL-E2E-07-02: 期間内ファイル（in-scope.md）の [dry-run] ログが出力される', async () => {
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', inputDir, '--config', configFile]);
+          await main(['claude', '2026-03', '--dry-run', '--config', configFile]);
 
           assertEquals(
             loggerStub.infoLogs.some((l) => l.includes('[dry-run]') && l.includes('in-scope.md')),
@@ -654,8 +662,8 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
    * Deno.exit(1) が発生することを確認する。
    */
   describe('Given: agent ディレクトリは存在するが period ディレクトリが存在しない', () => {
-    /** `main(["claude", "2026-99", "--base-dir", inputDir, "--config", configFile])` を呼び出すとき。 */
-    describe('When: main(["claude", "2026-99", "--base-dir", inputDir, ...]) を呼び出す', () => {
+    /** `main(["claude", "2026-99", "--config", configFile])` を呼び出すとき（GlobalConfig の chatlogsDir 経由で解決）。 */
+    describe('When: main(["claude", "2026-99", "--config", configFile]) を呼び出す', () => {
       /** InputNotFound エラーが発生し Deno.exit(1) が呼ばれること。 */
       describe('Then: T-CL-E2E-11 - InputNotFound → exit(1)', () => {
         let inputDir: string;
@@ -668,6 +676,11 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
         beforeEach(async () => {
           // 2026-03 ディレクトリは作成されるが、2026-99 は存在しない
           ({ inputDir, configsDir, configFile } = await _makeTestDirs('claude', '2026-03'));
+          // chatlogsDir を GlobalConfig 経由で inputDir に設定し、resolveChatlogsDir の通常解決経路を通す
+          await Deno.writeTextFile(
+            configFile,
+            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`,
+          );
           errLogs = [];
           errStub = stub(console, 'error', (...args: unknown[]) => {
             errLogs.push(args.map(String).join(' '));
@@ -686,7 +699,7 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
 
         it('T-CL-E2E-11-01: Deno.exit が 1 で呼ばれる', async () => {
           try {
-            await main(['claude', '2026-99', '--base-dir', inputDir, '--config', configFile]);
+            await main(['claude', '2026-99', '--config', configFile]);
           } catch { /* ChatlogError が漏れた場合も継続 */ }
 
           assertEquals(exitStub.calls.length >= 1, true, 'Deno.exit が呼ばれていない');
@@ -695,7 +708,7 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
 
         it('T-CL-E2E-11-02: errorLogs に "入力ディレクトリが見つかりません" が含まれる', async () => {
           try {
-            await main(['claude', '2026-99', '--base-dir', inputDir, '--config', configFile]);
+            await main(['claude', '2026-99', '--config', configFile]);
           } catch { /* ChatlogError が漏れた場合も継続 */ }
 
           assertEquals(
@@ -708,10 +721,10 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
   });
 });
 
-// ─── T-CL-E2E-10: --chatlogs-dir フルパス直接指定 ────────────────────────────
+// ─── T-CL-E2E-10: --input-dir フルパス直接指定 ───────────────────────────────
 
-describe('main - --chatlogs-dir フルパス直接指定', () => {
-  describe('Given: --chatlogs-dir に月ディレクトリのフルパスを指定', () => {
+describe('main - --input-dir フルパス直接指定', () => {
+  describe('Given: --input-dir に月ディレクトリのフルパスを指定', () => {
     describe('When: main([...args, "--dry-run"]) を呼び出す', () => {
       describe('Then: T-CL-E2E-10 - dry-run でファイルが移動しない', () => {
         let inputDir: string;
@@ -747,13 +760,13 @@ describe('main - --chatlogs-dir フルパス直接指定', () => {
           await Deno.remove(configsDir, { recursive: true });
         });
 
-        it('T-CL-E2E-10-01: --chatlogs-dir フルパス dry-run → 元ファイルが残る', async () => {
-          await main(['--chatlogs-dir', monthDir, '--dry-run', '--config', configFile]);
+        it('T-CL-E2E-10-01: --input-dir フルパス dry-run → 元ファイルが残る', async () => {
+          await main(['--input-dir', monthDir, '--dry-run', '--config', configFile]);
           assertEquals(await fileExists(`${monthDir}/chat.md`), true);
         });
 
         it('T-CL-E2E-10-02: "[dry-run]" がログに出力される', async () => {
-          await main(['--chatlogs-dir', monthDir, '--dry-run', '--config', configFile]);
+          await main(['--input-dir', monthDir, '--dry-run', '--config', configFile]);
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]')), true);
         });
       });

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -11,7 +11,7 @@
  *
  * 使い方:
  *   deno run --allow-read --allow-run --allow-write classify-chatlogs.ts \
- *     [agent] [YYYY-MM] [--dry-run] [--config FILE] [--base-dir DIR] [--chatlogs-dir DIR]
+ *     [agent] [YYYY-MM] [--dry-run] [--config FILE] [--input-dir DIR]
  */
 
 // cspell:words noai
@@ -68,16 +68,16 @@ export const processClassify = async (
 export const main = async (argv?: string[]): Promise<void> => {
   try {
     const _parsed = parseArgs(argv ?? Deno.args);
-    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const _config = buildConfig(_parsed, _globalConfig);
 
     // 入力ディレクトリ確認
     const _agentDir = resolveChatlogsDir({
       chatlogsDir: _config.chatlogsDir,
-      baseDir: _config.baseDir,
       agent: _config.agent,
       period: _config.period,
       addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+      override: _config.inputDir,
     });
     if (!await dirExists(_agentDir)) {
       throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_agentDir}`);
@@ -98,10 +98,10 @@ export const main = async (argv?: string[]): Promise<void> => {
     // 対象ディレクトリ
     const _searchDir = resolveChatlogsDir({
       chatlogsDir: _config.chatlogsDir,
-      baseDir: _config.baseDir,
       agent: _config.agent,
       period: _config.period,
       addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+      override: _config.inputDir,
     });
 
     const stats: ClassifyStats = { moved: 0, movedByAI: 0, skipped: 0, error: 0, remaining: 0 };

--- a/skills/classify-chatlogs/scripts/constants/classify.constants.ts
+++ b/skills/classify-chatlogs/scripts/constants/classify.constants.ts
@@ -30,7 +30,7 @@ export const MIN_CLASSIFIABLE_LENGTH = 50;
 export const DEFAULT_CLASSIFY_CONFIG: ClassifyConfig = {
   agent: DEFAULT_AGENT,
   dryRun: false,
-  baseDir: DEFAULT_CHATLOGS_DIR,
+  chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dicsDir: DEFAULT_DICS_DIR,
   model: DEFAULT_AI_MODEL,
   chunkSize: DEFAULT_CHUNK_SIZE,

--- a/skills/classify-chatlogs/scripts/modules/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/functional/build-config.functional.spec.ts
@@ -32,7 +32,7 @@ async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
   resetProjectRoot('/home/user/project');
   GlobalConfig.resetInstance();
   return await GlobalConfig.getInstance({
-    readTextFileProvider: () => Promise.resolve(yaml),
+    readTextFileProvider: () => yaml,
     configFile: 'dummy.yaml',
   });
 }
@@ -148,7 +148,7 @@ describe('buildConfig', () => {
 
   // ─── parsed フィールドの上書き ───────────────────────────────────────────────
 
-  describe('Given: parsed に dryRun=true, baseDir が指定されている', () => {
+  describe('Given: parsed に dryRun=true, inputDir が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
       describe('Then: T-CL-BC-07 - parsed フィールドがデフォルトを上書きする', () => {
         let globalConfig: GlobalConfig;
@@ -156,9 +156,9 @@ describe('buildConfig', () => {
           globalConfig = await GlobalConfig.getInstance();
         });
         it('T-CL-BC-07-01: parsed.dryRun=true → result.dryRun === true', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, dryRun: true, baseDir: '/custom/input' }, globalConfig);
+          const result = buildConfig({ ..._EMPTY_PARSED, dryRun: true, inputDir: '/custom/input' }, globalConfig);
           assertEquals(result.dryRun, true);
-          assertEquals(result.baseDir, '/custom/input');
+          assertEquals(result.inputDir, '/custom/input');
         });
       });
     });
@@ -258,78 +258,71 @@ describe('buildConfig', () => {
     });
   });
 
-  // ─── baseDir 優先順位 ────────────────────────────────────────────────────────
+  // ─── inputDir（フルパス直接指定） ───────────────────────────────────────────
 
-  describe('Given: parsed.baseDir が指定されている', () => {
+  describe('Given: parsed.inputDir が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      describe('Then: T-CL-BC-14 - result.baseDir === parsed.baseDir', () => {
+      describe('Then: T-CL-BC-14 - result.inputDir === parsed.inputDir', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance();
         });
-        it('T-CL-BC-14-01: parsed.baseDir=/custom/input → result.baseDir === /custom/input', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, baseDir: '/custom/input' }, globalConfig);
-          assertEquals(result.baseDir, '/custom/input');
+        it('T-CL-BC-14-01: parsed.inputDir=/custom/input → result.inputDir === /custom/input', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom/input' }, globalConfig);
+          assertEquals(result.inputDir, '/custom/input');
         });
       });
     });
   });
 
-  describe('Given: parsed.baseDir が指定されている', () => {
+  describe('Given: parsed.inputDir が指定されている', () => {
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
-      describe('Then: T-CL-BC-20 - parsed.baseDir が最優先される', () => {
+      describe('Then: T-CL-BC-20 - parsed.inputDir と result.chatlogsDir は独立して両方保持される', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global/chatlog');
         });
-        it('T-CL-BC-20-01: parsed.baseDir=/custom/input → result.baseDir === /custom/input', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, baseDir: '/custom/input' }, globalConfig);
-          assertEquals(result.baseDir, '/custom/input');
+        it('T-CL-BC-20-01: parsed.inputDir=/custom/input → result.inputDir === /custom/input', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom/input' }, globalConfig);
+          assertEquals(result.inputDir, '/custom/input');
+        });
+        it('T-CL-BC-20-02: result.chatlogsDir === /global/chatlog（inputDir とは独立）', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom/input' }, globalConfig);
+          assertEquals(result.chatlogsDir, '/global/chatlog');
         });
       });
     });
   });
 
-  describe('Given: parsed.baseDir が未指定', () => {
+  // ─── chatlogsDir（GlobalConfig 由来の基準ディレクトリ） ──────────────────────
+
+  describe('Given: parsed.inputDir が未指定', () => {
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
       describe('Then: T-CL-BC-21 - GlobalConfig の chatlogsDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global/chatlog');
         });
-        it('T-CL-BC-21-01: baseDir 未指定, globalConfig.chatlogsDir=/global/chatlog → result.baseDir === /global/chatlog', () => {
+        it('T-CL-BC-21-01: inputDir 未指定, globalConfig.chatlogsDir=/global/chatlog → result.chatlogsDir === /global/chatlog', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, '/global/chatlog');
+          assertEquals(result.chatlogsDir, '/global/chatlog');
+        });
+        it('T-CL-BC-21-02: result.inputDir === undefined', () => {
+          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          assertEquals(result.inputDir, undefined);
         });
       });
     });
 
     describe('When: GlobalConfig に chatlogsDir が未登録（schema: {}）', () => {
-      describe('Then: T-CL-BC-15 - DEFAULT_CLASSIFY_CONFIG.baseDir が使われる', () => {
+      describe('Then: T-CL-BC-15 - DEFAULT_CLASSIFY_CONFIG.chatlogsDir が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance({ schema: {} });
         });
-        it('T-CL-BC-15-01: baseDir 未指定, chatlogsDir 未登録 → result.baseDir === DEFAULT_CLASSIFY_CONFIG.baseDir', () => {
+        it('T-CL-BC-15-01: inputDir 未指定, chatlogsDir 未登録 → result.chatlogsDir === DEFAULT_CLASSIFY_CONFIG.chatlogsDir', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, DEFAULT_CLASSIFY_CONFIG.baseDir);
-        });
-      });
-    });
-  });
-
-  // ─── chatlogsDir フィールド ──────────────────────────────────────────────────
-
-  describe('Given: parsed.chatlogsDir が指定されている', () => {
-    describe('When: buildConfig を呼び出す', () => {
-      describe('Then: T-CL-BC-22 - result.chatlogsDir に設定される', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
-        });
-        it('T-CL-BC-22-01: parsed.chatlogsDir=/data/claude/2026/2026-04 → result.chatlogsDir === /data/claude/2026/2026-04', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, chatlogsDir: '/data/claude/2026/2026-04' }, globalConfig);
-          assertEquals(result.chatlogsDir, '/data/claude/2026/2026-04');
+          assertEquals(result.chatlogsDir, DEFAULT_CLASSIFY_CONFIG.chatlogsDir);
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-config.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-config.unit.spec.ts
@@ -8,55 +8,68 @@
 
 // -- BDD modules --
 import { assert, assertEquals, assertThrows } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // -- modules for test --
 // test target
 import { parseArgs } from '../../classify-config.ts';
 // classes
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 
 describe('parseArgs', () => {
-  // ─── T-CL-PA-02: --base-dir オプション ─────────────────────────────────────
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
 
-  describe('Given: --base-dir または --base-dir=VALUE', () => {
+  // ─── T-CL-PA-02: --input-dir オプション ─────────────────────────────────────
+
+  describe('Given: --input-dir または --input-dir=VALUE', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
-      describe('Then: T-CL-PA-02 - baseDir に値が設定される', () => {
+      describe('Then: T-CL-PA-02 - inputDir に値が設定される', () => {
         const _cases: Array<[string, string[], string]> = [
-          ['T-CL-PA-02-01: --base-dir VALUE → baseDir が設定される', ['--base-dir', '/data/chatlog'], '/data/chatlog'],
-          ['T-CL-PA-02-02: --base-dir=VALUE → baseDir が設定される', ['--base-dir=/data/chatlog'], '/data/chatlog'],
+          [
+            'T-CL-PA-02-01: --input-dir VALUE → inputDir が設定される',
+            ['--input-dir', '/data/chatlog'],
+            '/data/chatlog',
+          ],
+          [
+            'T-CL-PA-02-02: --input-dir=VALUE → inputDir が設定される',
+            ['--input-dir=/data/chatlog'],
+            '/data/chatlog',
+          ],
         ];
         for (const [id, args, expected] of _cases) {
           it(id, () => {
             const result = parseArgs(args);
-            assertEquals(result.baseDir, expected);
+            assertEquals(result.inputDir, expected);
           });
         }
       });
     });
   });
 
-  // ─── T-CL-PA-07: --chatlogs-dir オプション ──────────────────────────────────
+  // ─── T-CL-PA-07: --input-dir フルパス直接指定オプション ──────────────────────
 
-  describe('Given: --chatlogs-dir または --chatlogs-dir=VALUE', () => {
+  describe('Given: --input-dir に月ディレクトリのフルパス', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
-      describe('Then: T-CL-PA-07 - chatlogsDir に値が設定される', () => {
+      describe('Then: T-CL-PA-07 - inputDir に値が設定される', () => {
         const _cases: Array<[string, string[], string]> = [
           [
-            'T-CL-PA-07-01: --chatlogs-dir VALUE → chatlogsDir が設定される',
-            ['--chatlogs-dir', '/data/chatlog/claude/2026/2026-04'],
+            'T-CL-PA-07-01: --input-dir VALUE → inputDir が設定される',
+            ['--input-dir', '/data/chatlog/claude/2026/2026-04'],
             '/data/chatlog/claude/2026/2026-04',
           ],
           [
-            'T-CL-PA-07-02: --chatlogs-dir=VALUE → chatlogsDir が設定される',
-            ['--chatlogs-dir=/data/chatlog/claude/2026/2026-04'],
+            'T-CL-PA-07-02: --input-dir=VALUE → inputDir が設定される',
+            ['--input-dir=/data/chatlog/claude/2026/2026-04'],
             '/data/chatlog/claude/2026/2026-04',
           ],
         ];
         for (const [id, args, expected] of _cases) {
           it(id, () => {
             const result = parseArgs(args);
-            assertEquals(result.chatlogsDir, expected);
+            assertEquals(result.inputDir, expected);
           });
         }
       });
@@ -122,14 +135,14 @@ describe('parseArgs', () => {
     });
   });
 
-  // ─── 正常系: --model 未指定時は undefined（globalConfig 解決は main() で行う） ─────
+  // ─── 正常系: --model 未指定時は GlobalConfig のデフォルト値が自動マージされる ─────
 
   describe('Given: --model 未指定', () => {
     describe('When: parseArgs([]) を呼び出す', () => {
-      describe('Then: T-CL-PA-13 - model が undefined になる（globalConfig 解決は main() で行う）', () => {
-        it('T-CL-PA-13-01: --model 未指定時、model は undefined になる', () => {
+      describe('Then: T-CL-PA-13 - model が GlobalConfig のデフォルト値になる（parseArgs 内で自動マージ）', () => {
+        it('T-CL-PA-13-01: --model 未指定時、model は GlobalConfig のデフォルト値 "sonnet" になる', () => {
           const result = parseArgs([]);
-          assertEquals(result.model, undefined);
+          assertEquals(result.model, 'sonnet');
         });
 
         it('T-CL-PA-13-02: --model 明示指定は優先される', () => {
@@ -167,20 +180,23 @@ describe('parseArgs', () => {
 
   // ─── T-CL-PA-03: period 位置引数 ────────────────────────────────────────────
 
-  describe('Given: YYYY-MM または YYYY 形式の位置引数', () => {
+  describe('Given: YYYY-MM または YYYY 形式の位置引数（agent 省略）', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
-      describe('Then: T-CL-PA-03 - period に値が設定される', () => {
-        const _cases: Array<[string, string[], string | undefined]> = [
-          ['T-CL-PA-03-01: YYYY-MM 形式 → period が設定される', ['2026-04'], '2026-04'],
-          ['T-CL-PA-03-02: YYYY 形式 → period が設定される', ['2026'], '2026'],
-          ['T-CL-PA-03-03: 引数なし → period が undefined になる', [], undefined],
+      describe('Then: T-CL-PA-03 - period 単独は不明な引数としてエラーになる', () => {
+        const _cases: Array<[string, string[]]> = [
+          ['T-CL-PA-03-01: YYYY-MM 形式 → ChatlogError(InvalidArgs)', ['2026-04']],
+          ['T-CL-PA-03-02: YYYY 形式 → ChatlogError(InvalidArgs)', ['2026']],
         ];
-        for (const [id, args, expected] of _cases) {
+        for (const [id, args] of _cases) {
           it(id, () => {
-            const result = parseArgs(args);
-            assertEquals(result.period, expected);
+            assertThrows(() => parseArgs(args), ChatlogError);
           });
         }
+
+        it('T-CL-PA-03-03: 引数なし → period が undefined になる', () => {
+          const result = parseArgs([]);
+          assertEquals(result.period, undefined);
+        });
       });
     });
   });

--- a/skills/classify-chatlogs/scripts/modules/classify-config.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-config.ts
@@ -11,7 +11,7 @@
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 import { isValidModel } from '../../../_scripts/libs/ai/model-utils.ts';
-import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
+import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 // types
 import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
 
@@ -22,21 +22,21 @@ import type { ClassifyConfig, ParsedConfig } from '../types/classify.types.ts';
 import { DEFAULT_CLASSIFY_CONFIG } from '../constants/classify.constants.ts';
 
 /** classify-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema = [
+const _SCHEMA: ArgsSchema<ParsedConfig> = [
   { option: '--period', field: 'period', type: 'period' },
   { option: '--model', field: 'model', type: 'string' },
 ];
 
 export const parseArgs = (args: string[]): ParsedConfig => {
-  return parseArgsToConfig<ParsedConfig>(args, _SCHEMA) as ParsedConfig;
+  return parseArgsToConfig<ParsedConfig>(args, _SCHEMA);
 };
 
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な ClassifyConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - model 優先順位: `parsed.model` > `globalConfig.get('model')` > `defaults.model`
- * - baseDir 優先順位: `parsed.baseDir` > `globalConfig.get('chatlogsDir')` > `defaults.baseDir`
- * - chatlogsDir: `parsed.chatlogsDir`（指定時のみ設定される）
+ * - chatlogsDir: `globalConfig.get('chatlogsDir')`（基準ディレクトリ）
+ * - inputDir: `parsed.inputDir`（指定時のみ設定される。フルパス直接指定の短絡パラメータ）
  * - dicsDir 優先順位: `globalConfig.get('dicsDir')` > `defaults.dicsDir`
  * - projectsDic 優先順位: `globalConfig.get('projectsDic')` > `defaults.projectsDic`（`dicsDir` とは独立）
  * - 不正なモデル名は `ChatlogError('InvalidArgs')` をスローする。
@@ -54,9 +54,7 @@ export const buildConfig = (
   }
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _dicsDir = globalConfig.get('dicsDir') as string;
-  const _globalChatlogDir = globalConfig.get('chatlogsDir') as string;
-  const _baseDir = parsed.baseDir ?? _globalChatlogDir;
-  const _chatlogsDir = parsed.chatlogsDir;
+  const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
   const _projectsDic = globalConfig.get('projectsDic') as string;
   const _chunkSize = globalConfig.get('chunkSize') as number;
   const _concurrency = globalConfig.get('concurrency') as number;
@@ -68,8 +66,8 @@ export const buildConfig = (
     model: _model,
     dicsDir: _dicsDir,
     projectsDic: _projectsDic,
-    baseDir: _baseDir,
     chatlogsDir: _chatlogsDir,
+    inputDir: parsed.inputDir,
     chunkSize: _chunkSize,
     concurrency: _concurrency,
   };

--- a/skills/classify-chatlogs/scripts/types/classify.types.ts
+++ b/skills/classify-chatlogs/scripts/types/classify.types.ts
@@ -66,16 +66,16 @@ export interface ClassifyConfig {
   period?: string;
   /** `true` のときファイルを移動せず分類結果のみ表示する。 */
   dryRun: boolean;
-  /** チャットログが格納されたベースディレクトリのパス。 */
-  baseDir: string;
   /** `projects.dic` が置かれた辞書ディレクトリのパス。 */
   dicsDir: string;
   /** プロジェクト辞書ファイルのパス。省略時は DEFAULT_PROJECTS_DIC_PATH。 */
   projectsDic?: string;
   /** claude CLI に渡すモデル名。 */
   model: string;
-  /** チャットログ格納ディレクトリ。位置引数のディレクトリパスが設定される。 */
-  chatlogsDir?: string;
+  /** チャットログが格納された基準ディレクトリのパス（GlobalConfig の chatlogsDir 由来）。 */
+  chatlogsDir: string;
+  /** 入力ディレクトリのフルパス直接指定。指定時は agent/period を無視してこのパスをそのまま使う。 */
+  inputDir?: string;
   /** バッチリクエスト1回あたりの最大ファイル数。 */
   chunkSize: number;
   /** 同時実行する並列タスク数の上限。 */

--- a/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
@@ -42,7 +42,7 @@ async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
   resetProjectRoot('/home/user/project');
   GlobalConfig.resetInstance();
   return await GlobalConfig.getInstance({
-    readTextFileProvider: () => Promise.resolve(yaml),
+    readTextFileProvider: () => yaml,
     configFile: 'dummy.yaml',
   });
 }

--- a/skills/export-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/parse-args.unit.spec.ts
@@ -46,8 +46,6 @@ describe('parseArgs', () => {
       describe('Then: 対応フィールドに値が設定される', () => {
         const _cases: { id: string; args: string[]; field: keyof ParsedConfig & string; expected: unknown }[] = [
           { id: 'T-EC-PA-02-01', args: ['codex'], field: 'agent', expected: 'codex' },
-          { id: 'T-EC-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
-          { id: 'T-EC-PA-03-02', args: ['2026'], field: 'period', expected: '2026' },
           { id: 'T-EC-PA-04-01', args: ['--output-dir', '/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
           { id: 'T-EC-PA-04-02', args: ['--output-dir=/tmp/out'], field: 'outputDir', expected: '/tmp/out' },
           { id: 'T-EC-PA-08-01', args: ['--base', '/data/logs'], field: 'baseDir', expected: '/data/logs' },
@@ -71,18 +69,6 @@ describe('parseArgs', () => {
             expected: '/data/chatgpt-export',
           },
           { id: 'T-EC-PA-13-01', args: ['chatgpt'], field: 'agent', expected: 'chatgpt' },
-          {
-            id: 'T-EC-PA-15-01',
-            args: ['chatgpt', '/path/to/export'],
-            field: 'chatlogsDir',
-            expected: '/path/to/export',
-          },
-          {
-            id: 'T-EC-PA-15-04',
-            args: ['chatgpt', 'C:\\Users\\foo\\export'],
-            field: 'chatlogsDir',
-            expected: 'C:/Users/foo/export',
-          },
         ];
         for (const { id, args, field, expected } of _cases) {
           it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
@@ -147,32 +133,6 @@ describe('parseArgs', () => {
     });
   });
 
-  /**
-   * chatgpt + period + inputDir の3フィールド組み合わせケース。
-   * 位置引数として period と inputDir（パス）が並んでも
-   * パス判定（/ または ドライブレター:/ で始まる）により正しく区別されることを確認する。
-   */
-  describe('Given: ["chatgpt", "2026-03", "/path/to/export"]', () => {
-    it('T-EC-PA-15-02: period と chatlogsDir が同時に設定される', () => {
-      const result = parseArgs(['chatgpt', '2026-03', '/path/to/export']);
-      assertEquals(result.period, '2026-03');
-      assertEquals(result.chatlogsDir, '/path/to/export');
-    });
-  });
-
-  /**
-   * period と chatlogsDir の順番を逆にした境界値ケース。
-   * パスと期間文字列の順序に依存せず正しく解析されることを確認する。
-   * 順序不問の解析仕様を明示的に検証する。
-   */
-  describe('Given: ["chatgpt", "/path/to/export", "2026-03"]（順番逆）', () => {
-    it('T-EC-PA-15-03: 順番が逆でも period と chatlogsDir が正しく設定される', () => {
-      const result = parseArgs(['chatgpt', '/path/to/export', '2026-03']);
-      assertEquals(result.period, '2026-03');
-      assertEquals(result.chatlogsDir, '/path/to/export');
-    });
-  });
-
   // ─── T-EC-PA-16: --config オプション ────────────────────────────────────────
 
   /**
@@ -193,6 +153,36 @@ describe('parseArgs', () => {
           it(`${id}: ${args.join(' ')} → configFile が "${expected}" になる`, () => {
             const result = parseArgs(args);
             assertEquals(result.configFile, expected);
+          });
+        }
+      });
+    });
+  });
+
+  // ─── T-EC-PA-03: period 単独指定（agent なし）はエラー ──────────────────────
+
+  /**
+   * period 形式の位置引数のみ（agent なし）を渡した場合のエラー検証。
+   * インデックスベース方式では `positionals[0]` は directory 型または agent 型固定であり、
+   * period 形式は directory でも agent でもないため `ChatlogError(InvalidArgs)` がスローされる
+   * （`export-chatlog 2026-03` のような agent 省略・period 単独指定は非サポート）。
+   */
+  describe('Given: period 形式の位置引数のみ（agent なし）', () => {
+    /** `parseArgs(args)` を呼び出したときにエラーがスローされることを検証する。 */
+    describe('When: parseArgs(args) を呼び出す', () => {
+      /** ChatlogError(InvalidArgs) がスローされることを確認する。 */
+      describe('Then: T-EC-PA-03 - ChatlogError(InvalidArgs) がスローされる', () => {
+        const _cases: { id: string; args: string[] }[] = [
+          { id: 'T-EC-PA-03-01', args: ['2026-03'] },
+          { id: 'T-EC-PA-03-02', args: ['2026'] },
+        ];
+        for (const { id, args } of _cases) {
+          it(`${id}: ${args.join(' ')} → ChatlogError(InvalidArgs) がスローされる`, () => {
+            assertThrows(
+              () => parseArgs(args),
+              ChatlogError,
+              'Invalid Args',
+            );
           });
         }
       });

--- a/skills/export-chatlogs/scripts/export-chatlogs.ts
+++ b/skills/export-chatlogs/scripts/export-chatlogs.ts
@@ -25,7 +25,7 @@ import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 // libs
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { parseArgs as parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { joinPath } from '../../_scripts/libs/path-utils/path-utils.ts';
 import type { ArgsSchema } from '../../_scripts/types/args-schema.types.ts';
 // constants
@@ -46,10 +46,9 @@ import type { ExportConfig, ParsedConfig } from './types/export-config.types.ts'
 // ─────────────────────────────────────────────
 
 /** export-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema = [
+const _SCHEMA: ArgsSchema<ParsedConfig> = [
   { option: '--output-dir', field: 'outputDir', type: 'directory' },
   { option: '--base', field: 'baseDir', type: 'directory' },
-  { option: '--input-dir', field: 'inputDir', type: 'directory' },
 ];
 
 /**
@@ -59,7 +58,7 @@ const _SCHEMA: ArgsSchema = [
  * @returns 解析済みの `ParsedConfig`
  */
 export const parseArgs = (args: string[]): ParsedConfig => {
-  return parseArgsToConfig<ParsedConfig>(args, _SCHEMA) as ParsedConfig;
+  return parseArgsToConfig<ParsedConfig>(args, _SCHEMA);
 };
 
 // ─────────────────────────────────────────────
@@ -71,7 +70,7 @@ export const parseArgs = (args: string[]): ParsedConfig => {
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - outputDir 優先順位: `parsed.outputDir` > `join(globalConfig.get('chatlogsDir') ?? DEFAULT_CHATLOGS_DIR, 'originalLogs')`
  * - baseDir 優先順位: `parsed.baseDir` > `defaults.baseDir`
- * - inputDir 優先順位: `parsed.inputDir` > `parsed.chatlogsDir` > `defaults.inputDir`
+ * - inputDir 優先順位: `parsed.inputDir` > `defaults.inputDir`
  * - period: `parsed.period` のみ (GlobalConfig に期間設定なし)
  */
 export function buildConfig(
@@ -84,7 +83,7 @@ export function buildConfig(
   const _chatlogsDir = (globalConfig.get('chatlogsDir') as string | undefined) ?? DEFAULT_CHATLOGS_DIR;
   const _outputDir = parsed.outputDir ?? joinPath(_chatlogsDir, DEFAULT_ORIGINAL_LOGS_DIR);
   const _baseDir = parsed.baseDir ?? _defaults.baseDir;
-  const _inputDir = parsed.inputDir ?? parsed.chatlogsDir ?? _defaults.inputDir;
+  const _inputDir = parsed.inputDir ?? _defaults.inputDir;
   const { configFile: _configFile, ...parsedRest } = parsed;
   return {
     ..._defaults,
@@ -121,7 +120,7 @@ export function buildConfig(
 export const main = async (argv?: string[]): Promise<void> => {
   try {
     const _parsed = parseArgs(argv ?? Deno.args);
-    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const config = buildConfig(_parsed, _globalConfig);
     const { agent, period, outputDir } = config;
 

--- a/skills/export-chatlogs/scripts/types/export-config.types.ts
+++ b/skills/export-chatlogs/scripts/types/export-config.types.ts
@@ -36,8 +36,6 @@ export interface ExportConfig {
   inputDir?: string;
   /** 出力先ディレクトリのベースパス。デフォルトは "./chatlogs" */
   outputDir: string;
-  /** チャットログ格納ディレクトリ。位置引数のディレクトリパスが設定される。 */
-  chatlogsDir?: string;
   /** dry-run モード。`--dry-run` オプションの解析結果を保持する（現状 `main()` 側での書き込みスキップは未実装）。 */
   dryRun?: boolean;
 }

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -20,6 +20,8 @@ import type { Stub } from '@std/testing/mock';
 
 // ─── Test target
 import { main } from '../../filter-chatlogs.ts';
+// classes
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 // constants
 import { LOGGER_HEADER } from '../../../../_scripts/constants/logger-header.constants.ts';
 
@@ -34,6 +36,7 @@ import {
 // stub
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants
+import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
 import { FILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -42,6 +45,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 import { assertFileNotExist } from '../../../../_scripts/__tests__/helpers/assert.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { makeRepeatedContent, makeTestDirs } from '../_helpers/fixtures.ts';
+// helpers
+import { resetProjectRoot } from '../../../../_scripts/libs/path-utils/dir-utils.ts';
 
 // ─── Internal Helpers
 
@@ -52,6 +57,24 @@ const _makeTestDirs = (agent = 'claude', period = '2026-03') => makeTestDirs(age
 
 /** `_makeValidContent` のラッパー。`FILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
 const _makeValidContent = (title = 'テスト') => makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH, title);
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを YAML 文字列から生成する。
+ *
+ * 毎回 `GlobalConfig.resetInstance()` でシングルトンをリセットしてから
+ * `resetProjectRoot` でプロジェクトルートをシードして初期化する。
+ *
+ * @param yaml - GlobalConfig に読み込ませる YAML テキスト（例: `'chatlogsDir: /tmp/test'`）
+ * @returns 初期化済みの `GlobalConfig` インスタンス
+ */
+const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
+  resetProjectRoot('/home/user/project');
+  GlobalConfig.resetInstance();
+  return await GlobalConfig.getInstance({
+    readTextFileProvider: () => yaml,
+    configFile: 'dummy.yaml',
+  });
+};
 
 // ─── Tests
 
@@ -105,7 +128,7 @@ describe('main - dry-run モード', () => {
           });
 
           it('T-FL-E2E-01-01: ファイルが削除されずに残り "[dry-run]" がログに出力される', async () => {
-            await main(['claude', '2026-03', '--dry-run', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
             assertEquals(loggerStub.logLogs.some((l) => l.includes('[dry-run]')), true);
@@ -166,7 +189,7 @@ describe('main - DISCARD 判定', () => {
           });
 
           it('T-FL-E2E-02-01: ファイルが削除される', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             await assertFileNotExist(`${chatlogsDir}/discard.md`);
           });
@@ -225,7 +248,7 @@ describe('main - KEEP 判定', () => {
           });
 
           it('T-FL-E2E-03-01: ファイルが残っている', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/keep.md`), true);
           });
@@ -258,12 +281,13 @@ describe('main - 対象ファイルなし', () => {
       /** "対象ファイルなし" を含む info ログが出力されること。 */
       describe('Then: T-FL-E2E-04 - "対象ファイルなし" ログが出力される', () => {
         let tempDir: string;
+        let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
         let exitStub: Stub;
 
         beforeEach(async () => {
-          ({ tempDir } = await _makeTestDirs());
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode('[]')),
           );
@@ -279,7 +303,7 @@ describe('main - 対象ファイルなし', () => {
         });
 
         it('T-FL-E2E-04-01: "対象ファイルなし" がログに出力される', async () => {
-          await main(['claude', '2026-03', '--base-dir', tempDir]);
+          await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes(LOGGER_HEADER.NO_FILE_FOUND)), true);
         });
@@ -342,13 +366,13 @@ describe('main - DISCARD + KEEP 混在', () => {
           });
 
           it('T-FL-E2E-05-01: discard.md が削除される', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             await assertFileNotExist(`${chatlogsDir}/discard.md`);
           });
 
           it('T-FL-E2E-05-02: keep.md が残っている', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/keep.md`), true);
           });
@@ -398,28 +422,35 @@ describe('main - period 絞り込み', () => {
         afterEach(async () => {
           commandHandle.restore();
           loggerStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(tempDir, { recursive: true });
         });
 
         describe('Given: 2026-03/march.md と 2026-04/april.md を配置', () => {
           beforeEach(async () => {
-            const agentDir = `${tempDir}/claude`;
+            // 探索ディレクトリは GlobalConfig.chatlogsDir + originalLogs から解決されるため、
+            // ファイルは originalLogs 配下に作成する。
+            const agentDir = `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude`;
             await Deno.mkdir(`${agentDir}/2026/2026-03`, { recursive: true });
             await Deno.mkdir(`${agentDir}/2026/2026-04`, { recursive: true });
             await Deno.writeTextFile(`${agentDir}/2026/2026-03/march.md`, _makeValidContent('March'));
             await Deno.writeTextFile(`${agentDir}/2026/2026-04/april.md`, _makeValidContent('April'));
+            await _makeGlobalConfig(`chatlogsDir: '${tempDir}'`);
           });
 
           it('T-FL-E2E-06-01: 指定月 (2026-03) のファイルが削除される', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03']);
 
-            await assertFileNotExist(`${tempDir}/claude/2026/2026-03/march.md`);
+            await assertFileNotExist(`${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude/2026/2026-03/march.md`);
           });
 
           it('T-FL-E2E-06-02: 他の月 (2026-04) のファイルは残っている', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03']);
 
-            assertEquals(await fileExists(`${tempDir}/claude/2026/2026-04/april.md`), true);
+            assertEquals(
+              await fileExists(`${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude/2026/2026-04/april.md`),
+              true,
+            );
           });
         });
       });
@@ -474,7 +505,7 @@ describe('main - Claude CLI NotFound', () => {
           });
 
           it('T-FL-E2E-07-01: ファイルが残っている（全件 KEEP 扱い）', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
           });
@@ -533,7 +564,7 @@ describe('main - confidence 閾値未満', () => {
           });
 
           it('T-FL-E2E-08-01: confidence=0.69 の DISCARD ファイルが削除されずに残っている', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/low-conf.md`), true);
           });
@@ -590,7 +621,7 @@ describe('main - Claude CLI 異常終了', () => {
           });
 
           it('T-FL-E2E-09-01: ファイルが残っている（全件 KEEP 扱い）', async () => {
-            await main(['claude', '2026-03', '--base-dir', tempDir]);
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
           });
@@ -620,8 +651,8 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
    * Deno.exit(1) が発生することを確認する。
    */
   describe('Given: agent ディレクトリは存在するが period ディレクトリが存在しない', () => {
-    /** `main(["claude", "2026-99", "--base-dir", tempDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "2026-99", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "2026-99"])` を呼び出すとき（GlobalConfig に chatlogsDir を設定）。 */
+    describe('When: main(["claude", "2026-99"]) を呼び出す', () => {
       /** InputNotFound エラーが発生し Deno.exit(1) が呼ばれること。 */
       describe('Then: T-FL-E2E-11 - InputNotFound → exit(1)', () => {
         let tempDir: string;
@@ -631,6 +662,11 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
         beforeEach(async () => {
           // agent ディレクトリは存在するが、2026-99 月ディレクトリは存在しない
           ({ tempDir } = await _makeTestDirs('claude', '2026-03'));
+          // 探索ディレクトリは GlobalConfig.chatlogsDir + originalLogs から解決されるため、
+          // agent ディレクトリは originalLogs 配下に作成する。
+          const originalLogsAgentDir = `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude/2026/2026-03`;
+          await Deno.mkdir(originalLogsAgentDir, { recursive: true });
+          await _makeGlobalConfig(`chatlogsDir: '${tempDir}'`);
           loggerStub = makeLoggerStub();
           exitStub = stub(Deno, 'exit');
         });
@@ -638,12 +674,13 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
         afterEach(async () => {
           loggerStub.restore();
           exitStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(tempDir, { recursive: true });
         });
 
         it('T-FL-E2E-11-01: Deno.exit が 1 で呼ばれる', async () => {
           try {
-            await main(['claude', '2026-99', '--base-dir', tempDir]);
+            await main(['claude', '2026-99']);
           } catch { /* ChatlogError が漏れた場合も継続 */ }
 
           assertEquals(exitStub.calls.length >= 1, true, 'Deno.exit が呼ばれていない');
@@ -652,7 +689,7 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
 
         it('T-FL-E2E-11-02: errorLogs に "入力ディレクトリが見つかりません" が含まれる', async () => {
           try {
-            await main(['claude', '2026-99', '--base-dir', tempDir]);
+            await main(['claude', '2026-99']);
           } catch { /* ChatlogError が漏れた場合も継続 */ }
 
           assertEquals(
@@ -683,8 +720,8 @@ describe('main - period 未指定', () => {
    * period 未指定時は全月のファイルが処理対象となり、両月のファイルが削除されることを確認する。
    */
   describe('Given: 複数月に DISCARD ファイルが存在し period 未指定', () => {
-    /** `main(["claude", "--base-dir", tempDir])` を period なしで呼び出すとき。 */
-    describe('When: main(["claude", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude"])` を period なしで呼び出すとき（GlobalConfig に chatlogsDir を設定）。 */
+    describe('When: main(["claude"]) を呼び出す', () => {
       /** 両月のファイルが削除対象になること。 */
       describe('Then: T-FL-E2E-10 - 全月のファイルが処理される', () => {
         let tempDir: string;
@@ -707,28 +744,32 @@ describe('main - period 未指定', () => {
         afterEach(async () => {
           commandHandle.restore();
           loggerStub.restore();
+          GlobalConfig.resetInstance();
           await Deno.remove(tempDir, { recursive: true });
         });
 
         describe('Given: 2026-03/march.md と 2026-04/april.md を配置', () => {
           beforeEach(async () => {
-            const agentDir = `${tempDir}/claude`;
+            // 探索ディレクトリは GlobalConfig.chatlogsDir + originalLogs から解決されるため、
+            // ファイルは originalLogs 配下に作成する。
+            const agentDir = `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude`;
             await Deno.mkdir(`${agentDir}/2026/2026-03`, { recursive: true });
             await Deno.mkdir(`${agentDir}/2026/2026-04`, { recursive: true });
             await Deno.writeTextFile(`${agentDir}/2026/2026-03/march.md`, _makeValidContent('March'));
             await Deno.writeTextFile(`${agentDir}/2026/2026-04/april.md`, _makeValidContent('April'));
+            await _makeGlobalConfig(`chatlogsDir: '${tempDir}'`);
           });
 
           it('T-FL-E2E-10-01: 2026-03 のファイルが削除される', async () => {
-            await main(['claude', '--base-dir', tempDir]);
+            await main(['claude']);
 
-            await assertFileNotExist(`${tempDir}/claude/2026/2026-03/march.md`);
+            await assertFileNotExist(`${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude/2026/2026-03/march.md`);
           });
 
           it('T-FL-E2E-10-02: 2026-04 のファイルが削除される', async () => {
-            await main(['claude', '--base-dir', tempDir]);
+            await main(['claude']);
 
-            await assertFileNotExist(`${tempDir}/claude/2026/2026-04/april.md`);
+            await assertFileNotExist(`${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/claude/2026/2026-04/april.md`);
           });
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
@@ -56,7 +56,7 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
   resetProjectRoot('/home/user/project');
   GlobalConfig.resetInstance();
   return await GlobalConfig.getInstance({
-    readTextFileProvider: () => Promise.resolve(yaml),
+    readTextFileProvider: () => yaml,
     configFile: 'dummy.yaml',
   });
 };
@@ -83,8 +83,8 @@ describe('main (prefilter) - dry-run モード', () => {
    * dry-run 時にファイルが削除されず、パスがログに出力されることを確認する。
    */
   describe('Given: ノイズファイル名の .md ファイルと --dry-run フラグ', () => {
-    /** `main(["claude", "--dry-run", "--base-dir", tempDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--dry-run", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "--dry-run", "--input-dir", chatlogsDir])` を呼び出すとき。 */
+    describe('When: main(["claude", "--dry-run", "--input-dir", chatlogsDir]) を呼び出す', () => {
       /** ファイルが削除されず、stdout にノイズファイルのパスが出力されること。 */
       describe('Then: T-PF-E2E-01 - ファイルが削除されずパスが stdout に出力される', () => {
         let tempDir: string;
@@ -106,7 +106,7 @@ describe('main (prefilter) - dry-run モード', () => {
           const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, _makeValidContent());
 
-          await main(['claude', '2026-03', '--dry-run', '--base-dir', tempDir]);
+          await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
           assertEquals(await fileExists(filePath), true);
           assertEquals(loggerStub.logLogs.some((line) => line.includes('say-ok-and-nothing-else.md')), true);
@@ -136,8 +136,8 @@ describe('main (prefilter) - report モード', () => {
    * ファイルの削除は発生しないことを確認する。
    */
   describe('Given: ノイズファイル名の .md ファイルと --report フラグ', () => {
-    /** `main(["claude", "--report", "--base-dir", tempDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--report", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "--report", "--input-dir", chatlogsDir])` を呼び出すとき。 */
+    describe('When: main(["claude", "--report", "--input-dir", chatlogsDir]) を呼び出す', () => {
       /** `NOISE\t{reason}\t{path}` 形式でログ出力され、ファイルが削除されないこと。 */
       describe('Then: T-PF-E2E-02 - NOISE タブ区切り形式で出力、削除なし', () => {
         let tempDir: string;
@@ -159,7 +159,7 @@ describe('main (prefilter) - report モード', () => {
           const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, _makeValidContent());
 
-          await main(['claude', '2026-03', '--report', '--base-dir', tempDir]);
+          await main(['claude', '2026-03', '--report', '--input-dir', chatlogsDir]);
 
           const noiseLine = loggerStub.logLogs.find((line) => line.startsWith('NOISE\t'));
           assertEquals(noiseLine !== undefined, true);
@@ -191,8 +191,8 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
    * 通常実行時にノイズファイルのみが削除され、正常ファイルは残ることを確認する。
    */
   describe('Given: ノイズと正常ファイルが混在するディレクトリ', () => {
-    /** `main(["claude", "--base-dir", tempDir])` を通常モードで呼び出すとき。 */
-    describe('When: main(["claude", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "--input-dir", chatlogsDir])` を通常モードで呼び出すとき。 */
+    describe('When: main(["claude", "--input-dir", chatlogsDir]) を呼び出す', () => {
       /** ノイズファイルが削除され、正常ファイルはファイルシステムに残ること。 */
       describe('Then: T-PF-E2E-03 - ノイズは削除、正常は残る', () => {
         let tempDir: string;
@@ -216,7 +216,7 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
           await Deno.writeTextFile(noisePath, _makeValidContent());
           await Deno.writeTextFile(validPath, _makeValidContent());
 
-          await main(['claude', '2026-03', '--base-dir', tempDir]);
+          await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
           await assertFileNotExist(noisePath);
           assertEquals(await fileExists(validPath), true);
@@ -245,8 +245,8 @@ describe('main (prefilter) - 全件 keep', () => {
    * 全件 keep 時にファイルが削除されず、完了ログに `noise=0` が含まれることを確認する。
    */
   describe('Given: 正常ファイル 2 件', () => {
-    /** `main(["claude", "--base-dir", tempDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "--input-dir", chatlogsDir])` を呼び出すとき。 */
+    describe('When: main(["claude", "--input-dir", chatlogsDir]) を呼び出す', () => {
       /** 全ファイルが残り、完了ログに `noise=0` が含まれること。 */
       describe('Then: T-PF-E2E-04 - 全ファイルが残っており keep=2 のログ', () => {
         let tempDir: string;
@@ -270,7 +270,7 @@ describe('main (prefilter) - 全件 keep', () => {
           await Deno.writeTextFile(path1, _makeValidContent());
           await Deno.writeTextFile(path2, _makeValidContent());
 
-          await main(['claude', '2026-03', '--base-dir', tempDir]);
+          await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
 
           await assertFileExist(path1);
           await assertFileExist(path2);
@@ -300,8 +300,8 @@ describe('main (prefilter) - 空ディレクトリ', () => {
    * 対象ファイルが 0 件の場合の完了ログが適切に出力されることを確認する。
    */
   describe('Given: .md ファイルが 0 件のディレクトリ', () => {
-    /** `main(["claude", "--base-dir", tempDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "--input-dir", agentDir])` を呼び出すとき。 */
+    describe('When: main(["claude", "--input-dir", agentDir]) を呼び出す', () => {
       /** 完了ログに `noise=0` と `keep=0` が含まれること。 */
       describe('Then: T-PF-E2E-06 - "noise=0 keep=0 error=0" を含むログが出力される', () => {
         let tempDir: string;
@@ -319,9 +319,10 @@ describe('main (prefilter) - 空ディレクトリ', () => {
         });
 
         it('T-PF-E2E-06-01: 完了ログに "noise=0 keep=0 error=0" が含まれる', async () => {
-          await Deno.mkdir(`${tempDir}/claude`, { recursive: true });
+          const agentDir = `${tempDir}/claude`;
+          await Deno.mkdir(agentDir, { recursive: true });
 
-          await main(['claude', '--base-dir', tempDir]);
+          await main(['claude', '--input-dir', agentDir]);
 
           assertEquals(loggerStub.infoLogs.some((line) => line.includes('noise=0') && line.includes('keep=0')), true);
         });
@@ -367,7 +368,7 @@ describe('main (prefilter) - period 絞り込み', () => {
             '2026-03',
             '2026-04',
           ));
-          // baseDir は GlobalConfig.chatlogsDir + originalLogs から解決されるため、
+          // 探索ディレクトリは GlobalConfig.chatlogsDir + originalLogs から解決されるため、
           // ノイズファイルは originalLogs 配下に作成する。
           chatlogsDir03 = periodDir1.replace(`${tempDir}/`, `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/`);
           chatlogsDir04 = periodDir2.replace(`${tempDir}/`, `${tempDir}/${DEFAULT_ORIGINAL_LOGS_DIR}/`);
@@ -417,8 +418,8 @@ describe('main (prefilter) - report 完了ログ', () => {
    * report モードの完了ログが `report` キーワードを含むことを確認する。
    */
   describe('Given: 正常ファイル 1 件と --report フラグ', () => {
-    /** `main(["claude", "--report", "--base-dir", tempDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--report", "--base-dir", tempDir]) を呼び出す', () => {
+    /** `main(["claude", "--report", "--input-dir", chatlogsDir])` を呼び出すとき。 */
+    describe('When: main(["claude", "--report", "--input-dir", chatlogsDir]) を呼び出す', () => {
       /** 完了ログに `report` キーワードが含まれること。 */
       describe('Then: T-PF-E2E-08 - 完了ログに "report" が含まれる', () => {
         let tempDir: string;
@@ -439,7 +440,7 @@ describe('main (prefilter) - report 完了ログ', () => {
         it('T-PF-E2E-08-01: 完了ログに "report" が含まれる', async () => {
           await Deno.writeTextFile(`${chatlogsDir}/valid.md`, _makeValidContent());
 
-          await main(['claude', '2026-03', '--report', '--base-dir', tempDir]);
+          await main(['claude', '2026-03', '--report', '--input-dir', chatlogsDir]);
 
           assertEquals(loggerStub.infoLogs.some((line) => line.includes('report')), true);
         });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -18,16 +18,11 @@ import type { FilterConfig, FilterParsedConfig } from '../../../types/filter.typ
 
 // ─── Helpers
 // constants
-import {
-  DEFAULT_CHATLOGS_DIR,
-  DEFAULT_ORIGINAL_LOGS_DIR,
-} from '../../../../../_scripts/constants/defaults.constants.ts';
 import { DEFAULT_FILTER_CONFIG } from '../../../constants/common.constants.ts';
 // classes
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 // helpers
 import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
-import { joinPath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Internal Helpers
 
@@ -44,7 +39,7 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
   resetProjectRoot('/home/user/project');
   GlobalConfig.resetInstance();
   return await GlobalConfig.getInstance({
-    readTextFileProvider: () => Promise.resolve(yaml),
+    readTextFileProvider: () => yaml,
     configFile: 'dummy.yaml',
   });
 };
@@ -67,10 +62,11 @@ const _CUSTOM_DEFAULTS: FilterConfig = {
  * `FilterParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `FilterConfig` を構築する。
  *
  * ## 優先順位ルール
- * - `agent`    : parsed > globalConfig > defaults
- * - `baseDir`  : parsed > joinPath(globalConfig.chatlogsDir, 'originalLogs')
- * - `dryRun`   : parsed > defaults (false)
- * - `period`   : parsed のみ（GlobalConfig 連携なし）
+ * - `agent`      : parsed > globalConfig > defaults
+ * - `chatlogsDir`: globalConfig.chatlogsDir（基準ディレクトリ）
+ * - `inputDir`   : parsed.inputDir（指定時のみ設定される）
+ * - `dryRun`     : parsed > defaults (false)
+ * - `period`     : parsed のみ（GlobalConfig 連携なし）
  * - `configFile` は FilterConfig に存在しないため結果に含まれない
  *
  * - `chunkSize`   : parsed > globalConfig.chunkSize > defaults
@@ -145,59 +141,59 @@ describe('buildConfig', () => {
     });
   });
 
-  // ─── baseDir 優先順位 ───────────────────────────────────────────────────────
+  // ─── inputDir / chatlogsDir ─────────────────────────────────────────────────
 
   /**
-   * `parsed.baseDir` がセットされている前提条件グループ。
+   * `parsed.inputDir` がセットされている前提条件グループ。
    *
-   * `parsed.baseDir` が GlobalConfig.chatlogsDir より優先されることを検証する。
+   * `parsed.inputDir` が結果にそのまま反映されることを検証する。
    */
-  describe('Given: parsed.baseDir が指定されている', () => {
+  describe('Given: parsed.inputDir が指定されている', () => {
     describe('When: GlobalConfig にも chatlogsDir が設定されている', () => {
-      /** `parsed.baseDir` が最優先されることを検証する。 */
-      describe('Then: T-FL-BC-30 - parsed.baseDir が優先される', () => {
+      /** `parsed.inputDir` が結果に反映されることを検証する。 */
+      describe('Then: T-FL-BC-30 - parsed.inputDir が結果に反映される', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-FL-BC-30: parsed.baseDir=/custom → result.baseDir === /custom', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, baseDir: '/custom' }, globalConfig);
-          assertEquals(result.baseDir, '/custom');
+        it('T-FL-BC-30: parsed.inputDir=/custom → result.inputDir === /custom', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom' }, globalConfig);
+          assertEquals(result.inputDir, '/custom');
         });
       });
     });
   });
 
   /**
-   * `parsed.baseDir` が未指定の前提条件グループ。
+   * `parsed.inputDir` が未指定の前提条件グループ。
    *
-   * GlobalConfig.chatlogsDir に `originalLogs` を付加した値が使われることを検証する。
+   * GlobalConfig.chatlogsDir がそのまま `chatlogsDir` として使われることを検証する。
    */
-  describe('Given: parsed.baseDir が未指定', () => {
+  describe('Given: parsed.inputDir が未指定', () => {
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
-      /** GlobalConfig.chatlogsDir + originalLogs が baseDir に使われることを検証する。 */
-      describe('Then: T-FL-BC-31 - GlobalConfig の chatlogsDir + originalLogs が baseDir に使われる', () => {
+      /** GlobalConfig.chatlogsDir が chatlogsDir に使われることを検証する。 */
+      describe('Then: T-FL-BC-31 - GlobalConfig の chatlogsDir が chatlogsDir に使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-FL-BC-31: globalConfig.chatlogsDir=/global → result.baseDir === /global/originalLogs', () => {
+        it('T-FL-BC-31: globalConfig.chatlogsDir=/global → result.chatlogsDir === /global', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, joinPath('/global', DEFAULT_ORIGINAL_LOGS_DIR));
+          assertEquals(result.chatlogsDir, '/global');
         });
       });
     });
 
     describe('When: GlobalConfig にもデフォルトの chatlogsDir のみ設定されている', () => {
-      /** DEFAULT_CHATLOGS_DIR + originalLogs が baseDir に使われることを検証する。 */
-      describe('Then: T-FL-BC-32 - DEFAULT_CHATLOGS_DIR + originalLogs が baseDir に使われる', () => {
+      /** DEFAULT_CHATLOGS_DIR が chatlogsDir に使われることを検証する。 */
+      describe('Then: T-FL-BC-32 - DEFAULT_CHATLOGS_DIR が chatlogsDir に使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance();
         });
-        it('T-FL-BC-32: chatlogsDir 未設定 → result.baseDir === DEFAULT_CHATLOGS_DIR/originalLogs', () => {
+        it('T-FL-BC-32: chatlogsDir 未設定 → result.chatlogsDir === DEFAULT_CHATLOGS_DIR', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
+          assertEquals(result.chatlogsDir, DEFAULT_FILTER_CONFIG.chatlogsDir);
         });
       });
     });
@@ -608,24 +604,24 @@ describe('buildConfig', () => {
   });
 
   /**
-   * `parsed.chatlogsDir` が結果に含まれることを検証するグループ。
+   * `parsed.inputDir` が結果に含まれることを検証するグループ。
    *
-   * `chatlogsDir` は `FilterConfig` に追加されたため、buildConfig の結果に含まれる。
+   * `inputDir` は `FilterConfig` に追加されたため、buildConfig の結果に含まれる。
    */
-  describe('Given: parsed.chatlogsDir が指定されている', () => {
+  describe('Given: parsed.inputDir が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** `result` に `chatlogsDir` フィールドが含まれることを検証する。 */
-      describe('Then: T-FL-BC-19 - result に chatlogsDir フィールドが含まれる', () => {
+      /** `result` に `inputDir` フィールドが含まれることを検証する。 */
+      describe('Then: T-FL-BC-19 - result に inputDir フィールドが含まれる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance();
         });
-        it('T-FL-BC-19: parsed.chatlogsDir=/base → result.chatlogsDir === /base', () => {
+        it('T-FL-BC-19: parsed.inputDir=/base → result.inputDir === /base', () => {
           const result: FilterConfig = buildConfig(
-            { ..._EMPTY_PARSED, chatlogsDir: '/base' },
+            { ..._EMPTY_PARSED, inputDir: '/base' },
             globalConfig,
           );
-          assertEquals(result.chatlogsDir, '/base');
+          assertEquals(result.inputDir, '/base');
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/prefilter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/prefilter/build-config.functional.spec.ts
@@ -17,17 +17,12 @@ import { buildConfig } from '../../../configs/prefilter-config.ts';
 import type { PrefilterConfig, PrefilterParsedConfig } from '../../../types/prefilter.types.ts';
 
 // ─── Helpers
-// constants
-import {
-  DEFAULT_CHATLOGS_DIR,
-  DEFAULT_ORIGINAL_LOGS_DIR,
-} from '../../../../../_scripts/constants/defaults.constants.ts';
-import { DEFAULT_PREFILTER_CONFIG } from '../../../constants/common.constants.ts';
 // classes
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_PREFILTER_CONFIG } from '../../../constants/common.constants.ts';
 // helpers
 import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
-import { joinPath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Internal Helpers
 
@@ -44,7 +39,7 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
   resetProjectRoot('/home/user/project');
   GlobalConfig.resetInstance();
   return await GlobalConfig.getInstance({
-    readTextFileProvider: () => Promise.resolve(yaml),
+    readTextFileProvider: () => yaml,
     configFile: 'dummy.yaml',
   });
 };
@@ -69,8 +64,8 @@ const _CUSTOM_DEFAULTS: PrefilterConfig = {
  *
  * ## 優先順位ルール
  * - `agent`      : parsed > globalConfig > defaults
- * - `chatlogsDir`: parsed > globalConfig.chatlogsDir > defaults.chatlogsDir
- * - `baseDir`    : parsed.baseDir > joinPath(globalConfig.chatlogsDir, 'originalLogs')
+ * - `chatlogsDir`: globalConfig.chatlogsDir（基準ディレクトリ）
+ * - `inputDir`   : parsed.inputDir（指定時のみ設定される）
  * - `period`     : parsed のみ（GlobalConfig 連携なし）
  * - `dryRun`     : parsed > defaults (false)
  * - `report`     : parsed > defaults (false)
@@ -148,33 +143,12 @@ describe('buildConfig (prefilter functional)', () => {
   // ─── chatlogsDir 優先順位 ────────────────────────────────────────────────────
 
   /**
-   * `parsed.chatlogsDir` がセットされている前提条件グループ。
+   * GlobalConfig に chatlogsDir が設定されている前提条件グループ。
    *
-   * `parsed.chatlogsDir` が GlobalConfig/defaults より優先されることを検証する。
+   * GlobalConfig.chatlogsDir がそのまま chatlogsDir になることを検証する。
    */
-  describe('Given: parsed.chatlogsDir が指定されている', () => {
+  describe('Given: GlobalConfig に chatlogsDir が設定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** `parsed.chatlogsDir` が最優先されることを検証する。 */
-      describe('Then: T-PF-BC-09 - parsed.chatlogsDir が最優先される', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
-        });
-        it('T-PF-BC-09: parsed.chatlogsDir=/custom → result.chatlogsDir === /custom', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, chatlogsDir: '/custom' }, globalConfig);
-          assertEquals(result.chatlogsDir, '/custom');
-        });
-      });
-    });
-  });
-
-  /**
-   * `parsed.chatlogsDir` が未指定の前提条件グループ。
-   *
-   * GlobalConfig.chatlogsDir がある場合はその値が chatlogsDir になることを検証する。
-   */
-  describe('Given: parsed.chatlogsDir が未指定', () => {
-    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
       /** GlobalConfig.chatlogsDir が chatlogsDir に使われることを検証する。 */
       describe('Then: T-PF-BC-10 - GlobalConfig の chatlogsDir が chatlogsDir になる', () => {
         let globalConfig: GlobalConfig;
@@ -187,8 +161,15 @@ describe('buildConfig (prefilter functional)', () => {
         });
       });
     });
+  });
 
-    describe('When: GlobalConfig にも chatlogsDir が設定されていない', () => {
+  /**
+   * GlobalConfig に chatlogsDir が設定されていない前提条件グループ。
+   *
+   * DEFAULT_PREFILTER_CONFIG.chatlogsDir にフォールバックすることを検証する。
+   */
+  describe('Given: GlobalConfig にも chatlogsDir が設定されていない', () => {
+    describe('When: buildConfig を呼び出す', () => {
       /** DEFAULT_PREFILTER_CONFIG.chatlogsDir が使われることを検証する。 */
       describe('Then: T-PF-BC-11 - defaults.chatlogsDir にフォールバック', () => {
         let globalConfig: GlobalConfig;
@@ -203,59 +184,45 @@ describe('buildConfig (prefilter functional)', () => {
     });
   });
 
-  // ─── baseDir 優先順位 ─────────────────────────────────────────────────────────
+  // ─── inputDir ───────────────────────────────────────────────────────────────
 
   /**
-   * `parsed.baseDir` がセットされている前提条件グループ。
+   * `parsed.inputDir` がセットされている前提条件グループ。
    *
-   * `parsed.baseDir` が GlobalConfig.chatlogsDir より優先されることを検証する。
+   * `parsed.inputDir` が結果にそのまま反映されることを検証する。
    */
-  describe('Given: parsed.baseDir が指定されている', () => {
+  describe('Given: parsed.inputDir が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** `parsed.baseDir` が最優先されることを検証する。 */
-      describe('Then: T-PF-BC-16 - parsed.baseDir が優先される', () => {
+      /** `parsed.inputDir` が結果に反映されることを検証する。 */
+      describe('Then: T-PF-BC-16 - parsed.inputDir が結果に反映される', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-PF-BC-16-01: parsed.baseDir=/custom → result.baseDir === /custom', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, baseDir: '/custom' }, globalConfig);
-          assertEquals(result.baseDir, '/custom');
+        it('T-PF-BC-16-01: parsed.inputDir=/custom → result.inputDir === /custom', () => {
+          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom' }, globalConfig);
+          assertEquals(result.inputDir, '/custom');
         });
       });
     });
   });
 
   /**
-   * `parsed.baseDir` が未指定の前提条件グループ。
+   * `parsed.inputDir` が未指定の前提条件グループ。
    *
-   * GlobalConfig.chatlogsDir に `originalLogs` を付加した値が baseDir にフォールバックすることを検証する。
+   * `result.inputDir` が `undefined` のままであることを検証する。
    */
-  describe('Given: parsed.baseDir が未指定', () => {
-    describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
-      /** GlobalConfig.chatlogsDir + originalLogs が baseDir になることを検証する。 */
-      describe('Then: T-PF-BC-16-02 - GlobalConfig の chatlogsDir + originalLogs が baseDir になる', () => {
+  describe('Given: parsed.inputDir が未指定', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.inputDir` が `undefined` になることを検証する。 */
+      describe('Then: T-PF-BC-16-02 - result.inputDir === undefined', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-PF-BC-16-02: globalConfig.chatlogsDir=/global → result.baseDir === /global/originalLogs', () => {
+        it('T-PF-BC-16-02: inputDir 未指定 → result.inputDir === undefined', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, joinPath('/global', DEFAULT_ORIGINAL_LOGS_DIR));
-        });
-      });
-    });
-
-    describe('When: GlobalConfig にもデフォルトの chatlogsDir のみ設定されている', () => {
-      /** DEFAULT_CHATLOGS_DIR + originalLogs が baseDir になることを検証する。 */
-      describe('Then: T-PF-BC-16-03 - DEFAULT_CHATLOGS_DIR + originalLogs が baseDir になる', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: claude');
-        });
-        it('T-PF-BC-16-03: chatlogsDir 未設定 → result.baseDir === DEFAULT_CHATLOGS_DIR/originalLogs', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.baseDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
+          assertEquals(result.inputDir, undefined);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/integration/prefilter/prefilter.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/prefilter/prefilter.integration.spec.ts
@@ -44,11 +44,11 @@ const _makeTestFile = async (path: string, content: string): Promise<void> => {
 };
 
 const _runPipeline = async (
-  baseDir: string,
+  chatlogsDir: string,
   agent: string,
   period?: string,
 ): Promise<{ noise: number; keep: number }> => {
-  const _searchDir = resolveChatlogsDir({ baseDir, agent, period });
+  const _searchDir = resolveChatlogsDir({ chatlogsDir, agent, period });
   const files = await findFiles(_searchDir);
   let noise = 0;
   let keep = 0;
@@ -108,7 +108,9 @@ describe('findMdFiles → classifyFile パイプライン', () => {
           await _makeTestFile(`${tempDir}/claude/2026/2026-03/chat.md`, _makeValidContent());
           await _makeTestFile(`${tempDir}/claude/2026/2026-04/chat.md`, _makeValidContent());
 
-          const files = await findFiles(resolveChatlogsDir({ baseDir: tempDir, agent: 'claude', period: '2026-03' }));
+          const files = await findFiles(
+            resolveChatlogsDir({ chatlogsDir: tempDir, agent: 'claude', period: '2026-03' }),
+          );
 
           assertEquals(files.length, 1);
           assertEquals(files[0].includes('2026-03'), true);
@@ -118,7 +120,9 @@ describe('findMdFiles → classifyFile パイプライン', () => {
           await _makeTestFile(`${tempDir}/claude/2026/2026-03/chat.md`, _makeValidContent());
           await _makeTestFile(`${tempDir}/claude/2026/2026-04/chat.md`, _makeValidContent());
 
-          const files = await findFiles(resolveChatlogsDir({ baseDir: tempDir, agent: 'claude', period: '2026-03' }));
+          const files = await findFiles(
+            resolveChatlogsDir({ chatlogsDir: tempDir, agent: 'claude', period: '2026-03' }),
+          );
 
           assertEquals(files.some((f) => f.includes('2026-04')), false);
         });

--- a/skills/filter-chatlogs/scripts/__tests__/system/filter/main.system.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/system/filter/main.system.spec.ts
@@ -20,14 +20,14 @@ const runFilter = async (args: string[]): Promise<number> => {
   return code;
 };
 
-// ─── T-FL-SYS-01: 存在しない baseDir → exit(1) ──────────────────────────────
+// ─── T-FL-SYS-01: 存在しない inputDir → exit(1) ──────────────────────────────
 
 describe('main - エラー終了コード', () => {
-  describe('Given: 存在しない baseDir を指定', () => {
+  describe('Given: 存在しない inputDir を指定', () => {
     describe('When: filter-chatlogs をサブプロセスで実行する', () => {
       describe('Then: T-FL-SYS-01 - プロセスが終了コード 1 で終了する', () => {
         it('T-FL-SYS-01-01: 終了コードが 1 である', async () => {
-          const code = await runFilter(['claude', '--base-dir', '/nonexistent/path']);
+          const code = await runFilter(['claude', '--input-dir', '/nonexistent/path']);
           assertEquals(code, 1);
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/system/prefilter/prefilter.system.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/system/prefilter/prefilter.system.spec.ts
@@ -27,7 +27,7 @@ describe('main - エラー終了コード', () => {
     describe('When: prefilter-chatlogs をサブプロセスで実行する', () => {
       describe('Then: T-PF-SYS-01 - プロセスが終了コード 1 で終了する', () => {
         it('T-PF-SYS-01-01: 終了コードが 1 である', async () => {
-          const code = await runPrefilter(['claude', '--input', '/nonexistent/path']);
+          const code = await runPrefilter(['claude', '--input-dir', '/nonexistent/path']);
           assertEquals(code, 1);
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/unit/filter/parse-args.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/unit/filter/parse-args.unit.spec.ts
@@ -9,7 +9,7 @@
 
 // ─── BDD modules
 import { assert, assertEquals, assertThrows } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { parseArgs } from '../../../filter-chatlogs.ts';
@@ -17,6 +17,9 @@ import { parseArgs } from '../../../filter-chatlogs.ts';
 // ─── Helpers
 // classes
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_CHATLOGS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { FilterParsedConfig } from '../../../types/filter.types.ts';
 
@@ -28,23 +31,33 @@ type Args = FilterParsedConfig;
 // ─── Tests
 
 describe('parseArgs', () => {
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
   // ─── T-FL-PA-01: デフォルト値 ───────────────────────────────────────────────
 
   describe('Given: 引数なしの空配列', () => {
     describe('When: parseArgs([]) を呼び出す', () => {
-      describe('Then: T-FL-PA-01 - デフォルト値が適用される', () => {
+      describe('Then: T-FL-PA-01 - GlobalConfig が管理しないフィールドは undefined になる', () => {
         const _defaultCases: { id: string; field: keyof Args; expected: unknown }[] = [
-          { id: 'T-FL-PA-01-01', field: 'agent', expected: undefined },
           { id: 'T-FL-PA-01-02', field: 'dryRun', expected: undefined },
-          { id: 'T-FL-PA-01-03', field: 'baseDir', expected: undefined },
+          { id: 'T-FL-PA-01-03', field: 'inputDir', expected: undefined },
           { id: 'T-FL-PA-01-04', field: 'period', expected: undefined },
-          { id: 'T-FL-PA-01-05', field: 'chatlogsDir', expected: undefined },
         ];
         for (const { id, field, expected } of _defaultCases) {
           it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
             assertEquals(parseArgs([])[field], expected);
           });
         }
+
+        it('T-FL-PA-01-01: agent が GlobalConfig のデフォルト値 "claude" になる', () => {
+          assertEquals(parseArgs([]).agent, 'claude');
+        });
+
+        it('T-FL-PA-01-05: chatlogsDir が GlobalConfig のデフォルト値になる', () => {
+          assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
+        });
       });
     });
   });
@@ -56,10 +69,19 @@ describe('parseArgs', () => {
       describe('Then: 対応フィールドに値が設定される', () => {
         const _cases: { id: string; args: string[]; field: keyof Args; expected: unknown }[] = [
           { id: 'T-FL-PA-02-01', args: ['chatgpt'], field: 'agent', expected: 'chatgpt' },
-          { id: 'T-FL-PA-03-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
           { id: 'T-FL-PA-05-01', args: ['--dry-run'], field: 'dryRun', expected: true },
-          { id: 'T-FL-PA-06-01', args: ['--base-dir', '/path/to/base'], field: 'baseDir', expected: '/path/to/base' },
-          { id: 'T-FL-PA-07-01', args: ['--base-dir=/path/to/base'], field: 'baseDir', expected: '/path/to/base' },
+          {
+            id: 'T-FL-PA-06-01',
+            args: ['--input-dir', '/path/to/input'],
+            field: 'inputDir',
+            expected: '/path/to/input',
+          },
+          {
+            id: 'T-FL-PA-07-01',
+            args: ['--input-dir=/path/to/input'],
+            field: 'inputDir',
+            expected: '/path/to/input',
+          },
         ];
         for (const { id, args, field, expected } of _cases) {
           it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
@@ -72,13 +94,13 @@ describe('parseArgs', () => {
 
   // ─── T-FL-PA-08: 複数オプション組み合わせ ────────────────────────────────────
 
-  describe('Given: claude 2026-03 --dry-run --base-dir /base を渡す', () => {
+  describe('Given: claude 2026-03 --dry-run --input-dir /input を渡す', () => {
     it('T-FL-PA-08-01: 全フィールドが正しく解析される', () => {
-      const result = parseArgs(['claude', '2026-03', '--dry-run', '--base-dir', '/base']);
+      const result = parseArgs(['claude', '2026-03', '--dry-run', '--input-dir', '/input']);
       assertEquals(result.agent, 'claude');
       assertEquals(result.period, '2026-03');
       assert(result.dryRun);
-      assertEquals(result.baseDir, '/base');
+      assertEquals(result.inputDir, '/input');
     });
   });
 
@@ -90,6 +112,13 @@ describe('parseArgs', () => {
         () => parseArgs(['--unknown']),
         ChatlogError,
         'Invalid Args',
+      );
+    });
+
+    it('T-FL-PA-03-01: period 単独指定（agent 省略）→ ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => parseArgs(['2026-03']),
+        ChatlogError,
       );
     });
   });
@@ -110,31 +139,17 @@ describe('parseArgs', () => {
     });
   });
 
-  // ─── T-FL-PA-11: --chatlogs-dir オプション ───────────────────────────────────
+  // ─── T-FL-PA-11: --input-dir オプション ──────────────────────────────────────
 
-  describe('Given: --chatlogs-dir オプションが渡される', () => {
+  describe('Given: --input-dir オプションが渡される', () => {
     describe('When: parseArgs を呼び出す', () => {
-      describe('Then: chatlogsDir フィールドに値が設定される', () => {
-        it('T-FL-PA-11-01: --chatlogs-dir /base → chatlogsDir が "/base" になる', () => {
-          assertEquals(parseArgs(['--chatlogs-dir', '/base']).chatlogsDir, '/base');
+      describe('Then: inputDir フィールドに値が設定される', () => {
+        it('T-FL-PA-11-01: --input-dir /input → inputDir が "/input" になる', () => {
+          assertEquals(parseArgs(['--input-dir', '/input']).inputDir, '/input');
         });
 
-        it('T-FL-PA-11-02: --chatlogs-dir=/base → chatlogsDir が "/base" になる', () => {
-          assertEquals(parseArgs(['--chatlogs-dir=/base']).chatlogsDir, '/base');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-12: --chatlogs-dir と --base-dir の組み合わせ ──────────────────────
-
-  describe('Given: --chatlogs-dir と --base-dir の両方が渡される', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: 両フィールドに別々の値が設定される', () => {
-        it('T-FL-PA-12-01: --chatlogs-dir と --base-dir が同時指定できる', () => {
-          const result = parseArgs(['--chatlogs-dir', '/logs', '--base-dir', '/base']);
-          assertEquals(result.chatlogsDir, '/logs');
-          assertEquals(result.baseDir, '/base');
+        it('T-FL-PA-11-02: --input-dir=/input → inputDir が "/input" になる', () => {
+          assertEquals(parseArgs(['--input-dir=/input']).inputDir, '/input');
         });
       });
     });
@@ -142,37 +157,33 @@ describe('parseArgs', () => {
 
   // ─── T-FL-PA-13: 全オプション組み合わせ ─────────────────────────────────────
 
-  describe('Given: claude 2026-03 --dry-run --chatlogs-dir /base を渡す', () => {
+  describe('Given: claude 2026-03 --dry-run --input-dir /input を渡す', () => {
     describe('When: parseArgs を呼び出す', () => {
       describe('Then: 全フィールドが正しく解析される', () => {
         it('T-FL-PA-13-01: 全フィールドが正しく解析される', () => {
-          const result = parseArgs(['claude', '2026-03', '--dry-run', '--chatlogs-dir', '/base']);
+          const result = parseArgs(['claude', '2026-03', '--dry-run', '--input-dir', '/input']);
           assertEquals(result.agent, 'claude');
           assertEquals(result.period, '2026-03');
           assert(result.dryRun);
-          assertEquals(result.chatlogsDir, '/base');
-        });
-        it('T-FL-PA-13-02: chatlogsDir=/base のとき baseDir が undefined', () => {
-          const result = parseArgs(['claude', '2026-03', '--dry-run', '--chatlogs-dir', '/base']);
-          assertEquals(result.baseDir, undefined);
+          assertEquals(result.inputDir, '/input');
         });
       });
     });
   });
 
-  // ─── T-FL-PA-14: --chatlogs-dir バリデーション ───────────────────────────────
+  // ─── T-FL-PA-14: --input-dir バリデーション ──────────────────────────────────
 
   /**
-   * `--chatlogs-dir` にディレクトリパスでない値を渡した場合の異常系グループ。
+   * `--input-dir` にディレクトリパスでない値を渡した場合の異常系グループ。
    *
    * ディレクトリパス（`/` を含む正規化済みパス）でない値は `ChatlogError(InvalidArgs)` をスローする。
    */
-  describe('Given: --chatlogs-dir にディレクトリパスでない値を渡す', () => {
+  describe('Given: --input-dir にディレクトリパスでない値を渡す', () => {
     describe('When: parseArgs を呼び出す', () => {
       describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
-        it('T-FL-PA-14-01: --chatlogs-dir foo（スラッシュなし）→ ChatlogError(InvalidArgs) がスローされる', () => {
+        it('T-FL-PA-14-01: --input-dir foo（スラッシュなし）→ ChatlogError(InvalidArgs) がスローされる', () => {
           assertThrows(
-            () => parseArgs(['--chatlogs-dir', 'foo']),
+            () => parseArgs(['--input-dir', 'foo']),
             ChatlogError,
             'Invalid Args',
           );
@@ -181,79 +192,20 @@ describe('parseArgs', () => {
     });
   });
 
-  // ─── T-FL-PA-15: --base-dir オプション ──────────────────────────────────────
+  // ─── T-FL-PA-16: --input-dir 未指定 ──────────────────────────────────────────
 
   /**
-   * `--base-dir` オプションが `baseDir` フィールドに設定されることを検証するグループ。
+   * `--input-dir` が未指定のとき `chatlogsDir` は GlobalConfig のデフォルト値、
+   * `inputDir` は `undefined` になることを検証するグループ。
    */
-  describe('Given: --base-dir オプションが渡される', () => {
+  describe('Given: --input-dir が未指定', () => {
     describe('When: parseArgs を呼び出す', () => {
-      describe('Then: baseDir フィールドに値が設定される', () => {
-        it('T-FL-PA-15-01: --base-dir /base → baseDir が "/base" になる', () => {
-          assertEquals(parseArgs(['--base-dir', '/base']).baseDir, '/base');
+      describe('Then: chatlogsDir は GlobalConfig のデフォルト値、inputDir は undefined になる', () => {
+        it('T-FL-PA-16-01: 引数なし → chatlogsDir が GlobalConfig のデフォルト値になる', () => {
+          assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
         });
-        it('T-FL-PA-15-02: --base-dir=/base → baseDir が "/base" になる', () => {
-          assertEquals(parseArgs(['--base-dir=/base']).baseDir, '/base');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-16: --chatlogs-dir も --base-dir も未指定 ─────────────────────────
-
-  /**
-   * `--chatlogs-dir` も `--base-dir` も未指定のとき両フィールドが `undefined` になることを検証するグループ。
-   */
-  describe('Given: --chatlogs-dir も --base-dir も未指定', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: chatlogsDir と baseDir が undefined になる', () => {
-        it('T-FL-PA-16-01: 引数なし → chatlogsDir が undefined になる', () => {
-          assertEquals(parseArgs([]).chatlogsDir, undefined);
-        });
-        it('T-FL-PA-16-02: 引数なし → baseDir が undefined になる', () => {
-          assertEquals(parseArgs([]).baseDir, undefined);
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-17: --chatlogs-dir 指定時に baseDir は undefined ────────────────
-
-  /**
-   * `--chatlogs-dir` のみ指定したとき `baseDir` が `undefined` のままであることを検証するグループ。
-   *
-   * `chatlogsDir` が指定されても `baseDir` は独立したフィールドであり、
-   * `--base-dir` を渡さない限り `undefined` になる。
-   */
-  describe('Given: --chatlogs-dir が指定されて --base-dir が未指定', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-FL-PA-17 - baseDir が undefined のまま', () => {
-        it('T-FL-PA-17-01: --chatlogs-dir /base → baseDir が undefined', () => {
-          assertEquals(parseArgs(['--chatlogs-dir', '/base']).baseDir, undefined);
-        });
-        it('T-FL-PA-17-02: --chatlogs-dir /base → chatlogsDir が "/base"', () => {
-          assertEquals(parseArgs(['--chatlogs-dir', '/base']).chatlogsDir, '/base');
-        });
-      });
-    });
-  });
-
-  // ─── T-FL-PA-18: --base-dir バリデーション ──────────────────────────────────
-
-  /**
-   * `--base-dir` にディレクトリパスでない値を渡した場合の異常系グループ。
-   *
-   * ディレクトリパス（`/` を含む）でない値は `ChatlogError(InvalidArgs)` をスローする。
-   */
-  describe('Given: --base-dir にディレクトリパスでない値を渡す', () => {
-    describe('When: parseArgs を呼び出す', () => {
-      describe('Then: T-FL-PA-18 - ChatlogError(InvalidArgs) がスローされる', () => {
-        it('T-FL-PA-18-01: --base-dir foo（スラッシュなし）→ ChatlogError(InvalidArgs) がスローされる', () => {
-          assertThrows(
-            () => parseArgs(['--base-dir', 'foo']),
-            ChatlogError,
-            'Invalid Args',
-          );
+        it('T-FL-PA-16-02: 引数なし → inputDir が undefined になる', () => {
+          assertEquals(parseArgs([]).inputDir, undefined);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/configs/__tests__/unit/prefilter-config.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/configs/__tests__/unit/prefilter-config.unit.spec.ts
@@ -17,6 +17,8 @@ import { buildConfig, parseArgs } from '../../../configs/prefilter-config.ts';
 // ─── Helpers
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_CHATLOGS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
 
@@ -36,18 +38,22 @@ import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-ut
  * @see parseArgs
  */
 describe('parseArgs (prefilter)', () => {
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
   /** 引数なし・agent/period・フラグ・オプション形式の正常ケース。 */
   describe('When: 正常系', () => {
-    it('[Normal] T-PF-PA-01-01: agent が undefined になる', () => {
-      assertEquals(parseArgs([]).agent, undefined);
+    it('[Normal] T-PF-PA-01-01: agent が GlobalConfig のデフォルト値 "claude" になる', () => {
+      assertEquals(parseArgs([]).agent, 'claude');
     });
 
     it('[Normal] T-PF-PA-01-02: dryRun が false になる', () => {
       assertFalse(parseArgs([]).dryRun);
     });
 
-    it('[Normal] T-PF-PA-01-03: chatlogsDir が undefined になる', () => {
-      assertEquals(parseArgs([]).chatlogsDir, undefined);
+    it('[Normal] T-PF-PA-01-03: chatlogsDir が GlobalConfig のデフォルト値になる', () => {
+      assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
     });
 
     it('[Normal] T-PF-PA-01-04: period が undefined になる', () => {
@@ -60,10 +66,6 @@ describe('parseArgs (prefilter)', () => {
 
     it('[Normal] T-PF-PA-02-01: agent が "codex" になる', () => {
       assertEquals(parseArgs(['codex']).agent, 'codex');
-    });
-
-    it('[Normal] T-PF-PA-03-01: period が "2026-03" になる', () => {
-      assertEquals(parseArgs(['2026-03']).period, '2026-03');
     });
 
     it('[Normal] T-PF-PA-04-01: agent="claude", period="2026-03" が正しく解析される', () => {
@@ -97,25 +99,25 @@ describe('parseArgs (prefilter)', () => {
     });
 
     it('[Normal] T-PF-PA-10-01: 全フィールドが正しく解析される', () => {
-      const result = parseArgs(['codex', '2026-03', '--report', '--base-dir', '/path/to/base']);
+      const result = parseArgs(['codex', '2026-03', '--report', '--input-dir', '/path/to/input']);
 
       assertEquals(result.agent, 'codex');
       assertEquals(result.period, '2026-03');
       assert(result.report);
       assert(result.dryRun);
-      assertEquals(result.baseDir, '/path/to/base');
+      assertEquals(result.inputDir, '/path/to/input');
     });
 
-    it('[Normal] T-PF-PA-14-01: baseDir が "/path/to/base" になる', () => {
-      assertEquals(parseArgs(['--base-dir', '/path/to/base']).baseDir, '/path/to/base');
+    it('[Normal] T-PF-PA-14-01: inputDir が "/path/to/input" になる', () => {
+      assertEquals(parseArgs(['--input-dir', '/path/to/input']).inputDir, '/path/to/input');
     });
 
-    it('[Normal] T-PF-PA-14-02: --base-dir=value 形式のパース', () => {
-      assertEquals(parseArgs(['--base-dir=/path/to/base']).baseDir, '/path/to/base');
+    it('[Normal] T-PF-PA-14-02: --input-dir=value 形式のパース', () => {
+      assertEquals(parseArgs(['--input-dir=/path/to/input']).inputDir, '/path/to/input');
     });
 
-    it('[Normal] T-PF-PA-12-01: chatlogsDir が "/path/to/chatlogs" になる', () => {
-      assertEquals(parseArgs(['--chatlogs-dir', '/path/to/chatlogs']).chatlogsDir, '/path/to/chatlogs');
+    it('[Normal] T-PF-PA-12-01: inputDir が "/path/to/chatlogs" になる', () => {
+      assertEquals(parseArgs(['--input-dir', '/path/to/chatlogs']).inputDir, '/path/to/chatlogs');
     });
   });
 
@@ -137,9 +139,16 @@ describe('parseArgs (prefilter)', () => {
       );
     });
 
-    it('[Error] T-PF-PA-13-01: --chatlogs-dir にパスでない値 → ChatlogError がスローされる', () => {
+    it('[Error] T-PF-PA-13-01: --input-dir にパスでない値 → ChatlogError がスローされる', () => {
       assertThrows(
-        () => parseArgs(['--chatlogs-dir', 'notapath']),
+        () => parseArgs(['--input-dir', 'notapath']),
+        ChatlogError,
+      );
+    });
+
+    it('[Error] T-PF-PA-03-01: period 単独指定（agent 省略）→ ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => parseArgs(['2026-03']),
         ChatlogError,
       );
     });
@@ -168,19 +177,19 @@ describe('buildConfig', () => {
    *
    * @returns 初期化済みの `GlobalConfig` インスタンス（空設定）
    */
-  const _makeEmptyGlobalConfig = async (): Promise<GlobalConfig> => {
+  const _makeEmptyGlobalConfig = (): GlobalConfig => {
     resetProjectRoot('/home/user/project');
     GlobalConfig.resetInstance();
-    return await GlobalConfig.getInstance({
-      readTextFileProvider: () => Promise.resolve('{}'),
+    return GlobalConfig.getInstance({
+      readTextFileProvider: () => '{}',
       configFile: 'dummy.yaml',
       schema: {},
     });
   };
 
   let globalConfig: GlobalConfig;
-  beforeEach(async () => {
-    globalConfig = await _makeEmptyGlobalConfig();
+  beforeEach(() => {
+    globalConfig = _makeEmptyGlobalConfig();
   });
   afterEach(() => {
     GlobalConfig.resetInstance();
@@ -212,9 +221,9 @@ describe('buildConfig', () => {
       assert(buildConfig({ dryRun: true, report: true }, globalConfig).report);
     });
 
-    it('[Normal] T-PF-BC-04-01: chatlogsDir が "/chat" になる', () => {
+    it('[Normal] T-PF-BC-04-01: inputDir が "/chat" になる', () => {
       assertEquals(
-        buildConfig({ chatlogsDir: '/chat', dryRun: false, report: false }, globalConfig).chatlogsDir,
+        buildConfig({ inputDir: '/chat', dryRun: false, report: false }, globalConfig).inputDir,
         '/chat',
       );
     });

--- a/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
@@ -8,8 +8,7 @@
 
 // ─── shared ───
 // functions
-import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
-import { joinPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
+import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 // types
 import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
 // classes
@@ -17,7 +16,6 @@ import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── internal ───
 // constants
-import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../_scripts/constants/defaults.constants.ts';
 import { DEFAULT_PREFILTER_CONFIG } from '../constants/common.constants.ts';
 // types
 import type { PrefilterConfig, PrefilterParsedConfig } from '../types/prefilter.types.ts';
@@ -27,12 +25,12 @@ import type { PrefilterConfig, PrefilterParsedConfig } from '../types/prefilter.
 // ─────────────────────────────────────────────
 
 /** prefilter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema = [
+const _SCHEMA: ArgsSchema<PrefilterParsedConfig> = [
   { option: '--report', field: 'report', type: 'flag' },
 ];
 
 export const parseArgs = (args: string[]): PrefilterParsedConfig => {
-  const _parsed = parseArgsToConfig<PrefilterParsedConfig>(args, _SCHEMA) as PrefilterParsedConfig;
+  const _parsed = parseArgsToConfig<PrefilterParsedConfig>(args, _SCHEMA);
   _parsed.dryRun ??= (_parsed.dryRun ?? false) || (_parsed.report ?? false);
   _parsed.report ??= false;
   return {
@@ -47,8 +45,8 @@ export const parseArgs = (args: string[]): PrefilterParsedConfig => {
 /**
  * PrefilterParsedConfig・GlobalConfig・デフォルト値から完全な PrefilterConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - baseDir 優先順位: `parsed.baseDir` > `joinPath(globalConfig.get('chatlogsDir'), DEFAULT_ORIGINAL_LOGS_DIR)`
- * - chatlogsDir 優先順位: `parsed.chatlogsDir` > `globalConfig.get('chatlogsDir')`
+ * - chatlogsDir: `globalConfig.get('chatlogsDir')`（基準ディレクトリ）
+ * - inputDir: `parsed.inputDir`（指定時のみ設定される。フルパス直接指定の短絡パラメータ）
  * - `configFile` は PrefilterConfig に存在しないため結果に含まれない。
  */
 export const buildConfig = (
@@ -57,15 +55,13 @@ export const buildConfig = (
   defaults: PrefilterConfig = DEFAULT_PREFILTER_CONFIG,
 ): PrefilterConfig => {
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
-  const _globalChatlogDir = globalConfig.get('chatlogsDir') as string;
-  const _baseDir = parsed.baseDir ?? joinPath(_globalChatlogDir, DEFAULT_ORIGINAL_LOGS_DIR);
-  const _chatlogsDir = parsed.chatlogsDir ?? _globalChatlogDir;
+  const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
   const { configFile: _configFile, ...rest } = parsed;
   return {
     ...defaults,
     ...rest,
     agent: _agent,
-    baseDir: _baseDir,
     chatlogsDir: _chatlogsDir,
+    inputDir: parsed.inputDir,
   };
 };

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -37,6 +37,7 @@ export const DEFAULT_PREFILTER_CONFIG: PrefilterConfig = {
 /** filter-chatlogs の parseArgs で未指定のフィールドに適用するデフォルト設定。 */
 export const DEFAULT_FILTER_CONFIG: FilterConfig = {
   agent: DEFAULT_AGENT,
+  chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dryRun: false,
   // config.yaml only
   chunkSize: DEFAULT_VALUES.chunkSize,

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -10,7 +10,7 @@
  * filter-chatlogs.ts — チャットログを claude CLI でバッチ判定し DISCARD ファイルを削除する
  *
  * 使い方:
- *   deno run --allow-read --allow-run filter-chatlogs.ts [YYYY-MM] [--dry-run] [--base-dir DIR]
+ *   deno run --allow-read --allow-run filter-chatlogs.ts [YYYY-MM] [--dry-run] [--input-dir DIR]
  */
 
 // ─────────────────────────────────────────────
@@ -26,9 +26,8 @@ import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-director
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { parseArgs as parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
-import { joinPath } from '../../_scripts/libs/path-utils/path-utils.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.ts';
@@ -49,10 +48,10 @@ import type { FilterConfig, FilterParsedConfig } from './types/filter.types.ts';
 // ─────────────────────────────────────────────
 
 /** filter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema = [];
+const _SCHEMA: ArgsSchema<FilterParsedConfig> = [];
 
 export const parseArgs = (args: string[]): FilterParsedConfig => {
-  return parseArgsToConfig<FilterParsedConfig>(args, _SCHEMA) as FilterParsedConfig;
+  return parseArgsToConfig<FilterParsedConfig>(args, _SCHEMA);
 };
 
 // ─────────────────────────────────────────────
@@ -62,8 +61,8 @@ export const parseArgs = (args: string[]): FilterParsedConfig => {
 /**
  * FilterParsedConfig・GlobalConfig・デフォルト値から完全な FilterConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - baseDir 優先順位: `parsed.baseDir` > `joinPath(globalConfig.get('chatlogsDir'), DEFAULT_ORIGINAL_LOGS_DIR)`
- * - chatlogsDir 優先順位: `parsed.chatlogsDir`（直接指定のみ、未指定なら `undefined`）
+ * - chatlogsDir: `globalConfig.get('chatlogsDir')`（基準ディレクトリ）
+ * - inputDir: `parsed.inputDir`（指定時のみ設定される。フルパス直接指定の短絡パラメータ）
  * - dryRun: `parsed.dryRun` > `defaults.dryRun`（false）
  * - period: `parsed` のみ（GlobalConfig 連携なし）
  * - discardThreshold: `globalConfig.get('discardThreshold')` > `defaults.discardThreshold`
@@ -75,9 +74,7 @@ export const buildConfig = (
   defaults: FilterConfig = DEFAULT_FILTER_CONFIG,
 ): FilterConfig => {
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
-  const _globalChatlogDir = globalConfig.get('chatlogsDir') as string;
-  const _baseDir = parsed.baseDir ?? joinPath(_globalChatlogDir, DEFAULT_ORIGINAL_LOGS_DIR);
-  const _chatlogsDir = parsed.chatlogsDir;
+  const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
   const _chunkSize = parsed.chunkSize ?? globalConfig.get('chunkSize') as number;
   const _concurrency = parsed.concurrency ?? globalConfig.get('concurrency') as number;
   const _minCharCount = parsed.minCharCount ?? globalConfig.get('minCharCount') as number;
@@ -88,8 +85,8 @@ export const buildConfig = (
     ...defaults,
     ...rest,
     agent: _agent,
-    baseDir: _baseDir,
     chatlogsDir: _chatlogsDir,
+    inputDir: parsed.inputDir,
     chunkSize: _chunkSize,
     concurrency: _concurrency,
     minCharCount: _minCharCount,
@@ -105,32 +102,26 @@ export const buildConfig = (
 export const main = async (args?: string[]): Promise<void> => {
   try {
     const _parsed = parseArgs(args ?? Deno.args);
-    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const _config = buildConfig(_parsed, _globalConfig);
 
-    const _baseDir = _config.baseDir ?? _globalConfig.get('chatlogsDir') as string;
-    const _agentDir = resolveChatlogsDir({
+    const _searchDir = resolveChatlogsDir({
       chatlogsDir: _config.chatlogsDir,
-      baseDir: _baseDir,
       agent: _config.agent,
       period: _config.period,
+      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+      override: _config.inputDir,
     });
 
     // 入力ディレクトリ確認
-    if (!await dirExists(_agentDir)) {
-      throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_agentDir}`);
+    if (!await dirExists(_searchDir)) {
+      throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_searchDir}`);
     }
 
     logger.info(`対象 agent: ${_config.agent}`);
     if (_config.period) { logger.info(`対象期間: ${_config.period}`); }
 
     // ファイル列挙
-    const _searchDir = resolveChatlogsDir({
-      chatlogsDir: _config.chatlogsDir,
-      baseDir: _baseDir,
-      agent: _config.agent,
-      period: _config.period,
-    });
     const allFiles = await findFiles(_searchDir);
 
     // 事前フィルタ

--- a/skills/filter-chatlogs/scripts/prefilter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/prefilter-chatlogs.ts
@@ -26,7 +26,7 @@
  *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts codex 2026-01
  *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --dry-run
  *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --report
- *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --input ./temp/chatlogs
+ *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --input-dir ./temp/chatlogs
  */
 
 // ─── shared ───
@@ -40,6 +40,8 @@ import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── internal ───
+// constants
+import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 // types
 import type { PrefilterStats } from './types/prefilter.types.ts';
 // functions
@@ -53,13 +55,14 @@ import { processNoiseFiles } from './modules/prefilter/process-noise-files.ts';
 export const main = async (args: string[] = Deno.args): Promise<void> => {
   try {
     const _parsed = parseArgs(args);
-    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
-    const { agent, period, baseDir, chatlogsDir, dryRun, report } = buildConfig(_parsed, _globalConfig);
+    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const { agent, period, chatlogsDir, inputDir, dryRun, report } = buildConfig(_parsed, _globalConfig);
     const _searchDir = resolveChatlogsDir({
-      chatlogsDir: _parsed.chatlogsDir,
-      baseDir: baseDir ?? chatlogsDir,
+      chatlogsDir,
       agent,
       period,
+      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+      override: inputDir,
     });
 
     if (!await dirExists(_searchDir)) {

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -16,10 +16,10 @@ export interface FilterConfig {
   agent: string;
   /** 対象年月（`YYYY-MM` 形式）。省略時は全期間。 */
   period?: string;
-  /** チャットログ基底ディレクトリのパス。GlobalConfig の chatlogsDir を CLI で上書きする。省略時は `undefined`。 */
-  baseDir?: string;
-  /** チャットログ最終探索パス直接指定。省略時は `undefined`。 */
-  chatlogsDir?: string;
+  /** チャットログが格納された基準ディレクトリのパス（GlobalConfig の chatlogsDir 由来）。 */
+  chatlogsDir: string;
+  /** 入力ディレクトリのフルパス直接指定。指定時は agent/period を無視してこのパスをそのまま使う。 */
+  inputDir?: string;
 
   // flags
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */

--- a/skills/filter-chatlogs/scripts/types/prefilter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/prefilter.types.ts
@@ -12,10 +12,10 @@ export interface PrefilterConfig {
   agent: string;
   /** 対象年月（`YYYY-MM` 形式）。省略時は全期間。 */
   period?: string;
-  /** チャットログ基底ディレクトリのパス。`--base-dir` で指定するルートディレクトリ。 */
-  baseDir?: string;
-  /** チャットログ基底ディレクトリのパス。buildConfig 後のベースディレクトリ（GlobalConfig 由来 or --chatlogs-dir 直接指定）。 */
+  /** チャットログが格納された基準ディレクトリのパス（GlobalConfig の chatlogsDir 由来）。 */
   chatlogsDir: string;
+  /** 入力ディレクトリのフルパス直接指定。指定時は agent/period を無視してこのパスをそのまま使う。 */
+  inputDir?: string;
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */
   dryRun: boolean;
   /** `true` のときノイズファイル一覧をタブ区切りで出力する（`dryRun` も暗示）。 */

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/aggregation.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/aggregation.e2e.spec.ts
@@ -22,6 +22,7 @@ import {
 import { makeTempDirs, removeTempDirs } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // test target
@@ -69,13 +70,14 @@ describe('main - aggregation', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-01-02 - withConcurrency を使ってファイルを並列処理する', () => {
         it('T-15-01-02-01: 全 4 件が処理されて結果レポートに success=4 が含まれる', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           assertMatch(loggerStub.infoLogs.join('\n'), /success=4/);
         });
@@ -114,13 +116,14 @@ describe('main - aggregation', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-03-02 - AI バッチ呼び出し失敗でバッチ内全ファイルが fail にカウントされる', () => {
         it('T-15-03-02-01: fail=3 がレポートに含まれる', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           assertMatch([...loggerStub.infoLogs, ...loggerStub.warnLogs].join('\n'), /fail=3/);
         });
@@ -147,13 +150,14 @@ describe('main - aggregation', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-04-01 - 空ディレクトリでも完了し 0 件レポートを出力する', () => {
         it('T-15-04-01-01: success=0, skip=0, fail=0 がレポートに含まれる', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           assertMatch(loggerStub.infoLogs.join('\n'), /success=0.*skip=0.*fail=0/);
         });

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
@@ -19,6 +19,7 @@ import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__test
 import { makeTempDirs, removeTempDirs } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { assertAllOutputFiles } from '../../../../_scripts/__tests__/helpers/output-validator.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
@@ -76,11 +77,12 @@ describe('normalize-chatlogs - full E2E', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     it('T-FULL-01: 3 件の入力から 3 件以上の出力ファイルが生成され success=3 がレポートされる', async () => {
-      await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+      await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
       // IO: 出力ファイルが生成されている
       const files = await findFiles(outputDir);
@@ -123,11 +125,12 @@ describe('normalize-chatlogs - full E2E', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     it('T-FULL-02: 出力ファイルが YAML frontmatter・## Summary・project フィールドを含む', async () => {
-      await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+      await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
       const files = await findFiles(outputDir);
       assertEquals(files.length >= 1, true);
@@ -169,6 +172,7 @@ describe('normalize-chatlogs - full E2E', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
@@ -176,11 +180,11 @@ describe('normalize-chatlogs - full E2E', () => {
       const fixedHash: HashProvider = () => '0000000';
 
       // 1 回目: 出力ファイルを生成
-      await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
+      await main(['--input-dir', inputDir, '--output-dir', outputDir], fixedHash);
 
       // 2 回目: normalize済みファイルをスキップ
       loggerStub.infoLogs.splice(0);
-      await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
+      await main(['--input-dir', inputDir, '--output-dir', outputDir], fixedHash);
 
       // reproducibility: 2 回目は skip=1
       assertMatch(loggerStub.infoLogs.join('\n'), /skip=1/);

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/io.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/io.e2e.spec.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run --allow-write
 // src: scripts/__tests__/e2e/normalize-chatlogs-io.e2e.spec.ts
 // @(#): main() の I/O 検証 E2E テスト
-//       ファイル生成・ディレクトリ解決（--chatlogs-dir / --agent --year-month）・エラー終了を確認する
+//       ファイル生成・ディレクトリ解決（--input-dir / --agent --year-month）・エラー終了を確認する
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -22,6 +22,7 @@ import {
   silenceLog,
 } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 // type
@@ -34,13 +35,13 @@ import type { HashProvider } from '../../../../_scripts/types/providers.types.ts
 
 /**
  * ファイル生成・ディレクトリ解決・エラー終了の I/O 検証。
- * --chatlogs-dir / --agent --year-month によるパス解決と出力ファイル生成を確認する。
+ * --input-dir / --agent --year-month によるパス解決と出力ファイル生成を確認する。
  */
 describe('main - I/O', () => {
-  // ─── T-15-01-01: --chatlogs-dir によるファイル生成 ───────────────────────────────────
+  // ─── T-15-01-01: --input-dir によるファイル生成 ───────────────────────────────────
 
-  /** 正常系: --chatlogs-dir で指定したディレクトリの MD ファイルを処理してセグメント出力ファイルを生成する */
-  describe('Given: マルチトピック MD ファイルが存在するディレクトリを --chatlogs-dir で指定する', () => {
+  /** 正常系: --input-dir で指定したディレクトリの MD ファイルを処理してセグメント出力ファイルを生成する */
+  describe('Given: マルチトピック MD ファイルが存在するディレクトリを --input-dir で指定する', () => {
     let inputDir: string;
     let outputDir: string;
     let commandHandle: CommandMockHandle;
@@ -73,14 +74,15 @@ describe('main - I/O', () => {
 
     afterEach(async () => {
       commandHandle.restore();
+      GlobalConfig.resetInstance();
       logSilencer.restore();
       await removeTempDirs(inputDir, outputDir);
     });
 
-    describe('When: main(["--chatlogs-dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+    describe('When: main(["--input-dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-01-01 - 収集した全 MD ファイルを処理してセグメント出力ファイルを生成する', () => {
         it('T-15-01-01-01: outputDir 配下に 2 件以上のセグメント出力ファイルが生成される', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           const files = await findFiles(outputDir);
           assertEquals(files.length >= 2, true);
@@ -89,10 +91,10 @@ describe('main - I/O', () => {
     });
   });
 
-  // ─── T-15-02-01: --chatlogs-dir によるパス解決（chatlogs 形式ディレクトリ） ───────────
+  // ─── T-15-02-01: --input-dir によるパス解決（chatlogs 形式ディレクトリ） ───────────
 
-  /** 正常系: --chatlogs-dir で chatlogs/<agent>/<year>/<year-month>/ を指定して処理する */
-  describe('Given: --chatlogs-dir で chatlogs/claude/2026/2026-03 と対応パスが存在する', () => {
+  /** 正常系: --input-dir で chatlogs/<agent>/<year>/<year-month>/ を指定して処理する */
+  describe('Given: --input-dir で chatlogs/claude/2026/2026-03 と対応パスが存在する', () => {
     let tmpRoot: string;
     let AGENT_DIR: string;
     let outputDir: string;
@@ -128,14 +130,15 @@ describe('main - I/O', () => {
 
     afterEach(async () => {
       commandHandle.restore();
+      GlobalConfig.resetInstance();
       loggerStub.restore();
       await Deno.remove(outputDir, { recursive: true });
     });
 
-    describe('When: main(["--chatlogs-dir", AGENT_DIR, "--output", outputDir]) を呼び出す', () => {
+    describe('When: main(["--input-dir", AGENT_DIR, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-02-01 - chatlogs/<agent>/<year>/<year-month>/ から入力を解決してファイルを処理する', () => {
         it('T-15-02-01-01: chatlogs/claude/2026/2026-03/ 内のファイルが処理されて出力が生成される', async () => {
-          await main(['--chatlogs-dir', AGENT_DIR, '--normalize-dir', outputDir]);
+          await main(['--input-dir', AGENT_DIR, '--output-dir', outputDir]);
 
           assertMatch(loggerStub.infoLogs.join('\n'), /success=1/);
         });
@@ -183,15 +186,16 @@ describe('main - I/O', () => {
 
     afterEach(async () => {
       commandHandle.restore();
+      GlobalConfig.resetInstance();
       logSilencer.restore();
       await Deno.remove(outputBase, { recursive: true });
     });
 
-    describe('When: main(["--chatlogs-dir", CHATLOG_INPUT_DIR, "--output", outputBase]) を呼び出す', () => {
+    describe('When: main(["--input-dir", CHATLOG_INPUT_DIR, "--output", outputBase]) を呼び出す', () => {
       describe('Then: Task T-15-05-01 - 出力が <outputBase>/claude/2026/2026-04/my-app/ 以下に生成される', () => {
         it('T-15-05-01-01: 出力ファイルのパスが <outputBase>/claude/2026/2026-04/my-app/ を含む', async () => {
           const fixedHash: HashProvider = () => 'abc1234';
-          await main(['--chatlogs-dir', CHATLOG_INPUT_DIR, '--normalize-dir', outputBase], fixedHash);
+          await main(['--input-dir', CHATLOG_INPUT_DIR, '--output-dir', outputBase], fixedHash);
 
           const files = await findFiles(outputBase);
           assertEquals(files.length >= 1, true);
@@ -232,15 +236,16 @@ describe('main - I/O', () => {
 
     afterEach(async () => {
       commandHandle.restore();
+      GlobalConfig.resetInstance();
       logSilencer.restore();
       await removeTempDirs(inputDir, outputBase);
     });
 
-    describe('When: main(["--chatlogs-dir", inputDir, "--output", outputBase]) を呼び出す', () => {
+    describe('When: main(["--input-dir", inputDir, "--output", outputBase]) を呼び出す', () => {
       describe('Then: Task T-15-06-01 - 出力が <outputBase>/custom-project/ 以下に生成される', () => {
         it('T-15-06-01-01: 出力ファイルのパスが <outputBase>/custom-project/ を含む', async () => {
           const fixedHash: HashProvider = () => 'def5678';
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputBase], fixedHash);
+          await main(['--input-dir', inputDir, '--output-dir', outputBase], fixedHash);
 
           const files = await findFiles(outputBase);
           assertEquals(files.length >= 1, true);
@@ -280,14 +285,15 @@ describe('main - I/O', () => {
 
     afterEach(async () => {
       commandHandle.restore();
+      GlobalConfig.resetInstance();
       logSilencer.restore();
       await removeTempDirs(inputDir, outputBase);
     });
 
-    describe('When: main(["--chatlogs-dir", inputDir, "--output", outputBase]) を呼び出す', () => {
+    describe('When: main(["--input-dir", inputDir, "--output", outputBase]) を呼び出す', () => {
       describe('Then: Task T-15-07-01 - project なし時は misc サブディレクトリに出力される', () => {
         it('T-15-07-01-01: 出力ファイルのパスが <outputBase>/misc/ を含む', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputBase]);
+          await main(['--input-dir', inputDir, '--output-dir', outputBase]);
 
           const files = await findFiles(outputBase);
           assertEquals(files.length >= 1, true);
@@ -331,14 +337,15 @@ describe('main - I/O', () => {
 
     afterEach(async () => {
       commandHandle.restore();
+      GlobalConfig.resetInstance();
       logSilencer.restore();
       await removeTempDirs(inputDir, outputDir);
     });
 
-    describe('When: main(["--chatlogs-dir", inputDir, "--output", outputDir]) を呼び出す', () => {
+    describe('When: main(["--input-dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-04-04 - 単一トピックの MD ファイルから出力ファイルが正確に 1 件生成される', () => {
         it('T-15-04-04-01: outputDir 配下に正確に 1 件の .md ファイルが生成される', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           const files = await findFiles(outputDir);
           assertEquals(files.length, 1);

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
@@ -21,6 +21,7 @@ import { main } from '../../normalize-chatlogs.ts';
 // ─── Helpers
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -31,8 +32,8 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 /**
  * `main` の入力ディレクトリ解決テストスイート。
  *
- * `--chatlogs-dir` 未指定時に `originalLogs` を挟んだパスから
- * 入力ファイルを読み込むことを検証する。
+ * `--input-dir` 未指定時に GlobalConfig の `chatlogsDir` を基準として
+ * `originalLogs` を挟んだパスから入力ファイルを読み込むことを検証する。
  *
  * テスト ID 範囲: T-NC-MAIN-01
  *
@@ -41,24 +42,27 @@ import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-s
 describe('main', () => {
   /** originalLogs を挟んだ入力ディレクトリからファイルを読み込むケース。 */
   describe('When: 正常系', () => {
-    describe('Given: baseDir 配下の originalLogs/<agent>/<yyyy>/<yyyy-mm> にファイルが存在', () => {
-      describe('When: --chatlogs-dir を指定せず main() を呼び出す', () => {
+    describe('Given: chatlogsDir 配下の originalLogs/<agent>/<yyyy>/<yyyy-mm> にファイルが存在', () => {
+      describe('When: --input-dir を指定せず main() を呼び出す', () => {
         describe('Then: T-NC-MAIN-01 - originalLogs 配下のファイルが読み込まれる', () => {
-          let baseDir: string;
+          let chatlogsDir: string;
           let outputDir: string;
+          let configFile: string;
           let commandHandle: CommandMockHandle;
           let loggerStub: LoggerStub;
           let exitStub: Stub;
 
           beforeEach(async () => {
-            baseDir = normalizePath(await Deno.makeTempDir());
+            chatlogsDir = normalizePath(await Deno.makeTempDir());
             outputDir = normalizePath(await Deno.makeTempDir());
-            const monthDir = `${baseDir}/originalLogs/claude/2026/2026-03`;
+            configFile = `${chatlogsDir}/config.yaml`;
+            const monthDir = `${chatlogsDir}/originalLogs/claude/2026/2026-03`;
             await Deno.mkdir(monthDir, { recursive: true });
             await Deno.writeTextFile(
               `${monthDir}/chat.md`,
               '---\nproject: my-project\n---\n### User\nHello\n\n### AI\nHi there.',
             );
+            await Deno.writeTextFile(configFile, `chatlogsDir: "${chatlogsDir}"\n`);
 
             const chatPath = normalizePath(`${monthDir}/chat.md`);
             const segmentResponse = JSON.stringify([
@@ -72,25 +76,27 @@ describe('main', () => {
             );
             loggerStub = makeLoggerStub();
             exitStub = stub(Deno, 'exit');
+            GlobalConfig.resetInstance();
           });
 
           afterEach(async () => {
             commandHandle.restore();
             loggerStub.restore();
             exitStub.restore();
-            await Deno.remove(baseDir, { recursive: true });
+            GlobalConfig.resetInstance();
+            await Deno.remove(chatlogsDir, { recursive: true });
             await Deno.remove(outputDir, { recursive: true });
           });
 
           it('T-NC-MAIN-01-01: success=1 がレポートされる', async () => {
             await main([
-              '--base-dir',
-              baseDir,
+              '--config',
+              configFile,
               '--agent',
               'claude',
               '--period',
               '2026-03',
-              '--normalize-dir',
+              '--output-dir',
               outputDir,
             ]);
 
@@ -99,13 +105,13 @@ describe('main', () => {
 
           it('T-NC-MAIN-01-02: Deno.exit が呼ばれない（入力ディレクトリが見つかる）', async () => {
             await main([
-              '--base-dir',
-              baseDir,
+              '--config',
+              configFile,
               '--agent',
               'claude',
               '--period',
               '2026-03',
-              '--normalize-dir',
+              '--output-dir',
               outputDir,
             ]);
 

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/output-structure.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/output-structure.e2e.spec.ts
@@ -18,6 +18,7 @@ import { makeTempDirs, removeTempDirs } from '../../../../_scripts/__tests__/hel
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { assertAllOutputFiles } from '../../../../_scripts/__tests__/helpers/output-validator.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // test target
@@ -68,13 +69,14 @@ describe('main - output structure', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: Task T-15-01-01-02 - 各出力ファイルが YAML frontmatter を含む', () => {
         it('T-15-01-01-02-01: 各出力ファイルが ---\\n で始まる YAML frontmatter と ## Summary セクションを含む', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           const files = await findFiles(outputDir);
           await assertAllOutputFiles(files);
@@ -116,13 +118,14 @@ describe('main - output structure', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     describe('When: main(["--dir", inputDir, "--output", outputDir]) を呼び出す', () => {
       describe('Then: 入力の project フィールドが出力 frontmatter に伝播される', () => {
         it('出力ファイルの frontmatter に project: my-project が含まれる', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           const files = await findFiles(outputDir);
           await assertAllOutputFiles(files, {

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
@@ -26,6 +26,7 @@ import {
   removeTempDirs,
   silenceLog,
 } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
@@ -73,6 +74,7 @@ describe('main - reproducibility', () => {
     afterEach(async () => {
       commandHandle.restore();
       loggerStub.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
@@ -83,13 +85,13 @@ describe('main - reproducibility', () => {
           const fixedHash: HashProvider = () => '0000000';
 
           // First run: creates output
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir], fixedHash);
 
           // Reset log capture for second run
           loggerStub.infoLogs.splice(0);
 
           // Second run: should skip already-normalized file
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir], fixedHash);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir], fixedHash);
 
           assertMatch(loggerStub.infoLogs.join('\n'), /skip=1/);
         });
@@ -125,13 +127,14 @@ describe('main - reproducibility', () => {
     afterEach(async () => {
       commandHandle.restore();
       logSilencer.restore();
+      GlobalConfig.resetInstance();
       await removeTempDirs(inputDir, outputDir);
     });
 
     describe('When: main() が完了する', () => {
       describe('Then: Task T-15-04-03 - 実行全体を通じて入力ファイルが変更されない', () => {
         it('T-15-04-03-01: 入力ファイルの内容が main() 実行後も変化しない', async () => {
-          await main(['--chatlogs-dir', inputDir, '--normalize-dir', outputDir]);
+          await main(['--input-dir', inputDir, '--output-dir', outputDir]);
 
           const afterContent = await readTextFile(`${inputDir}/input.md`);
           assertEquals(afterContent, inputContent);

--- a/skills/normalize-chatlogs/scripts/constants/normalize.constants.ts
+++ b/skills/normalize-chatlogs/scripts/constants/normalize.constants.ts
@@ -17,7 +17,7 @@ import type { NormalizeConfig } from '../types/normalize.types.ts';
 export const DEFAULT_NORMALIZE_CONFIG: Partial<NormalizeConfig> = {
   dryRun: false,
   concurrency: DEFAULT_CONCURRENCY,
-  normalizeDir: DEFAULT_NORMALIZE_DIR,
+  outputDir: DEFAULT_NORMALIZE_DIR,
 };
 
 /** Maximum number of segments per file. Segments returned by the AI are truncated to this count. */

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/normalize-config.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/normalize-config.unit.spec.ts
@@ -9,10 +9,16 @@
 
 // ─── BDD modules
 import { assertEquals, assertThrows } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { buildConfig, parseArgs } from '../../normalize-config.ts';
+
+// ─── Helpers
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_CHATLOGS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { NormalizeParsedConfig } from '../../../types/normalize.types.ts';
 
@@ -26,69 +32,116 @@ type _ParsedField = keyof NormalizeParsedConfig;
 /**
  * `buildConfig` のユニットテストスイート。
  *
- * NormalizeParsedConfig にデフォルト値を適用して NormalizeConfig を生成する処理を検証する。
+ * NormalizeParsedConfig・GlobalConfig・デフォルト値から NormalizeConfig を構築する処理を検証する。
  *
- * テスト ID 範囲: T-NC-BC-01 〜 T-NC-BC-06
+ * テスト ID 範囲: T-NC-BC-01 〜 T-NC-BC-07
  *
  * @see buildConfig
  */
 describe('buildConfig', () => {
+  afterEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
   /** デフォルト値が適用されるケース。 */
   describe('When: 正常系', () => {
     describe('Given: 空の parsed', () => {
-      describe('When: buildConfig({}) を呼び出す', () => {
+      let globalConfig: GlobalConfig;
+      beforeEach(async () => {
+        globalConfig = await GlobalConfig.getInstance({ schema: {} });
+      });
+
+      describe('When: buildConfig(parsed, globalConfig) を呼び出す', () => {
         describe('Then: T-NC-BC-01 - デフォルト値が適用される', () => {
           it('T-NC-BC-01-01: concurrency が 4 になる', () => {
-            assertEquals(buildConfig({}).concurrency, 4);
+            assertEquals(buildConfig({}, globalConfig).concurrency, 4);
           });
           it('T-NC-BC-01-02: dryRun が false になる', () => {
-            assertEquals(buildConfig({}).dryRun, false);
+            assertEquals(buildConfig({}, globalConfig).dryRun, false);
           });
           it('T-NC-BC-01-03: timeoutMs が undefined になる', () => {
-            assertEquals(buildConfig({}).timeoutMs, undefined);
+            assertEquals(buildConfig({}, globalConfig).timeoutMs, undefined);
           });
         });
       });
     });
 
     describe('Given: 値を持つ parsed', () => {
-      describe('When: buildConfig(parsed) を呼び出す', () => {
+      let globalConfig: GlobalConfig;
+      beforeEach(async () => {
+        globalConfig = await GlobalConfig.getInstance({ schema: {} });
+      });
+
+      describe('When: buildConfig(parsed, globalConfig) を呼び出す', () => {
         describe('Then: T-NC-BC-02 - parsed の値が defaults より優先される', () => {
           it('T-NC-BC-02-01: concurrency = 8 が適用される', () => {
-            assertEquals(buildConfig({ concurrency: 8 }).concurrency, 8);
+            assertEquals(buildConfig({ concurrency: 8 }, globalConfig).concurrency, 8);
           });
           it('T-NC-BC-02-02: dryRun = true が適用される', () => {
-            assertEquals(buildConfig({ dryRun: true }).dryRun, true);
+            assertEquals(buildConfig({ dryRun: true }, globalConfig).dryRun, true);
           });
         });
       });
     });
 
-    describe('Given: baseDir を含む parsed', () => {
-      describe('When: buildConfig(parsed) を呼び出す', () => {
-        describe('Then: T-NC-BC-03 - フィールドが適用される', () => {
-          it('T-NC-BC-03-01: baseDir = "./base" が適用される', () => {
-            assertEquals(buildConfig({ baseDir: './base' }).baseDir, './base');
+    describe('Given: GlobalConfig に chatlogsDir が設定されている', () => {
+      let globalConfig: GlobalConfig;
+      beforeEach(async () => {
+        globalConfig = await GlobalConfig.getInstance({
+          readTextFileProvider: () => 'chatlogsDir: /global/chatlog',
+          configFile: 'dummy.yaml',
+        });
+      });
+
+      describe('When: buildConfig(parsed, globalConfig) を呼び出す', () => {
+        describe('Then: T-NC-BC-03 - GlobalConfig の chatlogsDir が適用される', () => {
+          it('T-NC-BC-03-01: result.chatlogsDir === "/global/chatlog"', () => {
+            assertEquals(buildConfig({}, globalConfig).chatlogsDir, '/global/chatlog');
           });
         });
       });
     });
 
     describe('Given: 空の parsed', () => {
-      describe('When: buildConfig({}) を呼び出す', () => {
-        describe('Then: T-NC-BC-04 - normalizeDir のデフォルト値が適用される', () => {
-          it('T-NC-BC-04-01: normalizeDir が "./chatlogs/normalizelogs" になる', () => {
-            assertEquals(buildConfig({}).normalizeDir, './chatlogs/normalizelogs');
+      let globalConfig: GlobalConfig;
+      beforeEach(async () => {
+        globalConfig = await GlobalConfig.getInstance({ schema: {} });
+      });
+
+      describe('When: buildConfig(parsed, globalConfig) を呼び出す', () => {
+        describe('Then: T-NC-BC-04 - outputDir のデフォルト値が適用される', () => {
+          it('T-NC-BC-04-01: outputDir が "./chatlogs/normalizelogs" になる', () => {
+            assertEquals(buildConfig({}, globalConfig).outputDir, './chatlogs/normalizelogs');
           });
         });
       });
     });
 
     describe('Given: timeoutMs を含む parsed', () => {
-      describe('When: buildConfig(parsed) を呼び出す', () => {
+      let globalConfig: GlobalConfig;
+      beforeEach(async () => {
+        globalConfig = await GlobalConfig.getInstance({ schema: {} });
+      });
+
+      describe('When: buildConfig(parsed, globalConfig) を呼び出す', () => {
         describe('Then: T-NC-BC-07 - timeoutMs が適用される', () => {
           it('T-NC-BC-07-01: timeoutMs = 300000 が適用される', () => {
-            assertEquals(buildConfig({ timeoutMs: 300000 }).timeoutMs, 300000);
+            assertEquals(buildConfig({ timeoutMs: 300000 }, globalConfig).timeoutMs, 300000);
+          });
+        });
+      });
+    });
+
+    describe('Given: inputDir を含む parsed', () => {
+      let globalConfig: GlobalConfig;
+      beforeEach(async () => {
+        globalConfig = await GlobalConfig.getInstance({ schema: {} });
+      });
+
+      describe('When: buildConfig(parsed, globalConfig) を呼び出す', () => {
+        describe('Then: T-NC-BC-08 - inputDir が適用される', () => {
+          it('T-NC-BC-08-01: inputDir = "/data/chatlog" が適用される', () => {
+            assertEquals(buildConfig({ inputDir: '/data/chatlog' }, globalConfig).inputDir, '/data/chatlog');
           });
         });
       });
@@ -97,25 +150,31 @@ describe('buildConfig', () => {
 
   /** 境界値・defaults 明示指定など特殊なケース。 */
   describe('When: エッジケース', () => {
+    let globalConfig: GlobalConfig;
+    beforeEach(async () => {
+      globalConfig = await GlobalConfig.getInstance({
+        readTextFileProvider: () => 'chatlogsDir: /full',
+        configFile: 'dummy.yaml',
+      });
+    });
+
     it('[Edge] T-NC-BC-05-01: parsed に全フィールドが揃っているとき defaults は完全に上書きされる', () => {
       const parsed: NormalizeParsedConfig = {
-        chatlogsDir: '/full',
-        baseDir: './base',
         agent: 'claude',
         period: '2026-03',
         dryRun: true,
         concurrency: 8,
-        normalizeDir: './out',
+        outputDir: './out',
         configFile: './config.yaml',
       };
-      const result = buildConfig(parsed);
+      const result = buildConfig(parsed, globalConfig);
       assertEquals(result.concurrency, 8);
       assertEquals(result.dryRun, true);
-      assertEquals(result.normalizeDir, './out');
+      assertEquals(result.outputDir, './out');
     });
 
     it('[Edge] T-NC-BC-06-01: defaults を明示指定したとき parsed がない値は defaults が適用される', () => {
-      const result = buildConfig({}, { concurrency: 16, dryRun: true, normalizeDir: './custom' });
+      const result = buildConfig({}, globalConfig, { concurrency: 16, dryRun: true, outputDir: './custom' });
       assertEquals(result.concurrency, 16);
       assertEquals(result.dryRun, true);
     });
@@ -133,30 +192,46 @@ describe('buildConfig', () => {
  * @see parseArgs
  */
 describe('parseArgs', () => {
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
   /**
-   * 空配列を渡したとき、全フィールドが undefined になることを検証する。
-   * デフォルト値（dryRun=false, concurrency=4）は buildConfig の責務。
+   * 空配列を渡したとき、GlobalConfig が管理しないフィールドは undefined になることを検証する。
+   * GlobalConfig が管理するフィールド（chatlogsDir, agent, concurrency, timeoutMs）は
+   * parseArgs 内で GlobalConfig のデフォルト値が自動マージされる。
    */
   describe('When: 正常系', () => {
     describe('Given: オプションなしの空配列', () => {
       describe('When: parseArgs([]) を呼び出す', () => {
-        describe('Then: T-NC-PA-01 - 全フィールドが undefined になる', () => {
+        describe('Then: T-NC-PA-01 - GlobalConfig が管理しないフィールドは undefined になる', () => {
           const _defaultCases: { id: string; field: _ParsedField }[] = [
-            { id: 'T-NC-PA-01-01', field: 'chatlogsDir' },
-            { id: 'T-NC-PA-01-02', field: 'agent' },
             { id: 'T-NC-PA-01-03', field: 'period' },
             { id: 'T-NC-PA-01-04', field: 'dryRun' },
-            { id: 'T-NC-PA-01-05', field: 'concurrency' },
-            { id: 'T-NC-PA-01-06', field: 'normalizeDir' },
+            { id: 'T-NC-PA-01-06', field: 'outputDir' },
             { id: 'T-NC-PA-01-07', field: 'configFile' },
-            { id: 'T-NC-PA-01-08', field: 'baseDir' },
-            { id: 'T-NC-PA-01-09', field: 'timeoutMs' },
+            { id: 'T-NC-PA-01-08', field: 'inputDir' },
           ];
           for (const { id, field } of _defaultCases) {
             it(`${id}: ${field} が undefined になる`, () => {
               assertEquals(parseArgs([])[field], undefined);
             });
           }
+        });
+
+        describe('Then: T-NC-PA-01 - GlobalConfig が管理するフィールドはデフォルト値が自動マージされる', () => {
+          it('T-NC-PA-01-01: chatlogsDir が GlobalConfig のデフォルト値になる', () => {
+            assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
+          });
+          it('T-NC-PA-01-02: agent が GlobalConfig のデフォルト値 "claude" になる', () => {
+            assertEquals(parseArgs([]).agent, 'claude');
+          });
+          it('T-NC-PA-01-05: concurrency が GlobalConfig のデフォルト値 4 になる', () => {
+            assertEquals(parseArgs([]).concurrency, 4);
+          });
+          it('T-NC-PA-01-09: timeoutMs が GlobalConfig のデフォルト値 120000 になる', () => {
+            assertEquals(parseArgs([]).timeoutMs, 120_000);
+          });
         });
       });
     });
@@ -165,24 +240,18 @@ describe('parseArgs', () => {
       describe('When: parseArgs(args) を呼び出す', () => {
         describe('Then: 対応フィールドに値が設定される', () => {
           const _cases: { id: string; args: string[]; field: _ParsedField; expected: unknown }[] = [
-            {
-              id: 'T-NC-PA-02-01',
-              args: ['--chatlogs-dir', '/some/path'],
-              field: 'chatlogsDir',
-              expected: '/some/path',
-            },
+            { id: 'T-NC-PA-02-01', args: ['--input-dir', '/some/path'], field: 'inputDir', expected: '/some/path' },
             { id: 'T-NC-PA-03-01', args: ['--agent', 'claude'], field: 'agent', expected: 'claude' },
             { id: 'T-NC-PA-04-01', args: ['--period', '2026-03'], field: 'period', expected: '2026-03' },
             { id: 'T-NC-PA-05-01', args: ['--dry-run'], field: 'dryRun', expected: true },
             { id: 'T-NC-PA-06-01', args: ['--concurrency', '8'], field: 'concurrency', expected: 8 },
-            { id: 'T-NC-PA-07-01', args: ['--normalize-dir', './out'], field: 'normalizeDir', expected: 'out' },
+            { id: 'T-NC-PA-07-01', args: ['--output-dir', './out'], field: 'outputDir', expected: 'out' },
             {
               id: 'T-NC-PA-11-01',
               args: ['--config', './config.yaml'],
               field: 'configFile',
               expected: './config.yaml',
             },
-            { id: 'T-NC-PA-12-01', args: ['--base-dir', './base'], field: 'baseDir', expected: 'base' },
             { id: 'T-NC-PA-15-01', args: ['--timeout-ms', '300000'], field: 'timeoutMs', expected: 300000 },
           ];
           for (const { id, args, field, expected } of _cases) {
@@ -198,43 +267,32 @@ describe('parseArgs', () => {
       describe('When: parseArgs(args) を呼び出す', () => {
         describe('Then: T-NC-PA-08 - 位置引数が適切なフィールドに設定される', () => {
           const _pathCases: { id: string; args: string[]; field: _ParsedField; expected: unknown }[] = [
-            { id: 'T-NC-PA-08-01', args: ['2026-03'], field: 'period', expected: '2026-03' },
             { id: 'T-NC-PA-08-02', args: ['claude'], field: 'agent', expected: 'claude' },
-            {
-              id: 'T-NC-PA-08-03',
-              args: ['chatlogs/claude/2026/2026-03'],
-              field: 'chatlogsDir',
-              expected: 'chatlogs/claude/2026/2026-03',
-            },
-            {
-              id: 'T-NC-PA-08-04',
-              args: ['chatlogs\\claude\\2026\\2026-03'],
-              field: 'chatlogsDir',
-              expected: 'chatlogs/claude/2026/2026-03',
-            },
           ];
           for (const { id, args, field, expected } of _pathCases) {
             it(`${id}: ${field} が "${expected}" になる`, () => {
               assertEquals(parseArgs(args)[field], expected);
             });
           }
+
+          it('T-NC-PA-08-01: period 単独指定（agent 省略）→ ChatlogError(InvalidArgs)', () => {
+            assertThrows(() => parseArgs(['2026-03']), ChatlogError);
+          });
         });
       });
     });
 
-    describe('Given: --chatlogs-dir のバックスラッシュ', () => {
-      it('T-NC-PA-02-02: --chatlogs-dir chatlogs\\claude → chatlogsDir = "chatlogs/claude"', () => {
-        assertEquals(parseArgs(['--chatlogs-dir', 'chatlogs\\claude']).chatlogsDir, 'chatlogs/claude');
+    describe('Given: --input-dir のバックスラッシュ', () => {
+      it('T-NC-PA-02-02: --input-dir chatlogs\\claude → inputDir = "chatlogs/claude"', () => {
+        assertEquals(parseArgs(['--input-dir', 'chatlogs\\claude']).inputDir, 'chatlogs/claude');
       });
     });
 
     describe('Given: 全オプションを組み合わせた引数', () => {
       it('T-NC-PA-09-01: 全フィールドが正しく解析される', () => {
         const result = parseArgs([
-          '--chatlogs-dir',
+          '--input-dir',
           '/some/path',
-          '--base-dir',
-          './base',
           '--agent',
           'claude',
           '--period',
@@ -244,17 +302,16 @@ describe('parseArgs', () => {
           '--dry-run',
           '--concurrency',
           '8',
-          '--normalize-dir',
+          '--output-dir',
           './out',
         ]);
-        assertEquals(result.chatlogsDir, '/some/path');
-        assertEquals(result.baseDir, 'base');
+        assertEquals(result.inputDir, '/some/path');
         assertEquals(result.agent, 'claude');
         assertEquals(result.period, '2026-03');
         assertEquals(result.configFile, './config.yaml');
         assertEquals(result.dryRun, true);
         assertEquals(result.concurrency, 8);
-        assertEquals(result.normalizeDir, 'out');
+        assertEquals(result.outputDir, 'out');
       });
     });
   });

--- a/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
+++ b/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
@@ -9,7 +9,10 @@
 
 // --- shared
 // functions
-import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
+import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
+
+// classes
+import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
 // types
 import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
@@ -26,28 +29,33 @@ import { DEFAULT_NORMALIZE_CONFIG } from '../constants/normalize.constants.ts';
 
 // --- local
 // constants
-const _SCHEMA: ArgsSchema = [
+const _SCHEMA: ArgsSchema<NormalizeParsedConfig> = [
   { option: '--agent', field: 'agent', type: 'agent' },
   { option: '--period', field: 'period', type: 'period' },
   { option: '--concurrency', field: 'concurrency', type: 'integer' },
   { option: '--timeout-ms', field: 'timeoutMs', type: 'integer' },
-  { option: '--normalize-dir', field: 'normalizeDir', type: 'directory' },
+  { option: '--output-dir', field: 'outputDir', type: 'directory' },
   { option: '--fail-fast', field: 'failFast', type: 'flag' },
   { option: '--single-file', field: 'singleFile', type: 'flag' },
 ];
 
 export const parseArgs = (args: string[]): NormalizeParsedConfig => {
-  return parseArgsToConfig<NormalizeParsedConfig>(args, _SCHEMA) as NormalizeParsedConfig;
+  return parseArgsToConfig<NormalizeParsedConfig>(args, _SCHEMA);
 };
 
 export const buildConfig = (
   parsed: NormalizeParsedConfig,
+  globalConfig: GlobalConfig,
   defaults: Partial<NormalizeConfig> = DEFAULT_NORMALIZE_CONFIG,
 ): NormalizeConfig => {
+  const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
   const { configFile: _configFile, ...rest } = parsed;
   return {
     ...defaults,
     ...rest,
+    chatlogsDir: _chatlogsDir,
+    inputDir: parsed.inputDir,
+    outputDir: parsed.outputDir ?? defaults.outputDir,
     dryRun: parsed.dryRun ?? defaults.dryRun ?? false,
     concurrency: parsed.concurrency ?? defaults.concurrency ?? DEFAULT_CONCURRENCY,
   };

--- a/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
+++ b/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
@@ -20,7 +20,6 @@ import type { HashProvider } from '../../_scripts/types/providers.types.ts';
 // -- constants --
 import {
   DEFAULT_AGENT,
-  DEFAULT_CHATLOGS_DIR,
   DEFAULT_NORMALIZE_DIR,
   DEFAULT_ORIGINAL_LOGS_DIR,
   DEFAULT_TIMEOUT_MS,
@@ -62,23 +61,23 @@ import type { Stats } from './types/normalize.types.ts';
 export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void> => {
   try {
     const _parsed = parseArgs(argv ?? Deno.args);
-    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const _timeoutMs = Number(_globalConfig.get('timeoutMs') ?? DEFAULT_TIMEOUT_MS);
-    const config = buildConfig(_parsed, {
+    const config = buildConfig(_parsed, _globalConfig, {
       ...DEFAULT_NORMALIZE_CONFIG,
       timeoutMs: _timeoutMs,
     });
     const inputDir = resolveChatlogsDir({
       chatlogsDir: config.chatlogsDir,
-      baseDir: config.baseDir ?? DEFAULT_CHATLOGS_DIR,
       agent: config.agent ?? DEFAULT_AGENT,
       period: config.period,
       addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+      override: config.inputDir,
     });
     if (!dirExistsSync(inputDir)) {
       throw new ChatlogError('InputNotFound', 'NotFound', `directory not found: ${inputDir}`);
     }
-    const outputBase = config.normalizeDir ?? DEFAULT_NORMALIZE_DIR;
+    const outputBase = config.outputDir ?? DEFAULT_NORMALIZE_DIR;
 
     const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
     await processFiles(inputDir, outputBase, config, stats, hashFn);

--- a/skills/normalize-chatlogs/scripts/types/normalize.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/normalize.types.ts
@@ -48,15 +48,15 @@ export type Stats = {
 };
 
 export interface NormalizeConfig {
-  chatlogsDir?: string;
-  baseDir?: string;
+  chatlogsDir: string;
+  inputDir?: string;
   agent?: string;
   period?: string;
   model?: string;
   timeoutMs?: number;
   dryRun: boolean;
   concurrency: number;
-  normalizeDir?: string;
+  outputDir?: string;
   failFast?: boolean;
   singleFile?: boolean;
 }

--- a/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 
 // ─── テスト用一時ディレクトリセットアップ ─────────────────────────────────────
@@ -815,6 +816,72 @@ describe('main - dry-run FAIL抑制 (T-SF-E2E-DR-05)', () => {
           ]);
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('fail=0')), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-12: --input-dir 未指定 → resolveChatlogsDir による agent 絞り込み ────
+
+/**
+ * `--input-dir` を省略したとき、`chatlogsDir/normalizelogs/<agent>` が
+ * `resolveChatlogsDir` により算出され、そのディレクトリ配下のファイルが処理されることを検証する。
+ *
+ * テスト ID 範囲: T-SF-E2E-12-01
+ */
+describe('main - --input-dir 未指定（デフォルト絞り込み）', () => {
+  describe('Given: chatlogsDir/normalizelogs/claude 配下に .md ファイルを配置し --input-dir を省略', () => {
+    describe('When: main(["claude", "--output-dir", outDir, ...]) を呼び出す（GlobalConfig.chatlogsDir で注入）', () => {
+      describe('Then: T-SF-E2E-12 - chatlogsDir/normalizelogs/claude 配下のファイルが処理される', () => {
+        let chatlogsDir: string;
+        let outputDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          chatlogsDir = await Deno.makeTempDir();
+          const agentDir = `${chatlogsDir}/normalizelogs/claude`;
+          await Deno.mkdir(agentDir, { recursive: true });
+          await Deno.writeTextFile(`${agentDir}/test.md`, '# テスト\n本文テキスト');
+
+          outputDir = await Deno.makeTempDir();
+          dicsDir = await _makeDicsDir();
+
+          GlobalConfig.resetInstance();
+          await GlobalConfig.getInstance({
+            readTextFileProvider: () => `chatlogsDir: '${chatlogsDir}'`,
+            configFile: 'dummy.yaml',
+          });
+
+          commandHandle = installCommandMock(
+            makeSuccessMock(_enc.encode('research\ndevelopment'), { value: [] }),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(chatlogsDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Normal] T-SF-E2E-12-01: chatlogsDir/normalizelogs/claude/test.md がメタ読み込みされる', async () => {
+          await main([
+            'claude',
+            '--output-dir',
+            outputDir,
+            '--dry-run',
+            '--no-review',
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(loggerStub.infoLogs.some((l) => l.includes('メタ読み込み: 1件')), true);
         });
       });
     });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/build-config.unit.spec.ts
@@ -181,33 +181,69 @@ describe('buildConfig', () => {
   });
 
   /**
-   * `inputDir` フィールドのデフォルト値と指定値テスト。
+   * `inputDir`・`agent`・`period`・`chatlogsDir` フィールドのテスト。
+   *
+   * `inputDir` の実際の解決（`resolveChatlogsDir` によるagent/period絞り込み）は
+   * main() 側の責務になったため、buildConfig は `parsed.inputDir` をそのまま通し、
+   * agent/period/chatlogsDir を「生の材料」として config に含めるだけになった。
    */
   describe('When: inputDir の設定', () => {
-    /** inputDir 未指定でデフォルト値が使われる正常ケース。 */
+    /** inputDir 未指定 → 空文字列（main() 側で resolveChatlogsDir により解決される）。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-SF-BC-07-01: inputDir undefined → joinPath(chatlogsDir, normalizelogs) が使われる', () => {
+      it('[Normal] T-SF-BC-07-01: inputDir undefined → 空文字列になる（main() が resolveChatlogsDir で解決する）', () => {
         const result = buildConfig({}, globalConfig);
-        assertEquals(result.inputDir, joinPath(DEFAULT_CHATLOGS_DIR, 'normalizelogs'));
+        assertEquals(result.inputDir, '');
       });
 
-      it('[Normal] T-SF-BC-07-02: parsed.inputDir 指定 → その値が使われる', () => {
+      it('[Normal] T-SF-BC-07-02: parsed.inputDir 指定 → その値がそのまま使われる', () => {
         const result = buildConfig({ inputDir: '/custom/input' }, globalConfig);
         assertEquals(result.inputDir, '/custom/input');
       });
-
-      it('[Normal] T-SF-BC-07-04: GlobalConfig.chatlogsDir=./custom → inputDir=joinPath(./custom, normalizelogs)', async () => {
-        const gc = await _makeGlobalConfig('chatlogsDir: ./custom');
-        const result = buildConfig({}, gc);
-        assertEquals(result.inputDir, joinPath('./custom', 'normalizelogs'));
-      });
     });
+  });
 
-    /** inputDir 空文字列のエッジケース。 */
-    describe('When: エッジケース', () => {
-      it('[Edge] T-SF-BC-07-03: inputDir 空文字列 → joinPath(chatlogsDir, normalizelogs) が使われる', () => {
-        const result = buildConfig({ inputDir: '' }, globalConfig);
-        assertEquals(result.inputDir, joinPath(DEFAULT_CHATLOGS_DIR, 'normalizelogs'));
+  /**
+   * `agent`/`period`/`chatlogsDir` フィールドの解決ロジックテスト。
+   *
+   * これらは `resolveChatlogsDir` の材料として main() 側で使われる。
+   */
+  describe('When: agent/period/chatlogsDir の設定', () => {
+    describe('When: 正常系', () => {
+      it('[Normal] T-SF-BC-12-01: agent 未指定 + GlobalConfig 未設定 → DEFAULT_AGENT が使われる', () => {
+        const result = buildConfig({}, globalConfig);
+        assertEquals(result.agent, 'claude');
+      });
+
+      it('[Normal] T-SF-BC-12-02: parsed.agent 指定 → その値が使われる', () => {
+        const result = buildConfig({ agent: 'chatgpt' }, globalConfig);
+        assertEquals(result.agent, 'chatgpt');
+      });
+
+      it('[Normal] T-SF-BC-12-03: GlobalConfig.agent=chatgpt → agent=chatgpt が使われる', async () => {
+        const gc = await _makeGlobalConfig('agent: chatgpt');
+        const result = buildConfig({}, gc);
+        assertEquals(result.agent, 'chatgpt');
+      });
+
+      it('[Normal] T-SF-BC-12-04: parsed.period 指定 → その値がそのまま設定される', () => {
+        const result = buildConfig({ period: '2026-01' }, globalConfig);
+        assertEquals(result.period, '2026-01');
+      });
+
+      it('[Normal] T-SF-BC-12-05: period 未指定 → undefined になる', () => {
+        const result = buildConfig({}, globalConfig);
+        assertEquals(result.period, undefined);
+      });
+
+      it('[Normal] T-SF-BC-12-06: chatlogsDir 未指定 → GlobalConfig.chatlogsDir が使われる', () => {
+        const result = buildConfig({}, globalConfig);
+        assertEquals(result.chatlogsDir, DEFAULT_CHATLOGS_DIR);
+      });
+
+      it('[Normal] T-SF-BC-12-10: GlobalConfig.chatlogsDir=/custom/chatlogs → その値が使われる', async () => {
+        const gc = await _makeGlobalConfig('chatlogsDir: /custom/chatlogs');
+        const result = buildConfig({}, gc);
+        assertEquals(result.chatlogsDir, '/custom/chatlogs');
       });
     });
   });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/parse-args.unit.spec.ts
@@ -10,13 +10,16 @@
 
 // ─── BDD modules
 import { assertEquals, assertThrows } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { parseArgs } from '../../setfm-config.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
+// constants
+import { DEFAULT_DICS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
 
 // ─── Internal Helpers
 
@@ -39,12 +42,17 @@ const _PATH = '/path/to/dir';
  * @see parseArgs
  */
 describe('parseArgs', () => {
+  beforeEach(() => {
+    GlobalConfig.resetInstance();
+  });
+
   // ─── T-SF-PA-01: デフォルト値 ────────────────────────────────────────────────
 
   /**
    * `--output-dir` のみ指定した場合のデフォルト値テスト。
    *
    * 省略可能なオプションが未指定のとき undefined になることを検証する。
+   * ただし GlobalConfig が管理するフィールド（dicsDir）はデフォルト値が自動マージされる。
    */
   describe('Given: 最小引数 ["--output-dir", "/path/to/dir"]', () => {
     describe('When: parseArgs(["--output-dir", "/path/to/dir"]) を呼び出す', () => {
@@ -52,7 +60,6 @@ describe('parseArgs', () => {
       describe('Then: T-SF-PA-01 - デフォルト値が適用される', () => {
         const _defaultCases: { id: string; field: keyof ParsedResult; expected: unknown }[] = [
           { id: 'T-SF-PA-01-01', field: 'outputDir', expected: _PATH },
-          { id: 'T-SF-PA-01-02', field: 'dicsDir', expected: undefined },
           { id: 'T-SF-PA-01-03', field: 'dryRun', expected: undefined },
           { id: 'T-SF-PA-01-04', field: 'review', expected: undefined },
         ];
@@ -61,6 +68,10 @@ describe('parseArgs', () => {
             assertEquals(parseArgs([_TARGET, _PATH])[field], expected);
           });
         }
+
+        it('T-SF-PA-01-02: dicsDir が GlobalConfig のデフォルト値になる', () => {
+          assertEquals(parseArgs([_TARGET, _PATH]).dicsDir, DEFAULT_DICS_DIR);
+        });
       });
     });
   });
@@ -148,10 +159,10 @@ describe('parseArgs', () => {
         }
       });
 
-      /** 正常系: 未指定のとき undefined になる。 */
+      /** 正常系: 未指定のとき GlobalConfig のデフォルト値になる。 */
       describe('Then: 正常系 - --concurrency 未指定', () => {
-        it('[Normal] T-SF-PA-12-03: --concurrency 未指定 → undefined', () => {
-          assertEquals(parseArgs(['--output-dir', '/path']).concurrency, undefined);
+        it('[Normal] T-SF-PA-12-03: --concurrency 未指定 → GlobalConfig のデフォルト値 4 になる', () => {
+          assertEquals(parseArgs(['--output-dir', '/path']).concurrency, 4);
         });
       });
 
@@ -166,6 +177,53 @@ describe('parseArgs', () => {
             assertThrows(() => parseArgs(args as unknown as string[]), ChatlogError);
           });
         }
+      });
+    });
+  });
+
+  // ─── T-SF-PA-13: agent/period 位置引数 ──────────────────────────────────────
+
+  /**
+   * 位置引数（デフォルトスキーマ由来）の agent/period の解析テスト。
+   */
+  describe('Given: agent/period 位置引数', () => {
+    describe('When: parseArgs(args) を呼び出す', () => {
+      /** 正常系: 位置引数が対応フィールドに設定される。 */
+      describe('Then: 正常系 - 対応フィールドに値が設定される', () => {
+        const _cases = [
+          { id: 'T-SF-PA-13-01', args: ['claude'], field: 'agent', expected: 'claude' },
+        ] as const;
+        for (const { id, args, field, expected } of _cases) {
+          it(`[Normal] ${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
+            assertEquals(parseArgs([...args])[field], expected);
+          });
+        }
+      });
+
+      /** 異常系: period のみの位置引数（agent 省略）は不明な引数としてエラーになる。 */
+      describe('Then: 異常系 - period 単独指定（agent 省略）は ChatlogError(InvalidArgs)', () => {
+        it('[Error] T-SF-PA-13-02: ["2026-01"] → ChatlogError(InvalidArgs)', () => {
+          assertThrows(
+            () => parseArgs(['2026-01']),
+            ChatlogError,
+          );
+        });
+      });
+
+      /** 正常系: 未指定のとき、GlobalConfig が管理しないフィールドは undefined になる。 */
+      describe('Then: 正常系 - 未指定時は undefined', () => {
+        const _cases = [
+          { id: 'T-SF-PA-13-06', field: 'period' },
+        ] as const;
+        for (const { id, field } of _cases) {
+          it(`[Normal] ${id}: ${field} 未指定 → undefined`, () => {
+            assertEquals(parseArgs([])[field], undefined);
+          });
+        }
+
+        it('[Normal] T-SF-PA-13-05: agent 未指定 → GlobalConfig のデフォルト値 "claude" になる', () => {
+          assertEquals(parseArgs([]).agent, 'claude');
+        });
       });
     });
   });

--- a/skills/set-frontmatter/scripts/modules/setfm-config.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-config.ts
@@ -12,10 +12,11 @@
 // ─── Shared scripts
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
-import { parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
+import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 import { isAbsolutePath, joinPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // constants
 import {
+  DEFAULT_AGENT,
   DEFAULT_CHATLOGS_DIR,
   DEFAULT_DICS_DIR,
   DEFAULT_MAX_RETRY,
@@ -29,9 +30,7 @@ import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
 import type { ParsedConfig, SetfmConfig } from '../types/args.types.ts';
 
 /** set-frontmatter の引数スキーマ。 */
-const _SCHEMA: ArgsSchema = [
-  { option: '--input-dir', field: 'inputDir', type: 'directory' },
-  { option: '--output-dir', field: 'outputDir', type: 'directory' },
+const _SCHEMA: ArgsSchema<ParsedConfig> = [
   { option: '--dics', field: 'dicsDir', type: 'directory' },
   { option: '--prompts', field: 'promptsDir', type: 'directory' },
   { option: '--review', field: 'review', type: 'flag' },
@@ -40,14 +39,16 @@ const _SCHEMA: ArgsSchema = [
 ];
 
 export const parseArgs = (args: string[]): ParsedConfig => {
-  return parseArgsToConfig(args, _SCHEMA) as unknown as ParsedConfig;
+  return parseArgsToConfig<ParsedConfig>(args, _SCHEMA);
 };
 
 /**
  * ParsedConfig・GlobalConfig・デフォルト値から完全な SetfmConfig を構築する。
- * - inputDir 優先順位: `parsed.inputDir` > `join(chatlogsDir, 'normalizelogs')`
+ * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `DEFAULT_AGENT`
+ * - period: `parsed.period`（そのまま、未指定なら全期間対象）
+ * - chatlogsDir 優先順位: `globalConfig.get('chatlogsDir')` > `DEFAULT_CHATLOGS_DIR`
+ * - inputDir: `parsed.inputDir` をそのまま通す（実際のディレクトリ解決は main() が `resolveChatlogsDir` で行う）
  * - outputDir: 絶対パスならそのまま使用、相対パスなら `join(chatlogsDir, outputDir)`、未指定なら `join(chatlogsDir, 'outputLogs')`
- * - chatlogsDir: `globalConfig.get('chatlogsDir')` > `DEFAULT_CHATLOGS_DIR`
  * - dicsDir 優先順位: `parsed.dicsDir` > `globalConfig.get('dicsDir')` > `DEFAULT_DICS_DIR`
  * - promptsDir 優先順位: `parsed.promptsDir` > `globalConfig.get('promptsDir')` > `DEFAULT_PROMPTS_DIR`
  * - dryRun: `parsed.dryRun ?? false`
@@ -59,7 +60,7 @@ export const buildConfig = (
   globalConfig: GlobalConfig,
 ): SetfmConfig => {
   const _chatlogsDir = (globalConfig.get('chatlogsDir') as string | undefined) ?? DEFAULT_CHATLOGS_DIR;
-  const _inputDir = parsed.inputDir || joinPath(_chatlogsDir, 'normalizelogs');
+  const _agent = parsed.agent ?? (globalConfig.get('agent') as string | undefined) ?? DEFAULT_AGENT;
   const _outputDir = parsed.outputDir
     ? (isAbsolutePath(parsed.outputDir) ? parsed.outputDir : joinPath(_chatlogsDir, parsed.outputDir))
     : joinPath(_chatlogsDir, 'outputLogs');
@@ -76,8 +77,11 @@ export const buildConfig = (
   const _cacheDir = parsed.cacheDir ?? joinPath(Deno.env.get('TEMP') ?? '.', 'setfm-cache');
   const _maxRetry = (globalConfig.get('maxRetry') as number) ?? DEFAULT_MAX_RETRY;
   return {
-    inputDir: _inputDir,
+    inputDir: parsed.inputDir ?? '',
     outputDir: _outputDir,
+    agent: _agent,
+    period: parsed.period,
+    chatlogsDir: _chatlogsDir,
     dicsDir: _dicsDir,
     promptsDir: _promptsDir,
     dryRun: _dryRun,

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -28,6 +28,7 @@
 // ─── Shared scripts
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
+import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../_scripts/libs/parallel/concurrency.ts';
@@ -274,11 +275,18 @@ const _phaseWrite = async (
 export const main = async (args: string[]): Promise<void> => {
   try {
     const _parsed = parseArgs(args);
-    const _globalConfig = await GlobalConfig.getInstance({ configFile: _parsed.configFile });
+    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const _config = buildConfig(_parsed, _globalConfig);
+    const _inputDir = resolveChatlogsDir({
+      chatlogsDir: _config.chatlogsDir,
+      agent: _config.agent,
+      period: _config.period,
+      addOnDir: 'normalizelogs',
+      override: _config.inputDir || undefined,
+    });
 
-    if (!await dirExists(_config.inputDir)) {
-      throw new ChatlogError('InputNotFound', 'NotFound', `ディレクトリが見つかりません: ${_config.inputDir}`);
+    if (!await dirExists(_inputDir)) {
+      throw new ChatlogError('InputNotFound', 'NotFound', `ディレクトリが見つかりません: ${_inputDir}`);
     }
 
     const _cache = new ChatlogWorks<SetfmCache>(
@@ -301,7 +309,7 @@ export const main = async (args: string[]): Promise<void> => {
     const stats: Stats = { total: 0, success: 0, fail: 0, skip: 0, written: 0 };
 
     // Phase 1.1: メタ読み込み
-    const entries = await loadAllEntries(_config.inputDir, stats);
+    const entries = await loadAllEntries(_inputDir, stats);
     logger.info(`メタ読み込み: ${entries.length}件（スキップ: ${stats.skip}件）`);
     if (entries.length === 0) {
       logger.info('対象ファイルなし');
@@ -376,7 +384,7 @@ export const main = async (args: string[]): Promise<void> => {
         stats.fail++;
       });
     }
-    await _phaseWrite(_writeEntries, _cache, _config, stats);
+    await _phaseWrite(_writeEntries, _cache, { ..._config, inputDir: _inputDir }, stats);
 
     logger.info(
       `\n完了: total=${stats.total} success=${stats.success} fail=${stats.fail} skip=${stats.skip} written=${stats.written} target=${_candidateEntries.length}`,

--- a/skills/set-frontmatter/scripts/types/args.types.ts
+++ b/skills/set-frontmatter/scripts/types/args.types.ts
@@ -14,10 +14,20 @@
 
 /** `buildConfig` が返す完全な設定（すべてのフィールドが必須）。 */
 export interface SetfmConfig {
-  /** チャットログを読み込む入力ディレクトリのパス。 */
+  /**
+   * チャットログを読み込む入力ディレクトリのパス。
+   * `--input-dir` 明示指定時のみ `buildConfig` が値を持つ（未指定時は空文字列）。
+   * 実際の入力ディレクトリは `main()` が `resolveChatlogsDir` で解決する。
+   */
   inputDir: string;
   /** フロントマター付きファイルの書き込み先ディレクトリのパス。 */
   outputDir: string;
+  /** 対象エージェント名。 */
+  agent: string;
+  /** 絞り込み対象の期間（`YYYY` または `YYYY-MM`）。未指定時は全期間対象。 */
+  period?: string;
+  /** チャットログの基準ディレクトリのパス（GlobalConfig 由来）。 */
+  chatlogsDir: string;
   /** 辞書ファイルが置かれたディレクトリのパス。 */
   dicsDir: string;
   /** プロンプトファイルが置かれたディレクトリのパス。 */


### PR DESCRIPTION
## Overview

**Summary**
Unify chatlogs directory resolution across all skills using GlobalConfig.

**Background / Motivation**
Each skill (classify-chatlogs, export-chatlogs, filter-chatlogs, normalize-chatlogs,
set-frontmatter) kept its own `baseDir` / input-directory config. This caused
duplicated and inconsistent directory-resolution logic across the codebase.
This PR moves directory resolution to a single source, `GlobalConfig.chatlogsDir`,
and cleans up related config loading and argument parsing.

## Changes

### Core Changes

- Centralize directory resolution in `resolve-directory.ts`
- Strengthen `parse-args.ts` schema typing (`args-schema.types.ts`, `providers.types.ts`)
- Change `GlobalConfig` / `ChatlogWorks` config loading from async to sync
- Replace `baseDir` with `inputDir`/`chatlogsDir` sourced from `GlobalConfig` in:
  classify-chatlogs, filter-chatlogs/prefilter, normalize-chatlogs, set-frontmatter
- Remove the per-skill `chatlogsDir` config in export-chatlogs
- Rename normalize-chatlogs config fields (`baseDir` → `inputDir`,
  `normalizeDir` → `outputDir`)

### Test Updates

- Update unit/functional/integration/e2e/system tests for all five skills to match
  the new directory-resolution behavior and config field names
- Add coverage for default input-directory resolution when `--input-dir` is omitted

### Removed

- Per-skill `baseDir` config fields (superseded by `GlobalConfig.chatlogsDir`)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

*Optional: add screenshots, design notes, or concerns for reviewers.*
