### PR TITLE
refactor(filter-chatlogs): remove --report option from noise-filter

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
@@ -6,7 +6,6 @@
 //         入力: inputDir/agent/YYYY/YYYY-MM/*.md
 //         正規表現でノイズと判定したファイルを削除する
 //         --dry-run: 削除せず対象パスを stdout に出力
-//         --report:  NOISE\t{reason}\t{path} 形式で stdout に出力（削除なし）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 // This software is released under the MIT License.
@@ -110,61 +109,6 @@ describe('main (noise-filter) - dry-run モード', () => {
 
           assertEquals(await fileExists(filePath), true);
           assertEquals(loggerStub.logLogs.some((line) => line.includes('say-ok-and-nothing-else.md')), true);
-        });
-      });
-    });
-  });
-});
-
-// ─── T-PF-E2E-02: --report → NOISE\t{reason}\t{path} 形式、削除なし ──────────
-
-/**
- * `main` 関数（noise-filter）の E2E テストスイート（report モード）。
- *
- * `--report` フラグを指定した際に `NOISE\t{reason}\t{path}` 形式で
- * stdout に出力され、ファイルが削除されないことを検証する。
- *
- * テスト ID 範囲: T-PF-E2E-02
- *
- * @see main
- */
-describe('main (noise-filter) - report モード', () => {
-  /**
-   * ノイズファイル名の `.md` ファイルと `--report` フラグが存在する前提。
-   *
-   * report モードでは NOISE タブ区切り形式の出力が行われ、
-   * ファイルの削除は発生しないことを確認する。
-   */
-  describe('Given: ノイズファイル名の .md ファイルと --report フラグ', () => {
-    /** `main(["claude", "--report", "--input-dir", chatlogsDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--report", "--input-dir", chatlogsDir]) を呼び出す', () => {
-      /** `NOISE\t{reason}\t{path}` 形式でログ出力され、ファイルが削除されないこと。 */
-      describe('Then: T-PF-E2E-02 - NOISE タブ区切り形式で出力、削除なし', () => {
-        let tempDir: string;
-        let chatlogsDir: string;
-        let loggerStub: LoggerStub;
-
-        beforeEach(async () => {
-          ({ tempDir, chatlogsDir } = await _makeTestDirs());
-          loggerStub = makeLoggerStub();
-        });
-
-        afterEach(async () => {
-          loggerStub.restore();
-          GlobalConfig.resetInstance();
-          await Deno.remove(tempDir, { recursive: true });
-        });
-
-        it('T-PF-E2E-02-01: NOISE タブ区切り形式で出力され、ファイルが削除されずに残っている', async () => {
-          const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
-          await Deno.writeTextFile(filePath, _makeValidContent());
-
-          await main(['claude', '2026-03', '--report', '--input-dir', chatlogsDir]);
-
-          const noiseLine = loggerStub.logLogs.find((line) => line.startsWith('NOISE\t'));
-          assertEquals(noiseLine !== undefined, true);
-          assertEquals(noiseLine!.split('\t').length >= 3, true);
-          assertEquals(await fileExists(filePath), true);
         });
       });
     });
@@ -394,55 +338,6 @@ describe('main (noise-filter) - period 絞り込み', () => {
 
           await assertFileNotExist(noisePath03);
           assertEquals(await fileExists(noisePath04), true);
-        });
-      });
-    });
-  });
-});
-
-// ─── T-PF-E2E-08: --report → 完了ログに "report" が含まれる ─────────────────
-
-/**
- * `main` 関数（noise-filter）の E2E テストスイート（report 完了ログ）。
- *
- * `--report` フラグを指定した際の完了ログに `report` が含まれることを検証する。
- *
- * テスト ID 範囲: T-PF-E2E-08
- *
- * @see main
- */
-describe('main (noise-filter) - report 完了ログ', () => {
-  /**
-   * 正常ファイル 1 件と `--report` フラグが存在する前提。
-   *
-   * report モードの完了ログが `report` キーワードを含むことを確認する。
-   */
-  describe('Given: 正常ファイル 1 件と --report フラグ', () => {
-    /** `main(["claude", "--report", "--input-dir", chatlogsDir])` を呼び出すとき。 */
-    describe('When: main(["claude", "--report", "--input-dir", chatlogsDir]) を呼び出す', () => {
-      /** 完了ログに `report` キーワードが含まれること。 */
-      describe('Then: T-PF-E2E-08 - 完了ログに "report" が含まれる', () => {
-        let tempDir: string;
-        let chatlogsDir: string;
-        let loggerStub: LoggerStub;
-
-        beforeEach(async () => {
-          ({ tempDir, chatlogsDir } = await _makeTestDirs());
-          loggerStub = makeLoggerStub();
-        });
-
-        afterEach(async () => {
-          loggerStub.restore();
-          GlobalConfig.resetInstance();
-          await Deno.remove(tempDir, { recursive: true });
-        });
-
-        it('T-PF-E2E-08-01: 完了ログに "report" が含まれる', async () => {
-          await Deno.writeTextFile(`${chatlogsDir}/valid.md`, _makeValidContent());
-
-          await main(['claude', '2026-03', '--report', '--input-dir', chatlogsDir]);
-
-          assertEquals(loggerStub.infoLogs.some((line) => line.includes('report')), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
@@ -68,7 +68,6 @@ const _CUSTOM_DEFAULTS: NoiseFilterConfig = {
  * - `inputDir`   : parsed.inputDir（指定時のみ設定される）
  * - `period`     : parsed のみ（GlobalConfig 連携なし）
  * - `dryRun`     : parsed > defaults (false)
- * - `report`     : parsed > defaults (false)
  * - `configFile` は NoiseFilterConfig に存在しないため結果に含まれない
  *
  * テスト ID 範囲: T-PF-BC-06 〜 T-PF-BC-16

--- a/skills/filter-chatlogs/scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
@@ -60,10 +60,6 @@ describe('parseArgs (noise-filter)', () => {
       assertEquals(parseArgs([]).period, undefined);
     });
 
-    it('[Normal] T-PF-PA-01-05: report が false になる', () => {
-      assertFalse(parseArgs([]).report);
-    });
-
     it('[Normal] T-PF-PA-02-01: agent が "codex" になる', () => {
       assertEquals(parseArgs(['codex']).agent, 'codex');
     });
@@ -79,31 +75,11 @@ describe('parseArgs (noise-filter)', () => {
       assert(parseArgs(['--dry-run']).dryRun);
     });
 
-    it('[Normal] T-PF-PA-05-02: report が false のまま', () => {
-      assertFalse(parseArgs(['--dry-run']).report);
-    });
-
-    it('[Normal] T-PF-PA-06-01: report が true になる', () => {
-      assert(parseArgs(['--report']).report);
-    });
-
-    it('[Normal] T-PF-PA-06-02: dryRun が true になる（--report は dryRun も暗示）', () => {
-      assert(parseArgs(['--report']).dryRun);
-    });
-
-    it('[Normal] T-PF-PA-07-01: report=true、dryRun=true になる', () => {
-      const result = parseArgs(['--report', '--dry-run']);
-
-      assert(result.report);
-      assert(result.dryRun);
-    });
-
     it('[Normal] T-PF-PA-10-01: 全フィールドが正しく解析される', () => {
-      const result = parseArgs(['codex', '2026-03', '--report', '--input-dir', '/path/to/input']);
+      const result = parseArgs(['codex', '2026-03', '--dry-run', '--input-dir', '/path/to/input']);
 
       assertEquals(result.agent, 'codex');
       assertEquals(result.period, '2026-03');
-      assert(result.report);
       assert(result.dryRun);
       assertEquals(result.inputDir, '/path/to/input');
     });
@@ -198,32 +174,28 @@ describe('buildConfig', () => {
   /** 空 Args・agent/chatlogsDir 指定・フラグ反映の正常ケース。 */
   describe('When: 正常系', () => {
     it('[Normal] T-PF-BC-01-01: agent が "claude" になる', () => {
-      assertEquals(buildConfig({ dryRun: false, report: false }, globalConfig).agent, 'claude');
+      assertEquals(buildConfig({ dryRun: false }, globalConfig).agent, 'claude');
     });
 
     it('[Normal] T-PF-BC-01-02: chatlogsDir が "./chatlogs" になる', () => {
-      assertEquals(buildConfig({ dryRun: false, report: false }, globalConfig).chatlogsDir, './chatlogs');
+      assertEquals(buildConfig({ dryRun: false }, globalConfig).chatlogsDir, './chatlogs');
     });
 
     it('[Normal] T-PF-BC-01-03: dryRun が false になる', () => {
-      assertFalse(buildConfig({ dryRun: false, report: false }, globalConfig).dryRun);
+      assertFalse(buildConfig({ dryRun: false }, globalConfig).dryRun);
     });
 
     it('[Normal] T-PF-BC-02-01: agent が "codex" になる', () => {
-      assertEquals(buildConfig({ agent: 'codex', dryRun: false, report: false }, globalConfig).agent, 'codex');
+      assertEquals(buildConfig({ agent: 'codex', dryRun: false }, globalConfig).agent, 'codex');
     });
 
     it('[Normal] T-PF-BC-03-01: dryRun が true になる', () => {
-      assert(buildConfig({ dryRun: true, report: true }, globalConfig).dryRun);
-    });
-
-    it('[Normal] T-PF-BC-03-02: report が true になる', () => {
-      assert(buildConfig({ dryRun: true, report: true }, globalConfig).report);
+      assert(buildConfig({ dryRun: true }, globalConfig).dryRun);
     });
 
     it('[Normal] T-PF-BC-04-01: inputDir が "/chat" になる', () => {
       assertEquals(
-        buildConfig({ inputDir: '/chat', dryRun: false, report: false }, globalConfig).inputDir,
+        buildConfig({ inputDir: '/chat', dryRun: false }, globalConfig).inputDir,
         '/chat',
       );
     });

--- a/skills/filter-chatlogs/scripts/configs/noise-filter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/noise-filter-config.ts
@@ -25,14 +25,11 @@ import type { NoiseFilterConfig, NoiseFilterParsedConfig } from '../types/noise-
 // ─────────────────────────────────────────────
 
 /** noise-filter-chatlogs の引数スキーマ。 */
-const _SCHEMA: ArgSchema<NoiseFilterParsedConfig> = [
-  { option: '--report', field: 'report', type: 'flag' },
-];
+const _SCHEMA: ArgSchema<NoiseFilterParsedConfig> = [];
 
 export const parseArgs = (args: string[]): NoiseFilterParsedConfig => {
   const _parsed = parseArgsToConfig<NoiseFilterParsedConfig>(args, _SCHEMA);
-  _parsed.dryRun ??= (_parsed.dryRun ?? false) || (_parsed.report ?? false);
-  _parsed.report ??= false;
+  _parsed.dryRun ??= false;
   return {
     ..._parsed,
   };

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -31,7 +31,6 @@ export const DEFAULT_NOISE_FILTER_CONFIG: NoiseFilterConfig = {
   agent: DEFAULT_AGENT,
   chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dryRun: false,
-  report: false,
 };
 
 /** filter-chatlogs の parseArgs で未指定のフィールドに適用するデフォルト設定。 */

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
 // @(#): noise-filter-chatlogs.ts の機能テスト
-//       対象: processNoiseFiles — filelist ループ処理（分類→削除/dry-run/report）
+//       対象: processNoiseFiles — filelist ループ処理（分類→削除/dry-run）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -41,8 +41,8 @@ const _makeValidContent = () => makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LEN
 /**
  * `processNoiseFiles` 関数の機能テストスイート。
  *
- * `processNoiseFiles(files, counts, { dryRun, report })` はファイルリストを受け取り、
- * 各ファイルを分類してノイズを削除（または dry-run/report 出力）し、counts を更新する。
+ * `processNoiseFiles(files, counts, { dryRun })` はファイルリストを受け取り、
+ * 各ファイルを分類してノイズを削除（または dry-run 出力）し、counts を更新する。
  *
  * テスト ID 範囲: T-PF-PNF-01 〜 T-PF-PNF-06
  *
@@ -73,7 +73,7 @@ describe('processNoiseFiles', () => {
    * ファイルが削除され、`counts.remove` が加算されることを検証する。
    */
   describe('Given: ノイズファイル 1 件', () => {
-    /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
+    /** `processNoiseFiles(files, counts, { dryRun: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
       /** ファイルが削除され、counts.remove=1 になること。 */
       describe('Then: T-PF-PNF-01 - ファイルが削除され、counts.remove が 1 になる', () => {
@@ -82,7 +82,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
+          await processNoiseFiles([filePath], counts, { dryRun: false });
 
           assertEquals(await fileExists(filePath), false);
         });
@@ -92,7 +92,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
+          await processNoiseFiles([filePath], counts, { dryRun: false });
 
           assertEquals(counts.remove, 1);
         });
@@ -108,7 +108,7 @@ describe('processNoiseFiles', () => {
    * ファイルが残り、`counts.keep` が加算されることを検証する。
    */
   describe('Given: 正常ファイル 1 件', () => {
-    /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
+    /** `processNoiseFiles(files, counts, { dryRun: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
       /** ファイルが削除されず、counts.keep=1 になること。 */
       describe('Then: T-PF-PNF-02 - ファイルが残り、counts.keep が 1 になる', () => {
@@ -117,7 +117,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
+          await processNoiseFiles([filePath], counts, { dryRun: false });
 
           assertEquals(await fileExists(filePath), true);
         });
@@ -127,7 +127,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: false, report: false });
+          await processNoiseFiles([filePath], counts, { dryRun: false });
 
           assertEquals(counts.keep, 1);
         });
@@ -143,7 +143,7 @@ describe('processNoiseFiles', () => {
    * ファイルが削除されず、パスがログに出力されることを検証する。
    */
   describe('Given: ノイズファイル 1 件と dryRun=true', () => {
-    /** `processNoiseFiles(files, counts, { dryRun: true, report: false })` を呼び出すとき。 */
+    /** `processNoiseFiles(files, counts, { dryRun: true })` を呼び出すとき。 */
     describe('When: processNoiseFiles を dry-run モードで呼び出す', () => {
       /** ファイルが削除されず、ログにファイルパスが含まれること。 */
       describe('Then: T-PF-PNF-03 - ファイルが削除されずパスがログに出力される', () => {
@@ -152,7 +152,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: true, report: false });
+          await processNoiseFiles([filePath], counts, { dryRun: true });
 
           assertEquals(await fileExists(filePath), true);
         });
@@ -162,7 +162,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: true, report: false });
+          await processNoiseFiles([filePath], counts, { dryRun: true });
 
           assertEquals(loggerStub.logLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
         });
@@ -172,54 +172,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([filePath], counts, { dryRun: true, report: false });
-
-          assertEquals(counts.skip, 1);
-        });
-      });
-    });
-  });
-
-  // ─── T-PF-PNF-04: ノイズファイル + report → NOISE\t{reason}\t{path} 形式ログ ──
-
-  /**
-   * ノイズファイルが report モードで処理される前提グループ。
-   *
-   * `NOISE\t{reason}\t{path}` 形式のログが出力され、ファイルが削除されないことを検証する。
-   */
-  describe('Given: ノイズファイル 1 件と report=true', () => {
-    /** `processNoiseFiles(files, counts, { dryRun: true, report: true })` を呼び出すとき。 */
-    describe('When: processNoiseFiles を report モードで呼び出す', () => {
-      /** NOISE タブ区切り形式のログが出力され、ファイルが残ること。 */
-      describe('Then: T-PF-PNF-04 - NOISE タブ区切り形式でログ出力、削除なし', () => {
-        it('T-PF-PNF-04-01: logLogs に "NOISE\\t..." 形式の行が含まれる', async () => {
-          const filePath = `${tempDir}/${_NOISE_FILENAME}`;
-          await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
-
-          await processNoiseFiles([filePath], counts, { dryRun: true, report: true });
-
-          const noiseLine = loggerStub.logLogs.find((line) => line.startsWith('NOISE\t'));
-          assertEquals(noiseLine !== undefined, true);
-          assertEquals(noiseLine!.split('\t').length >= 3, true);
-        });
-
-        it('T-PF-PNF-04-02: ファイルが削除されずに残る', async () => {
-          const filePath = `${tempDir}/${_NOISE_FILENAME}`;
-          await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
-
-          await processNoiseFiles([filePath], counts, { dryRun: true, report: true });
-
-          assertEquals(await fileExists(filePath), true);
-        });
-
-        it('T-PF-PNF-04-03: counts.skip が 1 になる', async () => {
-          const filePath = `${tempDir}/${_NOISE_FILENAME}`;
-          await Deno.writeTextFile(filePath, _makeValidContent());
-          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
-
-          await processNoiseFiles([filePath], counts, { dryRun: true, report: true });
+          await processNoiseFiles([filePath], counts, { dryRun: true });
 
           assertEquals(counts.skip, 1);
         });
@@ -235,7 +188,7 @@ describe('processNoiseFiles', () => {
    * `stats.error` が 1 増加し、ファイル削除が行われないことを検証する。
    */
   describe('Given: readTextFile が例外を throw するパス', () => {
-    /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
+    /** `processNoiseFiles(files, counts, { dryRun: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
       /** stats.error が 1 になり、stats.remove と stats.keep が 0 のままであること。 */
       describe('When: 異常系', () => {
@@ -243,7 +196,7 @@ describe('processNoiseFiles', () => {
           const nonExistentPath = `${tempDir}/non-existent-file.md`;
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([nonExistentPath], counts, { dryRun: false, report: false });
+          await processNoiseFiles([nonExistentPath], counts, { dryRun: false });
 
           assertEquals(counts.error, 1);
           assertEquals(counts.remove, 0);
@@ -261,7 +214,7 @@ describe('processNoiseFiles', () => {
    * `counts.remove` と `counts.keep` がそれぞれ正しく加算されることを検証する。
    */
   describe('Given: ノイズ 1 件 + 正常 1 件', () => {
-    /** `processNoiseFiles(files, counts, { dryRun: false, report: false })` を呼び出すとき。 */
+    /** `processNoiseFiles(files, counts, { dryRun: false })` を呼び出すとき。 */
     describe('When: processNoiseFiles を通常モードで呼び出す', () => {
       /** counts.remove=1、counts.keep=1 になること。 */
       describe('Then: T-PF-PNF-05 - remove=1, keep=1 になる', () => {
@@ -272,7 +225,7 @@ describe('processNoiseFiles', () => {
           await Deno.writeTextFile(keepPath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([noisePath, keepPath], counts, { dryRun: false, report: false });
+          await processNoiseFiles([noisePath, keepPath], counts, { dryRun: false });
 
           assertEquals(counts.remove, 1);
           assertEquals(counts.keep, 1);

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
@@ -1,5 +1,5 @@
 // src: scripts/modules/noise-filter/process-noise-files.ts
-// @(#): ノイズファイルのリスト処理（分類・削除・dry-run・report）
+// @(#): ノイズファイルのリスト処理（分類・削除・dry-run）
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -26,9 +26,9 @@ import { classifyFile } from '../../libs/classify-file.ts';
 export const processNoiseFiles = async (
   files: string[],
   stats: NoiseFilterStats,
-  options: { dryRun: boolean; report: boolean },
+  options: { dryRun: boolean },
 ): Promise<void> => {
-  const { dryRun, report } = options;
+  const { dryRun } = options;
 
   for (const filePath of files) {
     const filename = getFilename(filePath);
@@ -42,13 +42,10 @@ export const processNoiseFiles = async (
       continue;
     }
 
-    const { isNoise, reason } = classifyFile(filename, text);
+    const { isNoise, reason: _reason } = classifyFile(filename, text);
 
     if (isNoise) {
-      if (report) {
-        logger.log(`NOISE\t${reason}\t${filePath}`);
-        stats.skip++;
-      } else if (dryRun) {
+      if (dryRun) {
         logger.log(filePath);
         stats.skip++;
       } else {

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -25,7 +25,6 @@
  *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts
  *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts codex 2026-01
  *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts --dry-run
- *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts --report
  *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts --input-dir ./temp/chatlogs
  */
 
@@ -56,7 +55,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
   try {
     const _parsed = parseArgs(args);
     const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
-    const { agent, period, chatlogsDir, inputDir, dryRun, report } = buildConfig(_parsed, _globalConfig);
+    const { agent, period, chatlogsDir, inputDir, dryRun } = buildConfig(_parsed, _globalConfig);
     const _searchDir = resolveChatlogsDir({
       chatlogsDir,
       agent,
@@ -72,13 +71,13 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
     const files = await findFiles(_searchDir);
     logger.info(`対象ファイル数: ${files.length}`);
     if (dryRun) {
-      logger.info(`${report ? 'report' : 'dry-run'} モード: ファイルは削除しません`);
+      logger.info('dry-run モード: ファイルは削除しません');
     }
 
     const stats: NoiseFilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
-    await processNoiseFiles(files, stats, { dryRun, report });
+    await processNoiseFiles(files, stats, { dryRun });
 
-    const suffix = dryRun ? ` (${report ? 'report' : 'dry-run'})` : '';
+    const suffix = dryRun ? ' (dry-run)' : '';
     logger.info(
       `\n完了${suffix}: keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
     );

--- a/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
@@ -17,8 +17,6 @@ export type NoiseFilterConfig = DefaultArgFields & {
   chatlogsDir: string;
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */
   dryRun: boolean;
-  /** `true` のときノイズファイル一覧をタブ区切りで出力する（`dryRun` も暗示）。 */
-  report: boolean;
 };
 
 /** `noise-filter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */


### PR DESCRIPTION
## Overview

**Summary**
Remove the `--report` option from `noise-filter-chatlogs`.

**Background / Motivation**
The `--report` mode printed noise classifications as `NOISE\t<reason>\t<path>`, but this
duplicated what `--dry-run` already provided. Removing it drops unnecessary branching and
maintenance cost. `--dry-run` is now the single way to preview noise-filter results.

## Changes

### Core Changes

- `noise-filter-chatlogs.ts`: removed `--report` usage example and `report` handling
- `configs/noise-filter-config.ts`: removed the `--report` CLI option and simplified `dryRun`
  parsing
- `modules/noise-filter/process-noise-files.ts`: removed the `report` option; `dryRun` alone
  now controls skip/logging behavior
- `constants/common.constants.ts`: removed the default `report` setting
- `types/noise-filter.types.ts`: removed the `report` field from `NoiseFilterConfig`

### Test Updates

- Updated unit/functional/e2e tests for `noise-filter-config`, `process-noise-files`, and
  `build-config` to drop `report`-related cases and use `--dry-run` instead

### Removed

- `--report` CLI flag and the `report` field on `NoiseFilterConfig`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Breaking change: any script using `--report` will fail with an unrecognized-option error.
Use `--dry-run` instead.
