### PR TITLE
refactor(filter-chatlogs): rename prefilter to noise-filter

### DIFF
--- a/skills/filter-chatlogs/SKILL.md
+++ b/skills/filter-chatlogs/SKILL.md
@@ -5,7 +5,7 @@ description: >
   再利用価値の低いファイル（DISCARD）を削除する。
   /filter-chatlogs で呼び出す。
   KEEP/DISCARD判定にはclaude CLIを使用するため ANTHROPIC_API_KEY 不要。
-argument-hint: "[prefilter|filter] [agent] [YYYY-MM [project]] [--dry-run]"
+argument-hint: "[noise-filter|filter] [agent] [YYYY-MM [project]] [--dry-run]"
 allowed-tools: Bash, Glob
 ---
 
@@ -25,7 +25,7 @@ allowed-tools: Bash, Glob
 
 `$ARGUMENTS` の先頭トークンでサブコマンドを判定する:
 
-- 先頭トークンが `prefilter` → prefilter モード（残りの引数を prefilter スクリプトに渡す）
+- 先頭トークンが `noise-filter` → noise-filter モード（残りの引数を noise-filter スクリプトに渡す）
 - 先頭トークンが `filter` → filter モード（先頭トークンを除いた残りの引数を filter スクリプトに渡す）
 - それ以外（サブコマンドなし）→ filter モード（`$ARGUMENTS` 全体を filter スクリプトに渡す）
 
@@ -38,7 +38,7 @@ allowed-tools: Bash, Glob
 - `agent YYYY-MM project`（例: `chatgpt 2026-03 aplys`）→ 指定 agent・指定月・プロジェクト
 - `--dry-run` → 削除せず判定結果のみ表示
 
-**prefilter モードの引数解析**（`prefilter` トークンを除いた残りの引数に適用）:
+**noise-filter モードの引数解析**（`noise-filter` トークンを除いた残りの引数に適用）:
 
 - 引数なし → `chatlogs/claude/` 全体を処理
 - `agent`（例: `chatgpt`）→ 指定 agent の全体
@@ -52,29 +52,29 @@ allowed-tools: Bash, Glob
 Glob ツールで `**/commands/filter-chatlogs.md` を検索し、そのディレクトリを `SKILL_DIR` として確定する。
 
 ```bash
-SKILL_DIR      = <filter-chatlogs.md が存在するディレクトリの絶対パス>
-SCRIPT_PATH    = $SKILL_DIR/scripts/filter-chatlogs.ts
-PREFILTER_PATH = $SKILL_DIR/scripts/prefilter-chatlogs.ts
+SKILL_DIR         = <filter-chatlogs.md が存在するディレクトリの絶対パス>
+SCRIPT_PATH       = $SKILL_DIR/scripts/filter-chatlogs.ts
+NOISE_FILTER_PATH = $SKILL_DIR/scripts/noise-filter-chatlogs.ts
 ```
 
 ## ステップ2: スクリプト実行
 
 `$ARGUMENTS` の先頭トークンで分岐する。
 
-### prefilter サブコマンドの場合
+### noise-filter サブコマンドの場合
 
-先頭トークンが `prefilter` であれば、残りの引数 `$REST_ARGS` をそのまま渡す:
+先頭トークンが `noise-filter` であれば、残りの引数 `$REST_ARGS` をそのまま渡す:
 
 ```bash
-deno run --allow-read --allow-write "$PREFILTER_PATH" $REST_ARGS
+deno run --allow-read --allow-write "$NOISE_FILTER_PATH" $REST_ARGS
 ```
 
 引数からオプションを組み立てるルール（`--input` は**追加しない**）:
 
-- 引数なし → `deno run --allow-read --allow-write "$PREFILTER_PATH"`
-- `agent` のみ → `deno run --allow-read --allow-write "$PREFILTER_PATH" chatgpt`
-- `agent YYYY-MM` → `deno run --allow-read --allow-write "$PREFILTER_PATH" chatgpt 2026-03`
-- `path`（パス区切り含む）→ `deno run --allow-read --allow-write "$PREFILTER_PATH" chatlogs/claude/2026/2026-04`
+- 引数なし → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH"`
+- `agent` のみ → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt`
+- `agent YYYY-MM` → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt 2026-03`
+- `path`（パス区切り含む）→ `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatlogs/claude/2026/2026-04`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
 - `--report` を含む → 末尾に `--report` を追加
 
@@ -121,7 +121,7 @@ deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" $ARGS
 - dry-run モードの場合はその旨を明示する
 - DISCARDされたファイルのパスと理由を簡潔にまとめる
 
-**prefilter モードの通知形式**:
+**noise-filter モードの通知形式**:
 
 - noise / keep / error の件数を報告
 - dry-run / report モードの場合はその旨を明示する

--- a/skills/filter-chatlogs/scripts/__tests__/_helpers/constants.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/_helpers/constants.ts
@@ -13,8 +13,8 @@ import { MAX_BODY_CHARS } from '../../constants/common.constants.ts';
 /** filter-chatlogs の KEEP 判定を通過する最小テキスト長（文字数）。 */
 export const FILTER_MIN_CONTENT_LENGTH = 500;
 
-/** prefilter-chatlogs のコンテンツフィルタを通過する最小テキスト長（文字数）。 */
-export const PREFILTER_MIN_CONTENT_LENGTH = 300;
+/** noise-filter-chatlogs のコンテンツフィルタを通過する最小テキスト長（文字数）。 */
+export const NOISE_FILTER_MIN_CONTENT_LENGTH = 300;
 
 /** MAX_BODY_CHARS（8000）を大幅に超える本文長。切り詰めメカニズムの検証に使用する。 */
 export const OVER_MAX_CHARS_LENGTH = 20000;

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
@@ -1,8 +1,8 @@
-// src: scripts/__tests__/e2e/prefilter.main.e2e.spec.ts
-// @(#): prefilter-chatlogs main() の E2E テスト
+// src: scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+// @(#): noise-filter-chatlogs main() の E2E テスト
 //       main() 経由でのノイズフィルタリングフロー（実 tempdir・Deno.exit stub）
 //
-//       prefilter-chatlogs の動作:
+//       noise-filter-chatlogs の動作:
 //         入力: inputDir/agent/YYYY/YYYY-MM/*.md
 //         正規表現でノイズと判定したファイルを削除する
 //         --dry-run: 削除せず対象パスを stdout に出力
@@ -16,7 +16,7 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { main } from '../../prefilter-chatlogs.ts';
+import { main } from '../../noise-filter-chatlogs.ts';
 
 // ─── Helpers
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -25,7 +25,7 @@ import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
-import { PREFILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
+import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // e2e helpers
 import { assertFileExist, assertFileNotExist } from '../../../../_scripts/__tests__/helpers/assert.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
@@ -40,8 +40,8 @@ import { resetProjectRoot } from '../../../../_scripts/libs/path-utils/dir-utils
 /** `_makeTestDirs` のラッパー。デフォルト引数付きで `makeTestDirs` を呼び出す。 */
 const _makeTestDirs = (agent = 'claude', period = '2026-03') => makeTestDirs(agent, period);
 
-/** `_makeValidContent` のラッパー。`PREFILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
-const _makeValidContent = () => makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH);
+/** `_makeValidContent` のラッパー。`NOISE_FILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
+const _makeValidContent = () => makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH);
 
 /**
  * テスト用 `GlobalConfig` インスタンスを YAML 文字列から生成する。
@@ -66,7 +66,7 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
 // ─── T-PF-E2E-01: --dry-run → ファイル削除なし、パスが stdout に出力 ──────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（dry-run モード）。
+ * `main` 関数（noise-filter）の E2E テストスイート（dry-run モード）。
  *
  * `--dry-run` フラグを指定した際にファイルが削除されず、
  * ノイズと判定されたファイルのパスが stdout に出力されることを検証する。
@@ -75,7 +75,7 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
  *
  * @see main
  */
-describe('main (prefilter) - dry-run モード', () => {
+describe('main (noise-filter) - dry-run モード', () => {
   /**
    * ノイズファイル名（`say-ok-and-nothing-else.md`）の `.md` ファイルと
    * `--dry-run` フラグが存在する前提。
@@ -119,7 +119,7 @@ describe('main (prefilter) - dry-run モード', () => {
 // ─── T-PF-E2E-02: --report → NOISE\t{reason}\t{path} 形式、削除なし ──────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（report モード）。
+ * `main` 関数（noise-filter）の E2E テストスイート（report モード）。
  *
  * `--report` フラグを指定した際に `NOISE\t{reason}\t{path}` 形式で
  * stdout に出力され、ファイルが削除されないことを検証する。
@@ -128,7 +128,7 @@ describe('main (prefilter) - dry-run モード', () => {
  *
  * @see main
  */
-describe('main (prefilter) - report モード', () => {
+describe('main (noise-filter) - report モード', () => {
   /**
    * ノイズファイル名の `.md` ファイルと `--report` フラグが存在する前提。
    *
@@ -174,7 +174,7 @@ describe('main (prefilter) - report モード', () => {
 // ─── T-PF-E2E-03: 通常実行 → ノイズファイルが削除される ─────────────────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（通常実行・削除あり）。
+ * `main` 関数（noise-filter）の E2E テストスイート（通常実行・削除あり）。
  *
  * ノイズと正常ファイルが混在する場合に、ノイズファイルのみが削除され
  * 正常ファイルが残ることを検証する。
@@ -183,7 +183,7 @@ describe('main (prefilter) - report モード', () => {
  *
  * @see main
  */
-describe('main (prefilter) - 通常実行（削除あり）', () => {
+describe('main (noise-filter) - 通常実行（削除あり）', () => {
   /**
    * ノイズファイル（`say-ok-and-nothing-else.md`）と正常ファイル（`valid-chat.md`）が
    * 混在するディレクトリが存在する前提。
@@ -229,7 +229,7 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
 // ─── T-PF-E2E-04: 正常ファイルのみ → 全件 keep ───────────────────────────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（全件 keep）。
+ * `main` 関数（noise-filter）の E2E テストスイート（全件 keep）。
  *
  * ノイズファイルが存在しない場合に全ファイルが keep となり、
  * 完了ログに `keep=2` が含まれることを検証する。
@@ -238,7 +238,7 @@ describe('main (prefilter) - 通常実行（削除あり）', () => {
  *
  * @see main
  */
-describe('main (prefilter) - 全件 keep', () => {
+describe('main (noise-filter) - 全件 keep', () => {
   /**
    * 正常ファイル 2 件のみが存在するディレクトリの前提。
    *
@@ -284,7 +284,7 @@ describe('main (prefilter) - 全件 keep', () => {
 // ─── T-PF-E2E-06: 空ディレクトリ → keep=0 remove=0 error=0 ログ ─────────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（空ディレクトリ）。
+ * `main` 関数（noise-filter）の E2E テストスイート（空ディレクトリ）。
  *
  * `.md` ファイルが 0 件の場合に `keep=0 remove=0 error=0` を含む
  * 完了ログが出力されることを検証する。
@@ -293,7 +293,7 @@ describe('main (prefilter) - 全件 keep', () => {
  *
  * @see main
  */
-describe('main (prefilter) - 空ディレクトリ', () => {
+describe('main (noise-filter) - 空ディレクトリ', () => {
   /**
    * `.md` ファイルが存在しないエージェントディレクトリが存在する前提。
    *
@@ -334,7 +334,7 @@ describe('main (prefilter) - 空ディレクトリ', () => {
 // ─── T-PF-E2E-07: period 絞り込み → 指定月のみ削除対象 ──────────────────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（period 絞り込み）。
+ * `main` 関数（noise-filter）の E2E テストスイート（period 絞り込み）。
  *
  * period を指定した場合に指定月のファイルのみが削除対象となり、
  * 他月のファイルは影響を受けないことを検証する。
@@ -343,7 +343,7 @@ describe('main (prefilter) - 空ディレクトリ', () => {
  *
  * @see main
  */
-describe('main (prefilter) - period 絞り込み', () => {
+describe('main (noise-filter) - period 絞り込み', () => {
   /**
    * 2026-03 と 2026-04 の両月にノイズファイルが存在する前提。
    *
@@ -403,7 +403,7 @@ describe('main (prefilter) - period 絞り込み', () => {
 // ─── T-PF-E2E-08: --report → 完了ログに "report" が含まれる ─────────────────
 
 /**
- * `main` 関数（prefilter）の E2E テストスイート（report 完了ログ）。
+ * `main` 関数（noise-filter）の E2E テストスイート（report 完了ログ）。
  *
  * `--report` フラグを指定した際の完了ログに `report` が含まれることを検証する。
  *
@@ -411,7 +411,7 @@ describe('main (prefilter) - period 絞り込み', () => {
  *
  * @see main
  */
-describe('main (prefilter) - report 完了ログ', () => {
+describe('main (noise-filter) - report 完了ログ', () => {
   /**
    * 正常ファイル 1 件と `--report` フラグが存在する前提。
    *

--- a/skills/filter-chatlogs/scripts/__tests__/functional/libs/classify-file.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/libs/classify-file.functional.spec.ts
@@ -1,5 +1,5 @@
 // src: scripts/__tests__/functional/libs/classify-file.functional.spec.ts
-// @(#): prefilter-chatlogs.ts の機能テスト
+// @(#): classifyFile の機能テスト
 //       対象: classifyFile
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -17,7 +17,7 @@ import { classifyFile } from '../../../libs/classify-file.ts';
 // ─── Helpers
 import { makeRepeatedContent } from '../../_helpers/fixtures.ts';
 // constants
-import { PREFILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
+import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
 
 // ─── Tests
 
@@ -51,7 +51,7 @@ describe('classifyFile', () => {
         it('T-PF-CL-01-01: isNoise が true になる', () => {
           const { isNoise } = classifyFile(
             'say-ok-and-nothing-else.md',
-            makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH),
+            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
           );
 
           assertEquals(isNoise, true);
@@ -60,7 +60,7 @@ describe('classifyFile', () => {
         it('T-PF-CL-01-02: reason に "ファイル名パターン:" が含まれる', () => {
           const { reason } = classifyFile(
             'say-ok-and-nothing-else.md',
-            makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH),
+            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
           );
 
           assertEquals(reason.includes('ファイル名パターン:'), true);
@@ -128,13 +128,13 @@ describe('classifyFile', () => {
       /** isNoise=false かつ reason が空文字列であることを検証する。 */
       describe('Then: T-PF-CL-04 - isNoise=false が返される', () => {
         it('T-PF-CL-04-01: isNoise が false になる', () => {
-          const { isNoise } = classifyFile('valid-chat.md', makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH));
+          const { isNoise } = classifyFile('valid-chat.md', makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH));
 
           assertEquals(isNoise, false);
         });
 
         it('T-PF-CL-04-02: reason が空文字列になる', () => {
-          const { reason } = classifyFile('valid-chat.md', makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH));
+          const { reason } = classifyFile('valid-chat.md', makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH));
 
           assertEquals(reason, '');
         });
@@ -160,7 +160,7 @@ describe('classifyFile', () => {
             'date: 2026-01-01',
             '---',
             '',
-            makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH),
+            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
           ].join('\n');
           const { isNoise } = classifyFile('valid-chat.md', text);
 
@@ -185,7 +185,7 @@ describe('classifyFile', () => {
           const text = [
             '---',
             'title: 不正フォーマット',
-            makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH),
+            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
           ].join('\n');
           let threw = false;
           try {
@@ -201,7 +201,7 @@ describe('classifyFile', () => {
           const text = [
             '---',
             'title: 不正フォーマット',
-            makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH),
+            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
           ].join('\n');
           const { isNoise } = classifyFile('malformed.md', text);
 

--- a/skills/filter-chatlogs/scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
@@ -1,5 +1,5 @@
-// src: scripts/__tests__/functional/prefilter/build-config.functional.spec.ts
-// @(#): prefilter buildConfig の機能テスト
+// src: scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
+// @(#): noise-filter buildConfig の機能テスト
 //       対象: buildConfig
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -12,15 +12,15 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { buildConfig } from '../../../configs/prefilter-config.ts';
+import { buildConfig } from '../../../configs/noise-filter-config.ts';
 // types
-import type { PrefilterConfig, PrefilterParsedConfig } from '../../../types/prefilter.types.ts';
+import type { NoiseFilterConfig, NoiseFilterParsedConfig } from '../../../types/noise-filter.types.ts';
 
 // ─── Helpers
 // classes
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 // constants
-import { DEFAULT_PREFILTER_CONFIG } from '../../../constants/common.constants.ts';
+import { DEFAULT_NOISE_FILTER_CONFIG } from '../../../constants/common.constants.ts';
 // helpers
 import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
 
@@ -44,12 +44,12 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
   });
 };
 
-/** 空の PrefilterParsedConfig。 */
-const _EMPTY_PARSED: PrefilterParsedConfig = {};
+/** 空の NoiseFilterParsedConfig。 */
+const _EMPTY_PARSED: NoiseFilterParsedConfig = {};
 
-/** `DEFAULT_PREFILTER_CONFIG` と異なる値を持つカスタムデフォルト設定。`defaults` パラメータの注入テストに使用する。 */
-const _CUSTOM_DEFAULTS: PrefilterConfig = {
-  ...DEFAULT_PREFILTER_CONFIG,
+/** `DEFAULT_NOISE_FILTER_CONFIG` と異なる値を持つカスタムデフォルト設定。`defaults` パラメータの注入テストに使用する。 */
+const _CUSTOM_DEFAULTS: NoiseFilterConfig = {
+  ...DEFAULT_NOISE_FILTER_CONFIG,
   agent: 'chatgpt',
   chatlogsDir: '/custom-default',
 };
@@ -60,7 +60,7 @@ const _CUSTOM_DEFAULTS: PrefilterConfig = {
  * `buildConfig` 関数の機能テストスイート。
  *
  * `buildConfig(parsed, globalConfig, defaults?)` は
- * `PrefilterParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `PrefilterConfig` を構築する。
+ * `NoiseFilterParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `NoiseFilterConfig` を構築する。
  *
  * ## 優先順位ルール
  * - `agent`      : parsed > globalConfig > defaults
@@ -69,13 +69,13 @@ const _CUSTOM_DEFAULTS: PrefilterConfig = {
  * - `period`     : parsed のみ（GlobalConfig 連携なし）
  * - `dryRun`     : parsed > defaults (false)
  * - `report`     : parsed > defaults (false)
- * - `configFile` は PrefilterConfig に存在しないため結果に含まれない
+ * - `configFile` は NoiseFilterConfig に存在しないため結果に含まれない
  *
  * テスト ID 範囲: T-PF-BC-06 〜 T-PF-BC-16
  *
  * @see buildConfig
  */
-describe('buildConfig (prefilter functional)', () => {
+describe('buildConfig (noise-filter functional)', () => {
   afterEach(() => {
     GlobalConfig.resetInstance();
   });
@@ -126,15 +126,15 @@ describe('buildConfig (prefilter functional)', () => {
     });
 
     describe('When: GlobalConfig にも agent が設定されていない', () => {
-      /** DEFAULT_PREFILTER_CONFIG.agent が使われることを検証する。 */
+      /** DEFAULT_NOISE_FILTER_CONFIG.agent が使われることを検証する。 */
       describe('Then: T-PF-BC-08 - defaults.agent にフォールバック', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('chatlogsDir: /some/dir');
         });
-        it('T-PF-BC-08: agent 未設定 → result.agent === DEFAULT_PREFILTER_CONFIG.agent', () => {
+        it('T-PF-BC-08: agent 未設定 → result.agent === DEFAULT_NOISE_FILTER_CONFIG.agent', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.agent, DEFAULT_PREFILTER_CONFIG.agent);
+          assertEquals(result.agent, DEFAULT_NOISE_FILTER_CONFIG.agent);
         });
       });
     });
@@ -166,19 +166,19 @@ describe('buildConfig (prefilter functional)', () => {
   /**
    * GlobalConfig に chatlogsDir が設定されていない前提条件グループ。
    *
-   * DEFAULT_PREFILTER_CONFIG.chatlogsDir にフォールバックすることを検証する。
+   * DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir にフォールバックすることを検証する。
    */
   describe('Given: GlobalConfig にも chatlogsDir が設定されていない', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** DEFAULT_PREFILTER_CONFIG.chatlogsDir が使われることを検証する。 */
+      /** DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir が使われることを検証する。 */
       describe('Then: T-PF-BC-11 - defaults.chatlogsDir にフォールバック', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await _makeGlobalConfig('agent: claude');
         });
-        it('T-PF-BC-11: chatlogsDir 未設定 → result.chatlogsDir === DEFAULT_PREFILTER_CONFIG.chatlogsDir', () => {
+        it('T-PF-BC-11: chatlogsDir 未設定 → result.chatlogsDir === DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir', () => {
           const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.chatlogsDir, DEFAULT_PREFILTER_CONFIG.chatlogsDir);
+          assertEquals(result.chatlogsDir, DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/integration/noise-filter/noise-filter.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/noise-filter/noise-filter.integration.spec.ts
@@ -1,5 +1,5 @@
-// src: scripts/__tests__/integration/prefilter/prefilter.integration.spec.ts
-// @(#): prefilter-chatlogs.ts の統合テスト
+// src: scripts/__tests__/integration/noise-filter/noise-filter.integration.spec.ts
+// @(#): noise-filter-chatlogs.ts の統合テスト
 //       findMdFiles → classifyFile パイプライン
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -18,7 +18,7 @@ import { resolveChatlogsDir } from '../../../../../_scripts/libs/file-io/resolve
 import { findFiles } from '../../../../../_scripts/libs/file-ops/find-files.ts';
 import { makeRepeatedContent } from '../../_helpers/fixtures.ts';
 // constants
-import { PREFILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
+import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
 
 // ─── 共通セットアップ ──────────────────────────────────────────────────────────
 
@@ -34,8 +34,8 @@ afterEach(async () => {
 
 // ─── ヘルパー ──────────────────────────────────────────────────────────────────
 
-/** `PREFILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
-const _makeValidContent = () => makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH);
+/** `NOISE_FILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
+const _makeValidContent = () => makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH);
 
 const _makeTestFile = async (path: string, content: string): Promise<void> => {
   const dir = path.replace(/\/[^/]+$/, '');

--- a/skills/filter-chatlogs/scripts/__tests__/system/noise-filter/noise-filter.system.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/system/noise-filter/noise-filter.system.spec.ts
@@ -1,5 +1,5 @@
-// src: scripts/__tests__/system/prefilter/prefilter.system.spec.ts
-// @(#): prefilter-chatlogs main() のシステムテスト（実プロセス起動による終了コード検証）
+// src: scripts/__tests__/system/noise-filter/noise-filter.system.spec.ts
+// @(#): noise-filter-chatlogs main() のシステムテスト（実プロセス起動による終了コード検証）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -8,9 +8,9 @@
 import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
-const SCRIPT_PATH = new URL('../../../prefilter-chatlogs.ts', import.meta.url).pathname;
+const SCRIPT_PATH = new URL('../../../noise-filter-chatlogs.ts', import.meta.url).pathname;
 
-const runPrefilter = async (args: string[]): Promise<number> => {
+const runNoiseFilter = async (args: string[]): Promise<number> => {
   const _cmd = new Deno.Command(Deno.execPath(), {
     args: ['run', '--allow-read', '--allow-write', '--allow-run', SCRIPT_PATH, ...args],
     stdout: 'null',
@@ -24,10 +24,10 @@ const runPrefilter = async (args: string[]): Promise<number> => {
 
 describe('main - エラー終了コード', () => {
   describe('Given: 存在しない inputDir を指定', () => {
-    describe('When: prefilter-chatlogs をサブプロセスで実行する', () => {
+    describe('When: noise-filter-chatlogs をサブプロセスで実行する', () => {
       describe('Then: T-PF-SYS-01 - プロセスが終了コード 1 で終了する', () => {
         it('T-PF-SYS-01-01: 終了コードが 1 である', async () => {
-          const code = await runPrefilter(['claude', '--input-dir', '/nonexistent/path']);
+          const code = await runNoiseFilter(['claude', '--input-dir', '/nonexistent/path']);
           assertEquals(code, 1);
         });
       });

--- a/skills/filter-chatlogs/scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
@@ -1,5 +1,5 @@
-// src: scripts/configs/__tests__/unit/prefilter-config.unit.spec.ts
-// @(#): prefilter-config.ts のユニットテスト
+// src: scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
+// @(#): noise-filter-config.ts のユニットテスト
 //       対象: parseArgs / buildConfig
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -12,7 +12,7 @@ import { assert, assertEquals, assertFalse, assertThrows } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { buildConfig, parseArgs } from '../../../configs/prefilter-config.ts';
+import { buildConfig, parseArgs } from '../../../configs/noise-filter-config.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
@@ -25,7 +25,7 @@ import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-ut
 // ─── Tests
 
 // ─────────────────────────────────────────────────────────────────────────────
-// parseArgs (prefilter)
+// parseArgs (noise-filter)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -37,7 +37,7 @@ import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-ut
  *
  * @see parseArgs
  */
-describe('parseArgs (prefilter)', () => {
+describe('parseArgs (noise-filter)', () => {
   beforeEach(() => {
     GlobalConfig.resetInstance();
   });

--- a/skills/filter-chatlogs/scripts/configs/noise-filter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/noise-filter-config.ts
@@ -1,5 +1,5 @@
-// src: scripts/config/prefilter-config.ts
-// @(#): prefilter-chatlogs の引数解析・設定構築
+// src: scripts/config/noise-filter-config.ts
+// @(#): noise-filter-chatlogs の引数解析・設定構築
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -16,21 +16,21 @@ import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── internal ───
 // constants
-import { DEFAULT_PREFILTER_CONFIG } from '../constants/common.constants.ts';
+import { DEFAULT_NOISE_FILTER_CONFIG } from '../constants/common.constants.ts';
 // types
-import type { PrefilterConfig, PrefilterParsedConfig } from '../types/prefilter.types.ts';
+import type { NoiseFilterConfig, NoiseFilterParsedConfig } from '../types/noise-filter.types.ts';
 
 // ─────────────────────────────────────────────
 // 引数解析
 // ─────────────────────────────────────────────
 
-/** prefilter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgSchema<PrefilterParsedConfig> = [
+/** noise-filter-chatlogs の引数スキーマ。 */
+const _SCHEMA: ArgSchema<NoiseFilterParsedConfig> = [
   { option: '--report', field: 'report', type: 'flag' },
 ];
 
-export const parseArgs = (args: string[]): PrefilterParsedConfig => {
-  const _parsed = parseArgsToConfig<PrefilterParsedConfig>(args, _SCHEMA);
+export const parseArgs = (args: string[]): NoiseFilterParsedConfig => {
+  const _parsed = parseArgsToConfig<NoiseFilterParsedConfig>(args, _SCHEMA);
   _parsed.dryRun ??= (_parsed.dryRun ?? false) || (_parsed.report ?? false);
   _parsed.report ??= false;
   return {
@@ -43,17 +43,17 @@ export const parseArgs = (args: string[]): PrefilterParsedConfig => {
 // ─────────────────────────────────────────────
 
 /**
- * PrefilterParsedConfig・GlobalConfig・デフォルト値から完全な PrefilterConfig を構築する。
+ * NoiseFilterParsedConfig・GlobalConfig・デフォルト値から完全な NoiseFilterConfig を構築する。
  * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
  * - chatlogsDir: `globalConfig.get('chatlogsDir')`（基準ディレクトリ）
  * - inputDir: `parsed.inputDir`（指定時のみ設定される。フルパス直接指定の短絡パラメータ）
- * - `configFile` は PrefilterConfig に存在しないため結果に含まれない。
+ * - `configFile` は NoiseFilterConfig に存在しないため結果に含まれない。
  */
 export const buildConfig = (
-  parsed: PrefilterParsedConfig,
+  parsed: NoiseFilterParsedConfig,
   globalConfig: GlobalConfig,
-  defaults: PrefilterConfig = DEFAULT_PREFILTER_CONFIG,
-): PrefilterConfig => {
+  defaults: NoiseFilterConfig = DEFAULT_NOISE_FILTER_CONFIG,
+): NoiseFilterConfig => {
   const _agent = parsed.agent ?? globalConfig.get('agent') as string;
   const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
   const { configFile: _configFile, ...rest } = parsed;

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -14,7 +14,7 @@ import { DEFAULT_AGENT, DEFAULT_CHATLOGS_DIR } from '../../../_scripts/constants
 // ─── internal ───
 // types
 import type { FilterConfig } from '../types/filter.types.ts';
-import type { PrefilterConfig } from '../types/prefilter.types.ts';
+import type { NoiseFilterConfig } from '../types/noise-filter.types.ts';
 
 // ─────────────────────────────────────────────
 // filter-chatlogs 固有定数
@@ -23,11 +23,11 @@ import type { PrefilterConfig } from '../types/prefilter.types.ts';
 /** バッチプロンプトに含める本文の最大文字数。 */
 export const MAX_BODY_CHARS = 8000;
 
-/** prefilter-chatlogs の Assistant 応答最小文字数閾値（userTurns=1 時）。 */
+/** noise-filter-chatlogs の Assistant 応答最小文字数閾値（userTurns=1 時）。 */
 export const MIN_ASSISTANT_CHARS = 100;
 
-/** prefilter-chatlogs の parseArgs で未指定のフィールドに適用するデフォルト設定。 */
-export const DEFAULT_PREFILTER_CONFIG: PrefilterConfig = {
+/** noise-filter-chatlogs の parseArgs で未指定のフィールドに適用するデフォルト設定。 */
+export const DEFAULT_NOISE_FILTER_CONFIG: NoiseFilterConfig = {
   agent: DEFAULT_AGENT,
   chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dryRun: false,

--- a/skills/filter-chatlogs/scripts/constants/patterns/filename.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/patterns/filename.constants.ts
@@ -31,5 +31,5 @@ const _BASE_FILENAME_PATTERNS: string[] = [
 /** 除外対象ファイル名パターン（文字列部分一致、`includes` 判定用）。 */
 export const EXCLUDE_FILENAME_PATTERNS_STR: string[] = [..._BASE_FILENAME_PATTERNS];
 
-/** prefilter-chatlogs のファイル名除外正規表現パターン一覧。 */
+/** noise-filter-chatlogs のファイル名除外正規表現パターン一覧。 */
 export const NOISE_FILENAME_PATTERNS: RegExp[] = _BASE_FILENAME_PATTERNS.map((p) => new RegExp(p));

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -1,5 +1,5 @@
-// src: scripts/modules/prefilter/__tests__/functional/process-noise-files.functional.spec.ts
-// @(#): prefilter-chatlogs.ts の機能テスト
+// src: scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+// @(#): noise-filter-chatlogs.ts の機能テスト
 //       対象: processNoiseFiles — filelist ループ処理（分類→削除/dry-run/report）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -21,7 +21,7 @@ import { makeRepeatedContent } from '../../../../__tests__/_helpers/fixtures.ts'
 // types
 import type { LoggerStub } from '../../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants
-import { PREFILTER_MIN_CONTENT_LENGTH } from '../../../../__tests__/_helpers/constants.ts';
+import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../../../../__tests__/_helpers/constants.ts';
 
 // ─── Internal Helpers
 
@@ -34,7 +34,7 @@ const _KEEP_FILENAME = 'valid-chat.md';
 
 // functions
 /** KEEP 判定を通過する最小コンテンツを生成する。 */
-const _makeValidContent = () => makeRepeatedContent(PREFILTER_MIN_CONTENT_LENGTH);
+const _makeValidContent = () => makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH);
 
 // ─── Tests
 

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
@@ -1,4 +1,4 @@
-// src: scripts/modules/prefilter/process-noise-files.ts
+// src: scripts/modules/noise-filter/process-noise-files.ts
 // @(#): ノイズファイルのリスト処理（分類・削除・dry-run・report）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -15,7 +15,7 @@ import { getFilename } from '../../../../_scripts/libs/path-utils/path-utils.ts'
 
 // ─── internal ───
 // types
-import type { PrefilterStats } from '../../types/stats.types.ts';
+import type { NoiseFilterStats } from '../../types/stats.types.ts';
 // functions
 import { classifyFile } from '../../libs/classify-file.ts';
 
@@ -25,7 +25,7 @@ import { classifyFile } from '../../libs/classify-file.ts';
 
 export const processNoiseFiles = async (
   files: string[],
-  stats: PrefilterStats,
+  stats: NoiseFilterStats,
   options: { dryRun: boolean; report: boolean },
 ): Promise<void> => {
   const { dryRun, report } = options;

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write
-// src: scripts/prefilter-chatlogs.ts
+// src: scripts/noise-filter-chatlogs.ts
 // @(#): チャットログの高速事前フィルタスクリプト
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
@@ -7,7 +7,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 /**
- * prefilter-chatlogs.ts — チャットログの高速事前フィルタスクリプト
+ * noise-filter-chatlogs.ts — チャットログの高速事前フィルタスクリプト
  *
  * Claude API呼び出し前に、正規表現・テキストパターンで
  * 明らかなノイズファイルを削除候補として絞り込む。
@@ -22,11 +22,11 @@
  *   7. 短すぎる応答      : Assistantが100文字未満（1ターン限定）
  *
  * 使い方:
- *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts
- *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts codex 2026-01
- *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --dry-run
- *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --report
- *   deno run --allow-read --allow-write scripts/prefilter-chatlogs.ts --input-dir ./temp/chatlogs
+ *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts
+ *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts codex 2026-01
+ *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts --dry-run
+ *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts --report
+ *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts --input-dir ./temp/chatlogs
  */
 
 // ─── shared ───
@@ -43,10 +43,10 @@ import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 // types
-import type { PrefilterStats } from './types/stats.types.ts';
+import type { NoiseFilterStats } from './types/stats.types.ts';
 // functions
-import { buildConfig, parseArgs } from './configs/prefilter-config.ts';
-import { processNoiseFiles } from './modules/prefilter/process-noise-files.ts';
+import { buildConfig, parseArgs } from './configs/noise-filter-config.ts';
+import { processNoiseFiles } from './modules/noise-filter/process-noise-files.ts';
 
 // ─────────────────────────────────────────────
 // メイン
@@ -75,7 +75,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
       logger.info(`${report ? 'report' : 'dry-run'} モード: ファイルは削除しません`);
     }
 
-    const stats: PrefilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
+    const stats: NoiseFilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
     await processNoiseFiles(files, stats, { dryRun, report });
 
     const suffix = dryRun ? ` (${report ? 'report' : 'dry-run'})` : '';

--- a/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
@@ -1,5 +1,5 @@
-// src: scripts/types/prefilter.types.ts
-// @(#): prefilter-chatlogs スクリプト固有の型定義
+// src: scripts/types/noise-filter.types.ts
+// @(#): noise-filter-chatlogs スクリプト固有の型定義
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -9,8 +9,8 @@
 // types
 import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
 
-/** `prefilter-chatlogs` の `main` が使用する設定。すべてのフィールドに値が入る。 */
-export type PrefilterConfig = DefaultArgFields & {
+/** `noise-filter-chatlogs` の `main` が使用する設定。すべてのフィールドに値が入る。 */
+export type NoiseFilterConfig = DefaultArgFields & {
   /** 対象 AI エージェント名（例: `claude`, `chatgpt`）。 */
   agent: string;
   /** チャットログが格納された基準ディレクトリのパス（GlobalConfig の chatlogsDir 由来）。 */
@@ -21,11 +21,11 @@ export type PrefilterConfig = DefaultArgFields & {
   report: boolean;
 };
 
-/** `prefilter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
-export type PrefilterParsedConfig = Partial<PrefilterConfig>;
+/** `noise-filter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
+export type NoiseFilterParsedConfig = Partial<NoiseFilterConfig>;
 
 /** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
 type _Assert<T extends Partial<ParsedArgs>> = T;
 
-/** PrefilterConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
-type _PrefilterConfigCheck = _Assert<PrefilterConfig>;
+/** NoiseFilterConfig が ArgValue 互換であることの型チェック（実行時に影響なし）。 */
+type _NoiseFilterConfigCheck = _Assert<NoiseFilterConfig>;

--- a/skills/filter-chatlogs/scripts/types/stats.types.ts
+++ b/skills/filter-chatlogs/scripts/types/stats.types.ts
@@ -6,7 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/** filter-chatlogs / prefilter-chatlogs に共通する統計カウンターフィールド。 */
+/** filter-chatlogs / noise-filter-chatlogs に共通する統計カウンターフィールド。 */
 export interface BaseStats {
   /** 保存確定数（AI判定でKEEP、または事前段階で対象外と確定したもの）。 */
   keep: number;
@@ -21,5 +21,5 @@ export interface BaseStats {
 /** バッチ処理全体の処理統計。 */
 export interface FilterStats extends BaseStats {}
 
-/** prefilter 処理の統計情報。 */
-export interface PrefilterStats extends BaseStats {}
+/** noise-filter 処理の統計情報。 */
+export interface NoiseFilterStats extends BaseStats {}


### PR DESCRIPTION
## Overview

**Summary**
Rename the standalone `prefilter-chatlogs` CLI series to `noise-filter` to resolve a naming collision with the unrelated internal pre-filter phase inside `filter-chatlogs.ts`.

**Background / Motivation**
`skills/filter-chatlogs` used the word "prefilter" for two unrelated concepts: the standalone `prefilter-chatlogs.ts` CLI (regex/string-only noise removal run *before* the AI batch judge) and `modules/prefilter.ts`, the internal pre-filter phase inside `filter-chatlogs.ts` itself (`prefilterFiles`). Having `modules/prefilter.ts` (file) and `modules/prefilter/` (directory) coexist at the same level compounded the confusion.

This PR renames the standalone CLI series (concept A) to `noiseFilter`, since that name better reflects what it actually does, resolving the naming collision with the internal pre-filter phase (concept B). No logic or runtime behavior changes — this is a rename-only refactor.

## Changes

### Core Changes

- `scripts/prefilter-chatlogs.ts` → `scripts/noise-filter-chatlogs.ts`
- `scripts/configs/prefilter-config.ts` → `scripts/configs/noise-filter-config.ts`
- `scripts/types/prefilter.types.ts` → `scripts/types/noise-filter.types.ts`
- `scripts/modules/prefilter/` → `scripts/modules/noise-filter/` (including `process-noise-files.ts`)
- Symbol renames: `PrefilterConfig` → `NoiseFilterConfig`, `PrefilterParsedConfig` →
  `NoiseFilterParsedConfig`, `PrefilterStats` → `NoiseFilterStats`,
  `DEFAULT_PREFILTER_CONFIG` → `DEFAULT_NOISE_FILTER_CONFIG`,
  `PREFILTER_MIN_CONTENT_LENGTH` → `NOISE_FILTER_MIN_CONTENT_LENGTH`
- `// src: ...` header comments updated to the new file paths
- `skills/filter-chatlogs/SKILL.md`: subcommand name, argument-hint, dispatch logic, script path
  variable, and notification wording updated from `prefilter` to `noise-filter`
- Fixed a pre-existing header comment mistake in
  `__tests__/functional/libs/classify-file.functional.spec.ts` (referenced
  `prefilter-chatlogs.ts` instead of the actual test target, `classify-file.ts`)

### Test Updates

- Renamed and updated 10 unit / functional / integration / system / e2e spec files under
  `prefilter*` paths to `noise-filter*`, including `describe` names, imports, and constant
  references (`NOISE_FILTER_MIN_CONTENT_LENGTH`, etc.)

### Removed

- None (rename-only; no files or logic removed)

### Out of scope (intentionally unchanged)

- `scripts/modules/prefilter.ts` and `prefilterFiles`, `PrefilterFilesOptions`,
  `isSystemOnlyMessage`, `isExcludedByFilename`, `isExcludedByContent` (the internal pre-filter
  phase inside `filter-chatlogs.ts`, concept B) — these keep the `prefilter` name deliberately.
- `classify-file.ts`, `NOISE_*_PATTERNS` constants, `NoiseConversationPattern` type (an existing,
  unrelated "noise" vocabulary).

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> Closes #299

## Breaking Changes

The `/filter-chatlogs` skill's subcommand keyword changes: invoking the standalone CLI via
`/filter-chatlogs prefilter ...` no longer works — use `/filter-chatlogs noise-filter ...` instead.

Everything else is unchanged: the script's own CLI arguments (`agent`, `YYYY-MM`, `project`,
`--dry-run`, `--report`) and output format are identical to before. Internal type/constant names
and file paths are implementation details with no external effect.

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (`dprint check` passes for all files touched by this PR)
- [x] Tests pass (`deno task test:unit`: 183 passed, 0 failed)
- [x] Documentation updated (`SKILL.md`)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is a purely mechanical rename (files, types, constants, comments) with no logic changes, so
regression risk is low. See issue #299 for the full design rationale, including why the internal
pre-filter phase (`modules/prefilter.ts`) was intentionally left out of scope.
