### PR TITLE
feat(filter-chatlogs): add cache-based resume support

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -808,3 +808,78 @@ describe('main - period 未指定', () => {
     });
   });
 });
+
+// ─── T-FL-E2E-12: キャッシュ KEEP 済み → claude CLI 未呼び出し ──────────────
+
+/**
+ * `main` 関数の E2E テストスイート（キャッシュ済み KEEP 判定）。
+ *
+ * ファイル単位の判定結果キャッシュに `decision: KEEP` が既に記録されている場合、
+ * `prefilterFiles` に渡す前に対象から除外され、claude CLI が呼び出されないことを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-12
+ *
+ * @see main
+ */
+describe('main - キャッシュ KEEP 済み', () => {
+  /**
+   * キャッシュに `keep.md` の判定結果として `decision: KEEP` が既に書き込まれている前提。
+   *
+   * キャッシュ済み KEEP ファイルは claude CLI 呼び出し前に除外され、
+   * ファイルシステム上にも残ることを確認する。
+   */
+  describe('Given: cacheDir に keep.md の KEEP キャッシュエントリを配置', () => {
+    /** `main(["claude", "2026-03", "--input-dir", chatlogsDir])` を呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** claude CLI が呼び出されず、ファイルが残ること。 */
+      describe('Then: T-FL-E2E-12 - claude CLI 未呼び出し・ファイルが残る', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let counter: { calls: number };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(makeCountingMock('[]', counter));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: keep.md を chatlogsDir に配置し、cacheDir に KEEP エントリを書き込む', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/keep.md`, _makeValidContent());
+
+            const cacheDir = `${tempDir}/cache/filter-cache`;
+            await Deno.mkdir(cacheDir, { recursive: true });
+            await Deno.writeTextFile(
+              `${cacheDir}/keep.json`,
+              JSON.stringify({ decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' }),
+            );
+
+            await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'`);
+          });
+
+          it('T-FL-E2E-12-01: claude CLI が呼び出されない', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(counter.calls, 0);
+          });
+
+          it('T-FL-E2E-12-02: keep.md が残っている', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(await fileExists(`${chatlogsDir}/keep.md`), true);
+          });
+        });
+      });
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -84,7 +84,7 @@ const _makeEmptyCache = async (): Promise<ChatlogCache<CLEResult>> => {
  * - `cache` にファイルの判定結果（DISCARD/KEEP）が既に存在する
  *   （dry-run 時は削除・stats 変更を行わず AI 対象からのみ除外する）
  *
- * テスト ID 範囲: T-FL-PFF-01 〜 T-FL-PFF-14
+ * テスト ID 範囲: T-FL-PFF-01 〜 T-FL-PFF-21
  *
  * @see prefilterFiles
  */
@@ -113,7 +113,7 @@ describe('prefilterFiles', () => {
     describe('When: prefilterFiles([file]) を呼び出す', () => {
       /** ファイルがスキップされ、結果に含まれないことを検証する。 */
       describe('Then: T-FL-PFF-01 - ファイルがスキップされる', () => {
-        it('T-FL-PFF-01-01: say-ok-and-nothing-else.md は通過しない', async () => {
+        it('T-FL-PFF-01-01: say-ok-and-nothing-else.md は通過せず実削除される', async () => {
           const filePath = `${periodDir1}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
@@ -122,6 +122,7 @@ describe('prefilterFiles', () => {
           errStub.restore();
 
           assertEquals(result.length, 0);
+          assertEquals(await Deno.stat(filePath).catch(() => null), null);
         });
       });
     });
@@ -266,7 +267,7 @@ describe('prefilterFiles', () => {
     describe('When: stats オブジェクトを渡して prefilterFiles を呼び出す', () => {
       /** stats.keep が事前 KEEP 確定数と一致し、戻り値が正常ファイルのみであることを検証する。 */
       describe('Then: T-FL-PFF-07 - stats.keep が事前 KEEP 確定数と一致する', () => {
-        it('T-FL-PFF-07-01: stats.keep === 2 かつ 戻り値は 1 ファイル', async () => {
+        it('T-FL-PFF-07-01: stats.keep === 1、stats.remove === 1 かつ 戻り値は 1 ファイル', async () => {
           const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
           const shortPath = `${periodDir1}/short-body.md`;
           const validPath = `${periodDir1}/valid.md`;
@@ -280,7 +281,8 @@ describe('prefilterFiles', () => {
           errStub.restore();
 
           assertEquals(result.length, 1);
-          assertEquals(_stats.keep, 2);
+          assertEquals(_stats.keep, 1);
+          assertEquals(_stats.remove, 1);
         });
       });
     });
@@ -374,7 +376,7 @@ describe('prefilterFiles', () => {
           assertEquals(loggerStub.infoLogs.length, 0);
         });
 
-        it('T-FL-PFF-09-02: [Normal] dryRun: true でも戻り値と stats.keep は dryRun なし時と同じ', async () => {
+        it('T-FL-PFF-09-02: [Normal] dryRun: true でも戻り値と stats.keep/remove は dryRun なし時と同じ', async () => {
           const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
           const shortPath = `${periodDir1}/short-body.md`;
           const validPath = `${periodDir1}/valid.md`;
@@ -394,6 +396,7 @@ describe('prefilterFiles', () => {
 
           assertEquals(resultDryRun, resultNormal);
           assertEquals(statsDryRun.keep, statsNormal.keep);
+          assertEquals(statsDryRun.remove, statsNormal.remove);
         });
       });
     });
@@ -600,6 +603,188 @@ describe('prefilterFiles', () => {
 
           // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
           await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(stats.error, 1);
+          assertEquals(stats.remove, 0);
+        });
+      });
+    });
+  });
+
+  /**
+   * 本文読み込みに失敗する（実ファイルが存在しない）ファイルを cache 指定で処理する前提条件グループ。
+   *
+   * 読み込み失敗時に cache へ ERROR decision が記録されることを検証する。
+   */
+  describe('Given: 本文読み込みに失敗するファイル（cache 指定あり）', () => {
+    /** prefilterFiles([file], { cache }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache }) を呼び出す', () => {
+      /** cache に ERROR decision が記録され、stats.error が加算され、passed に含まれないことを検証する。 */
+      describe('Then: T-FL-PFF-16 - cache に ERROR decision が記録される', () => {
+        it('T-FL-PFF-16-01: cache.read(filePath).decision === FILTER_DECISIONS.ERROR になる', async () => {
+          const filePath = `${periodDir1}/missing-read.md`;
+          const cache = await _makeEmptyCache();
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          const result = await prefilterFiles([filePath], { stats, cache });
+          errStub.restore();
+
+          assertEquals(cache.read(filePath).decision, FILTER_DECISIONS.ERROR);
+          assertEquals(stats.error, 1);
+          assertEquals(result.includes(filePath), false);
+        });
+      });
+    });
+  });
+
+  /**
+   * 本文読み込みに失敗する（実ファイルが存在しない）ファイルを cache 指定なしで処理する前提条件グループ。
+   *
+   * cache 未指定でも従来通り例外を投げず stats.error が加算されることを検証する（回帰確認）。
+   */
+  describe('Given: 本文読み込みに失敗するファイル（cache 指定なし）', () => {
+    /** prefilterFiles([file], { stats }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { stats }) を呼び出す', () => {
+      /** 例外が投げられず stats.error が加算されることを検証する。 */
+      describe('Then: T-FL-PFF-17 - 例外が投げられず stats.error が加算される', () => {
+        it('T-FL-PFF-17-01: stats.error === 1 になる', async () => {
+          const filePath = `${periodDir1}/missing-read-nocache.md`;
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats });
+          errStub.restore();
+
+          assertEquals(stats.error, 1);
+        });
+      });
+    });
+  });
+
+  /**
+   * ファイル名除外 1 件・短本文除外 1 件・正常ファイル複数件が混在するファイルリストの前提条件グループ。
+   *
+   * ステージ分割リファクタリングによって戻り値の順序が入力順から崩れていないことを検証する
+   * characterization test（現行実装でも新実装でも PASS する想定）。
+   */
+  describe('Given: ファイル名除外1 + 短本文除外1 + 正常3件が混在するファイルリスト', () => {
+    /** prefilterFiles(files) を呼び出すとき。 */
+    describe('When: prefilterFiles(files) を呼び出す', () => {
+      /** 戻り値配列が入力 files の順序と一致することを検証する。 */
+      describe('Then: T-FL-PFF-19 - 戻り値の順序が入力順と一致する', () => {
+        it('T-FL-PFF-19-01: passed 配列が入力 files の順序と一致する', async () => {
+          const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
+          const shortPath = `${periodDir1}/short-order.md`;
+          const validPath1 = `${periodDir1}/order-valid1.md`;
+          const validPath2 = `${periodDir1}/order-valid2.md`;
+          const validPath3 = `${periodDir1}/order-valid3.md`;
+          await Deno.writeTextFile(excludedPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(shortPath, '---\ntitle: テスト\n---\n短い本文\n');
+          await Deno.writeTextFile(validPath3, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(validPath1, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(validPath2, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const errStub = stub(console, 'error', () => {});
+
+          const files = [validPath3, excludedPath, validPath1, shortPath, validPath2];
+          const result = await prefilterFiles(files, { stats: _makeStats() });
+          errStub.restore();
+
+          assertEquals(result, [validPath3, validPath1, validPath2]);
+        });
+      });
+    });
+  });
+
+  /**
+   * cache に ERROR decision が既に記録されているファイル（実ファイルは正常）の前提条件グループ。
+   *
+   * ERROR キャッシュはヒットとみなさず、AI 判定対象（`passed`）に含めることを検証する。
+   */
+  describe('Given: cache に ERROR decision が既にあるファイル', () => {
+    /** prefilterFiles([file], { cache, discardThreshold }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, discardThreshold }) を呼び出す', () => {
+      /** passed に含まれることを検証する。 */
+      describe('Then: T-FL-PFF-18 - passed に含まれる', () => {
+        it('T-FL-PFF-18-01: ERROR キャッシュは再読み込みされ passed に含まれる', async () => {
+          const filePath = `${periodDir1}/cached-error.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.ERROR, confidence: 0, reason: 'read failure' });
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          const result = await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(result.includes(filePath), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * 除外パターンのファイル名を持つファイルを cache 指定で処理する前提条件グループ。
+   *
+   * ファイル名除外ファイルに対しても DISCARD decision が cache に書き込まれ、
+   * dry-run 時も書き込みだけは実行される（実削除は行わない）ことを検証する。
+   */
+  describe('Given: 除外パターンのファイル名を持つファイル（cache 指定あり）', () => {
+    /** prefilterFiles([file], { cache, discardThreshold }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, discardThreshold }) を呼び出す', () => {
+      /** cache に DISCARD decision が書き込まれ、ファイルが実削除されることを検証する。 */
+      describe('Then: T-FL-PFF-20 - cache に DISCARD decision が書き込まれる', () => {
+        it('T-FL-PFF-20-01: cache.read(filePath).decision === FILTER_DECISIONS.DISCARD になり実削除される', async () => {
+          const filePath = `${periodDir1}/say-ok-and-nothing-else-cached.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(cache.read(filePath).decision, FILTER_DECISIONS.DISCARD);
+          assertEquals(await Deno.stat(filePath).catch(() => null), null);
+          assertEquals(stats.remove, 1);
+        });
+
+        it('T-FL-PFF-20-02: dry-run 時も cache に DISCARD decision が書き込まれるがファイルは削除されない', async () => {
+          const filePath = `${periodDir1}/say-ok-and-nothing-else-cached-dryrun.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          const loggerStub = makeLoggerStub();
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7, dryRun: true });
+          loggerStub.restore();
+
+          assertEquals(cache.read(filePath).decision, FILTER_DECISIONS.DISCARD);
+          assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
+          assertEquals(stats.remove, 1);
+        });
+      });
+    });
+  });
+
+  /**
+   * 除外パターンのファイル名を持つが、削除実行前にファイルが既に存在しない前提条件グループ。
+   *
+   * `removeFile` が `false` を返すケースで stats.error が加算されることを検証する。
+   */
+  describe('Given: 除外パターンのファイル名を持つファイルが実削除前に既に存在しない', () => {
+    /** prefilterFiles([file], { stats }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { stats }) を呼び出す', () => {
+      /** stats.error が増え、stats.remove は増えないことを検証する。 */
+      describe('Then: T-FL-PFF-21 - stats.error が 1 になる', () => {
+        it('T-FL-PFF-21-01: removeFile 失敗 → stats.error === 1, stats.remove === 0', async () => {
+          const filePath = `${periodDir1}/say-ok-and-nothing-else-missing.md`;
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
+          await prefilterFiles([filePath], { stats });
           errStub.restore();
 
           assertEquals(stats.error, 1);

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -18,14 +18,18 @@ import { prefilterFiles } from '../../../modules/prefilter.ts';
 
 // ─── Helpers
 import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { makePeriodDir, makeRepeatedContent, makeValidContent } from '../../_helpers/fixtures.ts';
 // constants
+import { FILTER_DECISIONS } from '../../../types/filter-decision.const.types.ts';
 import { FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
 // types
+import type { CLEResult } from '../../../types/cache.types.ts';
 import type { BaseStats } from '../../../types/stats.types.ts';
 
 // ─── Internal Helpers
 
+// functions
 /**
  * テスト用の初期化済み `BaseStats` オブジェクトを返す。
  *
@@ -33,19 +37,54 @@ import type { BaseStats } from '../../../types/stats.types.ts';
  */
 const _makeStats = (): BaseStats => ({ keep: 0, skip: 0, remove: 0, error: 0 });
 
+/**
+ * テスト用の空キャッシュ（バッファバック）を生成する。
+ *
+ * ファイル I/O をせずにインメモリバッファで動作する `ChatlogCache<CLEResult>` を返す。
+ * @returns 初期化済みの空キャッシュ
+ */
+const _makeEmptyCache = async (): Promise<ChatlogCache<CLEResult>> => {
+  const buf = new Map<string, string>();
+  const cache = new ChatlogCache<CLEResult>(
+    'filter-cache',
+    '/fake/cache',
+    undefined,
+    {
+      cache: {
+        readTextFile: (path) => {
+          const data = buf.get(path);
+          if (data === undefined) { return Promise.reject(new Error('not found')); }
+          return Promise.resolve(data);
+        },
+        writeTextFile: (path, data) => {
+          buf.set(path, data);
+          return Promise.resolve();
+        },
+        mkdir: () => Promise.resolve(),
+        glob: () => Promise.resolve([]),
+      },
+    },
+  );
+  await cache.ready;
+  return cache;
+};
+
 // ─── Tests
 
 /**
  * `prefilterFiles` 関数の機能テストスイート。
  *
  * `prefilterFiles(files)` はファイル名パターンと本文長の 2 段階でノイズを除外し、
- * 通過したファイルパスの配列を返す。
+ * 通過したファイルパスの配列を返す。`cache` 指定時はさらにキャッシュ済み判定結果で
+ * AI 呼び出し対象からファイルを除外する。
  *
  * ## 除外条件
  * - ファイル名が除外パターンに一致する（例: `say-ok-and-nothing-else.md`）
  * - 本文（frontmatter を除いた部分）が空または 1000 文字未満
+ * - `cache` にファイルの判定結果（DISCARD/KEEP）が既に存在する
+ *   （dry-run 時は削除・stats 変更を行わず AI 対象からのみ除外する）
  *
- * テスト ID 範囲: T-FL-PFF-01 〜 T-FL-PFF-09
+ * テスト ID 範囲: T-FL-PFF-01 〜 T-FL-PFF-14
  *
  * @see prefilterFiles
  */
@@ -355,6 +394,216 @@ describe('prefilterFiles', () => {
 
           assertEquals(resultDryRun, resultNormal);
           assertEquals(statsDryRun.keep, statsNormal.keep);
+        });
+      });
+    });
+  });
+
+  /**
+   * cache に DISCARD(confidence >= discardThreshold) のエントリが存在するファイルの前提条件グループ。
+   *
+   * AI 呼び出し対象から除外され、その場で削除・stats.remove 加算が行われることを検証する。
+   */
+  describe('Given: cache に DISCARD(confidence >= discardThreshold) のエントリがあるファイル', () => {
+    /** prefilterFiles([file], { cache, discardThreshold }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, discardThreshold }) を呼び出す', () => {
+      /** ファイルが削除され、passed に含まれず、stats.remove が増えることを検証する。 */
+      describe('Then: T-FL-PFF-10 - ファイルが削除され stats.remove が増える', () => {
+        it('T-FL-PFF-10-01: passed に含まれない', async () => {
+          const filePath = `${periodDir1}/cached-discard.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' });
+          const errStub = stub(console, 'error', () => {});
+
+          const result = await prefilterFiles([filePath], { stats: _makeStats(), cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(result.includes(filePath), false);
+        });
+
+        it('T-FL-PFF-10-02: ファイルが削除され stats.remove が 1 になる', async () => {
+          const filePath = `${periodDir1}/cached-discard2.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' });
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(await Deno.stat(filePath).catch(() => null), null);
+          assertEquals(stats.remove, 1);
+        });
+      });
+    });
+  });
+
+  /**
+   * cache に KEEP、または confidence が discardThreshold 未満の DISCARD エントリが存在するファイルの前提条件グループ。
+   *
+   * AI 呼び出し対象から除外され、KEEP 確定（stats.keep 加算）が行われることを検証する。
+   */
+  describe('Given: cache に KEEP、または confidence 不足の DISCARD エントリがあるファイル', () => {
+    /** prefilterFiles([file], { cache, discardThreshold }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, discardThreshold }) を呼び出す', () => {
+      /** ファイルが残り、passed に含まれず、stats.keep が増えることを検証する。 */
+      describe('Then: T-FL-PFF-11 - ファイルが残り stats.keep が増える', () => {
+        it('T-FL-PFF-11-01: decision=KEEP → passed に含まれず stats.keep が 1 になる', async () => {
+          const filePath = `${periodDir1}/cached-keep.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' });
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          const result = await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(result.includes(filePath), false);
+          assertEquals(stats.keep, 1);
+          assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
+        });
+
+        it('T-FL-PFF-11-02: confidence が discardThreshold 未満 → stats.keep が 1 になり削除されない', async () => {
+          const filePath = `${periodDir1}/cached-lowconf.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.DISCARD, confidence: 0.5, reason: 'low conf' });
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(stats.keep, 1);
+          assertEquals(stats.remove, 0);
+          assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * cache にエントリが存在しないファイルの前提条件グループ。
+   *
+   * 従来通り AI 判定対象（`passed`）に含まれることを検証する。
+   */
+  describe('Given: cache にエントリが存在しないファイル', () => {
+    /** prefilterFiles([file], { cache }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache }) を呼び出す', () => {
+      /** passed に含まれることを検証する。 */
+      describe('Then: T-FL-PFF-12 - passed に含まれる', () => {
+        it('T-FL-PFF-12-01: キャッシュミス → passed に含まれる', async () => {
+          const filePath = `${periodDir1}/cache-miss.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          const errStub = stub(console, 'error', () => {});
+
+          const result = await prefilterFiles([filePath], { stats: _makeStats(), cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(result.includes(filePath), true);
+        });
+      });
+    });
+  });
+
+  /**
+   * dry-run モードで cache に DISCARD 確定エントリがあるファイルの前提条件グループ。
+   *
+   * dry-run 時はキャッシュヒットでもファイル削除は行わないが、
+   * サマリー集計 (`keep + skip + remove + error === total`) を保つため stats.remove は加算されることを検証する。
+   */
+  describe('Given: dry-run モードで cache に DISCARD 確定エントリがあるファイル', () => {
+    /** prefilterFiles([file], { cache, dryRun: true }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, dryRun: true }) を呼び出す', () => {
+      /** ファイルは削除されないが、stats.remove は加算されることを検証する。 */
+      describe('Then: T-FL-PFF-13 - ファイルは削除されないが stats.remove は加算される', () => {
+        it('T-FL-PFF-13-01: dry-run 時はファイルが削除されない', async () => {
+          const filePath = `${periodDir1}/dryrun-cached-discard.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' });
+          const loggerStub = makeLoggerStub();
+
+          await prefilterFiles([filePath], { stats: _makeStats(), cache, discardThreshold: 0.7, dryRun: true });
+          loggerStub.restore();
+
+          assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
+        });
+
+        it('T-FL-PFF-13-02: dry-run 時は stats.remove が加算される（would-remove）', async () => {
+          const filePath = `${periodDir1}/dryrun-cached-discard2.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' });
+          const loggerStub = makeLoggerStub();
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7, dryRun: true });
+          loggerStub.restore();
+
+          assertEquals(stats.remove, 1);
+          assertEquals(stats.keep, 0);
+        });
+      });
+    });
+  });
+
+  /**
+   * dry-run モードで cache に KEEP 相当エントリがあるファイルの前提条件グループ。
+   *
+   * dry-run 時でもキャッシュヒットの KEEP 判定は stats.keep に加算されることを検証する
+   * （`keep + skip + remove + error === total` の集計整合性を保つため）。
+   */
+  describe('Given: dry-run モードで cache に KEEP 相当エントリがあるファイル', () => {
+    /** prefilterFiles([file], { cache, dryRun: true }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, dryRun: true }) を呼び出す', () => {
+      /** stats.keep が加算されることを検証する。 */
+      describe('Then: T-FL-PFF-15 - stats.keep が加算される', () => {
+        it('T-FL-PFF-15-01: dry-run 時はキャッシュ KEEP で stats.keep が加算される', async () => {
+          const filePath = `${periodDir1}/dryrun-cached-keep.md`;
+          await Deno.writeTextFile(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'reusable' });
+          const loggerStub = makeLoggerStub();
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7, dryRun: true });
+          loggerStub.restore();
+
+          assertEquals(stats.keep, 1);
+          assertEquals(stats.remove, 0);
+        });
+      });
+    });
+  });
+
+  /**
+   * cache に DISCARD 確定エントリがあるが、削除実行前にファイルが既に存在しない前提条件グループ。
+   *
+   * `removeFile` が `false` を返すケースで stats.error が加算されることを検証する。
+   */
+  describe('Given: cache に DISCARD 確定エントリがあるが対象ファイルが既に存在しない', () => {
+    /** prefilterFiles([file], { cache, discardThreshold }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { cache, discardThreshold }) を呼び出す', () => {
+      /** stats.error が増え、stats.remove は増えないことを検証する。 */
+      describe('Then: T-FL-PFF-14 - stats.error が 1 になる', () => {
+        it('T-FL-PFF-14-01: removeFile 失敗 → stats.error === 1, stats.remove === 0', async () => {
+          const filePath = `${periodDir1}/cached-discard-missing.md`;
+          const cache = await _makeEmptyCache();
+          await cache.write(filePath, { decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' });
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+
+          // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
+          await prefilterFiles([filePath], { stats, cache, discardThreshold: 0.7 });
+          errStub.restore();
+
+          assertEquals(stats.error, 1);
+          assertEquals(stats.remove, 0);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/unit/filter/parse-args.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/unit/filter/parse-args.unit.spec.ts
@@ -12,7 +12,7 @@ import { assert, assertEquals, assertThrows } from '@std/assert';
 import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { parseArgs } from '../../../filter-chatlogs.ts';
+import { parseArgs } from '../../../../../_scripts/libs/io/parse-args.ts';
 
 // ─── Helpers
 // classes
@@ -20,10 +20,15 @@ import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 // constants
 import { DEFAULT_CHATLOGS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
+import { DEFAULT_FILTER_CONFIG } from '../../../constants/common.constants.ts';
 // types
+import type { ArgSchema } from '../../../../../_scripts/types/args-schema.types.ts';
 import type { FilterParsedConfig } from '../../../types/filter.types.ts';
 
 // ─── Internal Helpers
+
+// constants
+const _SCHEMA: ArgSchema<FilterParsedConfig> = [];
 
 // types
 type Args = FilterParsedConfig;
@@ -41,22 +46,22 @@ describe('parseArgs', () => {
     describe('When: parseArgs([]) を呼び出す', () => {
       describe('Then: T-FL-PA-01 - GlobalConfig が管理しないフィールドは undefined になる', () => {
         const _defaultCases: { id: string; field: keyof Args; expected: unknown }[] = [
-          { id: 'T-FL-PA-01-02', field: 'dryRun', expected: undefined },
+          { id: 'T-FL-PA-01-02', field: 'dryRun', expected: false },
           { id: 'T-FL-PA-01-03', field: 'inputDir', expected: undefined },
           { id: 'T-FL-PA-01-04', field: 'period', expected: undefined },
         ];
         for (const { id, field, expected } of _defaultCases) {
           it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
-            assertEquals(parseArgs([])[field], expected);
+            assertEquals(parseArgs([], _SCHEMA, DEFAULT_FILTER_CONFIG)[field], expected);
           });
         }
 
         it('T-FL-PA-01-01: agent が GlobalConfig のデフォルト値 "claude" になる', () => {
-          assertEquals(parseArgs([]).agent, 'claude');
+          assertEquals(parseArgs([], _SCHEMA, DEFAULT_FILTER_CONFIG).agent, 'claude');
         });
 
         it('T-FL-PA-01-05: chatlogsDir が GlobalConfig のデフォルト値になる', () => {
-          assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
+          assertEquals(parseArgs([], _SCHEMA, DEFAULT_FILTER_CONFIG).chatlogsDir, DEFAULT_CHATLOGS_DIR);
         });
       });
     });
@@ -85,7 +90,7 @@ describe('parseArgs', () => {
         ];
         for (const { id, args, field, expected } of _cases) {
           it(`${id}: ${field} が ${JSON.stringify(expected)} になる`, () => {
-            assertEquals(parseArgs(args)[field], expected);
+            assertEquals(parseArgs(args, _SCHEMA, DEFAULT_FILTER_CONFIG)[field], expected);
           });
         }
       });
@@ -96,7 +101,11 @@ describe('parseArgs', () => {
 
   describe('Given: claude 2026-03 --dry-run --input-dir /input を渡す', () => {
     it('T-FL-PA-08-01: 全フィールドが正しく解析される', () => {
-      const result = parseArgs(['claude', '2026-03', '--dry-run', '--input-dir', '/input']);
+      const result = parseArgs(
+        ['claude', '2026-03', '--dry-run', '--input-dir', '/input'],
+        _SCHEMA,
+        DEFAULT_FILTER_CONFIG,
+      );
       assertEquals(result.agent, 'claude');
       assertEquals(result.period, '2026-03');
       assert(result.dryRun);
@@ -109,7 +118,7 @@ describe('parseArgs', () => {
   describe('Given: 不正な引数', () => {
     it('T-FL-PA-09-01: 未知オプション → ChatlogError(InvalidArgs) がスローされる', () => {
       assertThrows(
-        () => parseArgs(['--unknown']),
+        () => parseArgs(['--unknown'], _SCHEMA, DEFAULT_FILTER_CONFIG),
         ChatlogError,
         'Invalid Args',
       );
@@ -117,7 +126,7 @@ describe('parseArgs', () => {
 
     it('T-FL-PA-03-01: period 単独指定（agent 省略）→ ChatlogError(InvalidArgs) がスローされる', () => {
       assertThrows(
-        () => parseArgs(['2026-03']),
+        () => parseArgs(['2026-03'], _SCHEMA, DEFAULT_FILTER_CONFIG),
         ChatlogError,
       );
     });
@@ -129,11 +138,11 @@ describe('parseArgs', () => {
     describe('When: parseArgs を呼び出す', () => {
       describe('Then: configFile フィールドに値が設定される', () => {
         it('T-FL-PA-10-01: --config cfg.yaml → configFile が "cfg.yaml" になる', () => {
-          assertEquals(parseArgs(['--config', 'cfg.yaml']).configFile, 'cfg.yaml');
+          assertEquals(parseArgs(['--config', 'cfg.yaml'], _SCHEMA, DEFAULT_FILTER_CONFIG).configFile, 'cfg.yaml');
         });
 
         it('T-FL-PA-10-02: --config=cfg.yaml → configFile が "cfg.yaml" になる', () => {
-          assertEquals(parseArgs(['--config=cfg.yaml']).configFile, 'cfg.yaml');
+          assertEquals(parseArgs(['--config=cfg.yaml'], _SCHEMA, DEFAULT_FILTER_CONFIG).configFile, 'cfg.yaml');
         });
       });
     });
@@ -145,11 +154,11 @@ describe('parseArgs', () => {
     describe('When: parseArgs を呼び出す', () => {
       describe('Then: inputDir フィールドに値が設定される', () => {
         it('T-FL-PA-11-01: --input-dir /input → inputDir が "/input" になる', () => {
-          assertEquals(parseArgs(['--input-dir', '/input']).inputDir, '/input');
+          assertEquals(parseArgs(['--input-dir', '/input'], _SCHEMA, DEFAULT_FILTER_CONFIG).inputDir, '/input');
         });
 
         it('T-FL-PA-11-02: --input-dir=/input → inputDir が "/input" になる', () => {
-          assertEquals(parseArgs(['--input-dir=/input']).inputDir, '/input');
+          assertEquals(parseArgs(['--input-dir=/input'], _SCHEMA, DEFAULT_FILTER_CONFIG).inputDir, '/input');
         });
       });
     });
@@ -161,7 +170,11 @@ describe('parseArgs', () => {
     describe('When: parseArgs を呼び出す', () => {
       describe('Then: 全フィールドが正しく解析される', () => {
         it('T-FL-PA-13-01: 全フィールドが正しく解析される', () => {
-          const result = parseArgs(['claude', '2026-03', '--dry-run', '--input-dir', '/input']);
+          const result = parseArgs(
+            ['claude', '2026-03', '--dry-run', '--input-dir', '/input'],
+            _SCHEMA,
+            DEFAULT_FILTER_CONFIG,
+          );
           assertEquals(result.agent, 'claude');
           assertEquals(result.period, '2026-03');
           assert(result.dryRun);
@@ -183,7 +196,7 @@ describe('parseArgs', () => {
       describe('Then: ChatlogError(InvalidArgs) がスローされる', () => {
         it('T-FL-PA-14-01: --input-dir foo（スラッシュなし）→ ChatlogError(InvalidArgs) がスローされる', () => {
           assertThrows(
-            () => parseArgs(['--input-dir', 'foo']),
+            () => parseArgs(['--input-dir', 'foo'], _SCHEMA, DEFAULT_FILTER_CONFIG),
             ChatlogError,
             'Invalid Args',
           );
@@ -202,10 +215,10 @@ describe('parseArgs', () => {
     describe('When: parseArgs を呼び出す', () => {
       describe('Then: chatlogsDir は GlobalConfig のデフォルト値、inputDir は undefined になる', () => {
         it('T-FL-PA-16-01: 引数なし → chatlogsDir が GlobalConfig のデフォルト値になる', () => {
-          assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
+          assertEquals(parseArgs([], _SCHEMA, DEFAULT_FILTER_CONFIG).chatlogsDir, DEFAULT_CHATLOGS_DIR);
         });
         it('T-FL-PA-16-02: 引数なし → inputDir が undefined になる', () => {
-          assertEquals(parseArgs([]).inputDir, undefined);
+          assertEquals(parseArgs([], _SCHEMA, DEFAULT_FILTER_CONFIG).inputDir, undefined);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -19,6 +19,7 @@
 
 // ─── shared ───
 // classes
+import { ChatlogCache } from '../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 // functions
@@ -26,7 +27,7 @@ import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-director
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
-import { parseArgs as parseArgsToConfig } from '../../_scripts/libs/io/parse-args.ts';
+import { parseArgs } from '../../_scripts/libs/io/parse-args.ts';
 import { runChunked } from '../../_scripts/libs/parallel/concurrency.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
@@ -40,7 +41,9 @@ import { processChunk } from './modules/filter/process-chunk.ts';
 import { prefilterFiles } from './modules/prefilter.ts';
 // constants
 import { DEFAULT_FILTER_CONFIG } from './constants/common.constants.ts';
+import { FILTER_DECISIONS } from './types/filter-decision.const.types.ts';
 // types
+import type { CLEResult } from './types/cache.types.ts';
 import type { FilterConfig, FilterParsedConfig } from './types/filter.types.ts';
 
 // ─────────────────────────────────────────────
@@ -49,10 +52,6 @@ import type { FilterConfig, FilterParsedConfig } from './types/filter.types.ts';
 
 /** filter-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgSchema<FilterParsedConfig> = [];
-
-export const parseArgs = (args: string[]): FilterParsedConfig => {
-  return parseArgsToConfig<FilterParsedConfig>(args, _SCHEMA);
-};
 
 // ─────────────────────────────────────────────
 // 設定構築
@@ -101,7 +100,7 @@ export const buildConfig = (
 
 export const main = async (args?: string[]): Promise<void> => {
   try {
-    const _parsed = parseArgs(args ?? Deno.args);
+    const _parsed = parseArgs<FilterParsedConfig>(args ?? Deno.args, _SCHEMA, DEFAULT_FILTER_CONFIG);
     const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
     const _config = buildConfig(_parsed, _globalConfig);
 
@@ -124,13 +123,24 @@ export const main = async (args?: string[]): Promise<void> => {
     // ファイル列挙
     const allFiles = await findFiles(_searchDir);
 
+    // 判定結果キャッシュ
+    const _cache = new ChatlogCache<CLEResult>('filter-cache');
+    await _cache.ready;
+
     // 事前フィルタ
     const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
-    const targetFiles = await prefilterFiles(allFiles, {
+
+    // キャッシュ上 KEEP 済みのファイルを処理対象から除外する
+    const _targetEntries = allFiles.filter((filePath) => _cache.read(filePath).decision !== FILTER_DECISIONS.KEEP);
+    stats.keep += allFiles.length - _targetEntries.length;
+
+    const targetFiles = await prefilterFiles(_targetEntries, {
       minCharCount: _config.minCharCount,
       minAssistantChars: _config.minAssistantChars,
       stats,
       dryRun: _config.dryRun,
+      cache: _cache,
+      discardThreshold: _config.discardThreshold,
     });
 
     const total = targetFiles.length;
@@ -153,7 +163,7 @@ export const main = async (args?: string[]): Promise<void> => {
       await runChunked(
         targetFiles,
         _config.chunkSize,
-        (chunk) => processChunk(chunk, stats, _config.discardThreshold),
+        (chunk) => processChunk(chunk, stats, _config.discardThreshold, _cache),
         _config.concurrency,
       );
     }
@@ -173,5 +183,5 @@ export const main = async (args?: string[]): Promise<void> => {
 };
 
 if (import.meta.main) {
-  await main();
+  await main(Deno.args);
 }

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -25,6 +25,7 @@ import {
   makeNotFoundMock,
   makeSuccessMock,
 } from '../../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { ChatlogCache } from '../../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { DEFAULT_CONFIG_VALUES } from '../../../../../../_scripts/constants/config-schema.constants.ts';
 // types
 import type { CommandMockHandle } from '../../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -33,21 +34,57 @@ import { makePeriodDir } from '../../../../__tests__/_helpers/fixtures.ts';
 import { fileOrDirExists } from '../../../../../../_scripts/libs/file-ops/exists-utils.ts';
 // constants
 import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
+// types
+import type { CLEResult } from '../../../../types/cache.types.ts';
 
 // ─── Internal Helpers
+
+// functions
+/**
+ * テスト用の空キャッシュ（バッファバック）を生成する。
+ *
+ * ファイル I/O をせずにインメモリバッファで動作する `ChatlogCache<CLEResult>` を返す。
+ * @returns 初期化済みの空キャッシュ
+ */
+const _makeEmptyCache = async (): Promise<ChatlogCache<CLEResult>> => {
+  const buf = new Map<string, string>();
+  const cache = new ChatlogCache<CLEResult>(
+    'filter-cache',
+    '/fake/cache',
+    undefined,
+    {
+      cache: {
+        readTextFile: (path) => {
+          const data = buf.get(path);
+          if (data === undefined) { return Promise.reject(new Error('not found')); }
+          return Promise.resolve(data);
+        },
+        writeTextFile: (path, data) => {
+          buf.set(path, data);
+          return Promise.resolve();
+        },
+        mkdir: () => Promise.resolve(),
+        glob: () => Promise.resolve([]),
+      },
+    },
+  );
+  await cache.ready;
+  return cache;
+};
 
 // ─── Tests
 
 /**
  * `processChunk` 関数の機能テストスイート。
  *
- * `processChunk(files, stats, discardThreshold)` は Claude CLI にバッチ判定を依頼し、
- * DISCARD/KEEP 判定に応じてファイル削除と統計更新を行う。
+ * `processChunk(files, stats, discardThreshold, cache)` は Claude CLI にバッチ判定を依頼し、
+ * DISCARD/KEEP 判定に応じてファイル削除と統計更新を行う。判定結果は `removeFile` 呼び出し前に
+ * `cache.write` へ書き込まれる。
  *
  * ## 判定ルール
  * - `decision === 'DISCARD'` かつ `confidence >= DEFAULT_CONFIG_VALUES.discardThreshold` → ファイルを削除
  * - `confidence < DEFAULT_CONFIG_VALUES.discardThreshold` → DISCARD 判定でも KEEP 扱い
- * - CLI エラー・JSON パース失敗・ファイル名不一致 → 全件 KEEP 扱い
+ * - CLI エラー・JSON パース失敗・ファイル名不一致 → 全件 KEEP 扱い（cache へは書き込まない）
  *
  * テスト ID 範囲: T-FL-PCK-01 〜 T-FL-PCK-10
  *
@@ -120,8 +157,9 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
           logStub.restore();
 
@@ -144,12 +182,42 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
           logStub.restore();
 
           assertEquals(stats.remove, 1);
+        });
+
+        it('T-FL-PCK-02-03: removeFile 呼び出し前に cache へ判定結果が書き込まれる', async () => {
+          const filePath = await _createTempFile('c2.md');
+          const response = JSON.stringify([
+            {
+              file: 'c2.md',
+              decision: FILTER_DECISIONS.DISCARD,
+              confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+              reason: 'trivial',
+            },
+          ]);
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode(response)),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const logStub = stub(console, 'log', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
+          errStub.restore();
+          logStub.restore();
+
+          assertEquals(cache.read(filePath), {
+            decision: FILTER_DECISIONS.DISCARD,
+            confidence: DEFAULT_CONFIG_VALUES.discardThreshold,
+            reason: 'trivial',
+          });
         });
       });
     });
@@ -175,11 +243,30 @@ describe('processChunk', () => {
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
 
           assertEquals(stats.keep, 1);
+        });
+
+        it('T-FL-PCK-03-02: KEEP 確定時も cache へ判定結果が書き込まれる', async () => {
+          const filePath = await _createTempFile('d2.md');
+          const response = JSON.stringify([
+            { file: 'd2.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
+          ]);
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode(response)),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
+          errStub.restore();
+
+          assertEquals(cache.read(filePath), { decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' });
         });
       });
     });
@@ -205,8 +292,9 @@ describe('processChunk', () => {
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
 
           assertEquals(stats.keep, 1);
@@ -232,11 +320,25 @@ describe('processChunk', () => {
           commandHandle = installCommandMock(makeFailMock(1));
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([file1, file2], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([file1, file2], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
 
           assertEquals(stats.keep, 2);
+        });
+
+        it('T-FL-PCK-05-02: cache へは書き込まれない', async () => {
+          const file1 = await _createTempFile('f3.md');
+          commandHandle = installCommandMock(makeFailMock(1));
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+
+          await processChunk([file1], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
+          errStub.restore();
+
+          assertEquals(cache.read(file1), {});
         });
       });
     });
@@ -259,11 +361,27 @@ describe('processChunk', () => {
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
 
           assertEquals(stats.keep, 1);
+        });
+
+        it('T-FL-PCK-06-02: cache へは書き込まれない', async () => {
+          const filePath = await _createTempFile('g2.md');
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
+          errStub.restore();
+
+          assertEquals(cache.read(filePath), {});
         });
       });
     });
@@ -290,8 +408,9 @@ describe('processChunk', () => {
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
 
           assertEquals(stats.keep, 1);
@@ -315,8 +434,9 @@ describe('processChunk', () => {
           commandHandle = installCommandMock(makeNotFoundMock());
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
 
           assertEquals(stats.keep, 1);
@@ -352,10 +472,11 @@ describe('processChunk', () => {
           const warnStub = stub(console, 'warn', () => {});
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
           // removeFile 内部の Deno.remove が NotFound を投げるようにし、"File not found" 分岐を発生させる
           const removeStub = stub(Deno, 'remove', () => Promise.reject(new Deno.errors.NotFound()));
 
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number);
+          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache);
           errStub.restore();
           warnStub.restore();
           logStub.restore();
@@ -363,6 +484,8 @@ describe('processChunk', () => {
 
           assertEquals(stats.error, 1);
           assertEquals(stats.remove, 0);
+          // removeFile が失敗しても cache.write は完了している（write-before-remove の再開可能性を保証する）
+          assertEquals(cache.read(filePath).decision, FILTER_DECISIONS.DISCARD);
         });
       });
     });
@@ -389,8 +512,9 @@ describe('processChunk', () => {
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});
           const stats = _makeStats();
+          const cache = await _makeEmptyCache();
 
-          await processChunk([filePath], stats, 0.5);
+          await processChunk([filePath], stats, 0.5, cache);
           errStub.restore();
           logStub.restore();
 

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -7,6 +7,8 @@
 // https://opensource.org/licenses/MIT
 
 // ─── shared ───
+// classes
+import type { ChatlogCache } from '../../../../_scripts/classes/ChatlogCache.class.ts';
 // functions
 import { runAI } from '../../../../_scripts/libs/ai/run-ai.ts';
 import { removeFile } from '../../../../_scripts/libs/file-ops/remove-utils.ts';
@@ -19,6 +21,7 @@ import { parseAiJsonArray } from '../../../../_scripts/libs/text/json-utils.ts';
 import { buildBatchPrompt } from '../../libs/batch-prompt.ts';
 import { FILTER_DECISIONS } from '../../types/filter-decision.const.types.ts';
 // types
+import type { CLEResult } from '../../types/cache.types.ts';
 import type { ClaudeResult } from '../../types/filter.types.ts';
 import type { FilterStats } from '../../types/stats.types.ts';
 
@@ -41,6 +44,7 @@ export const processChunk = async (
   chunkFiles: string[],
   stats: FilterStats,
   discardThreshold: number,
+  cache: ChatlogCache<CLEResult>,
 ): Promise<void> => {
   const batchPrompt = await buildBatchPrompt(chunkFiles);
 
@@ -79,6 +83,7 @@ export const processChunk = async (
     }
 
     const { decision, confidence, reason } = result;
+    await cache.write(filePath, { decision, confidence, reason });
 
     if (decision === FILTER_DECISIONS.DISCARD && confidence >= discardThreshold) {
       logger.log(`DISCARD (conf=${confidence}): ${filePath}`);

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -22,13 +22,13 @@ import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { removeFile } from '../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
-import { parseFrontmatterEntries } from '../../../_scripts/libs/text/frontmatter-utils.ts';
 // constants
 import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
 
 // ─── internal ───
 // classes
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
+import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 // functions
 import { checkFilename } from '../libs/classify-file.ts';
 import { extractConversation } from '../libs/common-utils.ts';
@@ -191,13 +191,6 @@ export const _phase1_2DiscardByFilename = async (
   );
 };
 
-/** `_phase2ReadSurvivors` を通過したファイルの本文情報。 */
-interface _ReadFileEntry {
-  filePath: string;
-  filename: string;
-  content: string;
-}
-
 /**
  * ファイルリストの本文を並列に読み込み、frontmatter を除いた content を取り出す。
  *
@@ -210,15 +203,14 @@ interface _ReadFileEntry {
 export const _phase2ReadSurvivors = async (
   survivors: string[],
   cache: ChatlogCache<CLEResult> | undefined,
-): Promise<{ readOk: _ReadFileEntry[]; results: _ClassifyResult[] }> => {
+): Promise<{ readOk: ChatlogEntry[]; results: _ClassifyResult[] }> => {
   const entries = await Promise.all(
     survivors.map(
-      async (filePath): Promise<{ ok: true; entry: _ReadFileEntry } | { ok: false; result: _ClassifyResult }> => {
+      async (filePath): Promise<{ ok: true; entry: ChatlogEntry } | { ok: false; result: _ClassifyResult }> => {
         const filename = getFilename(filePath);
         try {
           const text = await readTextFile(filePath);
-          const { content } = parseFrontmatterEntries(text);
-          return { ok: true, entry: { filePath, filename, content } };
+          return { ok: true, entry: new ChatlogEntry(text, { filePath }) };
         } catch {
           if (cache) {
             await cache.write(filePath, { decision: FILTER_DECISIONS.ERROR, confidence: 0, reason: '読み込み失敗' });
@@ -254,14 +246,18 @@ interface _ConversationEntry {
  * @returns 通過ファイル情報（`survivors`）と、この段階で確定した分類結果（`results`）
  */
 export const _phase3PartitionByContent = (
-  readOk: _ReadFileEntry[],
+  readOk: ChatlogEntry[],
   minCharCount: number,
   minAssistantChars: number,
 ): { survivors: _ConversationEntry[]; results: _ClassifyResult[] } => {
   const results: _ClassifyResult[] = [];
   const survivors: _ConversationEntry[] = [];
 
-  readOk.forEach(({ filePath, filename, content }) => {
+  readOk.forEach((entry) => {
+    const filePath = entry.filePath as string;
+    const filename = entry.filename as string;
+    const { content } = entry;
+
     if (!content.trim()) {
       results.push({ filePath, filename, outcome: 'excluded-content', reason: '本文が空' });
       return;

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -19,6 +19,7 @@ import {
   parseConversation,
 } from '../../../_scripts/libs/chatlogs/conversation-utils.ts';
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { removeFile } from '../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { parseFrontmatterEntries } from '../../../_scripts/libs/text/frontmatter-utils.ts';
@@ -26,13 +27,18 @@ import { parseFrontmatterEntries } from '../../../_scripts/libs/text/frontmatter
 import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
 
 // ─── internal ───
+// classes
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 // functions
 import { checkFilename } from '../libs/classify-file.ts';
 import { extractConversation } from '../libs/common-utils.ts';
 // constants
 import { SYSTEM_TAG_PREFIXES } from '../constants/patterns.constants.ts';
+import { FILTER_DECISIONS } from '../types/filter-decision.const.types.ts';
 // types
+import type { CLEResult } from '../types/cache.types.ts';
 import type { PrefilterFilesOptions } from '../types/filter.types.ts';
+import type { BaseStats } from '../types/stats.types.ts';
 
 // ─────────────────────────────────────────────
 // 事前フィルタ関数
@@ -106,6 +112,229 @@ export const isExcludedByContent = (
   return { excluded: false, reason: '' };
 };
 
+/** 分類結果の種別。stats 加算先・ログ出力・passed 抽出をこの値だけで判別する。 */
+type _PrefilterOutcome =
+  | 'read-error'
+  | 'excluded-content'
+  | 'cache-keep'
+  | 'cache-discard-removed'
+  | 'cache-discard-error'
+  | 'passed';
+
+/** 各ステージ関数の戻り値。1 ファイルにつき 1 件、stats 加算先が一意に定まる分類結果。 */
+interface _ClassifyResult {
+  filePath: string;
+  filename: string;
+  outcome: _PrefilterOutcome;
+  /** スキップ理由（`excluded-content` のときのみ意味を持つ）。 */
+  reason?: string;
+}
+
+/**
+ * ファイルリストをファイル名パターンで分類する。
+ *
+ * 除外パターンに一致するファイルは `discarded` として確定し、
+ * それ以外は本文チェックへ進む `survivors` として返す純粋関数。
+ * cache 書き込み・実削除・stats 加算などの副作用は一切行わない。
+ *
+ * @param files - 分類対象のファイルパス配列
+ * @returns 通過ファイルパス配列（`survivors`）と、除外確定ファイルパス配列（`discarded`）
+ */
+export const _phase1_1PartitionByFilename = (files: string[]): { survivors: string[]; discarded: string[] } => {
+  const discarded = files.filter((filePath) => isExcludedByFilename(getFilename(filePath)));
+  const survivors = files.filter((filePath) => !isExcludedByFilename(getFilename(filePath)));
+  return { survivors, discarded };
+};
+
+/**
+ * ファイル名パターンで除外確定したファイルを、cache 書き込み・実削除・stats 加算まで一括処理する。
+ *
+ * cache 指定時は dry-run でも DISCARD decision を書き込む。実削除は `dryRun === false` のときのみ行う。
+ * `dryRun === true` のときは削除せず `stats.remove` に加算する（would-remove）。
+ * `removeFile()` が NotFound（`false`）を返した場合は `stats.remove` ではなく `stats.error` に加算する。
+ *
+ * @param discarded - `_phase1_1PartitionByFilename` が返したファイル名除外確定ファイルパス配列
+ * @param cache - DISCARD decision を書き込むキャッシュ（未指定なら書き込みしない）
+ * @param dryRun - `true` のとき実削除・ログ出力を行わない
+ * @param discardThreshold - cache に書き込む DISCARD decision の confidence 値
+ */
+export const _phase1_2DiscardByFilename = async (
+  discarded: string[],
+  cache: ChatlogCache<CLEResult> | undefined,
+  dryRun: boolean,
+  discardThreshold: number,
+  stats: BaseStats,
+): Promise<void> => {
+  await Promise.all(
+    discarded.map(async (filePath) => {
+      const filename = getFilename(filePath);
+      if (cache) {
+        await cache.write(filePath, {
+          decision: FILTER_DECISIONS.DISCARD,
+          confidence: discardThreshold,
+          reason: checkFilename(filename) ?? '',
+        });
+      }
+
+      if (dryRun) {
+        stats.remove++;
+        return;
+      }
+
+      if (await removeFile(filePath)) {
+        stats.remove++;
+        logger.info(`  skipped (ファイル名パターン): ${filename}`);
+      } else {
+        stats.error++;
+      }
+    }),
+  );
+};
+
+/** `_phase2ReadSurvivors` を通過したファイルの本文情報。 */
+interface _ReadFileEntry {
+  filePath: string;
+  filename: string;
+  content: string;
+}
+
+/**
+ * ファイルリストの本文を並列に読み込み、frontmatter を除いた content を取り出す。
+ *
+ * 読み込みに失敗したファイルは `read-error` として確定する（cache 指定時は ERROR decision を書き込む）。
+ *
+ * @param survivors - 読み込み対象のファイルパス配列
+ * @param cache - 読み込み失敗時に ERROR decision を書き込むキャッシュ（未指定なら書き込みしない）
+ * @returns 読み込みに成功したファイル情報（`readOk`）と、読み込み失敗として確定した分類結果（`results`）
+ */
+export const _phase2ReadSurvivors = async (
+  survivors: string[],
+  cache: ChatlogCache<CLEResult> | undefined,
+): Promise<{ readOk: _ReadFileEntry[]; results: _ClassifyResult[] }> => {
+  const entries = await Promise.all(
+    survivors.map(
+      async (filePath): Promise<{ ok: true; entry: _ReadFileEntry } | { ok: false; result: _ClassifyResult }> => {
+        const filename = getFilename(filePath);
+        try {
+          const text = await readTextFile(filePath);
+          const { content } = parseFrontmatterEntries(text);
+          return { ok: true, entry: { filePath, filename, content } };
+        } catch {
+          if (cache) {
+            await cache.write(filePath, { decision: FILTER_DECISIONS.ERROR, confidence: 0, reason: '読み込み失敗' });
+          }
+          return { ok: false, result: { filePath, filename, outcome: 'read-error' } };
+        }
+      },
+    ),
+  );
+
+  const readOk = entries.filter((entry) => entry.ok).map((entry) => entry.entry);
+  const results = entries.filter((entry) => !entry.ok).map((entry) => entry.result);
+
+  return { readOk, results };
+};
+
+/** `_phase3PartitionByContent` を通過したファイルの会話本文情報。 */
+interface _ConversationEntry {
+  filePath: string;
+  filename: string;
+  bodyText: string;
+}
+
+/**
+ * 読み込み済みファイルの本文を内容チェックで分類する。
+ *
+ * 本文が空・内容が短すぎる・会話本文が空のいずれかに該当するファイルは
+ * `excluded-content` として確定し、通過したファイルのみ `survivors` に含める。
+ *
+ * @param readOk - `_phase2ReadSurvivors` で読み込み済みのファイル情報
+ * @param minCharCount - 本文の最小文字数
+ * @param minAssistantChars - User ターン 1 件のときの Assistant 応答最小文字数
+ * @returns 通過ファイル情報（`survivors`）と、この段階で確定した分類結果（`results`）
+ */
+export const _phase3PartitionByContent = (
+  readOk: _ReadFileEntry[],
+  minCharCount: number,
+  minAssistantChars: number,
+): { survivors: _ConversationEntry[]; results: _ClassifyResult[] } => {
+  const results: _ClassifyResult[] = [];
+  const survivors: _ConversationEntry[] = [];
+
+  readOk.forEach(({ filePath, filename, content }) => {
+    if (!content.trim()) {
+      results.push({ filePath, filename, outcome: 'excluded-content', reason: '本文が空' });
+      return;
+    }
+
+    const { excluded, reason } = isExcludedByContent(content, minCharCount, minAssistantChars);
+    if (excluded) {
+      results.push({ filePath, filename, outcome: 'excluded-content', reason });
+      return;
+    }
+
+    const bodyText = extractConversation(content);
+    if (!bodyText.trim()) {
+      results.push({ filePath, filename, outcome: 'excluded-content', reason: '会話本文が空' });
+      return;
+    }
+
+    survivors.push({ filePath, filename, bodyText });
+  });
+
+  return { survivors, results };
+};
+
+/**
+ * 内容チェックを通過したファイルをキャッシュ判定で分類する。
+ *
+ * cache 未指定の場合は全件 `passed` として確定する。
+ * cache 指定時は既存判定（decision !== ERROR）があれば AI 呼び出しをスキップし、
+ * DISCARD かつ confidence が閾値以上ならファイル削除（dry-run 時は削除しない）、
+ * それ以外は KEEP として確定する。
+ *
+ * @param survivors - `_phase3PartitionByContent` を通過したファイル情報
+ * @param cache - ファイル単位の判定結果キャッシュ
+ * @param dryRun - `true` のとき DISCARD 確定時もファイルを削除しない
+ * @param discardThreshold - DISCARD 判定に必要な最低信頼度スコア
+ * @returns この段階で確定した分類結果
+ */
+export const _phase4ResolveCache = async (
+  survivors: _ConversationEntry[],
+  cache: ChatlogCache<CLEResult> | undefined,
+  dryRun: boolean,
+  discardThreshold: number,
+): Promise<_ClassifyResult[]> => {
+  if (!cache) {
+    return survivors.map(({ filePath, filename }) => ({ filePath, filename, outcome: 'passed' as const }));
+  }
+
+  return await Promise.all(
+    survivors.map(async ({ filePath, filename }): Promise<_ClassifyResult> => {
+      const cached = cache.read(filePath);
+      if (cached.decision !== undefined && cached.decision !== FILTER_DECISIONS.ERROR) {
+        if (cached.decision === FILTER_DECISIONS.DISCARD && (cached.confidence ?? 0) >= discardThreshold) {
+          if (dryRun || await removeFile(filePath)) {
+            return { filePath, filename, outcome: 'cache-discard-removed' };
+          }
+          return { filePath, filename, outcome: 'cache-discard-error' };
+        }
+        return { filePath, filename, outcome: 'cache-keep' };
+      }
+      return { filePath, filename, outcome: 'passed' };
+    }),
+  );
+};
+
+/** `_ClassifyResult.outcome` から `BaseStats` の加算先フィールド名への対応表。 */
+const _OUTCOME_STATS_FIELD: Partial<Record<_PrefilterOutcome, 'keep' | 'remove' | 'error'>> = {
+  'read-error': 'error',
+  'excluded-content': 'keep',
+  'cache-keep': 'keep',
+  'cache-discard-removed': 'remove',
+  'cache-discard-error': 'error',
+};
+
 /**
  * ファイルリストをファイル名パターンと本文内容で事前フィルタリングし、通過したパスを返す。
  *
@@ -113,8 +342,12 @@ export const isExcludedByContent = (
  * @param options - `prefilterFiles` のオプション
  * @param options.minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）
  * @param options.minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）
- * @param options.stats - 処理統計オブジェクト。事前段階での KEEP 確定数を `keep` に、読み込み失敗数を `error` に加算する。
+ * @param options.stats - 処理統計オブジェクト。ファイル名パターン除外の実削除数を `remove` に、
+ *   事前段階での KEEP 確定数を `keep` に、読み込み失敗数を `error` に加算する。
  * @param options.dryRun - `true` のとき、スキップ理由・サマリのログ出力を抑制する（デフォルト: `false`）
+ * @param options.cache - ファイル単位の判定結果キャッシュ。指定時は既存判定があれば AI 呼び出しをスキップし、
+ *   `decision`/`confidence` からその場で KEEP/DISCARD を再導出する（dry-run 時は削除を行わない）。
+ * @param options.discardThreshold - DISCARD 判定に必要な最低信頼度スコア。キャッシュヒット時の再判定に使用する。
  * @returns フィルタリングを通過したファイルパスの配列
  */
 export const prefilterFiles = async (
@@ -126,48 +359,30 @@ export const prefilterFiles = async (
     minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
     stats,
     dryRun = false,
+    cache,
+    discardThreshold = DEFAULT_CONFIG_VALUES.discardThreshold as number,
   } = options;
 
-  const passed: string[] = [];
+  const byFilename = _phase1_1PartitionByFilename(files);
+  await _phase1_2DiscardByFilename(byFilename.discarded, cache, dryRun, discardThreshold, stats);
 
-  for (const filePath of files) {
-    const filename = getFilename(filePath);
+  const byRead = await _phase2ReadSurvivors(byFilename.survivors, cache);
+  const byContent = _phase3PartitionByContent(byRead.readOk, minCharCount, minAssistantChars);
+  const byCache = await _phase4ResolveCache(byContent.survivors, cache, dryRun, discardThreshold);
 
-    if (isExcludedByFilename(filename)) {
-      if (!dryRun) { logger.info(`  skipped (ファイル名パターン): ${filename}`); }
-      stats.keep++;
-      continue;
+  const _results = [...byRead.results, ...byContent.results, ...byCache];
+
+  _results.forEach((result) => {
+    const statsField = _OUTCOME_STATS_FIELD[result.outcome];
+    if (statsField) { stats[statsField]++; }
+
+    if (dryRun) { return; }
+    if (result.outcome === 'excluded-content') {
+      logger.info(`  skipped (${result.reason}): ${result.filename}`);
     }
+  });
 
-    let text: string;
-    try {
-      text = await readTextFile(filePath);
-    } catch {
-      stats.error++;
-      continue;
-    }
-
-    const { content } = parseFrontmatterEntries(text);
-    if (!content.trim()) {
-      stats.keep++;
-      continue;
-    }
-
-    const { excluded, reason } = isExcludedByContent(content, minCharCount, minAssistantChars);
-    if (excluded) {
-      if (!dryRun) { logger.info(`  skipped (${reason}): ${filename}`); }
-      stats.keep++;
-      continue;
-    }
-
-    const bodyText = extractConversation(content);
-    if (!bodyText.trim()) {
-      stats.keep++;
-      continue;
-    }
-
-    passed.push(filePath);
-  }
+  const passed = _results.filter((result) => result.outcome === 'passed').map((result) => result.filePath);
 
   if (!dryRun) {
     logger.info(`事前フィルタ: 対象=${files.length} 通過=${passed.length} keep=${stats.keep}`);

--- a/skills/filter-chatlogs/scripts/types/cache.types.ts
+++ b/skills/filter-chatlogs/scripts/types/cache.types.ts
@@ -1,0 +1,20 @@
+// src: scripts/types/cache.types.ts
+// @(#): filter-chatlogs キャッシュデータ型定義
+//       対象: CLEResult
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import type { FilterDecision } from './filter-decision.const.types.ts';
+
+/** ChatlogsCache が保存する filter 判定結果。claude CLI が返した raw な判定を保持する。 */
+export interface CLEResult {
+  /** KEEP、DISCARD、または ERROR（読み込み失敗の記録）の判定（`FILTER_DECISIONS` 参照）。 */
+  decision: FilterDecision;
+  /** 判定の信頼度スコア（0.0〜1.0）。DISCARD 確定には `discardThreshold` との比較が別途必要。 */
+  confidence: number;
+  /** 判定理由。 */
+  reason: string;
+}

--- a/skills/filter-chatlogs/scripts/types/filter-decision.const.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter-decision.const.types.ts
@@ -10,6 +10,7 @@
 export const FILTER_DECISIONS = {
   KEEP: 'KEEP',
   DISCARD: 'DISCARD',
+  ERROR: 'ERROR',
 } as const;
 
 /** `FILTER_DECISIONS` の値から派生したユニオン型。`'KEEP' | 'DISCARD'` と等価。 */

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -6,7 +6,10 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// classes
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 // types
+import type { CLEResult } from './cache.types.ts';
 import type { FilterDecision } from './filter-decision.const.types.ts';
 import type { BaseStats } from './stats.types.ts';
 
@@ -74,4 +77,8 @@ export interface PrefilterFilesOptions {
   stats: BaseStats;
   /** `true` のとき、スキップ理由・サマリのログ出力を抑制する。 */
   dryRun?: boolean;
+  /** DISCARD 判定に必要な最低信頼度スコア。キャッシュヒット時の DISCARD/KEEP 再判定に使用する。 */
+  discardThreshold?: number;
+  /** ファイル単位の判定結果キャッシュ。指定時は既存判定があれば AI 呼び出しをスキップする。 */
+  cache?: ChatlogCache<CLEResult>;
 }


### PR DESCRIPTION
## Overview

**Summary**
Add a filter-decision cache so `filter-chatlogs` can resume without reprocessing already-filtered files.

**Background / Motivation**
AI-based filtering can be interrupted or re-run, causing files that were already classified to be reprocessed and re-charged against the AI. This change caches KEEP/DISCARD/ERROR decisions and applies them on the next run, skipping redundant AI calls and file removals.

## Changes

### Core Changes

- `filter-chatlogs.ts`: initialize and await the filter cache, skip cached KEEP files before prefiltering, pass the cache and discard threshold to `prefilterFiles` and `processChunk`.
- `modules/prefilter.ts`: apply cached KEEP/DISCARD decisions during prefiltering, split prefilter processing into exported phase helpers, handle cache/dry-run/removal side effects, reconstruct results in original file order, and read survivors via `ChatlogEntry`.
- `modules/filter/process-chunk.ts`: add a `cache` parameter to `processChunk` and write AI filter decisions to the cache keyed by file path.
- `types/cache.types.ts`: add `CLEResult` type for cached filter decisions, including read errors.
- `types/filter-decision.const.types.ts`: add the `ERROR` filter decision constant.
- `types/filter.types.ts`: add a discard threshold and optional cache to `PrefilterFilesOptions`.

### Test Updates

- `__tests__/e2e/main.e2e.spec.ts`: verify a cached KEEP entry skips the claude CLI call and the file is retained.
- `__tests__/functional/filter/prefilter.functional.spec.ts`: expand coverage for cached discard/keep/low-confidence/miss/dry-run/remove-failure scenarios, cached read-failure handling, and result ordering.
- `__tests__/unit/filter/parse-args.unit.spec.ts`: update parser config tests, switch `parseArgs` import, update default `dryRun` expectation to `false`.
- `modules/filter/__tests__/functional/process-chunk.functional.spec.ts`: add cache fixtures and verify cached DISCARD/KEEP results and cache write behavior on failures.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #291

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
