### PR TITLE
refactor(schema): unify config and args schema across skills

### DIFF
--- a/skills/_scripts/classes/GlobalConfig.class.ts
+++ b/skills/_scripts/classes/GlobalConfig.class.ts
@@ -15,10 +15,11 @@ import { parse } from '@std/yaml';
 import { resolveConfigPath } from '../libs/path-utils/resolve-path.ts';
 import { parseNumber, parseString } from '../libs/text/string-utils.ts';
 // constants
+import { DEFAULT_CONFIG_SCHEMA, DEFAULT_CONFIG_VALUES } from '../constants/config-schema.constants.ts';
 import { DEFAULT_CONFIG_FILE } from '../constants/defaults.constants.ts';
-import { DEFAULT_SCHEMA, DEFAULT_VALUES } from '../constants/schema.constants.ts';
 // types
-import type { ConfigSchema, ConfigValues, DefaultSchemaKey, SchemaValueType } from '../constants/schema.constants.ts';
+import type { ConfigKey } from '../constants/config-schema.constants.ts';
+import type { ConfigSchema, ConfigValue, ConfigValues } from '../types/config-schema.types.ts';
 import type { ReadTextFileSyncProvider } from '../types/providers.types.ts';
 // classes
 import { ChatlogError } from './ChatlogError.class.ts';
@@ -40,15 +41,15 @@ export class GlobalConfig {
   private _fields: ConfigValues = {} as ConfigValues;
 
   private constructor(schema?: ConfigSchema) {
-    this._schema = schema || DEFAULT_SCHEMA;
-    this._fields = { ...DEFAULT_VALUES } as ConfigValues;
+    this._schema = schema || DEFAULT_CONFIG_SCHEMA;
+    this._fields = { ...DEFAULT_CONFIG_VALUES } as ConfigValues;
   }
 
   /**
    * シングルトンインスタンスを返す。インスタンスが未生成の場合は `options` を使って新規生成する。
    * - `yaml` が指定されていれば YAML 文字列を直接パースして `_fields` を上書きする（`configFile` より優先）。
-   * - `configFile` が指定されていれば YAML を読み込んで `_fields` を上書きする（DEFAULT_VALUES + YAML 値）。
-   * - ファイルが存在しない場合 (`FileDirNotFound`) はエラーを無視して `DEFAULT_VALUES` のまま返す。
+   * - `configFile` が指定されていれば YAML を読み込んで `_fields` を上書きする（DEFAULT_CONFIG_VALUES + YAML 値）。
+   * - ファイルが存在しない場合 (`FileDirNotFound`) はエラーを無視して `DEFAULT_CONFIG_VALUES` のまま返す。
    * - 既にインスタンスが存在する場合は `options` を無視して既存インスタンスを返す。
    */
   static getInstance(options?: {
@@ -62,19 +63,19 @@ export class GlobalConfig {
       if (options?.yaml !== undefined) {
         if (options.yaml !== '') {
           const _loaded = GlobalConfig._instance._parseYamlText(options.yaml);
-          GlobalConfig._instance._fields = { ...DEFAULT_VALUES, ..._loaded } as ConfigValues;
+          GlobalConfig._instance._fields = { ...DEFAULT_CONFIG_VALUES, ..._loaded } as ConfigValues;
         }
-        // 空文字列 → DEFAULT_VALUES のまま継続
+        // 空文字列 → DEFAULT_CONFIG_VALUES のまま継続
       } else if (options?.configFile) {
         try {
           const _loaded = GlobalConfig._instance.loadConfigFile({
             configPath: options.configFile,
             readTextFileProvider: options.readTextFileProvider,
           });
-          GlobalConfig._instance._fields = { ...DEFAULT_VALUES, ..._loaded } as ConfigValues;
+          GlobalConfig._instance._fields = { ...DEFAULT_CONFIG_VALUES, ..._loaded } as ConfigValues;
         } catch (e) {
           if (e instanceof ChatlogError && e.kind === 'FileDirNotFound') {
-            // ファイル未存在 → DEFAULT_VALUES のまま継続
+            // ファイル未存在 → DEFAULT_CONFIG_VALUES のまま継続
           } else {
             throw e;
           }
@@ -90,7 +91,7 @@ export class GlobalConfig {
   }
 
   /** `key` に対応する値を返す。すべてのスキーマキーはデフォルト値を持つため `undefined` は返さない。 */
-  get(key: DefaultSchemaKey): string | number {
+  get(key: ConfigKey): string | number {
     return this._fields[key];
   }
 
@@ -130,9 +131,9 @@ export class GlobalConfig {
     const _result: Partial<ConfigValues> = {};
     for (const [key, value] of Object.entries(raw)) {
       const _typeName = this._schema[key as keyof ConfigSchema];
-      const _parsed: SchemaValueType | undefined = _typeName === 'string' ? parseString(value) : parseNumber(value);
+      const _parsed: ConfigValue | undefined = _typeName === 'string' ? parseString(value) : parseNumber(value);
       if (_parsed !== undefined) {
-        (_result as Record<string, SchemaValueType>)[key] = _parsed;
+        (_result as Record<string, ConfigValue>)[key] = _parsed;
       }
     }
     return _result;

--- a/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
@@ -17,7 +17,7 @@ import { GlobalConfig } from '../../GlobalConfig.class.ts';
 // types
 import type { ReadTextFileSyncProvider } from '../../../types/providers.types.ts';
 // constants
-import { DEFAULT_VALUES } from '../../../constants/schema.constants.ts';
+import { DEFAULT_CONFIG_VALUES } from '../../../constants/config-schema.constants.ts';
 // classes
 import { ChatlogError } from '../../ChatlogError.class.ts';
 
@@ -93,7 +93,7 @@ describe('GlobalConfig', () => {
         assertEquals(_first.get('agent'), _second.get('agent'));
       });
 
-      it('[Normal] T-CLS-GC-40: 引数なしで呼ぶと get("agent") が DEFAULT_VALUES の値を返す', () => {
+      it('[Normal] T-CLS-GC-40: 引数なしで呼ぶと get("agent") が DEFAULT_CONFIG_VALUES の値を返す', () => {
         const _config = GlobalConfig.getInstance();
         assertEquals(_config.get('agent'), 'claude');
         assertEquals(_config.get('chatlogsDir'), './chatlogs');
@@ -200,7 +200,7 @@ describe('GlobalConfig', () => {
 
     /** 境界値・副作用・優先度など特殊なケース。 */
     describe('When: エッジケース', () => {
-      it('[Edge] T-CLS-GC-42: configFile 指定+存在しない → エラーなし、get("agent") が DEFAULT_VALUES の値を返す', () => {
+      it('[Edge] T-CLS-GC-42: configFile 指定+存在しない → エラーなし、get("agent") が DEFAULT_CONFIG_VALUES の値を返す', () => {
         const _config = GlobalConfig.getInstance({
           configFile: '/mock/missing.yaml',
           readTextFileProvider: _notFoundRead,
@@ -268,19 +268,19 @@ describe('GlobalConfig', () => {
   /**
    * `values` の全フィールド取得テスト。
    *
-   * DEFAULT_VALUES との一致・YAML 上書き後の反映を検証する。
+   * DEFAULT_CONFIG_VALUES との一致・YAML 上書き後の反映を検証する。
    */
   describe('values', () => {
     /** getInstance 直後・YAML 上書き後の全フィールド取得ケース。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-CLS-GC-81: getInstance 直後は DEFAULT_VALUES と一致する全フィールドを返す', () => {
+      it('[Normal] T-CLS-GC-81: getInstance 直後は DEFAULT_CONFIG_VALUES と一致する全フィールドを返す', () => {
         const _config = GlobalConfig.getInstance();
-        assertEquals(_config.values(), DEFAULT_VALUES);
+        assertEquals(_config.values(), DEFAULT_CONFIG_VALUES);
       });
 
-      it('[Normal] T-CLS-GC-82: YAML で agent を上書き後、agent は新しい値・他は DEFAULT_VALUES のままの全フィールドを返す', () => {
+      it('[Normal] T-CLS-GC-82: YAML で agent を上書き後、agent は新しい値・他は DEFAULT_CONFIG_VALUES のままの全フィールドを返す', () => {
         const _config = GlobalConfig.getInstance({ yaml: 'agent: chatgpt\n' });
-        assertEquals(_config.values(), { ...DEFAULT_VALUES, agent: 'chatgpt' });
+        assertEquals(_config.values(), { ...DEFAULT_CONFIG_VALUES, agent: 'chatgpt' });
       });
     });
   });
@@ -440,7 +440,7 @@ describe('GlobalConfig', () => {
         assertEquals(_calledPath, '/mock/config.yaml');
       });
 
-      it('[Normal] T-CLS-GC-32: loadConfigFile 後も get("agent") は DEFAULT_VALUES の値のまま（純粋関数性）', () => {
+      it('[Normal] T-CLS-GC-32: loadConfigFile 後も get("agent") は DEFAULT_CONFIG_VALUES の値のまま（純粋関数性）', () => {
         const _config = GlobalConfig.getInstance();
         _config.loadConfigFile({
           configPath: '/mock/config.yaml',

--- a/skills/_scripts/constants/config-schema.constants.ts
+++ b/skills/_scripts/constants/config-schema.constants.ts
@@ -1,4 +1,4 @@
-// src: skills/_scripts/constants/schema.constants.ts
+// src: skills/_scripts/constants/config-schema.constants.ts
 // @(#): GlobalConfig スキーマ定数
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -14,12 +14,11 @@ import {
   DEFAULT_PROJECTS_DIC_PATH,
   DEFAULT_PROMPTS_DIR,
 } from './defaults.constants.ts';
-
-export type SchemaValueType = string | number;
-export type SchemaValueTypeName = 'string' | 'number';
+// types
+import type { ConfigSchema, ConfigValues } from '../types/config-schema.types.ts';
 
 /** GlobalConfig のデフォルトスキーマ。登録済みキーと型を定義する。 */
-export const DEFAULT_SCHEMA: Record<string, SchemaValueTypeName> = {
+export const DEFAULT_CONFIG_SCHEMA: ConfigSchema = {
   /** 使用する AI エージェント識別子。例: "claude", "chatgpt" */
   agent: 'string',
   /** 使用するモデル名またはエイリアス。例: "sonnet", "opus" */
@@ -58,16 +57,11 @@ export const DEFAULT_SCHEMA: Record<string, SchemaValueTypeName> = {
   maxRetry: 'number',
 };
 
-/** DEFAULT_SCHEMA のキーのユニオン型。 */
-export type DefaultSchemaKey = keyof typeof DEFAULT_SCHEMA;
+/** DEFAULT_CONFIG_SCHEMA のキーのユニオン型。 */
+export type ConfigKey = keyof typeof DEFAULT_CONFIG_SCHEMA;
 
-/** GlobalConfig のスキーマ型。 */
-export type ConfigSchema = Record<DefaultSchemaKey, SchemaValueTypeName>;
-
-export type ConfigValues = Record<DefaultSchemaKey, SchemaValueType>;
-
-/** GlobalConfig のデフォルト値。DEFAULT_SCHEMA のすべてのキーに対する初期値を持つ。 */
-export const DEFAULT_VALUES = {
+/** GlobalConfig のデフォルト値。DEFAULT_CONFIG_SCHEMA のすべてのキーに対する初期値を持つ。 */
+export const DEFAULT_CONFIG_VALUES = {
   /** デフォルトエージェントは "claude" */
   agent: 'claude',
   /** デフォルトモデルは "sonnet" */

--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -27,7 +27,7 @@ import { GlobalConfig } from '../../../../classes/GlobalConfig.class.ts';
 // constants
 import { DEFAULT_CACHE_ROOT, DEFAULT_CHATLOGS_DIR } from '../../../../constants/defaults.constants.ts';
 // types
-import type { ArgsSchema } from '../../../../types/args-schema.types.ts';
+import type { ArgSchema, ParsedArgs } from '../../../../types/args-schema.types.ts';
 
 // ─── Internal Helpers
 
@@ -43,7 +43,7 @@ type TestConfig = {
 };
 
 // constants
-const TEST_SCHEMA: ArgsSchema<TestConfig> = [
+const TEST_SCHEMA: ArgSchema<TestConfig> = [
   { option: '--output', field: 'outputDir', type: 'string' },
   { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--verbose', field: 'verbose', type: 'flag' },
@@ -108,7 +108,7 @@ describe('_setByTypeForTest (negated)', () => {
   /** negated パラメータの正常系ケース。 */
   describe('When: 正常系', () => {
     it('[Normal] T-PA-ST-N-01: flag + negated=true → field が false にセットされる', () => {
-      const _config: Record<string, string | boolean | number> = {};
+      const _config: ParsedArgs = {};
       const _entry = { option: '--dry-run', field: 'dryRun', type: 'flag' as const };
       const _err = _setByTypeForTest(_config, _entry, undefined, true);
       assertEquals(_err, null);
@@ -116,7 +116,7 @@ describe('_setByTypeForTest (negated)', () => {
     });
 
     it('[Normal] T-PA-ST-N-04: flag + negated=false (未指定) → field が true にセットされる（既存回帰）', () => {
-      const _config: Record<string, string | boolean | number> = {};
+      const _config: ParsedArgs = {};
       const _entry = { option: '--dry-run', field: 'dryRun', type: 'flag' as const };
       const _err = _setByTypeForTest(_config, _entry, undefined);
       assertEquals(_err, null);
@@ -127,14 +127,14 @@ describe('_setByTypeForTest (negated)', () => {
   /** negated パラメータの異常系ケース。 */
   describe('When: 異常系', () => {
     it('[Error] T-PA-ST-N-02: flag + negated=true + rawValue → ChatlogError が返る', () => {
-      const _config: Record<string, string | boolean | number> = {};
+      const _config: ParsedArgs = {};
       const _entry = { option: '--dry-run', field: 'dryRun', type: 'flag' as const };
       const _err = _setByTypeForTest(_config, _entry, 'true', true);
       assertEquals(_err instanceof ChatlogError, true);
     });
 
     it('[Error] T-PA-ST-N-03: string 型 + negated=true → ChatlogError が返る', () => {
-      const _config: Record<string, string | boolean | number> = {};
+      const _config: ParsedArgs = {};
       const _entry = { option: '--output', field: 'outputDir', type: 'string' as const };
       const _err = _setByTypeForTest(_config, _entry, undefined, true);
       assertEquals(_err instanceof ChatlogError, true);
@@ -508,7 +508,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --period オプションに不正な形式の値', () => {
     /** period 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_PERIOD: ArgsSchema<TestConfig> = [
+    const _SCHEMA_WITH_PERIOD: ArgSchema<TestConfig> = [
       { option: '--period', field: 'period', type: 'period' },
     ];
 
@@ -562,7 +562,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --agent オプションに不明なエージェント名', () => {
     /** agent 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_AGENT: ArgsSchema<TestConfig> = [
+    const _SCHEMA_WITH_AGENT: ArgSchema<TestConfig> = [
       { option: '--agent', field: 'agent', type: 'agent' },
     ];
 
@@ -589,7 +589,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --limit オプションに非数値の値', () => {
     /** integer 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_INTEGER: ArgsSchema<TestConfig & { limit?: string }> = [
+    const _SCHEMA_WITH_INTEGER: ArgSchema<TestConfig & { limit?: string }> = [
       { option: '--limit', field: 'limit', type: 'integer' },
     ];
 
@@ -616,7 +616,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --ratio オプションに非数値の値', () => {
     /** number 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_WITH_NUMBER: ArgsSchema<TestConfig & { ratio?: string }> = [
+    const _SCHEMA_WITH_NUMBER: ArgSchema<TestConfig & { ratio?: string }> = [
       { option: '--ratio', field: 'ratio', type: 'number' },
     ];
 
@@ -642,7 +642,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --chunk-size オプションに整数値', () => {
     /** integer 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_INT: ArgsSchema<TestConfigWithChunkSize> = [
+    const _SCHEMA_INT: ArgSchema<TestConfigWithChunkSize> = [
       { option: '--chunk-size', field: 'chunkSize', type: 'integer' },
     ];
 
@@ -671,7 +671,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --threshold オプションに浮動小数点値', () => {
     /** number 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_NUM: ArgsSchema<TestConfigWithThreshold> = [
+    const _SCHEMA_NUM: ArgSchema<TestConfigWithThreshold> = [
       { option: '--threshold', field: 'threshold', type: 'number' },
     ];
 
@@ -696,7 +696,7 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: --agent オプションに既知エージェント名', () => {
     /** agent 型エントリを含むテスト用スキーマ。 */
-    const _SCHEMA_AGENT: ArgsSchema<TestConfig> = [
+    const _SCHEMA_AGENT: ArgSchema<TestConfig> = [
       { option: '--agent', field: 'agent', type: 'agent' },
     ];
 
@@ -847,7 +847,7 @@ describe('parseArgsToConfig', () => {
    * テスト ID 範囲: T-PA-31-01 〜 T-PA-31-03
    */
   describe('Given: --cache-dir オプションの directory 型バリデーション', () => {
-    const _SCHEMA_WITH_CACHE: ArgsSchema<TestConfigWithCache> = [
+    const _SCHEMA_WITH_CACHE: ArgSchema<TestConfigWithCache> = [
       { option: '--cache-dir', field: 'cacheDir', type: 'directory' },
     ];
 

--- a/skills/_scripts/libs/io/__tests__/unit/set-by-type.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/set-by-type.unit.spec.ts
@@ -18,13 +18,13 @@ import { _setByTypeForTest } from '../../parse-args.ts';
 // ─── Helpers
 import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
 // types
-import type { ArgSchemaEntry } from '../../../../types/args-schema.types.ts';
+import type { ArgSchemaEntry, ParsedArgs } from '../../../../types/args-schema.types.ts';
 
 // ─── Internal Helpers
 
 // functions
 /** テスト用に空の config オブジェクトを生成する。 */
-const _makeConfig = (): Record<string, string | boolean | number> => ({});
+const _makeConfig = (): ParsedArgs => ({});
 
 /** 指定した type と field を持つ ArgSchemaEntry を生成する。 */
 const _entry = (type: ArgSchemaEntry['type'], field = 'result'): ArgSchemaEntry => ({

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -14,7 +14,12 @@ import { normalizePath, toSlashPath } from '../path-utils/path-utils.ts';
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../classes/GlobalConfig.class.ts';
 // types
-import type { ArgSchemaEntry, ArgsSchema } from '../../types/args-schema.types.ts';
+import type {
+  ArgSchema,
+  ArgSchemaEntry,
+  DefaultArgFields,
+  ParsedArgs,
+} from '../../types/args-schema.types.ts';
 
 // -- internal modules ---
 // functions
@@ -29,7 +34,7 @@ export const isArgDirectory = (arg: string): boolean => {
 // --- Public API ---
 
 /** デフォルトで有効な位置引数フィールド定義。 */
-const _DEFAULT_SCHEMA: ArgsSchema = [
+const _DEFAULT_ARG_SCHEMA: ArgSchema<DefaultArgFields> = [
   { option: 'period', field: 'period', type: 'period' },
   { option: 'agent', field: 'agent', type: 'agent' },
   { option: '--config', field: 'configFile', type: 'string' },
@@ -44,8 +49,8 @@ const _DEFAULT_SCHEMA: ArgsSchema = [
  * @param schema - 呼び出し元が追加するスキーマ
  * @returns オプション名をキーとする `ArgSchemaEntry` の Map
  */
-const _initSchema = (schema: ArgsSchema): Map<string, ArgSchemaEntry> => {
-  const _merged = [..._DEFAULT_SCHEMA, ...schema];
+const _initSchema = (schema: ArgSchema): Map<string, ArgSchemaEntry> => {
+  const _merged = [..._DEFAULT_ARG_SCHEMA, ...schema];
   return new Map(_merged.map((e) => [e.option, e]));
 };
 
@@ -61,7 +66,7 @@ const _initSchema = (schema: ArgsSchema): Map<string, ArgSchemaEntry> => {
  * @returns 成功時 `null`、失敗時 `ChatlogError`
  */
 const _setByType = (
-  config: Record<string, string | boolean | number>,
+  config: ParsedArgs,
   entry: ArgSchemaEntry,
   rawValue?: string,
   negated?: boolean,
@@ -150,7 +155,7 @@ const _setByType = (
  * @param rawValue - CLI から取得した生文字列
  */
 const _assignEntry = (
-  config: Record<string, string | boolean | number>,
+  config: ParsedArgs,
   schemaMap: Map<string, ArgSchemaEntry>,
   optionKey: string,
   rawValue: string,
@@ -173,7 +178,7 @@ const _assignEntry = (
  * @param rawValue - CLI から取得した生文字列
  */
 const _assignOutputDirEntry = (
-  config: Record<string, string | boolean | number>,
+  config: ParsedArgs,
   schemaMap: Map<string, ArgSchemaEntry>,
   rawValue: string,
 ): void => {
@@ -196,7 +201,7 @@ const _assignOutputDirEntry = (
  * @param schemaMap - `_initSchema` が返すスキーマ Map（`_assignEntry` に渡すエントリ取得用）
  */
 const _parsePositionals = (
-  config: Record<string, string | boolean | number>,
+  config: ParsedArgs,
   positionals: string[],
   schemaMap: Map<string, ArgSchemaEntry>,
 ): void => {
@@ -246,9 +251,9 @@ const _parsePositionals = (
  */
 export const parseOptions = <T>(
   args: string[],
-  schema: ArgsSchema<T>,
-): { config: Partial<T>; positionals: string[] } => {
-  const _config: Record<string, string | boolean | number> = {};
+  schema: ArgSchema<T>,
+): { config: ParsedArgs; positionals: string[] } => {
+  const _config: ParsedArgs = {};
   const _positionals: string[] = [];
   const _schemaMap = _initSchema(schema);
 
@@ -287,7 +292,7 @@ export const parseOptions = <T>(
     _positionals.push(arg);
   }
 
-  return { config: _config as Partial<T>, positionals: _positionals };
+  return { config: _config, positionals: _positionals };
 };
 
 /**
@@ -303,13 +308,10 @@ export const parseOptions = <T>(
  */
 export const parseArgs = <T extends { period?: string; agent?: string; chatlogsDir?: string }>(
   args: string[],
-  schema: ArgsSchema<T>,
+  schema: ArgSchema<T>,
   defaults: Partial<T> = {},
-): Partial<T> => {
-  const { config: _config, positionals: _positionals } = parseOptions<T>(args, schema) as unknown as {
-    config: Record<string, string | boolean | number>;
-    positionals: string[];
-  };
+): T => {
+  const { config: _config, positionals: _positionals } = parseOptions<T>(args, schema);
   const _schemaMap = _initSchema(schema);
 
   _parsePositionals(_config, _positionals, _schemaMap);
@@ -317,13 +319,13 @@ export const parseArgs = <T extends { period?: string; agent?: string; chatlogsD
   // 優先度: CLI 解析値 > GlobalConfig 値 > defaults
   const _globalConfig = GlobalConfig.getInstance({ configFile: _config.configFile as string | undefined });
   const _globalValues = _globalConfig.values();
-  const _merged: Record<string, string | boolean | number> = {
-    ...(defaults as Record<string, string | boolean | number>),
+  const _merged: ParsedArgs = {
+    ...(defaults as ParsedArgs),
     ..._globalValues,
     ..._config,
   };
 
-  return _merged as Partial<T>;
+  return _merged as T;
 };
 
 // --- Test-only exports ---

--- a/skills/_scripts/types/args-schema.types.ts
+++ b/skills/_scripts/types/args-schema.types.ts
@@ -17,4 +17,26 @@ export interface ArgSchemaEntry<K extends string = string> {
 }
 
 /** parseArgs に渡すスキーマ。オプション定義の配列（複数スキーマを結合してから使う）。 */
-export type ArgsSchema<T = Record<string, unknown>> = ArgSchemaEntry<keyof T & string>[];
+export type ArgSchema<T = Record<string, unknown>> = ArgSchemaEntry<keyof T & string>[];
+
+/** `parseArgs` の `_DEFAULT_ARG_SCHEMA` が生成するフィールド定義。全 parseArgs 呼び出しに共通で追加される。 */
+export type DefaultArgFields = {
+  period?: string;
+  agent?: string;
+  configFile?: string;
+  dryRun?: boolean;
+  inputDir?: string;
+  outputDir?: string;
+};
+
+/** parseArgs 内部でパース中に使う値の型（文字列・真偽値・数値のいずれか）。 */
+export type ArgValue = string | boolean | number;
+
+/** parseArgs 内部でパース中に構築される config オブジェクトの型。 */
+export type ParsedArgs = Record<string, ArgValue>;
+
+/** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ParsedArgs>> = T;
+
+/** DefaultArgFields が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
+type _DefaultArgFieldsCheck = _Assert<DefaultArgFields>;

--- a/skills/_scripts/types/config-schema.types.ts
+++ b/skills/_scripts/types/config-schema.types.ts
@@ -1,0 +1,15 @@
+// src: skills/_scripts/types/config-schema.types.ts
+// @(#): GlobalConfig スキーマ型定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+export type ConfigValue = string | number;
+export type ConfigFieldType = 'string' | 'number';
+
+/** GlobalConfig のスキーマ型。 */
+export type ConfigSchema = Record<string, ConfigFieldType>;
+
+export type ConfigValues = Record<string, ConfigValue>;

--- a/skills/classify-chatlogs/scripts/modules/classify-config.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-config.ts
@@ -12,7 +12,7 @@ import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { isValidModel } from '../../../_scripts/libs/ai/model-utils.ts';
 import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 // types
-import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
+import type { ArgSchema } from '../../../_scripts/types/args-schema.types.ts';
 
 // ─── Local
 // types
@@ -20,8 +20,9 @@ import type { ClassifyConfig } from '../types/classify.types.ts';
 // constants
 import { DEFAULT_CLASSIFY_CONFIG } from '../constants/classify.constants.ts';
 
+// ─── internal
 /** classify-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema<ClassifyConfig> = [
+const _SCHEMA: ArgsSchema<Partial<ClassifyConfig>> = [
   { option: '--period', field: 'period', type: 'period' },
   { option: '--model', field: 'model', type: 'string' },
 ];
@@ -29,7 +30,7 @@ const _SCHEMA: ArgsSchema<ClassifyConfig> = [
 /**
  * CLI 引数から完全な ClassifyConfig を構築する。
  * - `parseArgsToConfig`（共通ライブラリの `parseArgs`）が CLI 引数・GlobalConfig・defaults を
- *   「CLI > GlobalConfig > defaults」の優先度で内部マージ済みの `Partial<ClassifyConfig>` を返すため、
+ *   「CLI > GlobalConfig > defaults」の優先度で内部マージ済みの `ClassifyParsedConfig` を返すため、
  *   GlobalConfig の値を個別に再取得しない。
  * - `model` は `isValidModel` で検証し、不正なモデル名は `ChatlogError('InvalidArgs', 'InvalidModel')` をスローする。
  */
@@ -40,9 +41,9 @@ export const buildConfig = (
   const _defaults = defaults ?? DEFAULT_CLASSIFY_CONFIG;
   const parsed = parseArgsToConfig<ClassifyConfig>(args, _SCHEMA, _defaults) as ClassifyConfig;
 
-  if (!isValidModel(parsed.model)) {
+  const _model = parsed.model;
+  if (!isValidModel(_model)) {
     throw new ChatlogError('InvalidArgs', 'InvalidModel', `不正なモデル名: ${parsed.model}`);
   }
-
   return parsed;
 };

--- a/skills/classify-chatlogs/scripts/modules/classify-config.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-config.ts
@@ -22,7 +22,7 @@ import { DEFAULT_CLASSIFY_CONFIG } from '../constants/classify.constants.ts';
 
 // ─── internal
 /** classify-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema<Partial<ClassifyConfig>> = [
+const _SCHEMA: ArgSchema<Partial<ClassifyConfig>> = [
   { option: '--period', field: 'period', type: 'period' },
   { option: '--model', field: 'model', type: 'string' },
 ];

--- a/skills/classify-chatlogs/scripts/types/classify.types.ts
+++ b/skills/classify-chatlogs/scripts/types/classify.types.ts
@@ -11,6 +11,7 @@
 // ─── Imports
 // types
 import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
 import type { GlobProvider } from '../../../_scripts/types/providers.types.ts';
 
 // ─────────────────────────────────────────────
@@ -59,11 +60,9 @@ export interface ClassifyStats {
 // ─────────────────────────────────────────────
 
 /** `main` が使用する分類処理の設定。すべてのフィールドに値が入る。 */
-export interface ClassifyConfig {
+export type ClassifyConfig = DefaultArgFields & {
   /** 対象 AI エージェント名（例: `claude`, `chatgpt`）。 */
   agent: string;
-  /** 対象年月（`YYYY-MM` 形式）。省略時は全期間。 */
-  period?: string;
   /** `true` のときファイルを移動せず分類結果のみ表示する。 */
   dryRun: boolean;
   /** `projects.dic` が置かれた辞書ディレクトリのパス。 */
@@ -74,13 +73,20 @@ export interface ClassifyConfig {
   model: string;
   /** チャットログが格納された基準ディレクトリのパス（GlobalConfig の chatlogsDir 由来）。 */
   chatlogsDir: string;
-  /** 入力ディレクトリのフルパス直接指定。指定時は agent/period を無視してこのパスをそのまま使う。 */
-  inputDir?: string;
   /** バッチリクエスト1回あたりの最大ファイル数。 */
   chunkSize: number;
   /** 同時実行する並列タスク数の上限。 */
   concurrency: number;
-}
+};
+
+/** `classify-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
+export type ClassifyParsedConfig = Partial<ClassifyConfig>;
+
+/** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ParsedArgs>> = T;
+
+/** ClassifyConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
+type _ClassifyConfigCheck = _Assert<ClassifyConfig>;
 
 // ─────────────────────────────────────────────
 // 分類バッファ型

--- a/skills/export-chatlogs/scripts/export-chatlogs.ts
+++ b/skills/export-chatlogs/scripts/export-chatlogs.ts
@@ -23,9 +23,9 @@
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 // libs
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { parseArgs as parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { parseArgs } from '../../_scripts/libs/io/parse-args.ts';
 import { joinPath } from '../../_scripts/libs/path-utils/path-utils.ts';
-import type { ArgsSchema } from '../../_scripts/types/args-schema.types.ts';
+import type { ArgSchema } from '../../_scripts/types/args-schema.types.ts';
 // constants
 import { DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 
@@ -45,7 +45,7 @@ import type { ExportResult } from './types/export-result.types.ts';
 // ─────────────────────────────────────────────
 
 /** export-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema<ParsedConfig> = [
+const _SCHEMA: ArgSchema<ParsedConfig> = [
   { option: '--export-dir', field: 'exportDir', type: 'directory' },
   { option: '--base', field: 'baseDir', type: 'directory' },
 ];
@@ -71,15 +71,12 @@ export const buildConfig = (
   defaults?: ExportConfig,
 ): ExportConfig => {
   const _defaults = defaults ?? DEFAULT_EXPORT_CONFIG;
-  const parsed = parseArgsToConfig<ParsedConfig>(args, _SCHEMA) as ParsedConfig;
+  const { exportDir: _unusedExportDir, ..._defaultsWithoutExportDir } = _defaults;
+  const parsed = parseArgs<ExportConfig>(args, _SCHEMA, _defaultsWithoutExportDir as ExportConfig);
   const _chatlogsDir = parsed.chatlogsDir ?? DEFAULT_CHATLOGS_DIR;
   const _exportDir = parsed.exportDir ?? joinPath(_chatlogsDir, DEFAULT_ORIGINAL_LOGS_DIR);
-  const { configFile: _configFile, chatlogsDir: _chatlogsDirField, outputDir: _outputDir, ...parsedRest } = parsed;
-  return {
-    ..._defaults,
-    ...parsedRest,
-    exportDir: _exportDir,
-  };
+  const { configFile: _unusedConfigFile, ..._rest } = parsed;
+  return { ..._rest, exportDir: _exportDir } as ExportConfig;
 };
 
 // ─────────────────────────────────────────────

--- a/skills/export-chatlogs/scripts/types/export-config.types.ts
+++ b/skills/export-chatlogs/scripts/types/export-config.types.ts
@@ -6,55 +6,46 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// types
+import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
+
+// --- type
+
 /**
  * `parseArgs()` が CLI 引数から生成するエクスポート実行設定。
  *
  * `main()` 関数がこの設定を受け取り、エージェント選択・期間フィルタ・
  * 出力先パスを決定する。`DEFAULT_EXPORT_CONFIG` がデフォルト値のベースになる。
  *
+ * `agent`・`period`・`configFile`・`dryRun`・`inputDir`・`outputDir` は
+ * 共通スキーマ由来の `DefaultArgFields` から供給される。
+ * `outputDir` は export-chatlogs では使用せず破棄する。
+ *
  * @see parseArgs
  * @see main
  * @see DEFAULT_EXPORT_CONFIG
  */
-export interface ExportConfig {
+export type ExportConfig = DefaultArgFields & {
   /** 対象エージェント名。"claude" または "codex" */
   agent: string;
-  /**
-   * エクスポート対象期間。
-   * "YYYY-MM"（月指定）または "YYYY"（年指定）の文字列。
-   * 省略時は全期間が対象となる。
-   */
-  period?: string;
   /**
    * 入力ベースディレクトリ（将来拡張用）。
    * 省略時は `homeDir()` を基点として各エージェントのデフォルトパスを使用する。
    */
   baseDir?: string;
-  /**
-   * ChatGPT エクスポートディレクトリ。`chatgpt` エージェント使用時に `baseDir` より優先される。
-   */
-  inputDir?: string;
   /** 出力先ディレクトリのベースパス。デフォルトは "./chatlogs" */
   exportDir: string;
-  /** dry-run モード。`--dry-run` オプションの解析結果を保持する（現状 `main()` 側での書き込みスキップは未実装）。 */
-  dryRun?: boolean;
-}
+  /** GlobalConfig から解決されたチャットログディレクトリ。`exportDir` 未指定時のフォールバック元。 */
+  chatlogsDir?: string;
+};
 
 /**
  * `parseArgs()` が CLI 引数から生成する未解決設定。`buildConfig()` が完全な `ExportConfig` に解決する。
- *
- * `configFile` は `GlobalConfig.getInstance()` に渡す設定ファイルパスを保持する専用フィールドであり、
- * `ExportConfig` には含まれない。
- * `chatlogsDir` は共通 `parseArgs()` が GlobalConfig からマージする値を受け取る専用フィールドであり、
- * `ExportConfig` には含まれない（`exportDir` の算出にのみ使用する）。
- * `outputDir` は共通スキーマ（`--output-dir`）が書き込む専用フィールドであり、
- * `ExportConfig` には含まれない（export-chatlogs では使用せず破棄する）。
  */
-export type ParsedConfig = Partial<ExportConfig> & {
-  /** グローバル設定ファイルのパス。`--config` オプションで指定する。 */
-  configFile?: string;
-  /** GlobalConfig から解決されたチャットログディレクトリ。`exportDir` 未指定時のフォールバック元。 */
-  chatlogsDir?: string;
-  /** 共通スキーマの `--output-dir` が書き込む値。export-chatlogs では使用せず破棄する。 */
-  outputDir?: string;
-};
+export type ParsedConfig = Partial<ExportConfig>;
+
+/** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ParsedArgs>> = T;
+
+/** ExportConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
+type _ExportConfigCheck = _Assert<ExportConfig>;

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -321,7 +321,7 @@ describe('buildConfig', () => {
     });
 
     describe('When: GlobalConfig にも chunkSize が設定されていない', () => {
-      /** GlobalConfig の DEFAULT_VALUES.chunkSize が使われることを検証する。 */
+      /** GlobalConfig の DEFAULT_CONFIG_VALUES.chunkSize が使われることを検証する。 */
       describe('Then: T-FL-BC-11b - GlobalConfig のデフォルト chunkSize が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
@@ -380,7 +380,7 @@ describe('buildConfig', () => {
     });
 
     describe('When: GlobalConfig にも concurrency が設定されていない', () => {
-      /** GlobalConfig の DEFAULT_VALUES.concurrency が使われることを検証する。 */
+      /** GlobalConfig の DEFAULT_CONFIG_VALUES.concurrency が使われることを検証する。 */
       describe('Then: T-FL-BC-16 - GlobalConfig のデフォルト concurrency が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
@@ -439,7 +439,7 @@ describe('buildConfig', () => {
     });
 
     describe('When: GlobalConfig にも minCharCount が設定されていない', () => {
-      /** GlobalConfig の DEFAULT_VALUES.minCharCount が使われることを検証する。 */
+      /** GlobalConfig の DEFAULT_CONFIG_VALUES.minCharCount が使われることを検証する。 */
       describe('Then: T-FL-BC-23 - GlobalConfig のデフォルト minCharCount が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
@@ -498,7 +498,7 @@ describe('buildConfig', () => {
     });
 
     describe('When: GlobalConfig にも minAssistantChars が設定されていない', () => {
-      /** GlobalConfig の DEFAULT_VALUES.minAssistantChars が使われることを検証する。 */
+      /** GlobalConfig の DEFAULT_CONFIG_VALUES.minAssistantChars が使われることを検証する。 */
       describe('Then: T-FL-BC-26 - GlobalConfig のデフォルト minAssistantChars が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {

--- a/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/prefilter-config.ts
@@ -10,7 +10,7 @@
 // functions
 import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 // types
-import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
+import type { ArgSchema } from '../../../_scripts/types/args-schema.types.ts';
 // classes
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
@@ -25,7 +25,7 @@ import type { PrefilterConfig, PrefilterParsedConfig } from '../types/prefilter.
 // ─────────────────────────────────────────────
 
 /** prefilter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema<PrefilterParsedConfig> = [
+const _SCHEMA: ArgSchema<PrefilterParsedConfig> = [
   { option: '--report', field: 'report', type: 'flag' },
 ];
 

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -8,8 +8,8 @@
 
 // ─── shared ───
 // constants
+import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
 import { DEFAULT_AGENT, DEFAULT_CHATLOGS_DIR } from '../../../_scripts/constants/defaults.constants.ts';
-import { DEFAULT_VALUES } from '../../../_scripts/constants/schema.constants.ts';
 
 // ─── internal ───
 // types
@@ -40,9 +40,9 @@ export const DEFAULT_FILTER_CONFIG: FilterConfig = {
   chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dryRun: false,
   // config.yaml only
-  chunkSize: DEFAULT_VALUES.chunkSize,
-  concurrency: DEFAULT_VALUES.concurrency,
-  minCharCount: DEFAULT_VALUES.minCharCount,
-  minAssistantChars: DEFAULT_VALUES.minAssistantChars,
-  discardThreshold: DEFAULT_VALUES.discardThreshold,
+  chunkSize: DEFAULT_CONFIG_VALUES.chunkSize,
+  concurrency: DEFAULT_CONFIG_VALUES.concurrency,
+  minCharCount: DEFAULT_CONFIG_VALUES.minCharCount,
+  minAssistantChars: DEFAULT_CONFIG_VALUES.minAssistantChars,
+  discardThreshold: DEFAULT_CONFIG_VALUES.discardThreshold,
 };

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -32,7 +32,7 @@ import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.ts';
 // types
-import type { ArgsSchema } from '../../_scripts/types/args-schema.types.ts';
+import type { ArgSchema } from '../../_scripts/types/args-schema.types.ts';
 
 // ─── internal ───
 // functions
@@ -48,7 +48,7 @@ import type { FilterConfig, FilterParsedConfig } from './types/filter.types.ts';
 // ─────────────────────────────────────────────
 
 /** filter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgsSchema<FilterParsedConfig> = [];
+const _SCHEMA: ArgSchema<FilterParsedConfig> = [];
 
 export const parseArgs = (args: string[]): FilterParsedConfig => {
   return parseArgsToConfig<FilterParsedConfig>(args, _SCHEMA);

--- a/skills/filter-chatlogs/scripts/libs/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/libs/prefilter.ts
@@ -23,7 +23,7 @@ import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { parseFrontmatterEntries } from '../../../_scripts/libs/text/frontmatter-utils.ts';
 // constants
-import { DEFAULT_VALUES } from '../../../_scripts/constants/schema.constants.ts';
+import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
 
 // ─── internal ───
 // functions
@@ -71,14 +71,14 @@ export const isExcludedByFilename = (filename: string): boolean => checkFilename
  * 4. User ターンが 1 件のとき、Assistant 応答の合計文字数が `minAssistantChars` 未満
  *
  * @param body - 判定対象の本文テキスト（frontmatter を除いたコンテンツ部分）
- * @param minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_VALUES.minCharCount`）
- * @param minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_VALUES.minAssistantChars`）
+ * @param minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）
+ * @param minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）
  * @returns `excluded: true` の場合は除外対象。`reason` に除外理由を格納する。
  */
 export const isExcludedByContent = (
   body: string,
-  minCharCount = DEFAULT_VALUES.minCharCount as number,
-  minAssistantChars = DEFAULT_VALUES.minAssistantChars as number,
+  minCharCount = DEFAULT_CONFIG_VALUES.minCharCount as number,
+  minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
 ): { excluded: boolean; reason: string } => {
   if (body.length < minCharCount) {
     return { excluded: true, reason: `本文が短すぎる (${body.length} < ${minCharCount} 文字)` };
@@ -110,15 +110,15 @@ export const isExcludedByContent = (
  * ファイルリストをファイル名パターンと本文内容で事前フィルタリングし、通過したパスを返す。
  *
  * @param files - フィルタリング対象のファイルパス配列
- * @param minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_VALUES.minCharCount`）
- * @param minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_VALUES.minAssistantChars`）
+ * @param minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）
+ * @param minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）
  * @param stats - 処理統計オブジェクト（省略可）。指定時は `preSkipped` にスキップ数を代入する。
  * @returns フィルタリングを通過したファイルパスの配列
  */
 export const prefilterFiles = async (
   files: string[],
-  minCharCount = DEFAULT_VALUES.minCharCount as number,
-  minAssistantChars = DEFAULT_VALUES.minAssistantChars as number,
+  minCharCount = DEFAULT_CONFIG_VALUES.minCharCount as number,
+  minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
   stats?: FilterStats,
 ): Promise<string[]> => {
   const passed: string[] = [];

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -25,7 +25,7 @@ import {
   makeNotFoundMock,
   makeSuccessMock,
 } from '../../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import { DEFAULT_VALUES } from '../../../../../../_scripts/constants/schema.constants.ts';
+import { DEFAULT_CONFIG_VALUES } from '../../../../../../_scripts/constants/config-schema.constants.ts';
 // types
 import type { CommandMockHandle } from '../../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makePeriodDir } from '../../../../__tests__/_helpers/fixtures.ts';
@@ -43,8 +43,8 @@ import { fileExists, fileOrDirExists } from '../../../../../../_scripts/libs/fil
  * DISCARD/KEEP 判定に応じてファイル削除と統計更新を行う。
  *
  * ## 判定ルール
- * - `decision === 'DISCARD'` かつ `confidence >= DEFAULT_VALUES.discardThreshold` → ファイルを削除（dryRun=false 時）
- * - `confidence < DEFAULT_VALUES.discardThreshold` → DISCARD 判定でも KEEP 扱い
+ * - `decision === 'DISCARD'` かつ `confidence >= DEFAULT_CONFIG_VALUES.discardThreshold` → ファイルを削除（dryRun=false 時）
+ * - `confidence < DEFAULT_CONFIG_VALUES.discardThreshold` → DISCARD 判定でも KEEP 扱い
  * - CLI エラー・JSON パース失敗・ファイル名不一致 → 全件 KEEP 扱い
  *
  * テスト ID 範囲: T-FL-PCK-01 〜 T-FL-PCK-08
@@ -105,7 +105,12 @@ describe('processChunk', () => {
         it('T-FL-PCK-01-01: ファイルが残っている', async () => {
           const filePath = await _createTempFile('a.md');
           const response = JSON.stringify([
-            { file: 'a.md', decision: 'DISCARD', confidence: DEFAULT_VALUES.discardThreshold, reason: 'trivial' },
+            {
+              file: 'a.md',
+              decision: 'DISCARD',
+              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+              reason: 'trivial',
+            },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -114,7 +119,7 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], true, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], true, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
           logStub.restore();
 
@@ -124,7 +129,12 @@ describe('processChunk', () => {
         it('T-FL-PCK-01-02: stats.discarded が 1 になる', async () => {
           const filePath = await _createTempFile('a.md');
           const response = JSON.stringify([
-            { file: 'a.md', decision: 'DISCARD', confidence: DEFAULT_VALUES.discardThreshold, reason: 'trivial' },
+            {
+              file: 'a.md',
+              decision: 'DISCARD',
+              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+              reason: 'trivial',
+            },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -133,7 +143,7 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], true, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], true, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
           logStub.restore();
 
@@ -156,7 +166,12 @@ describe('processChunk', () => {
         it('T-FL-PCK-02-01: ファイルが削除される', async () => {
           const filePath = await _createTempFile('b.md');
           const response = JSON.stringify([
-            { file: 'b.md', decision: 'DISCARD', confidence: DEFAULT_VALUES.discardThreshold, reason: 'trivial' },
+            {
+              file: 'b.md',
+              decision: 'DISCARD',
+              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+              reason: 'trivial',
+            },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -165,7 +180,7 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
           logStub.restore();
 
@@ -175,7 +190,12 @@ describe('processChunk', () => {
         it('T-FL-PCK-02-02: stats.discarded が 1 になる', async () => {
           const filePath = await _createTempFile('c.md');
           const response = JSON.stringify([
-            { file: 'c.md', decision: 'DISCARD', confidence: DEFAULT_VALUES.discardThreshold, reason: 'trivial' },
+            {
+              file: 'c.md',
+              decision: 'DISCARD',
+              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+              reason: 'trivial',
+            },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -184,7 +204,7 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
           logStub.restore();
 
@@ -215,7 +235,7 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
           assertEquals(stats.kept, 1);
@@ -225,7 +245,7 @@ describe('processChunk', () => {
   });
 
   /**
-   * DISCARD 判定だが `confidence` が `DEFAULT_VALUES.discardThreshold`（0.7）未満の前提条件グループ。
+   * DISCARD 判定だが `confidence` が `DEFAULT_CONFIG_VALUES.discardThreshold`（0.7）未満の前提条件グループ。
    *
    * 信頼度不足の DISCARD は KEEP 扱いとなることを検証する。
    */
@@ -245,7 +265,7 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
           assertEquals(stats.kept, 1);
@@ -272,7 +292,7 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([file1, file2], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([file1, file2], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
           assertEquals(stats.kept, 2);
@@ -299,7 +319,7 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
           assertEquals(stats.kept, 1);
@@ -330,7 +350,7 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
           assertEquals(stats.kept, 1);
@@ -355,7 +375,7 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_VALUES.discardThreshold as number);
+          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
           assertEquals(stats.kept, 1);

--- a/skills/filter-chatlogs/scripts/types/prefilter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/prefilter.types.ts
@@ -6,26 +6,29 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// types
+import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
+
 /** `prefilter-chatlogs` の `main` が使用する設定。すべてのフィールドに値が入る。 */
-export interface PrefilterConfig {
+export type PrefilterConfig = DefaultArgFields & {
   /** 対象 AI エージェント名（例: `claude`, `chatgpt`）。 */
   agent: string;
-  /** 対象年月（`YYYY-MM` 形式）。省略時は全期間。 */
-  period?: string;
   /** チャットログが格納された基準ディレクトリのパス（GlobalConfig の chatlogsDir 由来）。 */
   chatlogsDir: string;
-  /** 入力ディレクトリのフルパス直接指定。指定時は agent/period を無視してこのパスをそのまま使う。 */
-  inputDir?: string;
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */
   dryRun: boolean;
   /** `true` のときノイズファイル一覧をタブ区切りで出力する（`dryRun` も暗示）。 */
   report: boolean;
-}
+};
 
 /** `prefilter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
-export type PrefilterParsedConfig = Partial<PrefilterConfig> & {
-  configFile?: string;
-};
+export type PrefilterParsedConfig = Partial<PrefilterConfig>;
+
+/** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ParsedArgs>> = T;
+
+/** PrefilterConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
+type _PrefilterConfigCheck = _Assert<PrefilterConfig>;
 
 /** prefilter 処理の統計情報。 */
 export interface PrefilterStats {

--- a/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
+++ b/skills/normalize-chatlogs/scripts/modules/normalize-config.ts
@@ -15,7 +15,7 @@ import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-
 import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
 // types
-import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
+import type { ArgSchema } from '../../../_scripts/types/args-schema.types.ts';
 
 // constants
 import { DEFAULT_CONCURRENCY } from '../../../_scripts/constants/defaults.constants.ts';
@@ -29,7 +29,7 @@ import { DEFAULT_NORMALIZE_CONFIG } from '../constants/normalize.constants.ts';
 
 // --- local
 // constants
-const _SCHEMA: ArgsSchema<NormalizeParsedConfig> = [
+const _SCHEMA: ArgSchema<NormalizeParsedConfig> = [
   { option: '--agent', field: 'agent', type: 'agent' },
   { option: '--period', field: 'period', type: 'period' },
   { option: '--concurrency', field: 'concurrency', type: 'integer' },

--- a/skills/normalize-chatlogs/scripts/types/normalize.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/normalize.types.ts
@@ -6,6 +6,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// types
+import type { ArgsRecordEntry, DefaultSchemaFields } from '../../../_scripts/types/args-schema.types.ts';
+
 /**
  * {@link segmentChatlogs} が AI から受け取る 1 トピックセグメント。
  *
@@ -47,20 +50,20 @@ export type Stats = {
   fallback: number;
 };
 
-export interface NormalizeConfig {
+export type NormalizeConfig = DefaultSchemaFields & {
   chatlogsDir: string;
-  inputDir?: string;
-  agent?: string;
-  period?: string;
   model?: string;
   timeoutMs?: number;
   dryRun: boolean;
   concurrency: number;
-  outputDir?: string;
   failFast?: boolean;
   singleFile?: boolean;
-}
-
-export type NormalizeParsedConfig = Partial<NormalizeConfig> & {
-  configFile?: string;
 };
+
+export type NormalizeParsedConfig = Partial<NormalizeConfig>;
+
+/** T が ArgsValueEntry 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ArgsRecordEntry>> = T;
+
+/** NormalizeConfig が ArgsValueEntry 互換であることの型チェック（実行時に影響なし）。 */
+type _NormalizeConfigCheck = _Assert<NormalizeConfig>;

--- a/skills/normalize-chatlogs/scripts/types/normalize.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/normalize.types.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { ArgsRecordEntry, DefaultSchemaFields } from '../../../_scripts/types/args-schema.types.ts';
+import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
 
 /**
  * {@link segmentChatlogs} が AI から受け取る 1 トピックセグメント。
@@ -50,7 +50,7 @@ export type Stats = {
   fallback: number;
 };
 
-export type NormalizeConfig = DefaultSchemaFields & {
+export type NormalizeConfig = DefaultArgFields & {
   chatlogsDir: string;
   model?: string;
   timeoutMs?: number;
@@ -62,8 +62,8 @@ export type NormalizeConfig = DefaultSchemaFields & {
 
 export type NormalizeParsedConfig = Partial<NormalizeConfig>;
 
-/** T が ArgsValueEntry 互換であることをコンパイル時に強制するための恒等型。 */
-type _Assert<T extends Partial<ArgsRecordEntry>> = T;
+/** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ParsedArgs>> = T;
 
-/** NormalizeConfig が ArgsValueEntry 互換であることの型チェック（実行時に影響なし）。 */
+/** NormalizeConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
 type _NormalizeConfigCheck = _Assert<NormalizeConfig>;

--- a/skills/set-frontmatter/scripts/modules/setfm-config.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-config.ts
@@ -23,14 +23,14 @@ import {
   DEFAULT_PROMPTS_DIR,
 } from '../../../_scripts/constants/defaults.constants.ts';
 // types
-import type { ArgsSchema } from '../../../_scripts/types/args-schema.types.ts';
+import type { ArgSchema } from '../../../_scripts/types/args-schema.types.ts';
 
 // ─── Local
 // types
 import type { ParsedConfig, SetfmConfig } from '../types/args.types.ts';
 
 /** set-frontmatter の引数スキーマ。 */
-const _SCHEMA: ArgsSchema<ParsedConfig> = [
+const _SCHEMA: ArgSchema<ParsedConfig> = [
   { option: '--dics', field: 'dicsDir', type: 'directory' },
   { option: '--prompts', field: 'promptsDir', type: 'directory' },
   { option: '--review', field: 'review', type: 'flag' },

--- a/skills/set-frontmatter/scripts/types/args.types.ts
+++ b/skills/set-frontmatter/scripts/types/args.types.ts
@@ -8,12 +8,15 @@
 
 // cspell:words setfm
 
+// types
+import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
+
 // ─────────────────────────────────────────────
 // 設定型
 // ─────────────────────────────────────────────
 
 /** `buildConfig` が返す完全な設定（すべてのフィールドが必須）。 */
-export interface SetfmConfig {
+export type SetfmConfig = DefaultArgFields & {
   /**
    * チャットログを読み込む入力ディレクトリのパス。
    * `--input-dir` 明示指定時のみ `buildConfig` が値を持つ（未指定時は空文字列）。
@@ -24,8 +27,6 @@ export interface SetfmConfig {
   outputDir: string;
   /** 対象エージェント名。 */
   agent: string;
-  /** 絞り込み対象の期間（`YYYY` または `YYYY-MM`）。未指定時は全期間対象。 */
-  period?: string;
   /** チャットログの基準ディレクトリのパス（GlobalConfig 由来）。 */
   chatlogsDir: string;
   /** 辞書ファイルが置かれたディレクトリのパス。 */
@@ -42,10 +43,13 @@ export interface SetfmConfig {
   maxRetry: number;
   /** フェーズ単位のキャッシュファイルを格納するディレクトリのパス。 */
   cacheDir: string;
-}
+};
 
 /** `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
-export type ParsedConfig = Partial<SetfmConfig> & {
-  /** `--config` で指定された設定ファイルのパス。省略時は `undefined`。 */
-  configFile?: string;
-};
+export type ParsedConfig = Partial<SetfmConfig>;
+
+/** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
+type _Assert<T extends Partial<ParsedArgs>> = T;
+
+/** SetfmConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
+type _SetfmConfigCheck = _Assert<SetfmConfig>;


### PR DESCRIPTION
## Overview

**Summary**
Unify config and args schema types across skills, removing duplicated fields and inconsistent naming.

**Background / Motivation**
Each skill (export-chatlogs, filter-chatlogs, normalize-chatlogs, set-frontmatter, classify-chatlogs) defined its own arg schema and config schema. This caused duplicated fields (`period`, `configFile`, `inputDir`, etc.) and inconsistent naming (`ArgsSchema` vs `ArgSchema`, `DEFAULT_VALUES` vs `DEFAULT_SCHEMA`) between skills.

## Changes

### Core Changes

- `skills/_scripts/types/args-schema.types.ts`: add `DefaultArgFields`, `ArgValue`, `ParsedArgs`; rename `ArgsSchema` to `ArgSchema`
- `skills/_scripts/types/config-schema.types.ts`: new module for `ConfigValue`, `ConfigFieldType`, `ConfigSchema`, `ConfigValues`, `ConfigKey`
- `skills/_scripts/constants/config-schema.constants.ts`: renamed from `schema.constants.ts`; `DEFAULT_SCHEMA`/`DEFAULT_VALUES` → `DEFAULT_CONFIG_SCHEMA`/`DEFAULT_CONFIG_VALUES`
- `skills/_scripts/libs/io/parse-args.ts`: type default arg schema with `DefaultArgFields`, return typed `ParsedArgs`
- `skills/_scripts/classes/GlobalConfig.class.ts`: use renamed config schema constants and types
- `skills/export-chatlogs/scripts/types/export-config.types.ts`, `export-chatlogs.ts`: build `ExportConfig` from `DefaultArgFields`
- `skills/filter-chatlogs/scripts/types/prefilter.types.ts`, `configs/prefilter-config.ts`, `filter-chatlogs.ts`, `libs/prefilter.ts`, `constants/common.constants.ts`: build `PrefilterConfig` from `DefaultArgFields`, use `DEFAULT_CONFIG_VALUES`
- `skills/normalize-chatlogs/scripts/types/normalize.types.ts`, `modules/normalize-config.ts`: build `NormalizeConfig` from `DefaultArgFields`, use renamed `ArgSchema`
- `skills/set-frontmatter/scripts/types/args.types.ts`, `modules/setfm-config.ts`: build `SetfmConfig` from `DefaultArgFields`, use renamed `ArgSchema`
- `skills/classify-chatlogs/scripts/types/classify.types.ts`, `modules/classify-config.ts`: build `ClassifyConfig` from `DefaultArgFields`, parse CLI args with `ArgSchema<Partial<ClassifyConfig>>`

### Test Updates

- `skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts`
- `skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts`
- `skills/_scripts/libs/io/__tests__/unit/set-by-type.unit.spec.ts`
- `skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts`
- `skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts`

All updated to reference the renamed `DEFAULT_CONFIG_VALUES`/`ArgSchema` symbols.

### Removed

- `skills/_scripts/constants/schema.constants.ts` (renamed to `config-schema.constants.ts`)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #288

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is a pure refactor. No functional behavior change is intended.
