### PR TITLE
refactor(filter): use filter decision constants instead of string literals

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -37,6 +37,7 @@ import {
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
+import { FILTER_DECISIONS } from '../../types/filter-decision.const.types.ts';
 import { FILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -110,7 +111,12 @@ describe('main - dry-run モード', () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
-              JSON.stringify([{ file: 'chat.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' }]),
+              JSON.stringify([{
+                file: 'chat.md',
+                decision: FILTER_DECISIONS.DISCARD,
+                confidence: 0.9,
+                reason: 'trivial',
+              }]),
             )),
           );
           loggerStub = makeLoggerStub();
@@ -171,7 +177,12 @@ describe('main - DISCARD 判定', () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
-              JSON.stringify([{ file: 'discard.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' }]),
+              JSON.stringify([{
+                file: 'discard.md',
+                decision: FILTER_DECISIONS.DISCARD,
+                confidence: 0.9,
+                reason: 'trivial',
+              }]),
             )),
           );
           loggerStub = makeLoggerStub();
@@ -230,7 +241,12 @@ describe('main - KEEP 判定', () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
-              JSON.stringify([{ file: 'keep.md', decision: 'KEEP', confidence: 0.9, reason: 'valuable' }]),
+              JSON.stringify([{
+                file: 'keep.md',
+                decision: FILTER_DECISIONS.KEEP,
+                confidence: 0.9,
+                reason: 'valuable',
+              }]),
             )),
           );
           loggerStub = makeLoggerStub();
@@ -345,8 +361,8 @@ describe('main - DISCARD + KEEP 混在', () => {
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([
-                { file: 'discard.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' },
-                { file: 'keep.md', decision: 'KEEP', confidence: 0.9, reason: 'valuable' },
+                { file: 'discard.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
+                { file: 'keep.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
               ]),
             )),
           );
@@ -413,7 +429,12 @@ describe('main - period 絞り込み', () => {
           tempDir = await Deno.makeTempDir();
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
-              JSON.stringify([{ file: 'march.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' }]),
+              JSON.stringify([{
+                file: 'march.md',
+                decision: FILTER_DECISIONS.DISCARD,
+                confidence: 0.9,
+                reason: 'trivial',
+              }]),
             )),
           );
           loggerStub = makeLoggerStub();
@@ -546,7 +567,12 @@ describe('main - confidence 閾値未満', () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
-              JSON.stringify([{ file: 'low-conf.md', decision: 'DISCARD', confidence: 0.69, reason: 'uncertain' }]),
+              JSON.stringify([{
+                file: 'low-conf.md',
+                decision: FILTER_DECISIONS.DISCARD,
+                confidence: 0.69,
+                reason: 'uncertain',
+              }]),
             )),
           );
           loggerStub = makeLoggerStub();
@@ -733,8 +759,8 @@ describe('main - period 未指定', () => {
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(
               JSON.stringify([
-                { file: 'march.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' },
-                { file: 'april.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' },
+                { file: 'march.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
+                { file: 'april.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
               ]),
             )),
           );

--- a/skills/filter-chatlogs/scripts/__tests__/fixtures/filter/fixtures.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/fixtures/filter/fixtures.spec.ts
@@ -22,6 +22,8 @@ import { parseAiJsonArray } from '../../../../../_scripts/libs/text/json-utils.t
 import { findFixtureDirs } from '../../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
+// types
+import type { FilterDecision } from '../../../types/filter-decision.const.types.ts';
 
 // ─── Internal Helpers
 
@@ -44,13 +46,13 @@ const _shouldRunAI = Deno.env.get('RUN_AI') === '1';
 
 // types
 interface FixtureOutput {
-  expected_decision: 'KEEP' | 'DISCARD';
+  expected_decision: FilterDecision;
   confidence_min: number;
   mock_response?: string;
 }
 
 interface ClaudeResult {
-  decision: 'KEEP' | 'DISCARD';
+  decision: FilterDecision;
   confidence: number;
 }
 

--- a/skills/filter-chatlogs/scripts/libs/__tests__/unit/text-utils.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/libs/__tests__/unit/text-utils.unit.spec.ts
@@ -18,6 +18,8 @@ import { parseFrontmatterEntries } from '../../../../../_scripts/libs/text/front
 import { parseAiJsonArray } from '../../../../../_scripts/libs/text/json-utils.ts';
 // types
 import type { ClaudeResult } from '../../../types/filter.types.ts';
+// constants
+import { FILTER_DECISIONS } from '../../../types/filter-decision.const.types.ts';
 
 // ─── Tests
 
@@ -97,30 +99,45 @@ describe('parseAiJsonArray', () => {
     describe('When: parseAiJsonArray(raw) を呼び出す', () => {
       describe('Then: T-FL-PJ-01 - 配列が返される', () => {
         it('T-FL-PJ-01-01: 有効な JSON 配列 → null でない', () => {
-          const raw = JSON.stringify([{ file: 'a.md', decision: 'KEEP', confidence: 0.9, reason: 'good' }]);
+          const raw = JSON.stringify([{
+            file: 'a.md',
+            decision: FILTER_DECISIONS.KEEP,
+            confidence: 0.9,
+            reason: 'good',
+          }]);
           const result = parseAiJsonArray(raw);
 
           assertNotNull(result);
         });
 
         it('T-FL-PJ-01-02: 配列の最初の要素の file が "a.md" になる', () => {
-          const raw = JSON.stringify([{ file: 'a.md', decision: 'KEEP', confidence: 0.9, reason: 'good' }]);
+          const raw = JSON.stringify([{
+            file: 'a.md',
+            decision: FILTER_DECISIONS.KEEP,
+            confidence: 0.9,
+            reason: 'good',
+          }]);
           const result = parseAiJsonArray<ClaudeResult>(raw);
 
           assertEquals(result![0].file, 'a.md');
         });
 
         it('T-FL-PJ-01-03: decision が "KEEP" になる', () => {
-          const raw = JSON.stringify([{ file: 'a.md', decision: 'KEEP', confidence: 0.9, reason: 'good' }]);
+          const raw = JSON.stringify([{
+            file: 'a.md',
+            decision: FILTER_DECISIONS.KEEP,
+            confidence: 0.9,
+            reason: 'good',
+          }]);
           const result = parseAiJsonArray<ClaudeResult>(raw);
 
-          assertEquals(result![0].decision, 'KEEP');
+          assertEquals(result![0].decision, FILTER_DECISIONS.KEEP);
         });
 
         it('T-FL-PJ-01-04: 複数件の配列が正しくパースされる', () => {
           const raw = JSON.stringify([
-            { file: 'a.md', decision: 'KEEP', confidence: 0.9, reason: 'good' },
-            { file: 'b.md', decision: 'DISCARD', confidence: 0.8, reason: 'bad' },
+            { file: 'a.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'good' },
+            { file: 'b.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.8, reason: 'bad' },
           ]);
           const result = parseAiJsonArray(raw);
 
@@ -136,7 +153,7 @@ describe('parseAiJsonArray', () => {
     describe('When: parseAiJsonArray(raw) を呼び出す', () => {
       describe('Then: T-FL-PJ-02 - フォールバックで配列が返される', () => {
         it('T-FL-PJ-02-01: 前置テキスト + JSON 配列 → null でない', () => {
-          const arr = [{ file: 'a.md', decision: 'KEEP', confidence: 0.9, reason: 'ok' }];
+          const arr = [{ file: 'a.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'ok' }];
           const raw = `前置テキスト\n${JSON.stringify(arr)}\n後置テキスト`;
           const result = parseAiJsonArray(raw);
 
@@ -144,7 +161,7 @@ describe('parseAiJsonArray', () => {
         });
 
         it('T-FL-PJ-02-02: マークダウンコードブロック内の JSON → null でない', () => {
-          const arr = [{ file: 'b.md', decision: 'DISCARD', confidence: 0.8, reason: 'no' }];
+          const arr = [{ file: 'b.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.8, reason: 'no' }];
           const raw = `\`\`\`json\n${JSON.stringify(arr)}\n\`\`\``;
           const result = parseAiJsonArray(raw);
 
@@ -160,7 +177,7 @@ describe('parseAiJsonArray', () => {
     describe('When: parseAiJsonArray(raw) を呼び出す', () => {
       describe('Then: T-FL-PJ-03 - 貪欲マッチで配列が返される', () => {
         it('T-FL-PJ-03-01: ネストした配列を含む文字列 → null でない', () => {
-          const arr = [{ file: 'c.md', decision: 'KEEP', confidence: 0.7, reason: 'nested [x]' }];
+          const arr = [{ file: 'c.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.7, reason: 'nested [x]' }];
           const raw = `some text ${JSON.stringify(arr)} more text`;
           const result = parseAiJsonArray(raw);
 

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -31,6 +31,8 @@ import type { CommandMockHandle } from '../../../../../../_scripts/__tests__/hel
 import { makePeriodDir } from '../../../../__tests__/_helpers/fixtures.ts';
 // exists
 import { fileExists, fileOrDirExists } from '../../../../../../_scripts/libs/file-ops/exists-utils.ts';
+// constants
+import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
 
 // ─── Internal Helpers
 
@@ -107,7 +109,7 @@ describe('processChunk', () => {
           const response = JSON.stringify([
             {
               file: 'a.md',
-              decision: 'DISCARD',
+              decision: FILTER_DECISIONS.DISCARD,
               confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
               reason: 'trivial',
             },
@@ -131,7 +133,7 @@ describe('processChunk', () => {
           const response = JSON.stringify([
             {
               file: 'a.md',
-              decision: 'DISCARD',
+              decision: FILTER_DECISIONS.DISCARD,
               confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
               reason: 'trivial',
             },
@@ -168,7 +170,7 @@ describe('processChunk', () => {
           const response = JSON.stringify([
             {
               file: 'b.md',
-              decision: 'DISCARD',
+              decision: FILTER_DECISIONS.DISCARD,
               confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
               reason: 'trivial',
             },
@@ -192,7 +194,7 @@ describe('processChunk', () => {
           const response = JSON.stringify([
             {
               file: 'c.md',
-              decision: 'DISCARD',
+              decision: FILTER_DECISIONS.DISCARD,
               confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
               reason: 'trivial',
             },
@@ -227,7 +229,7 @@ describe('processChunk', () => {
         it('T-FL-PCK-03-01: stats.kept が 1 になる', async () => {
           const filePath = await _createTempFile('d.md');
           const response = JSON.stringify([
-            { file: 'd.md', decision: 'KEEP', confidence: 0.9, reason: 'valuable' },
+            { file: 'd.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -257,7 +259,7 @@ describe('processChunk', () => {
         it('T-FL-PCK-04-01: confidence=0.6 の DISCARD → stats.kept が 1 になる', async () => {
           const filePath = await _createTempFile('e.md');
           const response = JSON.stringify([
-            { file: 'e.md', decision: 'DISCARD', confidence: 0.6, reason: 'low conf' },
+            { file: 'e.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'low conf' },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -342,7 +344,7 @@ describe('processChunk', () => {
           const filePath = await _createTempFile('h.md');
           // 対象は h.md だが結果は other.md
           const response = JSON.stringify([
-            { file: 'other.md', decision: 'DISCARD', confidence: 0.9, reason: 'trivial' },
+            { file: 'other.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),
@@ -397,7 +399,7 @@ describe('processChunk', () => {
         it('T-FL-PCK-09-01: threshold=0.5, confidence=0.6 → stats.discarded === 1', async () => {
           const filePath = await _createTempFile('j.md');
           const response = JSON.stringify([
-            { file: 'j.md', decision: 'DISCARD', confidence: 0.6, reason: 'trivial' },
+            { file: 'j.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'trivial' },
           ]);
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode(response)),

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -17,6 +17,7 @@ import { parseAiJsonArray } from '../../../../_scripts/libs/text/json-utils.ts';
 // ─── internal ───
 // functions
 import { buildBatchPrompt } from '../../libs/batch-prompt.ts';
+import { FILTER_DECISIONS } from '../../types/filter-decision.const.types.ts';
 // types
 import type { ClaudeResult, FilterStats } from '../../types/filter.types.ts';
 
@@ -79,7 +80,7 @@ export const processChunk = async (
 
     const { decision, confidence, reason } = result;
 
-    if (decision === 'DISCARD' && confidence >= discardThreshold) {
+    if (decision === FILTER_DECISIONS.DISCARD && confidence >= discardThreshold) {
       if (dryRun) {
         logger.log(`[dry-run] DISCARD (conf=${confidence}): ${filePath}`);
         logger.info(`  reason: ${reason}`);

--- a/skills/filter-chatlogs/scripts/types/filter-decision.const.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter-decision.const.types.ts
@@ -1,0 +1,16 @@
+// src: scripts/types/filter-decision.const.types.ts
+// @(#): Claude CLI 判定結果の識別子定数と派生型定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/** Claude CLI が返す判定識別子。`FilterDecision` のリテラル直書きを置き換える。 */
+export const FILTER_DECISIONS = {
+  KEEP: 'KEEP',
+  DISCARD: 'DISCARD',
+} as const;
+
+/** `FILTER_DECISIONS` の値から派生したユニオン型。`'KEEP' | 'DISCARD'` と等価。 */
+export type FilterDecision = typeof FILTER_DECISIONS[keyof typeof FILTER_DECISIONS];

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -6,6 +6,9 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// types
+import type { FilterDecision } from './filter-decision.const.types.ts';
+
 // ─────────────────────────────────────────────
 // 分類設定型
 // ─────────────────────────────────────────────
@@ -51,7 +54,7 @@ export type FilterParsedConfig = Partial<FilterConfig> & {
 /** Claude CLI が返すファイル単位の判定結果。 */
 export interface ClaudeResult {
   file: string;
-  decision: 'KEEP' | 'DISCARD';
+  decision: FilterDecision;
   confidence: number;
   reason: string;
 }


### PR DESCRIPTION
## Overview

**Summary**
Replace filter decision string literals with a shared `FILTER_DECISIONS` constant.

**Background / Motivation**
The filter module compared decisions against raw string literals (`'KEEP'` / `'DISCARD'`). This adds a single `FILTER_DECISIONS` constant and a derived `FilterDecision` type, so the value is defined once and reused everywhere.

## Changes

### Core Changes

- Add `FILTER_DECISIONS` constant and `FilterDecision` type in `filter-decision.const.types.ts`
- Update `filter.types.ts` to use the `FilterDecision` type for `ClaudeResult.decision`
- Update `process-chunk.ts` to compare against `FILTER_DECISIONS.DISCARD` instead of the literal

### Test Updates

- Update 4 test files to use `FILTER_DECISIONS` instead of raw string literals:
  - `main.e2e.spec.ts`
  - `fixtures.spec.ts`
  - `text-utils.unit.spec.ts`
  - `process-chunk.functional.spec.ts`

### Removed

- None

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
