### PR TITLE
refactor(export-chatlogs): replace baseDir with explicit inputDir

### DIFF
--- a/skills/export-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -376,22 +376,22 @@ describe('main (export-chatlogs)', () => {
   /**
    * chatgpt agent の正常実行シナリオ。
    *
-   * `--base` のみを指定して `runExport` の chatgpt ガード（inputDir/baseDir 両方未指定時に
+   * `--input-dir` のみを指定して `runExport` の chatgpt ガード（inputDir 未指定時に
    * throw する分岐）を通過させ、`exportChatGPT` が実行されて Markdown 出力まで
    * 完了することを確認する。claude/codex と異なる conversations-*.json 形式が
    * 正しく処理されることの基本確認。
    */
-  describe('Given: baseDir 直下に有効な chatgpt conversations JSON', () => {
-    let baseDir: string;
+  describe('Given: inputDir 直下に有効な chatgpt conversations JSON', () => {
+    let inputDir: string;
 
-    /** main(["chatgpt", "--base", baseDir, "--export-dir", outputDir]) を呼び出す */
-    describe('When: main(["chatgpt", "--base", baseDir, "--export-dir", outputDir]) を呼び出す', () => {
+    /** main(["chatgpt", "--input-dir", inputDir, "--export-dir", outputDir]) を呼び出す */
+    describe('When: main(["chatgpt", "--input-dir", inputDir, "--export-dir", outputDir]) を呼び出す', () => {
       beforeEach(async () => {
-        baseDir = `${tempDir}/chatgpt-export`;
-        await Deno.mkdir(baseDir, { recursive: true });
+        inputDir = `${tempDir}/chatgpt-export`;
+        await Deno.mkdir(inputDir, { recursive: true });
         const createTime = new Date('2026-03-15T10:00:00.000Z').getTime() / 1000;
         await Deno.writeTextFile(
-          `${baseDir}/conversations-2026-03-15.json`,
+          `${inputDir}/conversations-2026-03-15.json`,
           JSON.stringify([
             _chatgptConversation('sess-e2e-chatgpt-0001', createTime, 'E2Eテストの質問です', 'E2Eテストの回答です。'),
           ]),
@@ -401,7 +401,7 @@ describe('main (export-chatlogs)', () => {
       /** T-EC-E2E-09: ファイルが outputDir に生成される */
       describe('Then: T-EC-E2E-09 - ファイルが outputDir に生成される', () => {
         it('T-EC-E2E-09-01: logger.log に生成パスが出力される', async () => {
-          await main(['chatgpt', '--base', baseDir, '--export-dir', outputDir]);
+          await main(['chatgpt', '--input-dir', inputDir, '--export-dir', outputDir]);
 
           assertEquals(loggerStub.logLogs.some((p) => p.endsWith('.md')), true);
         });

--- a/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
@@ -58,7 +58,6 @@ async function _makeGlobalConfig(yaml: string): Promise<GlobalConfig> {
  * - `agent`     : CLI > GlobalConfig > defaults
  * - `exportDir` : CLI(--export-dir) > (GlobalConfig.chatlogsDir > defaults.chatlogsDir) + 'originalLogs'
  *                 （共通スキーマ由来の `--output-dir` は破棄され `exportDir` には影響しない）
- * - `baseDir`   : CLI(--base) のみ（GlobalConfig 連携なし）
  * - `inputDir`  : CLI(--input-dir) のみ（GlobalConfig 連携なし）
  * - `period`    : CLI 位置引数のみ
  *
@@ -243,56 +242,6 @@ describe('buildConfig', () => {
     });
   });
 
-  // ─── baseDir 優先順位 ───────────────────────────────────────────────────────
-
-  /**
-   * CLI で baseDir が指定されている前提条件グループ。
-   *
-   * CLI 引数 `--base` でベースディレクトリが明示されたケースを表す。
-   * `baseDir` は `GlobalConfig` 連携がなく CLI の値のみが反映されることを検証する。
-   */
-  describe('Given: CLI 引数に --base が指定されている', () => {
-    /** `buildConfig` を呼び出すとき。 */
-    describe('When: buildConfig を呼び出す', () => {
-      /** `result.baseDir` が CLI の値と一致することを検証する。 */
-      describe('Then: T-EC-BC-07 - result.baseDir === CLI の baseDir', () => {
-        beforeEach(async () => {
-          resetProjectRoot('/home/user/project');
-          GlobalConfig.resetInstance();
-          await GlobalConfig.getInstance({ schema: {} });
-        });
-        it('T-EC-BC-07-01: args=["--base", "/data"] → result.baseDir === /data', () => {
-          const result = buildConfig(['--base', '/data']);
-          assertEquals(result.baseDir, '/data');
-        });
-      });
-    });
-  });
-
-  /**
-   * CLI で baseDir が未指定である前提条件グループ。
-   *
-   * CLI 引数 `--base` が省略されたケースを表す。
-   * `baseDir` は `GlobalConfig` 連携がないため、未指定時は `undefined` になることを検証する。
-   */
-  describe('Given: CLI 引数に --base が未指定', () => {
-    /** `buildConfig` を呼び出すとき。 */
-    describe('When: buildConfig を呼び出す', () => {
-      /** `result.baseDir` が `undefined` になることを検証する。 */
-      describe('Then: T-EC-BC-08 - result.baseDir === undefined', () => {
-        beforeEach(async () => {
-          resetProjectRoot('/home/user/project');
-          GlobalConfig.resetInstance();
-          await GlobalConfig.getInstance({ schema: {} });
-        });
-        it('T-EC-BC-08-01: baseDir 未指定 → result.baseDir === undefined', () => {
-          const result = buildConfig([]);
-          assertEquals(result.baseDir, undefined);
-        });
-      });
-    });
-  });
-
   // ─── inputDir 優先順位 ──────────────────────────────────────────────────────
 
   /**
@@ -414,32 +363,6 @@ describe('buildConfig', () => {
         it("T-EC-BC-13-01: defaults 省略, chatlogsDir 未登録 → result.exportDir === DEFAULT_CHATLOGS_DIR + '/originalLogs'", () => {
           const result = buildConfig([]);
           assertEquals(result.exportDir, joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR));
-        });
-      });
-    });
-  });
-
-  // ─── configFile の ExportConfig 混入防止 ─────────────────────────────────────
-
-  /**
-   * configFile フィールドが ExportConfig に混入しないことを確認する。
-   *
-   * `--config` は GlobalConfig 初期化専用フィールドであり、
-   * buildConfig の戻り値 ExportConfig には含まれてはならない。
-   */
-  describe('Given: CLI 引数に --config が指定されている', () => {
-    /** `buildConfig` を呼び出すとき。 */
-    describe('When: buildConfig を呼び出す', () => {
-      /** `result` に `configFile` フィールドが含まれないことを検証する。 */
-      describe('Then: T-EC-BC-15 - result に configFile フィールドが含まれない', () => {
-        beforeEach(async () => {
-          resetProjectRoot('/home/user/project');
-          GlobalConfig.resetInstance();
-          await GlobalConfig.getInstance({ schema: {} });
-        });
-        it('T-EC-BC-15-01: --config を含む CLI 引数 → result に configFile が含まれない', () => {
-          const result = buildConfig(['claude', '--config', '/path/to/config.yaml']);
-          assertEquals((result as unknown as Record<string, unknown>).configFile, undefined);
         });
       });
     });

--- a/skills/export-chatlogs/scripts/__tests__/unit/run-export.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/run-export.unit.spec.ts
@@ -38,7 +38,7 @@ const _BASE_CONFIG: ExportConfig = { agent: 'chatgpt', exportDir: '/tmp/out' };
 describe('runExport', () => {
   /** 不正な agent 指定・未対応 agent 指定によるエラー分岐。 */
   describe('When: 異常系', () => {
-    it('[Error] T-EC-RE-01: agent=chatgpt かつ inputDir・baseDir 未指定 → ChatlogError(InvalidArgs/NotSpecified)', async () => {
+    it('[Error] T-EC-RE-01: agent=chatgpt かつ inputDir 未指定 → ChatlogError(InvalidArgs/NotSpecified)', async () => {
       const _config: ExportConfig = { ..._BASE_CONFIG, agent: 'chatgpt' };
 
       const error = await assertRejects(() => runExport(_config), ChatlogError);

--- a/skills/export-chatlogs/scripts/constants/defaults.constants.ts
+++ b/skills/export-chatlogs/scripts/constants/defaults.constants.ts
@@ -8,39 +8,22 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // constants
-import {
-  DEFAULT_AGENT,
-  DEFAULT_CHATLOGS_DIR,
-  DEFAULT_ORIGINAL_LOGS_DIR,
-} from '../../../_scripts/constants/defaults.constants.ts';
-// libs
-import { joinPath } from '../../../_scripts/libs/path-utils/path-utils.ts';
+import { DEFAULT_AGENT } from '../../../_scripts/constants/defaults.constants.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────
 // types
 import type { ExportConfig } from '../types/export-config.types.ts';
 
 /**
- * CLI で `--export-dir` が指定されなかった場合のデフォルト出力ディレクトリ。
- *
- * `parseArgs()` が引数なしで呼ばれた場合のフォールバック値として使用する。
- * `chatlogsDir` 配下の `originalLogs/` に出力される。
- *
- * @see parseArgs
- */
-export const DEFAULT_EXPORT_DIR = joinPath(DEFAULT_CHATLOGS_DIR, DEFAULT_ORIGINAL_LOGS_DIR);
-
-/**
  * `parseArgs()` が引数なしで呼ばれた場合に返す `ExportConfig` のデフォルト値。
  *
  * `parseArgs()` はこのオブジェクトをスプレッドコピーしてベースとし、
  * CLI 引数で指定された値で上書きしていく。
- * `period` と `baseDir` は省略値（undefined）のままになる。
+ * `exportDir`・`period`・`inputDir` は省略値（undefined）のままになる。
  *
  * @see parseArgs
  * @see ExportConfig
  */
 export const DEFAULT_EXPORT_CONFIG: ExportConfig = {
   agent: DEFAULT_AGENT,
-  exportDir: DEFAULT_EXPORT_DIR,
 };

--- a/skills/export-chatlogs/scripts/export-chatlogs.ts
+++ b/skills/export-chatlogs/scripts/export-chatlogs.ts
@@ -47,7 +47,6 @@ import type { ExportResult } from './types/export-result.types.ts';
 /** export-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgSchema<ParsedConfig> = [
   { option: '--export-dir', field: 'exportDir', type: 'directory' },
-  { option: '--base', field: 'baseDir', type: 'directory' },
 ];
 
 /**
@@ -62,7 +61,6 @@ const _SCHEMA: ArgSchema<ParsedConfig> = [
  *
  * - agent 優先順位: CLI > GlobalConfig > defaults
  * - exportDir 優先順位: CLI(--export-dir) > (GlobalConfig.chatlogsDir > DEFAULT_CHATLOGS_DIR) + 'originalLogs'
- * - baseDir 優先順位: CLI(--base) のみ（GlobalConfig 連携なし）
  * - inputDir 優先順位: CLI(--input-dir) のみ（GlobalConfig 連携なし）
  * - period: CLI 位置引数のみ（GlobalConfig に期間設定なし）
  */
@@ -71,12 +69,11 @@ export const buildConfig = (
   defaults?: ExportConfig,
 ): ExportConfig => {
   const _defaults = defaults ?? DEFAULT_EXPORT_CONFIG;
-  const { exportDir: _unusedExportDir, ..._defaultsWithoutExportDir } = _defaults;
-  const parsed = parseArgs<ExportConfig>(args, _SCHEMA, _defaultsWithoutExportDir as ExportConfig);
+  const parsed = parseArgs<ExportConfig>(args, _SCHEMA, _defaults);
   const _chatlogsDir = parsed.chatlogsDir ?? DEFAULT_CHATLOGS_DIR;
   const _exportDir = parsed.exportDir ?? joinPath(_chatlogsDir, DEFAULT_ORIGINAL_LOGS_DIR);
-  const { configFile: _unusedConfigFile, ..._rest } = parsed;
-  return { ..._rest, exportDir: _exportDir } as ExportConfig;
+  parsed.exportDir = _exportDir;
+  return parsed;
 };
 
 // ─────────────────────────────────────────────
@@ -91,7 +88,7 @@ export type RunExportProvider = (config: ExportConfig) => Promise<ExportResult>;
  *
  * - `claude` → `exportClaude`
  * - `codex` → `exportCodex`
- * - `chatgpt` → `exportChatGPT`（`inputDir`・`baseDir` がともに未指定の場合は `ChatlogError` を throw）
+ * - `chatgpt` → `exportChatGPT`（`inputDir` が未指定の場合は `ChatlogError` を throw）
  * - 上記以外 → `ChatlogError('InvalidArgs', 'UnsupportedAgent')` を throw
  *
  * @param config `buildConfig()` が構築した `ExportConfig`
@@ -104,7 +101,7 @@ export const runExport: RunExportProvider = async (config) => {
     case 'codex':
       return await exportCodex(config);
     case 'chatgpt':
-      if (!config.inputDir && !config.baseDir) {
+      if (!config.inputDir) {
         throw new ChatlogError(
           'InvalidArgs',
           'NotSpecified',

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
@@ -71,7 +71,7 @@ async function _writeConvFile(filePath: string, conversations: ChatGPTConversati
  * テストケース分類:
  * 正常系: T-EC-GE-01（1件）/ T-EC-GE-06（3件並列）/ T-EC-GE-10（順序保証）
  * スキップ: T-EC-GE-02（parseConversation が null）
- * 境界値: T-EC-GE-03（0件）/ T-EC-GE-04（baseDir 未設定）
+ * 境界値: T-EC-GE-03（0件）/ T-EC-GE-04（inputDir 未設定）
  * エラー系: T-EC-GE-05（writeSession 例外）/ T-EC-GE-09（全ファイル読み込み失敗）
  * 混在: T-EC-GE-07（エラー・正常・スキップ混在）/ T-EC-GE-08（複数会話・複数ファイル）
  *
@@ -116,7 +116,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -165,7 +165,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -199,7 +199,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -219,28 +219,28 @@ describe('exportChatGPT', () => {
     });
   });
 
-  // ─── T-EC-GE-04: config.baseDir が undefined → エラースロー ─────────────
+  // ─── T-EC-GE-04: config.inputDir が undefined → エラースロー ─────────────
 
   /**
-   * config.baseDir が未設定の必須パラメータ検証ケース。
+   * config.inputDir が未設定の必須パラメータ検証ケース。
    * ChatGPT エクスポートは入力ディレクトリが必須であるため、
-   * baseDir=undefined のときエラーがスローされることを検証する。
+   * inputDir=undefined のときエラーがスローされることを検証する。
    */
-  describe('Given: config.baseDir が undefined', () => {
+  describe('Given: config.inputDir が undefined', () => {
     /** `exportChatGPT` を呼び出したときにエラーがスローされることを検証する。 */
     describe('When: exportChatGPT(config) を呼び出す', () => {
       it('T-EC-GE-04: エラーをスローする', async () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: undefined,
+          inputDir: undefined,
           period: undefined,
         };
 
         await assertRejects(
           () => exportChatGPT(config),
           Error,
-          'ChatGPT エクスポートには --input/--base でディレクトリを指定してください',
+          'ChatGPT エクスポートには --input-dir でディレクトリを指定してください',
         );
       });
     });
@@ -270,7 +270,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -338,7 +338,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -405,7 +405,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -475,7 +475,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -525,7 +525,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 
@@ -598,7 +598,7 @@ describe('exportChatGPT', () => {
         const config: ExportConfig = {
           agent: 'chatgpt',
           exportDir: outputDir,
-          baseDir: tempDir,
+          inputDir: tempDir,
           period: undefined,
         };
 

--- a/skills/export-chatlogs/scripts/exporter/__tests__/unit/export-claude.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/unit/export-claude.unit.spec.ts
@@ -29,7 +29,6 @@ import type { ExportedSession } from '../../../types/session.types.ts';
 const BASE_CONFIG: ExportConfig = {
   agent: 'claude',
   exportDir: '/tmp/test-output',
-  baseDir: undefined,
   period: undefined,
 };
 
@@ -88,7 +87,7 @@ function _makeMockProviders(
  * - T-EC-CL-02: parseSession が null → exportedCount=0, skippedCount=1, errorCount=0
  * - T-EC-CL-03: findSessions が0件 → exportedCount=0, skippedCount=0, errorCount=0
  * - T-EC-CL-04: 3件中2件有効・1件スキップ → exportedCount=2, skippedCount=1, errorCount=0
- * - T-EC-CL-05: config.baseDir が存在しない → exportedCount=0
+ * - T-EC-CL-05: config.inputDir が存在しない → exportedCount=0
  * - T-EC-CL-06: writeSession が例外 → exportedCount=0, skippedCount=0, errorCount=1
  * - T-EC-CL-07: 3件中1件成功・1件スキップ・1件エラー → 各カウントが正確
  *
@@ -196,18 +195,18 @@ describe('exportClaude', () => {
     });
   });
 
-  // ─── T-EC-CL-05: config.baseDir が findClaudeSessions に渡される ─────────────
+  // ─── T-EC-CL-05: config.inputDir が findClaudeSessions に渡される ─────────────
 
   /**
-   * baseDir に存在しないディレクトリを渡してデフォルト provider を使うケース。
+   * inputDir に存在しないディレクトリを渡してデフォルト provider を使うケース。
    * デフォルト provider の findSessions が実ファイルシステムを参照するため、
    * 存在しないパスでは空配列が返り exportedCount=0 になることを確認する。
    */
-  describe('Given: config.baseDir に存在しないディレクトリを指定し、findSessions を省略する', () => {
+  describe('Given: config.inputDir に存在しないディレクトリを指定し、findSessions を省略する', () => {
     /** デフォルト provider で `exportClaude` を呼び出したときの戻り値を検証する。 */
     describe('When: exportClaude(config) をデフォルト provider で呼び出す', () => {
-      it('T-EC-CL-05: baseDir が空ディレクトリなら exportedCount=0, outputPaths=[]', async () => {
-        const config = { ...BASE_CONFIG, baseDir: '/nonexistent/custom/projects' };
+      it('T-EC-CL-05: inputDir が空ディレクトリなら exportedCount=0, outputPaths=[]', async () => {
+        const config = { ...BASE_CONFIG, inputDir: '/nonexistent/custom/projects' };
         const result = await exportClaude(config);
         assertEquals(result.exportedCount, 0);
         assertEquals(result.outputPaths, []);

--- a/skills/export-chatlogs/scripts/exporter/__tests__/unit/export-codex.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/unit/export-codex.unit.spec.ts
@@ -25,7 +25,6 @@ import type { ExportedSession } from '../../../types/session.types.ts';
 const BASE_CONFIG: ExportConfig = {
   agent: 'codex',
   exportDir: '/tmp/test-output',
-  baseDir: undefined,
   period: undefined,
 };
 

--- a/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
@@ -286,7 +286,7 @@ const _mergeResults = (results: FileResult[]): ExportResult => {
  * ChatGPT エージェントのセッション履歴をエクスポートするオーケストレーション関数。
  *
  * 処理フロー:
- * 1. `config.inputDir ?? config.baseDir` が undefined → エラースロー
+ * 1. `config.inputDir` が undefined → エラースロー
  * 2. `parsePeriod(config.period)` で PeriodRange 取得
  * 3. `findFiles()` でファイル一覧を収集
  * 4. 全ファイルを Promise.all で並列処理（各ファイルは独立して読み込み・パース・書き出し）
@@ -295,7 +295,7 @@ const _mergeResults = (results: FileResult[]): ExportResult => {
  * `_providers` を省略した場合は実際のファイルシステム操作を行う。
  * テスト時は `_providers` に差し替え実装を渡すことで I/O なしに動作を検証できる。
  *
- * @param config エクスポート設定（agent, period, exportDir, inputDir, baseDir）
+ * @param config エクスポート設定（agent, period, exportDir, inputDir）
  * @param _providers テスト用 Provider（省略時は実実装を使用）
  * @returns エクスポート結果（exportedCount, skippedCount, errorCount, outputPaths）
  */
@@ -307,12 +307,12 @@ export const exportChatGPT = async (
     writeSession?: WriteSessionProvider;
   },
 ): Promise<ExportResult> => {
-  const inputDir = config.inputDir ?? config.baseDir;
+  const inputDir = config.inputDir;
   if (!inputDir) {
     throw new ChatlogError(
       'MissingArg',
       'NotSpecified',
-      'ChatGPT エクスポートには --input/--base でディレクトリを指定してください',
+      'ChatGPT エクスポートには --input-dir でディレクトリを指定してください',
     );
   }
 
@@ -325,7 +325,8 @@ export const exportChatGPT = async (
   const files = await _findFiles(inputDir);
 
   const results = await Promise.all(
-    files.map((file) => _processFile(file, range, config.exportDir, config.agent, _parseConversation, _writeSession)),
+    // buildConfig() が常に exportDir を string に解決するため non-null。
+    files.map((file) => _processFile(file, range, config.exportDir!, config.agent, _parseConversation, _writeSession)),
   );
 
   return _mergeResults(results);

--- a/skills/export-chatlogs/scripts/exporter/claude-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/claude-exporter.ts
@@ -247,7 +247,7 @@ export const exportClaude = async (
   const range = parsePeriod(config.period);
 
   const _findSessions = _providers?.findSessions
-    ?? ((period: PeriodRange) => findClaudeSessions(period, config.baseDir));
+    ?? ((period: PeriodRange) => findClaudeSessions(period, config.inputDir));
   const _parseSession = _providers?.parseSession
     ?? ((filePath: string, r: PeriodRange) => parseClaudeSession(filePath, r));
   const _writeSession = _providers?.writeSession ?? writeSession;
@@ -265,7 +265,8 @@ export const exportClaude = async (
         skippedCount++;
         continue;
       }
-      const outPath = await _writeSession(config.exportDir, config.agent, session);
+      // buildConfig() が常に exportDir を string に解決するため non-null。
+      const outPath = await _writeSession(config.exportDir!, config.agent, session);
       outputPaths.push(outPath);
     } catch {
       errorCount++;

--- a/skills/export-chatlogs/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/codex-exporter.ts
@@ -223,7 +223,8 @@ export const exportCodex = async (
         skippedCount++;
         continue;
       }
-      const outPath = await _writeSession(config.exportDir, config.agent, session);
+      // buildConfig() が常に exportDir を string に解決するため non-null。
+      const outPath = await _writeSession(config.exportDir!, config.agent, session);
       outputPaths.push(outPath);
     } catch {
       errorCount++;

--- a/skills/export-chatlogs/scripts/types/export-config.types.ts
+++ b/skills/export-chatlogs/scripts/types/export-config.types.ts
@@ -28,24 +28,17 @@ import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-
 export type ExportConfig = DefaultArgFields & {
   /** 対象エージェント名。"claude" または "codex" */
   agent: string;
-  /**
-   * 入力ベースディレクトリ（将来拡張用）。
-   * 省略時は `homeDir()` を基点として各エージェントのデフォルトパスを使用する。
-   */
-  baseDir?: string;
   /** 出力先ディレクトリのベースパス。デフォルトは "./chatlogs" */
-  exportDir: string;
+  exportDir?: string;
   /** GlobalConfig から解決されたチャットログディレクトリ。`exportDir` 未指定時のフォールバック元。 */
   chatlogsDir?: string;
 };
 
-/**
- * `parseArgs()` が CLI 引数から生成する未解決設定。`buildConfig()` が完全な `ExportConfig` に解決する。
- */
+/** `parseArgs()` に渡される引数の型定義。 */
 export type ParsedConfig = Partial<ExportConfig>;
 
 /** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
-type _Assert<T extends Partial<ParsedArgs>> = T;
+type _Assert<T extends Partial<ExportConfig>> = T;
 
 /** ExportConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
 type _ExportConfigCheck = _Assert<ExportConfig>;

--- a/skills/export-chatlogs/scripts/types/export-config.types.ts
+++ b/skills/export-chatlogs/scripts/types/export-config.types.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
+import type { DefaultArgFields } from '../../../_scripts/types/args-schema.types.ts';
 
 // --- type
 


### PR DESCRIPTION
## Overview

**Summary**
Replace the implicit `baseDir` concept with an explicit `inputDir` field across the export-chatlogs skill.

**Background / Motivation**
The `export-chatlogs` skill resolved the source directory using an implicit `baseDir` field and a `--base` CLI flag. This made the config source ambiguous across the ChatGPT, Claude, and Codex exporters. This change removes `baseDir` entirely and uses `inputDir` (`--input-dir`) as the single source of truth. `exportDir` is now guaranteed to be resolved to a `string` by `buildConfig()`.

## Changes

### Core Changes

- `export-chatlogs.ts`: removed the `--base` argument schema; `exportDir` is now set on the parsed result, and the ChatGPT "missing input" check validates `inputDir` only.
- `export-config.types.ts`: removed `baseDir` from `ExportConfig`, made `exportDir` optional, and narrowed the `_Assert` constraint to `Partial<ExportConfig>`.
- `defaults.constants.ts`: removed the unused `DEFAULT_EXPORT_DIR` constant and its default `exportDir` value.
- `chatgpt-exporter.ts`: resolves `inputDir` from `config.inputDir` only, updates the `MissingArg` error message to reference `--input-dir`, and asserts `exportDir` is resolved.
- `claude-exporter.ts`: session lookup now uses `config.inputDir` instead of `config.baseDir`.
- `codex-exporter.ts`: asserts the `exportDir` argument passed to `_writeSession` is resolved by `buildConfig()`.

### Test Updates

- Updated unit, functional, and e2e specs across `export-chatlogs`, `export-chatgpt`, `export-claude`, `export-codex`, `run-export`, and `build-config` to drop `baseDir`/`--base` fixtures and use `inputDir`/`--input-dir` instead.

### Removed

- `--base` CLI flag
- `baseDir` field from `ExportConfig`
- `DEFAULT_EXPORT_DIR` constant

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is a breaking change: `--base` flag, `baseDir` field, and `DEFAULT_EXPORT_DIR` are removed. Callers must migrate to `--input-dir` / `inputDir`.
