### PR TITLE
refactor(filter-chatlogs): unify stats counters and rework dry-run

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -29,6 +29,7 @@ import { LOGGER_HEADER } from '../../../../_scripts/constants/logger-header.cons
 // mocks
 import {
   installCommandMock,
+  makeCountingMock,
   makeFailMock,
   makeNotFoundMock,
   makeSuccessMock,
@@ -84,7 +85,8 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
 /**
  * `main` 関数の E2E テストスイート（dry-run モード）。
  *
- * `--dry-run` フラグを指定した際にファイルが削除されないことを検証する。
+ * `--dry-run` フラグを指定した際に claude CLI を呼び出さず、対象ファイルを一覧表示するだけで
+ * ファイルが削除されないことを検証する。
  *
  * テスト ID 範囲: T-FL-E2E-01
  *
@@ -94,31 +96,24 @@ describe('main - dry-run モード', () => {
   /**
    * 1 件の `.md` ファイルと claude agent が存在する前提。
    *
-   * `--dry-run` フラグ付きで main を呼び出した際に、DISCARD 判定でもファイルが
-   * 削除されないことを確認する。
+   * `--dry-run` フラグ付きで main を呼び出した際に、claude CLI が呼ばれず、
+   * ファイルも削除されないことを確認する。
    */
-  describe('Given: 1 件の .md ファイルと DISCARD 判定モック', () => {
+  describe('Given: 1 件の .md ファイル', () => {
     /** `main([...args, "--dry-run"])` を呼び出すとき。 */
     describe('When: main([...args, "--dry-run"]) を呼び出す', () => {
-      /** dry-run モードではファイルが削除されず、`[dry-run]` ログが出力されること。 */
-      describe('Then: T-FL-E2E-01 - dry-run → ファイルが削除されない', () => {
+      /** dry-run モードでは claude CLI が呼ばれず、対象ファイルがログに一覧表示され、ファイルも削除されない。 */
+      describe('Then: T-FL-E2E-01 - dry-run → claude CLI 未呼び出し・ファイル一覧表示・削除なし', () => {
         let tempDir: string;
         let chatlogsDir: string;
         let commandHandle: CommandMockHandle;
         let loggerStub: LoggerStub;
+        let counter: { calls: number };
 
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
-          commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
-              JSON.stringify([{
-                file: 'chat.md',
-                decision: FILTER_DECISIONS.DISCARD,
-                confidence: 0.9,
-                reason: 'trivial',
-              }]),
-            )),
-          );
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(makeCountingMock('[]', counter));
           loggerStub = makeLoggerStub();
         });
 
@@ -133,11 +128,22 @@ describe('main - dry-run モード', () => {
             await Deno.writeTextFile(`${chatlogsDir}/chat.md`, _makeValidContent());
           });
 
-          it('T-FL-E2E-01-01: ファイルが削除されずに残り "[dry-run]" がログに出力される', async () => {
+          it('T-FL-E2E-01-01: ファイルが削除されずに残る', async () => {
             await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/chat.md`), true);
-            assertEquals(loggerStub.logLogs.some((l) => l.includes('[dry-run]')), true);
+          });
+
+          it('T-FL-E2E-01-02: 対象ファイルパスがログに一覧表示される', async () => {
+            await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('chat.md')), true);
+          });
+
+          it('T-FL-E2E-01-03: claude CLI が一度も呼ばれない', async () => {
+            await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
+
+            assertEquals(counter.calls, 0);
           });
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
@@ -232,7 +232,7 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
  * `main` 関数（prefilter）の E2E テストスイート（全件 keep）。
  *
  * ノイズファイルが存在しない場合に全ファイルが keep となり、
- * 完了ログに `noise=0` が含まれることを検証する。
+ * 完了ログに `keep=2` が含まれることを検証する。
  *
  * テスト ID 範囲: T-PF-E2E-04
  *
@@ -242,12 +242,12 @@ describe('main (prefilter) - 全件 keep', () => {
   /**
    * 正常ファイル 2 件のみが存在するディレクトリの前提。
    *
-   * 全件 keep 時にファイルが削除されず、完了ログに `noise=0` が含まれることを確認する。
+   * 全件 keep 時にファイルが削除されず、完了ログに `keep=2` が含まれることを確認する。
    */
   describe('Given: 正常ファイル 2 件', () => {
     /** `main(["claude", "--input-dir", chatlogsDir])` を呼び出すとき。 */
     describe('When: main(["claude", "--input-dir", chatlogsDir]) を呼び出す', () => {
-      /** 全ファイルが残り、完了ログに `noise=0` が含まれること。 */
+      /** 全ファイルが残り、完了ログに `keep=2` が含まれること。 */
       describe('Then: T-PF-E2E-04 - 全ファイルが残っており keep=2 のログ', () => {
         let tempDir: string;
         let chatlogsDir: string;
@@ -264,7 +264,7 @@ describe('main (prefilter) - 全件 keep', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        it('T-PF-E2E-04-01: 全ファイルが削除されずに残り、完了ログに "noise=0" が含まれる', async () => {
+        it('T-PF-E2E-04-01: 全ファイルが削除されずに残り、完了ログに "keep=2" が含まれる', async () => {
           const path1 = `${chatlogsDir}/valid-1.md`;
           const path2 = `${chatlogsDir}/valid-2.md`;
           await Deno.writeTextFile(path1, _makeValidContent());
@@ -274,19 +274,19 @@ describe('main (prefilter) - 全件 keep', () => {
 
           await assertFileExist(path1);
           await assertFileExist(path2);
-          assertEquals(loggerStub.infoLogs.some((line) => line.includes('noise=0')), true);
+          assertEquals(loggerStub.infoLogs.some((line) => line.includes('keep=2')), true);
         });
       });
     });
   });
 });
 
-// ─── T-PF-E2E-06: 空ディレクトリ → noise=0 keep=0 ログ ──────────────────────
+// ─── T-PF-E2E-06: 空ディレクトリ → keep=0 remove=0 error=0 ログ ─────────────
 
 /**
  * `main` 関数（prefilter）の E2E テストスイート（空ディレクトリ）。
  *
- * `.md` ファイルが 0 件の場合に `noise=0 keep=0 error=0` を含む
+ * `.md` ファイルが 0 件の場合に `keep=0 remove=0 error=0` を含む
  * 完了ログが出力されることを検証する。
  *
  * テスト ID 範囲: T-PF-E2E-06
@@ -302,8 +302,8 @@ describe('main (prefilter) - 空ディレクトリ', () => {
   describe('Given: .md ファイルが 0 件のディレクトリ', () => {
     /** `main(["claude", "--input-dir", agentDir])` を呼び出すとき。 */
     describe('When: main(["claude", "--input-dir", agentDir]) を呼び出す', () => {
-      /** 完了ログに `noise=0` と `keep=0` が含まれること。 */
-      describe('Then: T-PF-E2E-06 - "noise=0 keep=0 error=0" を含むログが出力される', () => {
+      /** 完了ログに `keep=0` と `remove=0` が含まれること。 */
+      describe('Then: T-PF-E2E-06 - "keep=0 remove=0 error=0" を含むログが出力される', () => {
         let tempDir: string;
         let loggerStub: LoggerStub;
 
@@ -318,13 +318,13 @@ describe('main (prefilter) - 空ディレクトリ', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        it('T-PF-E2E-06-01: 完了ログに "noise=0 keep=0 error=0" が含まれる', async () => {
+        it('T-PF-E2E-06-01: 完了ログに "keep=0 remove=0 error=0" が含まれる', async () => {
           const agentDir = `${tempDir}/claude`;
           await Deno.mkdir(agentDir, { recursive: true });
 
           await main(['claude', '--input-dir', agentDir]);
 
-          assertEquals(loggerStub.infoLogs.some((line) => line.includes('noise=0') && line.includes('keep=0')), true);
+          assertEquals(loggerStub.infoLogs.some((line) => line.includes('keep=0') && line.includes('remove=0')), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -14,23 +14,24 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { stub } from '@std/testing/mock';
 
 // ─── Test target
-import { prefilterFiles } from '../../../libs/prefilter.ts';
-// types
-import type { FilterStats } from '../../../types/filter.types.ts';
+import { prefilterFiles } from '../../../modules/prefilter.ts';
 
 // ─── Helpers
+import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makePeriodDir, makeRepeatedContent, makeValidContent } from '../../_helpers/fixtures.ts';
 // constants
 import { FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
+// types
+import type { BaseStats } from '../../../types/stats.types.ts';
 
 // ─── Internal Helpers
 
 /**
- * テスト用の初期化済み `FilterStats` オブジェクトを返す。
+ * テスト用の初期化済み `BaseStats` オブジェクトを返す。
  *
- * @returns `{ kept: 0, discarded: 0, skipped: 0, preSkipped: 0, error: 0 }` の FilterStats
+ * @returns `{ keep: 0, skip: 0, remove: 0, error: 0 }` の BaseStats
  */
-const _makeStats = (): FilterStats => ({ kept: 0, discarded: 0, skipped: 0, preSkipped: 0, error: 0 });
+const _makeStats = (): BaseStats => ({ keep: 0, skip: 0, remove: 0, error: 0 });
 
 // ─── Tests
 
@@ -44,7 +45,7 @@ const _makeStats = (): FilterStats => ({ kept: 0, discarded: 0, skipped: 0, preS
  * - ファイル名が除外パターンに一致する（例: `say-ok-and-nothing-else.md`）
  * - 本文（frontmatter を除いた部分）が空または 1000 文字未満
  *
- * テスト ID 範囲: T-FL-PFF-01 〜 T-FL-PFF-08
+ * テスト ID 範囲: T-FL-PFF-01 〜 T-FL-PFF-09
  *
  * @see prefilterFiles
  */
@@ -78,7 +79,7 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath]);
+          const result = await prefilterFiles([filePath], { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -102,7 +103,7 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath]);
+          const result = await prefilterFiles([filePath], { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -126,7 +127,7 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n短い本文\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath]);
+          const result = await prefilterFiles([filePath], { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -151,7 +152,7 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, makeRepeatedContent(1200));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath], 2428);
+          const result = await prefilterFiles([filePath], { minCharCount: 2428, stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -162,7 +163,7 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, makeRepeatedContent(1200));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath], 2426);
+          const result = await prefilterFiles([filePath], { minCharCount: 2426, stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -188,7 +189,11 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, makeValidContent('テスト', 'u'.repeat(1500), 'a'.repeat(400)));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath], 1000, 401);
+          const result = await prefilterFiles([filePath], {
+            minCharCount: 1000,
+            minAssistantChars: 401,
+            stats: _makeStats(),
+          });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -199,7 +204,11 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, makeValidContent('テスト', 'u'.repeat(1500), 'a'.repeat(400)));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath], 1000, 399);
+          const result = await prefilterFiles([filePath], {
+            minCharCount: 1000,
+            minAssistantChars: 399,
+            stats: _makeStats(),
+          });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -209,16 +218,16 @@ describe('prefilterFiles', () => {
   });
 
   /**
-   * stats 引数を渡した場合の preSkipped カウント検証グループ。
+   * stats 引数を渡した場合の keep カウント検証グループ。
    *
-   * スキップされたファイル数が stats.preSkipped に正しく反映されることを検証する。
+   * 事前段階で KEEP 確定したファイル数が stats.keep に正しく反映されることを検証する。
    */
   describe('Given: 3 ファイル（ファイル名パターン除外 1 + 本文短すぎ 1 + 正常 1）', () => {
     /** stats = _makeStats() を渡して prefilterFiles を呼び出すとき。 */
     describe('When: stats オブジェクトを渡して prefilterFiles を呼び出す', () => {
-      /** stats.preSkipped がスキップ数と一致し、戻り値が正常ファイルのみであることを検証する。 */
-      describe('Then: T-FL-PFF-07 - stats.preSkipped がスキップ数と一致する', () => {
-        it('T-FL-PFF-07-01: stats.preSkipped === 2 かつ 戻り値は 1 ファイル', async () => {
+      /** stats.keep が事前 KEEP 確定数と一致し、戻り値が正常ファイルのみであることを検証する。 */
+      describe('Then: T-FL-PFF-07 - stats.keep が事前 KEEP 確定数と一致する', () => {
+        it('T-FL-PFF-07-01: stats.keep === 2 かつ 戻り値は 1 ファイル', async () => {
           const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
           const shortPath = `${periodDir1}/short-body.md`;
           const validPath = `${periodDir1}/valid.md`;
@@ -228,32 +237,32 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
 
           const _stats = _makeStats();
-          const result = await prefilterFiles([excludedPath, shortPath, validPath], undefined, undefined, _stats);
+          const result = await prefilterFiles([excludedPath, shortPath, validPath], { stats: _stats });
           errStub.restore();
 
           assertEquals(result.length, 1);
-          assertEquals(_stats.preSkipped, 2);
+          assertEquals(_stats.keep, 2);
         });
       });
     });
   });
 
   /**
-   * stats 引数を省略した場合でもエラーなく動作することを検証するグループ。
+   * stats を渡して prefilterFiles を呼び出したときの基本動作を検証するグループ。
    */
   describe('Given: 正常な 2 ファイル', () => {
-    /** stats なしで prefilterFiles を呼び出すとき。 */
-    describe('When: stats 引数を省略して prefilterFiles を呼び出す', () => {
+    /** stats を渡して prefilterFiles を呼び出すとき。 */
+    describe('When: stats を渡して prefilterFiles を呼び出す', () => {
       /** エラーなく 2 ファイルが戻ることを検証する。 */
       describe('Then: T-FL-PFF-08 - エラーなく動作する', () => {
-        it('T-FL-PFF-08-01: stats 省略時も 2 ファイルが返される', async () => {
+        it('T-FL-PFF-08-01: stats を渡すと2ファイルが返される', async () => {
           const validPath1 = `${periodDir1}/valid1.md`;
           const validPath2 = `${periodDir1}/valid2.md`;
           await Deno.writeTextFile(validPath1, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           await Deno.writeTextFile(validPath2, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([validPath1, validPath2]);
+          const result = await prefilterFiles([validPath1, validPath2], { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 2);
@@ -277,7 +286,7 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([filePath]);
+          const result = await prefilterFiles([filePath], { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -291,11 +300,61 @@ describe('prefilterFiles', () => {
           await Deno.writeTextFile(shortPath, '---\ntitle: 短い\n---\n短い本文\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([validPath, shortPath]);
+          const result = await prefilterFiles([validPath, shortPath], { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(result.length, 1);
           assertEquals(result[0], validPath);
+        });
+      });
+    });
+  });
+
+  /**
+   * ファイル名パターン除外 1 件・本文短すぎ 1 件・正常 1 件が混在するファイルを入力とする前提条件グループ。
+   *
+   * `dryRun: true` を指定したときのログ抑制と、戻り値・stats の値が `dryRun: false` と一致することを検証する。
+   */
+  describe('Given: 3 ファイル（ファイル名パターン除外 1 + 本文短すぎ 1 + 正常 1）', () => {
+    /** dryRun: true を渡して prefilterFiles を呼び出すとき。 */
+    describe('When: dryRun: true を渡して prefilterFiles を呼び出す', () => {
+      /** ログ出力が抑制され、戻り値・stats は dryRun なし時と同じであることを検証する。 */
+      describe('Then: T-FL-PFF-09 - ログ出力が抑制され結果は変わらない', () => {
+        it('T-FL-PFF-09-01: [Normal] dryRun: true のとき logger.info が呼ばれない', async () => {
+          const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
+          const shortPath = `${periodDir1}/short-body.md`;
+          const validPath = `${periodDir1}/valid.md`;
+          await Deno.writeTextFile(excludedPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(shortPath, '---\ntitle: テスト\n---\n短い本文\n');
+          await Deno.writeTextFile(validPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const loggerStub = makeLoggerStub();
+
+          await prefilterFiles([excludedPath, shortPath, validPath], { stats: _makeStats(), dryRun: true });
+          loggerStub.restore();
+
+          assertEquals(loggerStub.infoLogs.length, 0);
+        });
+
+        it('T-FL-PFF-09-02: [Normal] dryRun: true でも戻り値と stats.keep は dryRun なし時と同じ', async () => {
+          const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
+          const shortPath = `${periodDir1}/short-body.md`;
+          const validPath = `${periodDir1}/valid.md`;
+          await Deno.writeTextFile(excludedPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(shortPath, '---\ntitle: テスト\n---\n短い本文\n');
+          await Deno.writeTextFile(validPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const loggerStub = makeLoggerStub();
+
+          const statsDryRun = _makeStats();
+          const resultDryRun = await prefilterFiles([excludedPath, shortPath, validPath], {
+            stats: statsDryRun,
+            dryRun: true,
+          });
+          const statsNormal = _makeStats();
+          const resultNormal = await prefilterFiles([excludedPath, shortPath, validPath], { stats: statsNormal });
+          loggerStub.restore();
+
+          assertEquals(resultDryRun, resultNormal);
+          assertEquals(statsDryRun.keep, statsNormal.keep);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
@@ -13,7 +13,9 @@ import { stub } from '@std/testing/mock';
 // test target
 import { findFiles } from '../../../../../_scripts/libs/file-ops/find-files.ts';
 import { buildBatchPrompt } from '../../../libs/batch-prompt.ts';
-import { prefilterFiles } from '../../../libs/prefilter.ts';
+import { prefilterFiles } from '../../../modules/prefilter.ts';
+// types
+import type { BaseStats } from '../../../types/stats.types.ts';
 
 // ─── Helpers
 import { makeRepeatedContent } from '../../_helpers/fixtures.ts';
@@ -36,6 +38,9 @@ afterEach(async () => {
 
 /** `FILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
 const _makeValidContent = (title: string) => makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH, title);
+
+/** テスト用の初期化済み `BaseStats` オブジェクトを返す。 */
+const _makeStats = (): BaseStats => ({ keep: 0, skip: 0, remove: 0, error: 0 });
 
 // ─── T-FL-IO-01: findMdFiles → prefilterFiles パイプライン ───────────────────
 
@@ -60,7 +65,7 @@ describe('findMdFiles → prefilterFiles パイプライン', () => {
 
           const allFiles = await findFiles(tempDir);
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(allFiles);
+          const passed = await prefilterFiles(allFiles, { stats: _makeStats() });
           errStub.restore();
 
           assertEquals(passed.length, 2);
@@ -83,7 +88,7 @@ describe('prefilterFiles → buildBatchPrompt パイプライン', () => {
           await Deno.writeTextFile(file2, _makeValidContent('Chat 2'));
 
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles([file1, file2]);
+          const passed = await prefilterFiles([file1, file2], { stats: _makeStats() });
           errStub.restore();
 
           const prompt = await buildBatchPrompt(passed);

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -36,8 +36,8 @@ import type { ArgSchema } from '../../_scripts/types/args-schema.types.ts';
 
 // ─── internal ───
 // functions
-import { prefilterFiles } from './libs/prefilter.ts';
 import { processChunk } from './modules/filter/process-chunk.ts';
+import { prefilterFiles } from './modules/prefilter.ts';
 // constants
 import { DEFAULT_FILTER_CONFIG } from './constants/common.constants.ts';
 // types
@@ -125,31 +125,43 @@ export const main = async (args?: string[]): Promise<void> => {
     const allFiles = await findFiles(_searchDir);
 
     // 事前フィルタ
-    const stats = { kept: 0, discarded: 0, skipped: 0, preSkipped: 0, error: 0 };
-    const targetFiles = await prefilterFiles(allFiles, _config.minCharCount, _config.minAssistantChars, stats);
+    const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
+    const targetFiles = await prefilterFiles(allFiles, {
+      minCharCount: _config.minCharCount,
+      minAssistantChars: _config.minAssistantChars,
+      stats,
+      dryRun: _config.dryRun,
+    });
 
     const total = targetFiles.length;
     if (total === 0) {
       logger.info(`${LOGGER_HEADER.NO_FILE_FOUND}: 対象ファイルなし`);
-      logger.info(`完了: total=${allFiles.length} preSkipped=${stats.preSkipped} kept=0 discarded=0 skipped=0 error=0`);
+      logger.info(
+        `完了: total=${allFiles.length} keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
+      );
       return;
     }
 
     logger.info(`判定対象ファイル数: ${total}`);
-    if (_config.dryRun) { logger.info('dry-run モード: ファイルは削除しません'); }
 
-    // チャンク分割して並列処理
-    await runChunked(
-      targetFiles,
-      _config.chunkSize,
-      (chunk) => processChunk(chunk, _config.dryRun, stats, _config.discardThreshold),
-      _config.concurrency,
-    );
+    if (_config.dryRun) {
+      logger.info('dry-run モード: claude CLI を呼び出さず対象ファイルを一覧表示します');
+      targetFiles.forEach((filePath) => logger.info(`対象: ${filePath}`));
+      stats.skip += targetFiles.length;
+    } else {
+      // チャンク分割して並列処理
+      await runChunked(
+        targetFiles,
+        _config.chunkSize,
+        (chunk) => processChunk(chunk, stats, _config.discardThreshold),
+        _config.concurrency,
+      );
+    }
 
     // サマリー
     const drySuffix = _config.dryRun ? ' (dry-run)' : '';
     logger.info(
-      `\n完了${drySuffix}: total=${allFiles.length} preSkipped=${stats.preSkipped} kept=${stats.kept} discarded=${stats.discarded} skipped=${stats.skipped} error=${stats.error}`,
+      `\n完了${drySuffix}: total=${allFiles.length} keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
     );
   } catch (e) {
     if (e instanceof ChatlogError) {

--- a/skills/filter-chatlogs/scripts/modules/__tests__/unit/prefilter.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/__tests__/unit/prefilter.unit.spec.ts
@@ -1,4 +1,4 @@
-// src: scripts/libs/__tests__/unit/prefilter.unit.spec.ts
+// src: scripts/modules/__tests__/unit/prefilter.unit.spec.ts
 // @(#): prefilter.ts のユニットテスト
 //       対象: isSystemOnlyMessage / isExcludedByFilename / isExcludedByContent
 //

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -16,7 +16,7 @@ import { stub } from '@std/testing/mock';
 // ─── Test target
 import { processChunk } from '../../process-chunk.ts';
 // types
-import type { FilterStats } from '../../../../types/filter.types.ts';
+import type { FilterStats } from '../../../../types/stats.types.ts';
 
 // ─── Helpers
 import {
@@ -30,7 +30,7 @@ import { DEFAULT_CONFIG_VALUES } from '../../../../../../_scripts/constants/conf
 import type { CommandMockHandle } from '../../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makePeriodDir } from '../../../../__tests__/_helpers/fixtures.ts';
 // exists
-import { fileExists, fileOrDirExists } from '../../../../../../_scripts/libs/file-ops/exists-utils.ts';
+import { fileOrDirExists } from '../../../../../../_scripts/libs/file-ops/exists-utils.ts';
 // constants
 import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
 
@@ -41,15 +41,15 @@ import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.
 /**
  * `processChunk` 関数の機能テストスイート。
  *
- * `processChunk(files, dryRun, stats, discardThreshold)` は Claude CLI にバッチ判定を依頼し、
+ * `processChunk(files, stats, discardThreshold)` は Claude CLI にバッチ判定を依頼し、
  * DISCARD/KEEP 判定に応じてファイル削除と統計更新を行う。
  *
  * ## 判定ルール
- * - `decision === 'DISCARD'` かつ `confidence >= DEFAULT_CONFIG_VALUES.discardThreshold` → ファイルを削除（dryRun=false 時）
+ * - `decision === 'DISCARD'` かつ `confidence >= DEFAULT_CONFIG_VALUES.discardThreshold` → ファイルを削除
  * - `confidence < DEFAULT_CONFIG_VALUES.discardThreshold` → DISCARD 判定でも KEEP 扱い
  * - CLI エラー・JSON パース失敗・ファイル名不一致 → 全件 KEEP 扱い
  *
- * テスト ID 範囲: T-FL-PCK-01 〜 T-FL-PCK-08
+ * テスト ID 範囲: T-FL-PCK-01 〜 T-FL-PCK-10
  *
  * @see processChunk
  */
@@ -66,10 +66,10 @@ describe('processChunk', () => {
   /**
    * 初期値がすべて 0 の `FilterStats` オブジェクトを生成する。
    *
-   * @returns `{ kept: 0, discarded: 0, skipped: 0, preSkipped: 0, error: 0 }` の FilterStats
+   * @returns `{ keep: 0, skip: 0, remove: 0, error: 0 }` の FilterStats
    */
   function _makeStats(): FilterStats {
-    return { kept: 0, discarded: 0, skipped: 0, preSkipped: 0, error: 0 };
+    return { keep: 0, skip: 0, remove: 0, error: 0 };
   }
 
   /**
@@ -95,76 +95,15 @@ describe('processChunk', () => {
   });
 
   /**
-   * DISCARD 判定を返す Claude モックと `dryRun=true` の前提条件グループ。
+   * DISCARD 判定を返す Claude モックの前提条件グループ。
    *
-   * dryRun モードではファイルを物理削除しないが、stats.discarded がインクリメントされることを検証する。
+   * ファイルが物理削除され、stats.remove がインクリメントされることを検証する。
    */
-  describe('Given: DISCARD 判定を返す Claude モックと dryRun=true', () => {
-    /** processChunk([file], true, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], true, stats) を呼び出す', () => {
-      /** ファイルが残り、stats.discarded が増えることを検証する。 */
-      describe('Then: T-FL-PCK-01 - ファイルが削除されず stats.discarded が増える', () => {
-        it('T-FL-PCK-01-01: ファイルが残っている', async () => {
-          const filePath = await _createTempFile('a.md');
-          const response = JSON.stringify([
-            {
-              file: 'a.md',
-              decision: FILTER_DECISIONS.DISCARD,
-              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
-              reason: 'trivial',
-            },
-          ]);
-          commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
-          );
-          const errStub = stub(console, 'error', () => {});
-          const logStub = stub(console, 'log', () => {});
-          const stats = _makeStats();
-
-          await processChunk([filePath], true, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
-          errStub.restore();
-          logStub.restore();
-
-          assertEquals(await fileExists(filePath), true);
-        });
-
-        it('T-FL-PCK-01-02: stats.discarded が 1 になる', async () => {
-          const filePath = await _createTempFile('a.md');
-          const response = JSON.stringify([
-            {
-              file: 'a.md',
-              decision: FILTER_DECISIONS.DISCARD,
-              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
-              reason: 'trivial',
-            },
-          ]);
-          commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
-          );
-          const errStub = stub(console, 'error', () => {});
-          const logStub = stub(console, 'log', () => {});
-          const stats = _makeStats();
-
-          await processChunk([filePath], true, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
-          errStub.restore();
-          logStub.restore();
-
-          assertEquals(stats.discarded, 1);
-        });
-      });
-    });
-  });
-
-  /**
-   * DISCARD 判定を返す Claude モックと `dryRun=false` の前提条件グループ。
-   *
-   * dryRun=false 時にはファイルが物理削除され、stats.discarded がインクリメントされることを検証する。
-   */
-  describe('Given: DISCARD 判定を返す Claude モックと dryRun=false', () => {
-    /** processChunk([file], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats) を呼び出す', () => {
-      /** ファイルが削除され、stats.discarded が増えることを検証する。 */
-      describe('Then: T-FL-PCK-02 - ファイルが削除され stats.discarded が増える', () => {
+  describe('Given: DISCARD 判定を返す Claude モック', () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** ファイルが削除され、stats.remove が増えることを検証する。 */
+      describe('Then: T-FL-PCK-02 - ファイルが削除され stats.remove が増える', () => {
         it('T-FL-PCK-02-01: ファイルが削除される', async () => {
           const filePath = await _createTempFile('b.md');
           const response = JSON.stringify([
@@ -182,14 +121,14 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
           logStub.restore();
 
           assertEquals(await fileOrDirExists(filePath), false);
         });
 
-        it('T-FL-PCK-02-02: stats.discarded が 1 になる', async () => {
+        it('T-FL-PCK-02-02: stats.remove が 1 になる', async () => {
           const filePath = await _createTempFile('c.md');
           const response = JSON.stringify([
             {
@@ -206,11 +145,11 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
           logStub.restore();
 
-          assertEquals(stats.discarded, 1);
+          assertEquals(stats.remove, 1);
         });
       });
     });
@@ -219,14 +158,14 @@ describe('processChunk', () => {
   /**
    * KEEP 判定を返す Claude モックの前提条件グループ。
    *
-   * ファイルが削除されず、stats.kept がインクリメントされることを検証する。
+   * ファイルが削除されず、stats.keep がインクリメントされることを検証する。
    */
   describe('Given: KEEP 判定を返す Claude モック', () => {
-    /** processChunk([file], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats) を呼び出す', () => {
-      /** ファイルが残り、stats.kept が増えることを検証する。 */
-      describe('Then: T-FL-PCK-03 - ファイルが残り stats.kept が増える', () => {
-        it('T-FL-PCK-03-01: stats.kept が 1 になる', async () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** ファイルが残り、stats.keep が増えることを検証する。 */
+      describe('Then: T-FL-PCK-03 - ファイルが残り stats.keep が増える', () => {
+        it('T-FL-PCK-03-01: stats.keep が 1 になる', async () => {
           const filePath = await _createTempFile('d.md');
           const response = JSON.stringify([
             { file: 'd.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
@@ -237,10 +176,10 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
-          assertEquals(stats.kept, 1);
+          assertEquals(stats.keep, 1);
         });
       });
     });
@@ -252,11 +191,11 @@ describe('processChunk', () => {
    * 信頼度不足の DISCARD は KEEP 扱いとなることを検証する。
    */
   describe('Given: DISCARD 判定だが confidence が 0.7 未満', () => {
-    /** processChunk([file], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats) を呼び出す', () => {
-      /** KEEP 扱いとなり、stats.kept が増えることを検証する。 */
-      describe('Then: T-FL-PCK-04 - KEEP 扱いで stats.kept が増える', () => {
-        it('T-FL-PCK-04-01: confidence=0.6 の DISCARD → stats.kept が 1 になる', async () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** KEEP 扱いとなり、stats.keep が増えることを検証する。 */
+      describe('Then: T-FL-PCK-04 - KEEP 扱いで stats.keep が増える', () => {
+        it('T-FL-PCK-04-01: confidence=0.6 の DISCARD → stats.keep が 1 になる', async () => {
           const filePath = await _createTempFile('e.md');
           const response = JSON.stringify([
             { file: 'e.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'low conf' },
@@ -267,11 +206,11 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
-          assertEquals(stats.kept, 1);
-          assertEquals(stats.discarded, 0);
+          assertEquals(stats.keep, 1);
+          assertEquals(stats.remove, 0);
         });
       });
     });
@@ -283,21 +222,21 @@ describe('processChunk', () => {
    * CLI 失敗時は全件 KEEP 扱いとなり、ファイルが削除されないことを検証する。
    */
   describe('Given: Claude CLI が失敗するモック', () => {
-    /** processChunk([file1, file2], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file1, file2], false, stats) を呼び出す', () => {
-      /** 全件 KEEP 扱いとなり、stats.kept が入力ファイル数と一致することを検証する。 */
-      describe('Then: T-FL-PCK-05 - 全件 KEEP 扱いで stats.kept が増える', () => {
-        it('T-FL-PCK-05-01: stats.kept が 2 になる（全件 KEEP）', async () => {
+    /** processChunk([file1, file2], stats) を呼び出すとき。 */
+    describe('When: processChunk([file1, file2], stats) を呼び出す', () => {
+      /** 全件 KEEP 扱いとなり、stats.keep が入力ファイル数と一致することを検証する。 */
+      describe('Then: T-FL-PCK-05 - 全件 KEEP 扱いで stats.keep が増える', () => {
+        it('T-FL-PCK-05-01: stats.keep が 2 になる（全件 KEEP）', async () => {
           const file1 = await _createTempFile('f1.md');
           const file2 = await _createTempFile('f2.md');
           commandHandle = installCommandMock(makeFailMock(1));
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([file1, file2], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([file1, file2], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
-          assertEquals(stats.kept, 2);
+          assertEquals(stats.keep, 2);
         });
       });
     });
@@ -309,11 +248,11 @@ describe('processChunk', () => {
    * JSON パース失敗時は全件 KEEP 扱いとなることを検証する。
    */
   describe('Given: JSON でないテキストを返す Claude モック', () => {
-    /** processChunk([file], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats) を呼び出す', () => {
-      /** 全件 KEEP 扱いとなり、stats.kept が増えることを検証する。 */
-      describe('Then: T-FL-PCK-06 - 全件 KEEP 扱いで stats.kept が増える', () => {
-        it('T-FL-PCK-06-01: stats.kept が 1 になる', async () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** 全件 KEEP 扱いとなり、stats.keep が増えることを検証する。 */
+      describe('Then: T-FL-PCK-06 - 全件 KEEP 扱いで stats.keep が増える', () => {
+        it('T-FL-PCK-06-01: stats.keep が 1 になる', async () => {
           const filePath = await _createTempFile('g.md');
           commandHandle = installCommandMock(
             makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
@@ -321,10 +260,10 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
-          assertEquals(stats.kept, 1);
+          assertEquals(stats.keep, 1);
         });
       });
     });
@@ -336,11 +275,11 @@ describe('processChunk', () => {
    * ファイル名不一致の場合は該当ファイルを KEEP 扱いとすることを検証する。
    */
   describe('Given: 対象ファイルと異なるファイル名の結果を返す Claude モック', () => {
-    /** processChunk([file], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats) を呼び出す', () => {
-      /** KEEP 扱いとなり、stats.kept が増えることを検証する。 */
-      describe('Then: T-FL-PCK-07 - KEEP 扱いで stats.kept が増える', () => {
-        it('T-FL-PCK-07-01: ファイル名不一致 → stats.kept が 1 になる', async () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** KEEP 扱いとなり、stats.keep が増えることを検証する。 */
+      describe('Then: T-FL-PCK-07 - KEEP 扱いで stats.keep が増える', () => {
+        it('T-FL-PCK-07-01: ファイル名不一致 → stats.keep が 1 になる', async () => {
           const filePath = await _createTempFile('h.md');
           // 対象は h.md だが結果は other.md
           const response = JSON.stringify([
@@ -352,10 +291,10 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
-          assertEquals(stats.kept, 1);
+          assertEquals(stats.keep, 1);
         });
       });
     });
@@ -367,20 +306,63 @@ describe('processChunk', () => {
    * CLI 未インストール時は KEEP 扱いとなり、ファイルが安全に保持されることを検証する。
    */
   describe('Given: claude CLI が見つからないモック', () => {
-    /** processChunk([file], false, stats) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats) を呼び出す', () => {
-      /** KEEP 扱いとなり、stats.kept が増えることを検証する。 */
-      describe('Then: T-FL-PCK-08 - KEEP 扱いで stats.kept が増える', () => {
-        it('T-FL-PCK-08-01: NotFound エラー → stats.kept が 1 になる', async () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** KEEP 扱いとなり、stats.keep が増えることを検証する。 */
+      describe('Then: T-FL-PCK-08 - KEEP 扱いで stats.keep が増える', () => {
+        it('T-FL-PCK-08-01: NotFound エラー → stats.keep が 1 になる', async () => {
           const filePath = await _createTempFile('i.md');
           commandHandle = installCommandMock(makeNotFoundMock());
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
           errStub.restore();
 
-          assertEquals(stats.kept, 1);
+          assertEquals(stats.keep, 1);
+        });
+      });
+    });
+  });
+
+  /**
+   * DISCARD 判定だが対象ファイルが削除実行前に既に存在しない前提条件グループ。
+   *
+   * `removeFile` が `false` を返すケースで stats.error がインクリメントされることを検証する。
+   */
+  describe('Given: DISCARD 判定だが対象ファイルが既に存在しない', () => {
+    /** processChunk([file], stats) を呼び出すとき。 */
+    describe('When: processChunk([file], stats) を呼び出す', () => {
+      /** stats.error が増え、stats.remove は増えないことを検証する。 */
+      describe('Then: T-FL-PCK-10 - stats.error が 1 になる', () => {
+        it('T-FL-PCK-10-01: removeFile が失敗 → stats.error === 1', async () => {
+          const filePath = await _createTempFile('k.md');
+          const response = JSON.stringify([
+            {
+              file: 'k.md',
+              decision: FILTER_DECISIONS.DISCARD,
+              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+              reason: 'trivial',
+            },
+          ]);
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode(response)),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const warnStub = stub(console, 'warn', () => {});
+          const logStub = stub(console, 'log', () => {});
+          const stats = _makeStats();
+          // removeFile 内部の Deno.remove が NotFound を投げるようにし、"File not found" 分岐を発生させる
+          const removeStub = stub(Deno, 'remove', () => Promise.reject(new Deno.errors.NotFound()));
+
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          errStub.restore();
+          warnStub.restore();
+          logStub.restore();
+          removeStub.restore();
+
+          assertEquals(stats.error, 1);
+          assertEquals(stats.remove, 0);
         });
       });
     });
@@ -392,11 +374,11 @@ describe('processChunk', () => {
    * discardThreshold が引数で制御できることを確認する。
    */
   describe('Given: DISCARD 判定 confidence=0.6 と discardThreshold=0.5', () => {
-    /** processChunk([file], false, stats, 0.5) を呼び出すとき。 */
-    describe('When: processChunk([file], false, stats, 0.5) を呼び出す', () => {
-      /** confidence(0.6) >= threshold(0.5) なので DISCARD → stats.discarded が 1 になる。 */
-      describe('Then: T-FL-PCK-09 - stats.discarded が 1 になる', () => {
-        it('T-FL-PCK-09-01: threshold=0.5, confidence=0.6 → stats.discarded === 1', async () => {
+    /** processChunk([file], stats, 0.5) を呼び出すとき。 */
+    describe('When: processChunk([file], stats, 0.5) を呼び出す', () => {
+      /** confidence(0.6) >= threshold(0.5) なので DISCARD → stats.remove が 1 になる。 */
+      describe('Then: T-FL-PCK-09 - stats.remove が 1 になる', () => {
+        it('T-FL-PCK-09-01: threshold=0.5, confidence=0.6 → stats.remove === 1', async () => {
           const filePath = await _createTempFile('j.md');
           const response = JSON.stringify([
             { file: 'j.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'trivial' },
@@ -408,11 +390,11 @@ describe('processChunk', () => {
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
 
-          await processChunk([filePath], false, stats, 0.5);
+          await processChunk([filePath], stats, 0.5);
           errStub.restore();
           logStub.restore();
 
-          assertEquals(stats.discarded, 1);
+          assertEquals(stats.remove, 1);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -39,7 +39,6 @@ DISCARD: execution-only, trivial Q&A, no reusable insight, context-dependent`;
 
 export const processChunk = async (
   chunkFiles: string[],
-  dryRun: boolean,
   stats: FilterStats,
   discardThreshold: number,
 ): Promise<void> => {

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -19,7 +19,8 @@ import { parseAiJsonArray } from '../../../../_scripts/libs/text/json-utils.ts';
 import { buildBatchPrompt } from '../../libs/batch-prompt.ts';
 import { FILTER_DECISIONS } from '../../types/filter-decision.const.types.ts';
 // types
-import type { ClaudeResult, FilterStats } from '../../types/filter.types.ts';
+import type { ClaudeResult } from '../../types/filter.types.ts';
+import type { FilterStats } from '../../types/stats.types.ts';
 
 // ─────────────────────────────────────────────
 // 内部定数
@@ -52,7 +53,7 @@ export const processChunk = async (
     logger.warn(`  error: ${e}`);
     for (const f of chunkFiles) {
       logger.info(`  kept (claude error): ${getFilename(f)}`);
-      stats.kept++;
+      stats.keep++;
     }
     return;
   }
@@ -63,7 +64,7 @@ export const processChunk = async (
     logger.warn(`  raw output: ${rawResult.slice(0, 200)}`);
     for (const f of chunkFiles) {
       logger.info(`  kept (parse error): ${getFilename(f)}`);
-      stats.kept++;
+      stats.keep++;
     }
     return;
   }
@@ -74,29 +75,24 @@ export const processChunk = async (
 
     if (!result) {
       logger.info(`  kept (not in result): ${filename}`);
-      stats.kept++;
+      stats.keep++;
       continue;
     }
 
     const { decision, confidence, reason } = result;
 
     if (decision === FILTER_DECISIONS.DISCARD && confidence >= discardThreshold) {
-      if (dryRun) {
-        logger.log(`[dry-run] DISCARD (conf=${confidence}): ${filePath}`);
-        logger.info(`  reason: ${reason}`);
-        stats.discarded++;
+      logger.log(`DISCARD (conf=${confidence}): ${filePath}`);
+      logger.info(`  reason: ${reason}`);
+      if (await removeFile(filePath)) {
+        stats.remove++;
       } else {
-        logger.log(`DISCARD (conf=${confidence}): ${filePath}`);
-        logger.info(`  reason: ${reason}`);
-        if (await removeFile(filePath)) {
-          stats.discarded++;
-        } else {
-          logger.warn(`  skip (File not found):${filePath}`);
-        }
+        logger.warn(`  skip (File not found):${filePath}`);
+        stats.error++;
       }
     } else {
       logger.info(`  kept (decision=${decision}, conf=${confidence}): ${filename}`);
-      stats.kept++;
+      stats.keep++;
     }
   }
 };

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -1,4 +1,4 @@
-// src: scripts/libs/prefilter.ts
+// src: scripts/modules/prefilter.ts
 // @(#): 内容ベース事前フィルタ関数群
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -27,12 +27,12 @@ import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema
 
 // ─── internal ───
 // functions
-import { checkFilename } from './classify-file.ts';
-import { extractConversation } from './common-utils.ts';
+import { checkFilename } from '../libs/classify-file.ts';
+import { extractConversation } from '../libs/common-utils.ts';
 // constants
 import { SYSTEM_TAG_PREFIXES } from '../constants/patterns.constants.ts';
 // types
-import type { FilterStats } from '../types/filter.types.ts';
+import type { PrefilterFilesOptions } from '../types/filter.types.ts';
 
 // ─────────────────────────────────────────────
 // 事前フィルタ関数
@@ -110,26 +110,32 @@ export const isExcludedByContent = (
  * ファイルリストをファイル名パターンと本文内容で事前フィルタリングし、通過したパスを返す。
  *
  * @param files - フィルタリング対象のファイルパス配列
- * @param minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）
- * @param minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）
- * @param stats - 処理統計オブジェクト（省略可）。指定時は `preSkipped` にスキップ数を代入する。
+ * @param options - `prefilterFiles` のオプション
+ * @param options.minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）
+ * @param options.minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）
+ * @param options.stats - 処理統計オブジェクト。事前段階での KEEP 確定数を `keep` に、読み込み失敗数を `error` に加算する。
+ * @param options.dryRun - `true` のとき、スキップ理由・サマリのログ出力を抑制する（デフォルト: `false`）
  * @returns フィルタリングを通過したファイルパスの配列
  */
 export const prefilterFiles = async (
   files: string[],
-  minCharCount = DEFAULT_CONFIG_VALUES.minCharCount as number,
-  minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
-  stats?: FilterStats,
+  options: PrefilterFilesOptions,
 ): Promise<string[]> => {
+  const {
+    minCharCount = DEFAULT_CONFIG_VALUES.minCharCount as number,
+    minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
+    stats,
+    dryRun = false,
+  } = options;
+
   const passed: string[] = [];
-  let skipped = 0;
 
   for (const filePath of files) {
     const filename = getFilename(filePath);
 
     if (isExcludedByFilename(filename)) {
-      logger.info(`  skipped (ファイル名パターン): ${filename}`);
-      skipped++;
+      if (!dryRun) { logger.info(`  skipped (ファイル名パターン): ${filename}`); }
+      stats.keep++;
       continue;
     }
 
@@ -137,33 +143,34 @@ export const prefilterFiles = async (
     try {
       text = await readTextFile(filePath);
     } catch {
-      skipped++;
+      stats.error++;
       continue;
     }
 
     const { content } = parseFrontmatterEntries(text);
     if (!content.trim()) {
-      skipped++;
+      stats.keep++;
       continue;
     }
 
     const { excluded, reason } = isExcludedByContent(content, minCharCount, minAssistantChars);
     if (excluded) {
-      logger.info(`  skipped (${reason}): ${filename}`);
-      skipped++;
+      if (!dryRun) { logger.info(`  skipped (${reason}): ${filename}`); }
+      stats.keep++;
       continue;
     }
 
     const bodyText = extractConversation(content);
     if (!bodyText.trim()) {
-      skipped++;
+      stats.keep++;
       continue;
     }
 
     passed.push(filePath);
   }
 
-  logger.info(`事前フィルタ: 対象=${files.length} 通過=${passed.length} スキップ=${skipped}`);
-  if (stats) { stats.preSkipped = skipped; }
+  if (!dryRun) {
+    logger.info(`事前フィルタ: 対象=${files.length} 通過=${passed.length} keep=${stats.keep}`);
+  }
   return passed;
 };

--- a/skills/filter-chatlogs/scripts/modules/prefilter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -65,36 +65,36 @@ describe('processNoiseFiles', () => {
     await Deno.remove(tempDir, { recursive: true });
   });
 
-  // ─── T-PF-PNF-01: ノイズファイル + 通常モード → 削除、counts.noise 加算 ───────
+  // ─── T-PF-PNF-01: ノイズファイル + 通常モード → 削除、counts.remove 加算 ──────
 
   /**
    * ノイズファイルが通常モードで処理される前提グループ。
    *
-   * ファイルが削除され、`counts.noise` が加算されることを検証する。
+   * ファイルが削除され、`counts.remove` が加算されることを検証する。
    */
   describe('Given: ノイズファイル 1 件', () => {
     /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
-      /** ファイルが削除され、counts.noise=1 になること。 */
-      describe('Then: T-PF-PNF-01 - ファイルが削除され、counts.noise が 1 になる', () => {
+      /** ファイルが削除され、counts.remove=1 になること。 */
+      describe('Then: T-PF-PNF-01 - ファイルが削除され、counts.remove が 1 になる', () => {
         it('T-PF-PNF-01-01: ノイズファイルが削除される', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
 
           assertEquals(await fileExists(filePath), false);
         });
 
-        it('T-PF-PNF-01-02: counts.noise が 1 になる', async () => {
+        it('T-PF-PNF-01-02: counts.remove が 1 になる', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
 
-          assertEquals(counts.noise, 1);
+          assertEquals(counts.remove, 1);
         });
       });
     });
@@ -115,7 +115,7 @@ describe('processNoiseFiles', () => {
         it('T-PF-PNF-02-01: 正常ファイルが削除されずに残る', async () => {
           const filePath = `${tempDir}/${_KEEP_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
 
@@ -125,7 +125,7 @@ describe('processNoiseFiles', () => {
         it('T-PF-PNF-02-02: counts.keep が 1 になる', async () => {
           const filePath = `${tempDir}/${_KEEP_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
 
@@ -150,7 +150,7 @@ describe('processNoiseFiles', () => {
         it('T-PF-PNF-03-01: ファイルが削除されずに残る', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: true, report: false });
 
@@ -160,11 +160,21 @@ describe('processNoiseFiles', () => {
         it('T-PF-PNF-03-02: logLogs にファイルパスが含まれる', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: true, report: false });
 
           assertEquals(loggerStub.logLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
+        });
+
+        it('T-PF-PNF-03-03: counts.skip が 1 になる', async () => {
+          const filePath = `${tempDir}/${_NOISE_FILENAME}`;
+          await Deno.writeTextFile(filePath, _makeValidContent());
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
+
+          await processNoiseFiles([filePath], counts, { dryRun: true, report: false });
+
+          assertEquals(counts.skip, 1);
         });
       });
     });
@@ -185,7 +195,7 @@ describe('processNoiseFiles', () => {
         it('T-PF-PNF-04-01: logLogs に "NOISE\\t..." 形式の行が含まれる', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: true, report: true });
 
@@ -197,11 +207,21 @@ describe('processNoiseFiles', () => {
         it('T-PF-PNF-04-02: ファイルが削除されずに残る', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: true, report: true });
 
           assertEquals(await fileExists(filePath), true);
+        });
+
+        it('T-PF-PNF-04-03: counts.skip が 1 になる', async () => {
+          const filePath = `${tempDir}/${_NOISE_FILENAME}`;
+          await Deno.writeTextFile(filePath, _makeValidContent());
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
+
+          await processNoiseFiles([filePath], counts, { dryRun: true, report: true });
+
+          assertEquals(counts.skip, 1);
         });
       });
     });
@@ -217,16 +237,16 @@ describe('processNoiseFiles', () => {
   describe('Given: readTextFile が例外を throw するパス', () => {
     /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
-      /** stats.error が 1 になり、stats.noise と stats.keep が 0 のままであること。 */
+      /** stats.error が 1 になり、stats.remove と stats.keep が 0 のままであること。 */
       describe('When: 異常系', () => {
         it('[Error] T-PF-PNF-06-01: readTextFile が例外を throw → stats.error が 1 増加し、ファイルは削除されない', async () => {
           const nonExistentPath = `${tempDir}/non-existent-file.md`;
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([nonExistentPath], counts, { dryRun: false, report: false });
 
           assertEquals(counts.error, 1);
-          assertEquals(counts.noise, 0);
+          assertEquals(counts.remove, 0);
           assertEquals(counts.keep, 0);
         });
       });
@@ -238,23 +258,23 @@ describe('processNoiseFiles', () => {
   /**
    * ノイズと正常ファイルが混在する前提グループ。
    *
-   * `counts.noise` と `counts.keep` がそれぞれ正しく加算されることを検証する。
+   * `counts.remove` と `counts.keep` がそれぞれ正しく加算されることを検証する。
    */
   describe('Given: ノイズ 1 件 + 正常 1 件', () => {
     /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
-      /** counts.noise=1、counts.keep=1 になること。 */
-      describe('Then: T-PF-PNF-05 - noise=1, keep=1 になる', () => {
-        it('T-PF-PNF-05-01: counts.noise=1, counts.keep=1 になる', async () => {
+      /** counts.remove=1、counts.keep=1 になること。 */
+      describe('Then: T-PF-PNF-05 - remove=1, keep=1 になる', () => {
+        it('T-PF-PNF-05-01: counts.remove=1, counts.keep=1 になる', async () => {
           const noisePath = `${tempDir}/${_NOISE_FILENAME}`;
           const keepPath = `${tempDir}/${_KEEP_FILENAME}`;
           await Deno.writeTextFile(noisePath, _makeValidContent());
           await Deno.writeTextFile(keepPath, _makeValidContent());
-          const counts = { noise: 0, keep: 0, error: 0 };
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([noisePath, keepPath], counts, { dryRun: false, report: false });
 
-          assertEquals(counts.noise, 1);
+          assertEquals(counts.remove, 1);
           assertEquals(counts.keep, 1);
         });
       });

--- a/skills/filter-chatlogs/scripts/modules/prefilter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter/process-noise-files.ts
@@ -15,7 +15,7 @@ import { getFilename } from '../../../../_scripts/libs/path-utils/path-utils.ts'
 
 // ─── internal ───
 // types
-import type { PrefilterStats } from '../../types/prefilter.types.ts';
+import type { PrefilterStats } from '../../types/stats.types.ts';
 // functions
 import { classifyFile } from '../../libs/classify-file.ts';
 
@@ -47,14 +47,14 @@ export const processNoiseFiles = async (
     if (isNoise) {
       if (report) {
         logger.log(`NOISE\t${reason}\t${filePath}`);
-        stats.noise++;
+        stats.skip++;
       } else if (dryRun) {
         logger.log(filePath);
-        stats.noise++;
+        stats.skip++;
       } else {
         if (await removeFile(filePath)) {
           logger.info(`deleted: ${filePath}`);
-          stats.noise++;
+          stats.remove++;
         } else {
           logger.warn(`  Skipped (File not found): ${filename}`);
           stats.error++;

--- a/skills/filter-chatlogs/scripts/prefilter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/prefilter-chatlogs.ts
@@ -43,7 +43,7 @@ import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 // types
-import type { PrefilterStats } from './types/prefilter.types.ts';
+import type { PrefilterStats } from './types/stats.types.ts';
 // functions
 import { buildConfig, parseArgs } from './configs/prefilter-config.ts';
 import { processNoiseFiles } from './modules/prefilter/process-noise-files.ts';
@@ -75,11 +75,13 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
       logger.info(`${report ? 'report' : 'dry-run'} モード: ファイルは削除しません`);
     }
 
-    const stats: PrefilterStats = { noise: 0, keep: 0, error: 0 };
+    const stats: PrefilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
     await processNoiseFiles(files, stats, { dryRun, report });
 
     const suffix = dryRun ? ` (${report ? 'report' : 'dry-run'})` : '';
-    logger.info(`\n完了${suffix}: noise=${stats.noise} keep=${stats.keep} error=${stats.error}`);
+    logger.info(
+      `\n完了${suffix}: keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
+    );
   } catch (e) {
     if (e instanceof ChatlogError) {
       logger.error(e.message);

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -8,6 +8,7 @@
 
 // types
 import type { FilterDecision } from './filter-decision.const.types.ts';
+import type { BaseStats } from './stats.types.ts';
 
 // ─────────────────────────────────────────────
 // 分類設定型
@@ -59,11 +60,18 @@ export interface ClaudeResult {
   reason: string;
 }
 
-/** バッチ処理全体の処理統計。 */
-export interface FilterStats {
-  kept: number;
-  discarded: number;
-  skipped: number;
-  preSkipped: number;
-  error: number;
+// ─────────────────────────────────────────────
+// prefilterFiles オプション型
+// ─────────────────────────────────────────────
+
+/** `prefilterFiles` のオプション引数。 */
+export interface PrefilterFilesOptions {
+  /** 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）。 */
+  minCharCount?: number;
+  /** User ターン 1 件時の Assistant 応答最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）。 */
+  minAssistantChars?: number;
+  /** 処理統計オブジェクト。事前段階での KEEP 確定数は `keep` に、読み込み失敗数は `error` に加算される。 */
+  stats: BaseStats;
+  /** `true` のとき、スキップ理由・サマリのログ出力を抑制する。 */
+  dryRun?: boolean;
 }

--- a/skills/filter-chatlogs/scripts/types/prefilter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/prefilter.types.ts
@@ -29,13 +29,3 @@ type _Assert<T extends Partial<ParsedArgs>> = T;
 
 /** PrefilterConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
 type _PrefilterConfigCheck = _Assert<PrefilterConfig>;
-
-/** prefilter 処理の統計情報。 */
-export interface PrefilterStats {
-  /** ノイズと判定し処理（削除 or 表示）したファイル数。 */
-  noise: number;
-  /** ノイズなしと判定し保持したファイル数。 */
-  keep: number;
-  /** 読み取りエラーや削除失敗が発生したファイル数。 */
-  error: number;
-}

--- a/skills/filter-chatlogs/scripts/types/stats.types.ts
+++ b/skills/filter-chatlogs/scripts/types/stats.types.ts
@@ -1,0 +1,25 @@
+// src: scripts/types/stats.types.ts
+// @(#): filter-chatlogs 統計カウンター型定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/** filter-chatlogs / prefilter-chatlogs に共通する統計カウンターフィールド。 */
+export interface BaseStats {
+  /** 保存確定数（AI判定でKEEP、または事前段階で対象外と確定したもの）。 */
+  keep: number;
+  /** dry-run/report 等により判定・削除の実行自体を行わなかった数。 */
+  skip: number;
+  /** 判定により削除が実行された数。 */
+  remove: number;
+  /** 読み取りエラーや削除失敗が発生したファイル数。 */
+  error: number;
+}
+
+/** バッチ処理全体の処理統計。 */
+export interface FilterStats extends BaseStats {}
+
+/** prefilter 処理の統計情報。 */
+export interface PrefilterStats extends BaseStats {}


### PR DESCRIPTION
## Overview

**Summary**
Unify filter/prefilter stats into a shared type and make dry-run skip the claude CLI call.

**Background / Motivation**
`filter-chatlogs` and `prefilter-chatlogs` used two different, inconsistent stats shapes. Dry-run also still called the claude CLI to get a decision before skipping the delete, which defeated the purpose of a dry run. This PR merges the stats shapes into one `BaseStats` type and makes dry-run stop before any claude CLI call.

## Changes

### Core Changes

- Add `types/stats.types.ts` with a shared `BaseStats` type (`keep`, `skip`, `remove`, `error`). `FilterStats` and `PrefilterStats` now extend it.
- Add `PrefilterFilesOptions` to `types/filter.types.ts` so `prefilterFiles` takes one options object instead of positional arguments.
- Move `libs/prefilter.ts` to `modules/prefilter.ts` and update its signature and imports.
- `filter-chatlogs.ts`: dry-run now lists target files and increments `stats.skip` directly, without calling `processChunk` (no claude CLI call). Completion log fields renamed to `keep/skip/remove/error`.
- `modules/filter/process-chunk.ts`: remove the `dryRun` branch. `DISCARD` now always calls `removeFile`, and a failure increments `stats.error` (previously only logged as a warning).
- `modules/prefilter/process-noise-files.ts`: counters renamed from `stats.noise` to `stats.skip`/`stats.remove`.
- `prefilter-chatlogs.ts`: completion log updated to the shared `keep/skip/remove/error` fields.

### Test Updates

- Update unit/functional/integration/e2e tests for the new stats field names, the `prefilterFiles` options-object signature, and the reworked dry-run behavior.
- Move `libs/__tests__/unit/prefilter.unit.spec.ts` to `modules/__tests__/unit/prefilter.unit.spec.ts`.

### Removed

- `PrefilterStats` duplicate definition in `types/prefilter.types.ts` (now in `stats.types.ts`).

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Breaking Changes

- Dry-run no longer calls the `claude` CLI or logs `[dry-run] DISCARD ...`. It now just lists target files.
- Completion log field names changed: `kept/discarded/skipped/preSkipped` → `keep/skip/remove/error` (filter), `noise/keep/error` → `keep/skip/remove/error` (prefilter). Any log parsing based on the old names must be updated.
- A `removeFile` failure in `processChunk` now increments `stats.error` instead of only logging a warning.

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

The `prefilter.ts` move (`libs/` → `modules/`) is a pure relocation plus the options-object signature change. No filtering logic changed beyond dry-run log suppression.
