### PR TITLE
fix(libs/read-utils)!: return null for suppressed read errors

### DIFF
--- a/skills/_scripts/libs/file-io/__tests__/system/read-utils.system.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/system/read-utils.system.spec.ts
@@ -56,7 +56,7 @@ describe('readTextFile', () => {
         await assertRejects(() => readTextFile(childPath));
       });
 
-      it('[Normal] T-LIB-S-RF-02: throwFileIoError: false → 例外を投げず空文字列が返る', async () => {
+      it('[Normal] T-LIB-S-RF-02: throwFileIoError: false → 例外を投げず null が返る', async () => {
         // arrange
         const filePath = `${tmpDir}/file.md`;
         await Deno.writeTextFile(filePath, 'content');
@@ -66,7 +66,7 @@ describe('readTextFile', () => {
         const result = await readTextFile(childPath, { throwFileIoError: false });
 
         // assert
-        assertEquals(result, '');
+        assertEquals(result, null);
       });
     });
   });

--- a/skills/_scripts/libs/file-io/__tests__/unit/read-utils.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/read-utils.unit.spec.ts
@@ -57,7 +57,7 @@ const _genericErrorProvider: ReadTextFileProvider = (_path: string) => Promise.r
  * ファイルが存在しない場合は `ChatlogError('FileDirNotFound')` を throw し、
  * その他のエラー（PermissionDenied 等）はそのまま再 throw する。
  * `options.throwFileIoError: false` を指定すると、ファイル I/O 起因のエラーは
- * throw せず空文字列を返す（ファイル I/O 起因ではないエラーは throwFileIoError の値に関わらず re-throw する）。
+ * throw せず null を返す（ファイル I/O 起因ではないエラーは throwFileIoError の値に関わらず re-throw する）。
  *
  * テスト ID 範囲: T-LIB-U-RF-01 〜 T-LIB-U-RF-11
  *
@@ -214,19 +214,19 @@ describe('readTextFile', () => {
   /**
    * 存在しないファイルパスを渡し throwFileIoError: false を指定する前提条件グループ。
    *
-   * 例外を投げず空文字列が返ることを検証する。
+   * 例外を投げず null が返ることを検証する。
    */
   describe('Given: 存在しないファイルパスを渡し throwFileIoError: false を指定する', () => {
     /** readTextFile を実行するとき。 */
     describe('When: readTextFile を実行する', () => {
-      /** 例外を投げず空文字列が返ることを検証する。 */
-      describe('Then: T-LIB-U-RF-08 - 例外を投げず空文字列が返る', () => {
-        it('T-LIB-U-RF-08: NotFound は例外を投げず空文字列を返す', async () => {
+      /** 例外を投げず null が返ることを検証する。 */
+      describe('Then: T-LIB-U-RF-08 - 例外を投げず null が返る', () => {
+        it('T-LIB-U-RF-08: NotFound は例外を投げず null を返す', async () => {
           const _result = await readTextFile('/nonexistent/path.md', {
             readProvider: _notFoundProvider,
             throwFileIoError: false,
           });
-          assertEquals(_result, '');
+          assertEquals(_result, null);
         });
       });
     });
@@ -235,19 +235,19 @@ describe('readTextFile', () => {
   /**
    * 読み込み権限のないファイルを渡し throwFileIoError: false を指定する前提条件グループ。
    *
-   * 例外を投げず空文字列が返ることを検証する。
+   * 例外を投げず null が返ることを検証する。
    */
   describe('Given: 読み込み権限のないファイルを渡し throwFileIoError: false を指定する', () => {
     /** readTextFile を実行するとき。 */
     describe('When: readTextFile を実行する', () => {
-      /** 例外を投げず空文字列が返ることを検証する。 */
-      describe('Then: T-LIB-U-RF-09 - 例外を投げず空文字列が返る', () => {
-        it('T-LIB-U-RF-09: PermissionDenied は例外を投げず空文字列を返す', async () => {
+      /** 例外を投げず null が返ることを検証する。 */
+      describe('Then: T-LIB-U-RF-09 - 例外を投げず null が返る', () => {
+        it('T-LIB-U-RF-09: PermissionDenied は例外を投げず null を返す', async () => {
           const _result = await readTextFile('/restricted/path.md', {
             readProvider: _permissionDeniedProvider,
             throwFileIoError: false,
           });
-          assertEquals(_result, '');
+          assertEquals(_result, null);
         });
       });
     });
@@ -281,19 +281,19 @@ describe('readTextFile', () => {
   /**
    * NotADirectory エラーが発生し throwFileIoError: false を指定する前提条件グループ。
    *
-   * 中間パスコンポーネントがファイルであるケースを想定し、例外を投げず空文字列が返ることを検証する。
+   * 中間パスコンポーネントがファイルであるケースを想定し、例外を投げず null が返ることを検証する。
    */
   describe('Given: NotADirectory エラーが発生し throwFileIoError: false を指定する', () => {
     /** readTextFile を実行するとき。 */
     describe('When: readTextFile を実行する', () => {
-      /** 例外を投げず空文字列が返ることを検証する。 */
-      describe('Then: T-LIB-U-RF-11 - 例外を投げず空文字列が返る', () => {
-        it('T-LIB-U-RF-11: NotADirectory は例外を投げず空文字列を返す', async () => {
+      /** 例外を投げず null が返ることを検証する。 */
+      describe('Then: T-LIB-U-RF-11 - 例外を投げず null が返る', () => {
+        it('T-LIB-U-RF-11: NotADirectory は例外を投げず null を返す', async () => {
           const _result = await readTextFile('/tmp/file/child.md', {
             readProvider: _notADirProvider,
             throwFileIoError: false,
           });
-          assertEquals(_result, '');
+          assertEquals(_result, null);
         });
       });
     });

--- a/skills/_scripts/libs/file-io/read-utils.ts
+++ b/skills/_scripts/libs/file-io/read-utils.ts
@@ -44,7 +44,7 @@ export const isFileIoError = (error: unknown): boolean =>
  * ファイルを読み込み、行末文字を LF に正規化して返す。
  * - ファイルが存在しない場合は `ChatlogError('FileDirNotFound')` を throw する（`throwFileIoError: false` を除く）。
  * - その他のファイル I/O 起因のエラー（PermissionDenied 等）はそのまま再 throw する（`throwFileIoError: false` を除く）。
- * - `throwFileIoError: false` を指定すると、ファイル I/O 起因のエラーは throw せず空文字列を返す。
+ * - `throwFileIoError: false` を指定すると、ファイル I/O 起因のエラーは throw せず null を返す。
  *   ファイル I/O 起因ではないエラーは `throwFileIoError` の値に関わらず常に再 throw する。
  *
  * @param path - 読み込むファイルの絶対パス
@@ -52,10 +52,18 @@ export const isFileIoError = (error: unknown): boolean =>
  * @param options.readProvider - テスト用注入可能な読み込み関数（デフォルト: `Deno.readTextFile`）
  * @param options.throwFileIoError - ファイル I/O 起因のエラーを throw するか（デフォルト: `true`）
  */
-export const readTextFile = async (
+export function readTextFile(
+  path: string,
+  options?: { readProvider?: ReadTextFileProvider; throwFileIoError?: true },
+): Promise<string>;
+export function readTextFile(
+  path: string,
+  options: { readProvider?: ReadTextFileProvider; throwFileIoError: false },
+): Promise<string | null>;
+export async function readTextFile(
   path: string,
   options?: { readProvider?: ReadTextFileProvider; throwFileIoError?: boolean },
-): Promise<string> => {
+): Promise<string | null> {
   const { readProvider = _DEFAULT_READ_PROVIDER, throwFileIoError = true } = options ?? {};
   try {
     return normalizeLine(await readProvider(path));
@@ -69,6 +77,6 @@ export const readTextFile = async (
       }
       throw e;
     }
-    return '';
+    return null;
   }
-};
+}


### PR DESCRIPTION
## Overview

**Summary**
Change `readTextFile` to return `null` instead of `''` when a read error is suppressed.

**Background / Motivation**
When `throwFileIoError: false` is set, `readTextFile` suppresses file I/O errors (`NotFound`, `PermissionDenied`, `NotADirectory`) and used to return `''`. This made a suppressed error look the same as reading a real empty file. Returning `null` lets callers tell the two cases apart.

## Changes

### Core Changes

- `skills/_scripts/libs/file-io/read-utils.ts`
  - Added overloads for `readTextFile`: `throwFileIoError: true` (default) returns `Promise<string>`, `throwFileIoError: false` returns `Promise<string | null>`.
  - Changed the suppressed-error return value from `''` to `null`.
  - Updated JSDoc to describe the new `null` behavior.

### Test Updates

- `skills/_scripts/libs/file-io/__tests__/unit/read-utils.unit.spec.ts`: updated `NotFound`, `PermissionDenied`, `NotADirectory` cases to expect `null`.
- `skills/_scripts/libs/file-io/__tests__/system/read-utils.system.spec.ts`: updated suppressed error cases to expect `null`.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Breaking Changes

`readTextFile(path, { throwFileIoError: false })` now returns `string | null` instead of `string`. Callers that rely on the old `''` behavior must handle `null` explicitly. No call sites are updated in this branch; updating them is left as follow-up work.

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (`dprint fmt --check`)
- [x] Tests pass (`deno task test`)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Follow-up: audit existing callers of `readTextFile(..., { throwFileIoError: false })` and update them to handle `null`.
