### PR TITLE
feat(remove-utils)!: add throwFileIoError option to removeFile

### DIFF
--- a/skills/_scripts/libs/file-ops/__tests__/unit/remove-utils.unit.spec.ts
+++ b/skills/_scripts/libs/file-ops/__tests__/unit/remove-utils.unit.spec.ts
@@ -9,10 +9,15 @@
 
 // ─── BDD modules
 import { assertEquals, assertRejects } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { afterEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { removeFile } from '../../remove-utils.ts';
+
+// ─── Helpers
+import { makeLoggerStub } from '../../../../__tests__/helpers/logger-stub.ts';
+// types
+import type { LoggerStub } from '../../../../__tests__/helpers/logger-stub.ts';
 
 // ─── Internal Helpers
 
@@ -27,43 +32,116 @@ const _removeNotFound = (_path: string): Promise<void> => Promise.reject(new Den
 const _removePermissionDenied = (_path: string): Promise<void> =>
   Promise.reject(new Deno.errors.PermissionDenied('permission denied'));
 
+/** ファイル I/O 起因ではないエラーを示す `RemoveProvider` モック。`TypeError` を reject する。 */
+const _removeTypeError = (_path: string): Promise<void> => Promise.reject(new TypeError('unexpected error'));
+
 // ─── Tests
 
 /**
  * `removeFile` 関数のユニットテストスイート。
  *
- * `removeFile(filePath, removeProvider?)` は `removeProvider` の成否に基づいて
- * 削除成功時は `true`、ファイル不在時は `false` を返し、その他エラーは再スローする。
+ * `removeFile(filePath, options?)` は `removeProvider` の成否に基づいて削除成功時は `true` を返す。
+ * ファイル I/O 起因のエラーは `throwFileIoError`（デフォルト `true`）の値に従って
+ * 再スローするか、`logger.warn` でログ出力した上で `false` を返す。
+ * ファイル I/O 起因ではないエラーは常に再スローする。
  *
- * テスト ID 範囲: T-LIB-RF-01 〜 T-LIB-RF-03
+ * テスト ID 範囲: T-LIB-RF-01 〜 T-LIB-RF-05
  *
  * @see removeFile
  */
 describe('removeFile', () => {
+  let loggerStub: LoggerStub | undefined;
+
+  afterEach(() => {
+    loggerStub?.restore();
+    loggerStub = undefined;
+  });
+
   /**
-   * `removeProvider` がファイルを正常に削除する正常系グループ。
+   * 削除成功時の正常系グループ。
    *
-   * 削除成功時に `true` が返ることを検証する。
+   * オプション有無に関わらず `true` が返ることを検証する。
    */
   describe('When: 正常系', () => {
     it('[Normal] T-LIB-RF-01-01: removeProvider が成功する場合、true が返る', async () => {
-      assertEquals(await removeFile('/some/file.md', _removeOk), true);
+      assertEquals(await removeFile('/some/file.md', { removeProvider: _removeOk }), true);
+    });
+
+    it('[Normal] T-LIB-RF-01-02: throwFileIoError: false を指定しても成功時は true が返る', async () => {
+      assertEquals(
+        await removeFile('/some/file.md', { removeProvider: _removeOk, throwFileIoError: false }),
+        true,
+      );
     });
   });
 
   /**
-   * `removeProvider` がエラーをスローする異常系グループ。
+   * `throwFileIoError: false` 指定時に、ファイル I/O 起因のエラーを握りつぶして
+   * `logger.warn` でログ出力し `false` を返すグループ。
    */
-  describe('When: 異常系', () => {
-    it('[Error] T-LIB-RF-02-01: removeProvider が NotFound をスローする場合、false が返る', async () => {
-      assertEquals(await removeFile('/nonexistent/file.md', _removeNotFound), false);
+  describe('When: throwFileIoError: false 指定時', () => {
+    it('[Normal] T-LIB-RF-02-01: NotFound 発生時、logger.warn が呼ばれ false が返る', async () => {
+      loggerStub = makeLoggerStub();
+      const result = await removeFile('/nonexistent/file.md', {
+        removeProvider: _removeNotFound,
+        throwFileIoError: false,
+      });
+      assertEquals(result, false);
+      assertEquals(loggerStub.warnLogs.length, 1);
     });
 
-    it('[Error] T-LIB-RF-03-01: removeProvider が PermissionDenied をスローする場合、そのまま再スローされる', async () => {
+    it('[Normal] T-LIB-RF-02-02: PermissionDenied 発生時、logger.warn が呼ばれ false が返る', async () => {
+      loggerStub = makeLoggerStub();
+      const result = await removeFile('/restricted/file.md', {
+        removeProvider: _removePermissionDenied,
+        throwFileIoError: false,
+      });
+      assertEquals(result, false);
+      assertEquals(loggerStub.warnLogs.length, 1);
+    });
+  });
+
+  /**
+   * `throwFileIoError` 省略時（デフォルト `true`）は、NotFound を含むファイル I/O 起因の
+   * エラーがそのまま再スローされることを検証する異常系グループ。
+   *
+   * 現行の「NotFound は握りつぶして false を返す」動作からの破壊的変更を明示する。
+   */
+  describe('When: 異常系', () => {
+    it('[Error] T-LIB-RF-03-01: throwFileIoError 省略時、NotFound はそのまま再スローされる', async () => {
       await assertRejects(
-        () => removeFile('/restricted/file.md', _removePermissionDenied),
+        () => removeFile('/nonexistent/file.md', { removeProvider: _removeNotFound }),
+        Deno.errors.NotFound,
+      );
+    });
+
+    it('[Error] T-LIB-RF-03-02: throwFileIoError: true 明示時、PermissionDenied はそのまま再スローされる', async () => {
+      await assertRejects(
+        () => removeFile('/restricted/file.md', { removeProvider: _removePermissionDenied, throwFileIoError: true }),
         Deno.errors.PermissionDenied,
       );
+    });
+
+    it('[Error] T-LIB-RF-04-01: throwFileIoError: false でも、file-io 起因ではないエラーは再スローされる', async () => {
+      await assertRejects(
+        () => removeFile('/some/file.md', { removeProvider: _removeTypeError, throwFileIoError: false }),
+        TypeError,
+      );
+    });
+  });
+
+  /**
+   * `removeProvider` と `throwFileIoError` を同時に指定できることを検証するエッジケース。
+   */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-LIB-RF-05-01: removeProvider と throwFileIoError を併用できる', async () => {
+      loggerStub = makeLoggerStub();
+      const result = await removeFile('/nonexistent/file.md', {
+        removeProvider: _removeNotFound,
+        throwFileIoError: false,
+      });
+      assertEquals(result, false);
+      assertEquals(loggerStub.warnLogs.length, 1);
     });
   });
 });

--- a/skills/_scripts/libs/file-ops/remove-utils.ts
+++ b/skills/_scripts/libs/file-ops/remove-utils.ts
@@ -10,6 +10,9 @@
 // shared modules
 // ─────────────────────────────────────────────
 
+// functions
+import { isFileIoError } from '../file-io/read-utils.ts';
+import { logger } from '../io/logger.ts';
 // types
 import type { RemoveProvider } from '../../types/providers.types.ts';
 
@@ -28,23 +31,40 @@ const _DEFAULT_REMOVE_PROVIDER: RemoveProvider = (path: string) => Deno.remove(p
  * 指定パスのファイルを削除する。
  *
  * - 削除成功時は `true` を返す。
- * - ファイルが存在しない場合は `false` を返す（エラーにしない）。
- * - `Deno.errors.NotFound` 以外のエラーは再スローする。
+ * - ファイル I/O 起因のエラー（`NotFound` 含む）は `throwFileIoError` の値に従う（デフォルト: `true`）。
+ *   - `true`（デフォルト）の場合はそのまま再スローする。
+ *   - `false` の場合は `logger.warn` でログ出力した上で `false` を返す。
+ * - ファイル I/O 起因ではないエラーは `throwFileIoError` の値に関わらず常に再スローする。
  *
  * @param filePath - 削除するファイルの絶対パス
- * @param removeProvider - テスト用注入可能な remove 関数（デフォルト: `Deno.remove`）
- * @returns 削除成功時は `true`、ファイルが存在しない場合は `false`
- * @throws パーミッションエラーなど `NotFound` 以外のエラー
+ * @param options - テスト用注入可能な remove 関数、およびエラー throw 挙動の指定
+ * @param options.removeProvider - テスト用注入可能な remove 関数（デフォルト: `Deno.remove`）
+ * @param options.throwFileIoError - ファイル I/O 起因のエラーを throw するか（デフォルト: `true`）
  */
-export const removeFile = async (
+export function removeFile(
   filePath: string,
-  removeProvider: RemoveProvider = _DEFAULT_REMOVE_PROVIDER,
-): Promise<boolean> => {
+  options?: { removeProvider?: RemoveProvider; throwFileIoError?: true },
+): Promise<boolean>;
+export function removeFile(
+  filePath: string,
+  options: { removeProvider?: RemoveProvider; throwFileIoError: false },
+): Promise<boolean>;
+export async function removeFile(
+  filePath: string,
+  options?: { removeProvider?: RemoveProvider; throwFileIoError?: boolean },
+): Promise<boolean> {
+  const { removeProvider = _DEFAULT_REMOVE_PROVIDER, throwFileIoError = true } = options ?? {};
   try {
     await removeProvider(filePath);
     return true;
   } catch (e) {
-    if (e instanceof Deno.errors.NotFound) { return false; }
-    throw e;
+    if (!isFileIoError(e)) {
+      throw e;
+    }
+    if (throwFileIoError) {
+      throw e;
+    }
+    logger.warn(`  削除失敗 (${(e as Error).message}): ${filePath}`);
+    return false;
   }
-};
+}

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -88,10 +88,9 @@ export const processChunk = async (
     if (decision === FILTER_DECISIONS.DISCARD && confidence >= discardThreshold) {
       logger.log(`DISCARD (conf=${confidence}): ${filePath}`);
       logger.info(`  reason: ${reason}`);
-      if (await removeFile(filePath)) {
+      if (await removeFile(filePath, { throwFileIoError: false })) {
         stats.remove++;
       } else {
-        logger.warn(`  skip (File not found):${filePath}`);
         stats.error++;
       }
     } else {

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -181,7 +181,7 @@ export const _phase1_2DiscardByFilename = async (
         return;
       }
 
-      if (await removeFile(filePath)) {
+      if (await removeFile(filePath, { throwFileIoError: false })) {
         stats.remove++;
         logger.info(`  skipped (ファイル名パターン): ${filename}`);
       } else {
@@ -310,7 +310,7 @@ export const _phase4ResolveCache = async (
       const cached = cache.read(filePath);
       if (cached.decision !== undefined && cached.decision !== FILTER_DECISIONS.ERROR) {
         if (cached.decision === FILTER_DECISIONS.DISCARD && (cached.confidence ?? 0) >= discardThreshold) {
-          if (dryRun || await removeFile(filePath)) {
+          if (dryRun || await removeFile(filePath, { throwFileIoError: false })) {
             return { filePath, filename, outcome: 'cache-discard-removed' };
           }
           return { filePath, filename, outcome: 'cache-discard-error' };

--- a/skills/filter-chatlogs/scripts/modules/prefilter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter/process-noise-files.ts
@@ -52,11 +52,10 @@ export const processNoiseFiles = async (
         logger.log(filePath);
         stats.skip++;
       } else {
-        if (await removeFile(filePath)) {
+        if (await removeFile(filePath, { throwFileIoError: false })) {
           logger.info(`deleted: ${filePath}`);
           stats.remove++;
         } else {
-          logger.warn(`  Skipped (File not found): ${filename}`);
           stats.error++;
         }
       }


### PR DESCRIPTION
## Overview

**Summary**
Add a `throwFileIoError` option to `removeFile` so callers can control whether file I/O errors are thrown or swallowed.

**Background / Motivation**
`removeFile` used to silently swallow `Deno.errors.NotFound` and return `false`. This hid real I/O failures from callers who actually wanted to know about them. The new `throwFileIoError` option (default `true`) makes error handling explicit: by default file I/O errors are rethrown, and callers that want the old ignore-and-continue behavior must opt in with `{ throwFileIoError: false }`.

## Changes

### Core Changes

- `skills/_scripts/libs/file-ops/remove-utils.ts`
  - Changed the second parameter of `removeFile` from a `removeProvider` function to an `options` object: `{ removeProvider?, throwFileIoError? }`
  - Added `isFileIoError` check to distinguish file I/O errors from other errors
  - When `throwFileIoError` is `false`, file I/O errors are logged with `logger.warn` and `false` is returned; otherwise (default `true`) they are rethrown
  - Non-file-I/O errors are always rethrown regardless of `throwFileIoError`
- `skills/filter-chatlogs/scripts/modules/prefilter.ts`
  - Pass `{ throwFileIoError: false }` to `removeFile` calls in `_phase1_2DiscardByFilename` and `_phase4ResolveCache` to keep the previous ignore-on-failure behavior
- `skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts`
  - Pass `{ throwFileIoError: false }` to the `removeFile` call and remove the now-redundant "File not found" warning log
- `skills/filter-chatlogs/scripts/modules/prefilter/process-noise-files.ts`
  - Pass `{ throwFileIoError: false }` to the `removeFile` call and remove the now-redundant "File not found" warning log

### Test Updates

- `skills/_scripts/libs/file-ops/__tests__/unit/remove-utils.unit.spec.ts`
  - Updated `removeFile` calls to use the new `options` object form
  - Added cases: `throwFileIoError: false` logs a warning and returns `false` on `NotFound` / `PermissionDenied`
  - Added cases: file I/O errors are rethrown when `throwFileIoError` is omitted or `true`
  - Added case: non-file-I/O errors (e.g. `TypeError`) are still rethrown even when `throwFileIoError: false`

### Removed

None

## Change Type (optional)

Select all that apply:

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This PR contains a breaking change:

1. **Signature change**: the second argument of `removeFile(filePath, removeProvider?)` is now `removeFile(filePath, options?)`. Existing calls passing a `removeProvider` function directly will fail to compile. Migrate with `removeFile(filePath, { removeProvider: myProvider })`.
2. **Default behavior change**: `removeFile` now rethrows file I/O errors (including `NotFound`) by default instead of silently returning `false`. Callers that want to ignore failures must pass `{ throwFileIoError: false }` explicitly. See the three `fix` commits in this PR for migration examples.
