### PR TITLE
feat(concurrency): pass AbortController to tasks

### DIFF
--- a/.claude/rules/coding-guidelines.md
+++ b/.claude/rules/coding-guidelines.md
@@ -48,7 +48,7 @@ this.filename = getFilename(filePath);
 // Bad
 const results = [];
 for (const item of items) {
-  if (item.active) results.push(transform(item));
+  if (item.active) { results.push(transform(item)); }
 }
 
 // Good

--- a/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
+++ b/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
@@ -117,6 +117,32 @@ describe('withConcurrency', () => {
     });
   });
 
+  describe('Given: 先頭タスクが ctl.abort() を呼び、後続タスクは呼び出し有無を記録する', () => {
+    describe('When: withConcurrency(tasks, 1) を実行する（limit=1 で決定的な実行順にする）', () => {
+      describe('Then: T-LIB-C-18 - abort 後も未着手タスクが呼ばれ続け結果配列に穴が空かない', () => {
+        it('T-LIB-C-18-01: 全タスクが呼ばれ calls が [0, 1, 2] になる', async () => {
+          const _calls: number[] = [];
+          const _tasks = [0, 1, 2].map((n) => (ctl: AbortController) => {
+            _calls.push(n);
+            if (n === 0) { ctl.abort(); }
+            return Promise.resolve(n * 10);
+          });
+          await withConcurrency(_tasks, 1);
+          assertEquals(_calls, [0, 1, 2]);
+        });
+
+        it('T-LIB-C-18-02: 結果配列に穴が空かず [0, 10, 20] になる', async () => {
+          const _tasks = [0, 1, 2].map((n) => (ctl: AbortController) => {
+            if (n === 0) { ctl.abort(); }
+            return Promise.resolve(n * 10);
+          });
+          const _results = await withConcurrency(_tasks, 1);
+          assertEquals(_results, [0, 10, 20]);
+        });
+      });
+    });
+  });
+
   describe('Given: limit=1（順序実行）', () => {
     describe('When: withConcurrency を実行する', () => {
       describe('Then: T-LIB-C-16 - タスクが順序通りに実行され結果が入力順で返る', () => {

--- a/skills/_scripts/libs/parallel/concurrency.ts
+++ b/skills/_scripts/libs/parallel/concurrency.ts
@@ -22,11 +22,12 @@ export const withConcurrency = async <T>(
   limit: number,
 ): Promise<T[]> => {
   const results: T[] = new Array(tasks.length);
+  const ctl = new AbortController();
   let idx = 0;
   const _worker = async (): Promise<void> => {
     while (idx < tasks.length) {
       const i = idx++;
-      results[i] = await tasks[i]();
+      results[i] = await tasks[i](ctl);
     }
   };
   await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, _worker));
@@ -42,9 +43,9 @@ export const withConcurrency = async <T>(
  */
 export const createTasks = <T, R>(
   items: T[],
-  fn: (item: T) => Promise<R>,
+  fn: (item: T, ctl: AbortController) => Promise<R>,
 ): Task<R>[] => {
-  return items.map((item) => () => fn(item));
+  return items.map((item) => (ctl) => fn(item, ctl));
 };
 
 /**
@@ -53,11 +54,11 @@ export const createTasks = <T, R>(
 export const createChunkedTasks = <T, R>(
   items: T[],
   chunkSize: number,
-  fn: (chunk: T[]) => Promise<R>,
+  fn: (chunk: T[], ctl: AbortController) => Promise<R>,
 ): Task<R>[] => {
   return Array.from(
     { length: Math.ceil(items.length / chunkSize) },
-    (_, i) => () => fn(items.slice(i * chunkSize, (i + 1) * chunkSize)),
+    (_, i) => (ctl) => fn(items.slice(i * chunkSize, (i + 1) * chunkSize), ctl),
   );
 };
 
@@ -70,7 +71,7 @@ export const createChunkedTasks = <T, R>(
  */
 export const runConcurrent = <T, R>(
   items: T[],
-  fn: (item: T) => Promise<R>,
+  fn: (item: T, ctl: AbortController) => Promise<R>,
   limit: number,
 ): Promise<R[]> => {
   return withConcurrency(createTasks(items, fn), limit);
@@ -82,7 +83,7 @@ export const runConcurrent = <T, R>(
 export const runChunked = <T, R>(
   items: T[],
   chunkSize: number,
-  fn: (chunk: T[]) => Promise<R>,
+  fn: (chunk: T[], ctl: AbortController) => Promise<R>,
   limit: number,
 ): Promise<R[]> => {
   return withConcurrency(createChunkedTasks(items, chunkSize, fn), limit);

--- a/skills/_scripts/types/common.types.ts
+++ b/skills/_scripts/types/common.types.ts
@@ -33,4 +33,4 @@ export type EntryOptions = {
 // ─────────────────────────────────────────────
 
 /** 非同期タスク関数の型。`withConcurrency` の入力として使用する。 */
-export type Task<T> = () => Promise<T>;
+export type Task<T> = (ctl: AbortController) => Promise<T>;


### PR DESCRIPTION
## Overview

**Summary**
Pass a shared `AbortController` to tasks running under `withConcurrency`.

**Background / Motivation**
Tasks had no way to signal early termination to sibling tasks. `Task<T>` took no arguments, so a task could not request cancellation or let other tasks observe that intent. This change gives each task access to a shared `AbortController` while keeping the existing guarantee that all scheduled tasks still run and the result array stays index-aligned.

## Changes

### Core Changes

- `skills/_scripts/libs/parallel/concurrency.ts`: `withConcurrency` creates one `AbortController` per call and passes it to every task. `createTasks`, `createChunkedTasks`, `runConcurrent`, and `runChunked` all thread the controller through their `fn` callbacks.
- `skills/_scripts/types/common.types.ts`: `Task<T>` signature changed from `() => Promise<T>` to `(ctl: AbortController) => Promise<T>`. Existing zero-arg task callbacks remain assignable, so this is source-compatible.

### Test Updates

- `skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts`: adds `T-LIB-C-18`, covering `withConcurrency(tasks, 1)` where the first task calls `ctl.abort()`. Verifies all tasks still run (`calls === [0, 1, 2]`) and the result array stays fully populated (`[0, 10, 20]`).

### Removed

None.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
