### PR TITLE
feat: add throw file io error option to readTextFile

### DIFF
--- a/skills/_scripts/libs/file-io/__tests__/system/read-utils.system.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/system/read-utils.system.spec.ts
@@ -1,0 +1,73 @@
+// src: skills/_scripts/libs/file-io/__tests__/system/read-utils.system.spec.ts
+// @(#): readTextFile のシステムテスト（Deno ファイルシステム実使用）
+//       対象: readTextFile
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertRejects } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { readTextFile } from '../../read-utils.ts';
+
+// ─── Tests
+
+/**
+ * `readTextFile` のシステムテストスイート。
+ *
+ * ファイルパスの中間コンポーネントがファイルであるパス（`<file>/<child>`）を実際に読み込み、
+ * 実ファイルシステム上で発生する I/O エラーに対する throw / swallow 挙動を検証する。
+ *
+ * テスト ID 範囲: T-LIB-S-RF-01 〜 T-LIB-S-RF-02
+ *
+ * @see readTextFile
+ */
+describe('readTextFile', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await Deno.makeTempDir({ prefix: 'read-utils-system-test-' });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmpDir, { recursive: true });
+  });
+
+  /**
+   * ファイルパスの配下を読み込もうとするケースの実 I/O 挙動テスト。
+   *
+   * `<tmpDir>/file.md` をファイルとして作成し、その配下パス `<tmpDir>/file.md/child.md` を
+   * `readTextFile` で読み込ませることで、ファイルをディレクトリとして扱おうとする I/O エラーを再現する。
+   */
+  describe('readTextFile', () => {
+    /** デフォルト挙動（throwFileIoError 省略）で例外がそのまま伝播するケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-LIB-S-RF-01: throwFileIoError 省略 → ファイルI/Oエラーがスローされる', async () => {
+        // arrange
+        const filePath = `${tmpDir}/file.md`;
+        await Deno.writeTextFile(filePath, 'content');
+        const childPath = `${filePath}/child.md`;
+
+        // act & assert
+        await assertRejects(() => readTextFile(childPath));
+      });
+
+      it('[Normal] T-LIB-S-RF-02: throwFileIoError: false → 例外を投げず空文字列が返る', async () => {
+        // arrange
+        const filePath = `${tmpDir}/file.md`;
+        await Deno.writeTextFile(filePath, 'content');
+        const childPath = `${filePath}/child.md`;
+
+        // act
+        const result = await readTextFile(childPath, { throwFileIoError: false });
+
+        // assert
+        assertEquals(result, '');
+      });
+    });
+  });
+});

--- a/skills/_scripts/libs/file-io/__tests__/unit/is-file-io-error.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/is-file-io-error.unit.spec.ts
@@ -1,0 +1,98 @@
+// src: skills/_scripts/libs/__tests__/file-io/unit/is-file-io-error.unit.spec.ts
+// @(#): isFileIoError ユニットテスト
+//       対象: isFileIoError
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// cspell:words FIOE
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { isFileIoError } from '../../read-utils.ts';
+
+// ─── Helpers
+// classes
+import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
+
+// ─── Tests
+
+/**
+ * `isFileIoError` 関数のユニットテストスイート。
+ *
+ * `isFileIoError(error)` は渡された値がファイル I/O 起因の `Deno.errors.*` インスタンスかどうかを判定する。
+ * 該当する場合は `true`、それ以外の値（通常の `Error` / `ChatlogError` / `Error` 以外の値）は `false` を返す。
+ *
+ * テスト ID 範囲: T-LIB-U-FIOE-01 〜 T-LIB-U-FIOE-02
+ *
+ * @see isFileIoError
+ */
+describe('isFileIoError', () => {
+  /**
+   * ファイル I/O 起因の Deno エラーを渡す前提条件グループ。
+   *
+   * 各 `Deno.errors.*` インスタンスに対して `true` を返すことを検証する。
+   */
+  describe('Given: ファイル I/O 起因の Deno エラーを渡す', () => {
+    // constants
+    /** ファイル I/O 起因の Deno エラーインスタンス一覧。それぞれ `true` を返すことを検証する。 */
+    const _fileIoErrorCases = [
+      { label: 'Deno.errors.NotFound', error: new Deno.errors.NotFound('no such file') },
+      { label: 'Deno.errors.PermissionDenied', error: new Deno.errors.PermissionDenied('permission denied') },
+      { label: 'Deno.errors.IsADirectory', error: new Deno.errors.IsADirectory('is a directory') },
+      { label: 'Deno.errors.NotADirectory', error: new Deno.errors.NotADirectory('not a directory') },
+      { label: 'Deno.errors.FilesystemLoop', error: new Deno.errors.FilesystemLoop('filesystem loop') },
+      { label: 'Deno.errors.NotCapable', error: new Deno.errors.NotCapable('not capable') },
+      { label: 'Deno.errors.Busy', error: new Deno.errors.Busy('busy') },
+      { label: 'Deno.errors.Interrupted', error: new Deno.errors.Interrupted('interrupted') },
+      { label: 'Deno.errors.InvalidData', error: new Deno.errors.InvalidData('invalid data') },
+    ] as const;
+
+    /** isFileIoError を実行するとき。 */
+    describe('When: isFileIoError を実行する', () => {
+      /** true が返ることを検証する。 */
+      describe('Then: T-LIB-U-FIOE-01 - true が返る', () => {
+        for (const { label, error } of _fileIoErrorCases) {
+          it(`T-LIB-U-FIOE-01: ${label} を渡すと true が返る`, () => {
+            assertEquals(isFileIoError(error), true);
+          });
+        }
+      });
+    });
+  });
+
+  /**
+   * ファイル I/O 起因ではない値を渡す前提条件グループ。
+   *
+   * 通常の `Error` / `ChatlogError` / `Error` 以外の値に対して `false` を返すことを検証する。
+   */
+  describe('Given: ファイル I/O 起因ではない値を渡す', () => {
+    // constants
+    /** ファイル I/O 起因ではない値一覧。それぞれ `false` を返すことを検証する。 */
+    const _nonFileIoErrorCases = [
+      { label: '通常の Error', error: new Error('some error') },
+      { label: 'ChatlogError', error: new ChatlogError('FileDirNotFound', 'NotFound', 'path') },
+      { label: 'undefined', error: undefined },
+      { label: 'null', error: null },
+      { label: '文字列', error: 'some error' },
+      { label: 'オブジェクトリテラル', error: { message: 'some error' } },
+    ] as const;
+
+    /** isFileIoError を実行するとき。 */
+    describe('When: isFileIoError を実行する', () => {
+      /** false が返ることを検証する。 */
+      describe('Then: T-LIB-U-FIOE-02 - false が返る', () => {
+        for (const { label, error } of _nonFileIoErrorCases) {
+          it(`T-LIB-U-FIOE-02: ${label} を渡すと false が返る`, () => {
+            assertEquals(isFileIoError(error), false);
+          });
+        }
+      });
+    });
+  });
+});

--- a/skills/_scripts/libs/file-io/__tests__/unit/read-utils.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/read-utils.unit.spec.ts
@@ -38,19 +38,28 @@ const _emptyProvider: ReadTextFileProvider = (_path: string) => Promise.resolve(
 const _isDirProvider: ReadTextFileProvider = (_path: string) =>
   Promise.reject(new Deno.errors.IsADirectory('is a directory'));
 
+/** `Deno.errors.NotADirectory` を throw する読み込みプロバイダ。 */
+const _notADirProvider: ReadTextFileProvider = (_path: string) =>
+  Promise.reject(new Deno.errors.NotADirectory('not a directory'));
+
 /** CRLF と LF が混在するテキストを返す読み込みプロバイダ。 */
 const _mixedProvider: ReadTextFileProvider = (_path: string) => Promise.resolve('line1\r\nline2\nline3\r\n');
+
+/** ファイル I/O 起因ではない通常の `Error` を throw する読み込みプロバイダ。 */
+const _genericErrorProvider: ReadTextFileProvider = (_path: string) => Promise.reject(new Error('boom'));
 
 // ─── Tests
 
 /**
  * `readTextFile` 関数のユニットテストスイート。
  *
- * `readTextFile(path, readProvider?)` はファイルを読み込み LF 正規化した文字列を返す。
+ * `readTextFile(path, options?)` はファイルを読み込み LF 正規化した文字列を返す。
  * ファイルが存在しない場合は `ChatlogError('FileDirNotFound')` を throw し、
  * その他のエラー（PermissionDenied 等）はそのまま再 throw する。
+ * `options.throwFileIoError: false` を指定すると、ファイル I/O 起因のエラーは
+ * throw せず空文字列を返す（ファイル I/O 起因ではないエラーは throwFileIoError の値に関わらず re-throw する）。
  *
- * テスト ID 範囲: T-LIB-U-RF-01 〜 T-LIB-U-RF-07
+ * テスト ID 範囲: T-LIB-U-RF-01 〜 T-LIB-U-RF-11
  *
  * @see readTextFile
  */
@@ -116,7 +125,7 @@ describe('readTextFile', () => {
       describe('Then: T-LIB-U-RF-03 - ChatlogError(FileDirNotFound) がスローされる', () => {
         it('T-LIB-U-RF-03: ChatlogError(FileDirNotFound) がスローされる', async () => {
           const err = await assertRejects(
-            () => readTextFile('/nonexistent/path.md', _notFoundProvider),
+            () => readTextFile('/nonexistent/path.md', { readProvider: _notFoundProvider }),
             ChatlogError,
           );
           assertEquals((err as ChatlogError).kind, 'FileDirNotFound');
@@ -138,7 +147,7 @@ describe('readTextFile', () => {
       describe('Then: T-LIB-U-RF-04 - PermissionDenied がそのまま再スローされる', () => {
         it('T-LIB-U-RF-04: Deno.errors.PermissionDenied がそのまま再スローされる', async () => {
           await assertRejects(
-            () => readTextFile('/restricted/path.md', _permissionDeniedProvider),
+            () => readTextFile('/restricted/path.md', { readProvider: _permissionDeniedProvider }),
             Deno.errors.PermissionDenied,
           );
         });
@@ -157,7 +166,7 @@ describe('readTextFile', () => {
       /** 空文字列が返ることを検証する。 */
       describe('Then: T-LIB-U-RF-05 - 空文字列が返る', () => {
         it('T-LIB-U-RF-05: 空ファイルを読み込むと空文字列が返る', async () => {
-          const _result = await readTextFile('/any/path.md', _emptyProvider);
+          const _result = await readTextFile('/any/path.md', { readProvider: _emptyProvider });
           assertEquals(_result, '');
         });
       });
@@ -176,7 +185,7 @@ describe('readTextFile', () => {
       describe('Then: T-LIB-U-RF-06 - IsADirectory がそのまま再スローされる', () => {
         it('T-LIB-U-RF-06: Deno.errors.IsADirectory はそのまま再スローされる', async () => {
           await assertRejects(
-            () => readTextFile('/some/dir/', _isDirProvider),
+            () => readTextFile('/some/dir/', { readProvider: _isDirProvider }),
             Deno.errors.IsADirectory,
           );
         });
@@ -195,8 +204,96 @@ describe('readTextFile', () => {
       /** LF に統一された文字列が返ることを検証する。 */
       describe('Then: T-LIB-U-RF-07 - LF に統一された文字列が返る', () => {
         it('T-LIB-U-RF-07: CRLF と LF が混在するテキストは LF に統一される', async () => {
-          const _result = await readTextFile('/any/path.md', _mixedProvider);
+          const _result = await readTextFile('/any/path.md', { readProvider: _mixedProvider });
           assertEquals(_result, 'line1\nline2\nline3\n');
+        });
+      });
+    });
+  });
+
+  /**
+   * 存在しないファイルパスを渡し throwFileIoError: false を指定する前提条件グループ。
+   *
+   * 例外を投げず空文字列が返ることを検証する。
+   */
+  describe('Given: 存在しないファイルパスを渡し throwFileIoError: false を指定する', () => {
+    /** readTextFile を実行するとき。 */
+    describe('When: readTextFile を実行する', () => {
+      /** 例外を投げず空文字列が返ることを検証する。 */
+      describe('Then: T-LIB-U-RF-08 - 例外を投げず空文字列が返る', () => {
+        it('T-LIB-U-RF-08: NotFound は例外を投げず空文字列を返す', async () => {
+          const _result = await readTextFile('/nonexistent/path.md', {
+            readProvider: _notFoundProvider,
+            throwFileIoError: false,
+          });
+          assertEquals(_result, '');
+        });
+      });
+    });
+  });
+
+  /**
+   * 読み込み権限のないファイルを渡し throwFileIoError: false を指定する前提条件グループ。
+   *
+   * 例外を投げず空文字列が返ることを検証する。
+   */
+  describe('Given: 読み込み権限のないファイルを渡し throwFileIoError: false を指定する', () => {
+    /** readTextFile を実行するとき。 */
+    describe('When: readTextFile を実行する', () => {
+      /** 例外を投げず空文字列が返ることを検証する。 */
+      describe('Then: T-LIB-U-RF-09 - 例外を投げず空文字列が返る', () => {
+        it('T-LIB-U-RF-09: PermissionDenied は例外を投げず空文字列を返す', async () => {
+          const _result = await readTextFile('/restricted/path.md', {
+            readProvider: _permissionDeniedProvider,
+            throwFileIoError: false,
+          });
+          assertEquals(_result, '');
+        });
+      });
+    });
+  });
+
+  /**
+   * ファイル I/O 起因ではないエラーが発生し throwFileIoError: false を指定する前提条件グループ。
+   *
+   * throwFileIoError の値に関わらず、ファイル I/O 起因ではないエラーは再 throw されることを検証する。
+   */
+  describe('Given: ファイル I/O 起因ではないエラーが発生し throwFileIoError: false を指定する', () => {
+    /** readTextFile を実行するとき。 */
+    describe('When: readTextFile を実行する', () => {
+      /** エラーがそのまま再スローされることを検証する。 */
+      describe('Then: T-LIB-U-RF-10 - エラーがそのまま再スローされる', () => {
+        it('T-LIB-U-RF-10: ファイル I/O 起因ではないエラーは throwFileIoError: false でも再スローされる', async () => {
+          await assertRejects(
+            () =>
+              readTextFile('/any/path.md', {
+                readProvider: _genericErrorProvider,
+                throwFileIoError: false,
+              }),
+            Error,
+            'boom',
+          );
+        });
+      });
+    });
+  });
+
+  /**
+   * NotADirectory エラーが発生し throwFileIoError: false を指定する前提条件グループ。
+   *
+   * 中間パスコンポーネントがファイルであるケースを想定し、例外を投げず空文字列が返ることを検証する。
+   */
+  describe('Given: NotADirectory エラーが発生し throwFileIoError: false を指定する', () => {
+    /** readTextFile を実行するとき。 */
+    describe('When: readTextFile を実行する', () => {
+      /** 例外を投げず空文字列が返ることを検証する。 */
+      describe('Then: T-LIB-U-RF-11 - 例外を投げず空文字列が返る', () => {
+        it('T-LIB-U-RF-11: NotADirectory は例外を投げず空文字列を返す', async () => {
+          const _result = await readTextFile('/tmp/file/child.md', {
+            readProvider: _notADirProvider,
+            throwFileIoError: false,
+          });
+          assertEquals(_result, '');
         });
       });
     });

--- a/skills/_scripts/libs/file-io/read-utils.ts
+++ b/skills/_scripts/libs/file-io/read-utils.ts
@@ -17,25 +17,58 @@ import type { ReadTextFileProvider } from '../../types/providers.types.ts';
 /** `Deno.readTextFile` をデフォルト実装として使う読み込みプロバイダ。 */
 const _DEFAULT_READ_PROVIDER: ReadTextFileProvider = (path: string) => Deno.readTextFile(path);
 
+/** ファイル I/O 操作で発生しうる `Deno.errors.*` エラークラスの一覧。 */
+const _FILE_IO_ERROR_CLASSES = [
+  Deno.errors.NotFound,
+  Deno.errors.PermissionDenied,
+  Deno.errors.IsADirectory,
+  Deno.errors.NotADirectory,
+  Deno.errors.FilesystemLoop,
+  Deno.errors.NotCapable,
+  Deno.errors.Busy,
+  Deno.errors.Interrupted,
+  Deno.errors.InvalidData,
+];
+
 // --- functions ---
 /**
+ * ファイル I/O 起因の Deno エラーかどうかを判定する。
+ *
+ * @param error - 判定対象の値
+ * @returns ファイル I/O 起因のエラーなら `true`
+ */
+export const isFileIoError = (error: unknown): boolean =>
+  _FILE_IO_ERROR_CLASSES.some((ErrorClass) => error instanceof ErrorClass);
+
+/**
  * ファイルを読み込み、行末文字を LF に正規化して返す。
- * - ファイルが存在しない場合は `ChatlogError('FileDirNotFound')` を throw する。
- * - その他のエラー（PermissionDenied 等）はそのまま再 throw する。
+ * - ファイルが存在しない場合は `ChatlogError('FileDirNotFound')` を throw する（`throwFileIoError: false` を除く）。
+ * - その他のファイル I/O 起因のエラー（PermissionDenied 等）はそのまま再 throw する（`throwFileIoError: false` を除く）。
+ * - `throwFileIoError: false` を指定すると、ファイル I/O 起因のエラーは throw せず空文字列を返す。
+ *   ファイル I/O 起因ではないエラーは `throwFileIoError` の値に関わらず常に再 throw する。
  *
  * @param path - 読み込むファイルの絶対パス
- * @param readProvider - テスト用注入可能な読み込み関数（デフォルト: `Deno.readTextFile`）
+ * @param options - テスト用注入可能な読み込み関数、およびエラー throw 挙動の指定
+ * @param options.readProvider - テスト用注入可能な読み込み関数（デフォルト: `Deno.readTextFile`）
+ * @param options.throwFileIoError - ファイル I/O 起因のエラーを throw するか（デフォルト: `true`）
  */
 export const readTextFile = async (
   path: string,
-  readProvider: ReadTextFileProvider = _DEFAULT_READ_PROVIDER,
+  options?: { readProvider?: ReadTextFileProvider; throwFileIoError?: boolean },
 ): Promise<string> => {
+  const { readProvider = _DEFAULT_READ_PROVIDER, throwFileIoError = true } = options ?? {};
   try {
     return normalizeLine(await readProvider(path));
   } catch (e) {
-    if (e instanceof Deno.errors.NotFound) {
-      throw new ChatlogError('FileDirNotFound', 'NotFound', path);
+    if (!isFileIoError(e)) {
+      throw e;
     }
-    throw e;
+    if (throwFileIoError) {
+      if (e instanceof Deno.errors.NotFound) {
+        throw new ChatlogError('FileDirNotFound', 'NotFound', path);
+      }
+      throw e;
+    }
+    return '';
   }
 };


### PR DESCRIPTION
## Overview

**Summary**
Add an opt-in flag to let `readTextFile` return an empty string instead of throwing on file I/O errors.

**Background / Motivation**
`readTextFile` always threw on a missing or unreadable file, forcing every caller to wrap it in try/catch when a missing file should just mean "no content". This adds a `throwFileIoError` option (default `true`, so existing behavior is unchanged) to opt out of that.

## Changes

### Core Changes

- `read-utils.ts`: added `isFileIoError(error)` to detect `Deno.errors.*` file I/O errors.
- `read-utils.ts`: changed `readTextFile`'s second parameter to an options object `{ readProvider?, throwFileIoError? }`. When `throwFileIoError` is `false`, file I/O errors return `''` instead of throwing; other errors still throw.

### Test Updates

- Added `is-file-io-error.unit.spec.ts` for `isFileIoError`.
- Updated `read-utils.unit.spec.ts` for the new options shape and `throwFileIoError: false` behavior.

### Removed

None.

## Change Type (optional)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`readTextFile`'s second argument changed from a bare function to an options object. All production call sites use a single argument, so no caller is affected.
