### PR TITLE
fix(prefilter): preserve read failure reasons and guard discard removal

### DIFF
--- a/skills/filter-chatlogs/SKILL.md
+++ b/skills/filter-chatlogs/SKILL.md
@@ -45,7 +45,6 @@ allowed-tools: Bash, Glob
 - `agent YYYY-MM`（例: `chatgpt 2026-03`）→ 指定 agent・指定月
 - `path`（例: `chatlogs\claude\2026\2026-04`）→ 指定パスをそのまま渡す（agent/period の代わり）
 - `--dry-run` → 削除せず、ノイズ候補のパスを標準出力に表示
-- `--report` → ノイズ理由付きで報告（`NOISE\t理由\tパス` 形式）
 
 ## ステップ1: スクリプトパスの解決
 
@@ -76,9 +75,8 @@ deno run --allow-read --allow-write "$NOISE_FILTER_PATH" $REST_ARGS
 - `agent YYYY-MM` → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt 2026-03`
 - `path`（パス区切り含む）→ `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatlogs/claude/2026/2026-04`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
-- `--report` を含む → 末尾に `--report` を追加
 
-スクリプトは以下のパターンで即座にノイズ判定し、該当ファイルを削除する（`--dry-run` / `--report` 時は削除しない）:
+スクリプトは以下のパターンで即座にノイズ判定し、該当ファイルを削除する（`--dry-run` 時は削除しない）:
 
 - ファイル名パターン（say-ok 等）
 - Git 操作ログのみの会話
@@ -124,5 +122,5 @@ deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" $ARGS
 **noise-filter モードの通知形式**:
 
 - noise / keep / error の件数を報告
-- dry-run / report モードの場合はその旨を明示する
+- dry-run モードの場合はその旨を明示する
 - ノイズ判定されたファイルのパスと判定理由を簡潔にまとめる

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/discard-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/discard-files.functional.spec.ts
@@ -20,6 +20,7 @@ import { _discardFiles } from '../../../modules/prefilter.ts';
 import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makePeriodDir, makeRepeatedContent } from '../../_helpers/fixtures.ts';
 // constants
+import { FILTER_DECISIONS } from '../../../types/filter-decision.const.types.ts';
 import { FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
 // types
 import type { DiscardFile } from '../../../types/filter.types.ts';
@@ -223,6 +224,49 @@ describe('_discardFiles', () => {
           await _discardFiles([], false, stats);
 
           assertEquals(stats, { keep: 0, skip: 0, remove: 0, error: 0 });
+        });
+      });
+    });
+  });
+
+  /**
+   * `decision` が `DISCARD` 以外（`ERROR` 等）のエントリが誤って渡される前提条件グループ。
+   *
+   * 呼び出し元が `toDelete` の組み立てを誤った場合でも `_discardFiles` 自体が
+   * 誤削除を防ぐガードとして機能し、非 DISCARD エントリは削除されずそのまま戻り値に残ることを検証する。
+   */
+  describe('Given: decision が DISCARD 以外（ERROR）のエントリを含むファイルリスト', () => {
+    /** _discardFiles([discardEntry, errorEntry], false, stats) を呼び出すとき。 */
+    describe('When: _discardFiles を呼び出す', () => {
+      /** ERROR エントリは削除されず戻り値に残り、DISCARD エントリのみ削除されることを検証する。 */
+      describe('Then: T-FL-DF-05 - ERROR エントリは削除されず戻り値に残る', () => {
+        it('T-FL-DF-05-01: ERROR エントリは実削除されず、戻り値にそのまま含まれる', async () => {
+          const discardPath = `${periodDir1}/guard-discard-target.md`;
+          const errorPath = `${periodDir1}/guard-error-target.md`;
+          await Deno.writeTextFile(discardPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(errorPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          const loggerStub = makeLoggerStub();
+          const stats = _makeStats();
+          const errorEntry: DiscardFile = {
+            filePath: errorPath,
+            filename: 'guard-error-target.md',
+            reason: '読み込み失敗',
+            decision: FILTER_DECISIONS.ERROR,
+          };
+          const discardEntry: DiscardFile = {
+            filePath: discardPath,
+            filename: 'guard-discard-target.md',
+            reason: 'trivial',
+            decision: FILTER_DECISIONS.DISCARD,
+          };
+
+          const result = await _discardFiles([discardEntry, errorEntry], false, stats);
+          loggerStub.restore();
+
+          assertEquals(await Deno.stat(errorPath).then(() => true).catch(() => false), true);
+          assertEquals(await Deno.stat(discardPath).catch(() => null), null);
+          assertEquals(result, [errorEntry]);
+          assertEquals(stats.remove, 1);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -8,7 +8,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assert, assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 // stub
 import { stub } from '@std/testing/mock';
@@ -398,6 +398,7 @@ describe('prefilterFiles', () => {
    * 本文読み込みに失敗する（実ファイルが存在しない）ファイルを cache 指定なしで処理する前提条件グループ。
    *
    * cache 未指定でも従来通り例外を投げず stats.error が加算されることを検証する（回帰確認）。
+   * 読み込み失敗ファイルは実削除されず、ユーザーが気づけるよう passed に含めたまま返す。
    */
   describe('Given: 本文読み込みに失敗するファイル（cache 指定なし）', () => {
     /** prefilterFiles([file], { stats }) を呼び出すとき。 */
@@ -415,7 +416,7 @@ describe('prefilterFiles', () => {
           assertEquals(stats.error, 1);
         });
 
-        it('T-FL-PFF-17-02: 読み込み失敗ファイルは削除されず passed に含まれる', async () => {
+        it('T-FL-PFF-17-02: 読み込み失敗ファイルは passed に含まれる', async () => {
           const filePath = `${periodDir1}/missing-read-passed.md`;
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -423,7 +424,7 @@ describe('prefilterFiles', () => {
           const result = await prefilterFiles([filePath], { stats });
           errStub.restore();
 
-          assertEquals(result.includes(filePath), true);
+          assertEquals(result, [filePath]);
         });
       });
     });
@@ -432,14 +433,14 @@ describe('prefilterFiles', () => {
   /**
    * 正常ファイルと読み込みエラーファイル（実ファイル未作成）が混在するファイルリストの前提条件グループ。
    *
-   * 読み込みエラーファイルも passed に含めたうえで、入力 files の順序が維持されることを検証する。
+   * 読み込みエラーファイルはゾンビ化を防ぐため passed に残したうえで、通過ファイルの入力順序が維持されることを検証する。
    */
   describe('Given: 正常ファイルと読み込みエラーファイルが混在するファイルリスト', () => {
     /** prefilterFiles(files) を呼び出すとき。 */
     describe('When: prefilterFiles(files) を呼び出す', () => {
-      /** passed 配列が入力 files の順序と一致することを検証する。 */
+      /** passed 配列が読み込みエラーファイルを含み、入力順と一致することを検証する。 */
       describe('Then: T-FL-PFF-18 - 読み込みエラーファイルを含め passed の順序が入力順と一致する', () => {
-        it('T-FL-PFF-18-01: passed 配列が入力 files の順序と一致する（読み込みエラー混在）', async () => {
+        it('T-FL-PFF-18-01: passed に読み込みエラーファイルが含まれ、通過ファイルの順序が入力順と一致する', async () => {
           const validPath1 = `${periodDir1}/mixed-valid1.md`;
           const missingPath = `${periodDir1}/mixed-missing.md`;
           const validPath2 = `${periodDir1}/mixed-valid2.md`;
@@ -452,6 +453,51 @@ describe('prefilterFiles', () => {
           errStub.restore();
 
           assertEquals(result, [validPath1, missingPath, validPath2]);
+        });
+
+        it('T-FL-PFF-18-02: ファイル名除外・内容除外は削除され、読み込みエラーファイルは正常ファイルとともに passed に残る', async () => {
+          const validPath = `${periodDir1}/mixed-all-valid.md`;
+          const excludedPath = `${periodDir1}/say-ok-and-nothing-else-mixed.md`;
+          const shortPath = `${periodDir1}/mixed-short-body.md`;
+          const missingPath = `${periodDir1}/mixed-all-missing.md`;
+          await Deno.writeTextFile(validPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(excludedPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
+          await Deno.writeTextFile(shortPath, '---\ntitle: テスト\n---\n短い本文\n');
+          const errStub = stub(console, 'error', () => {});
+
+          const files = [validPath, excludedPath, shortPath, missingPath];
+          const result = await prefilterFiles(files, { stats: _makeStats() });
+          errStub.restore();
+
+          assertEquals(result, [validPath, missingPath]);
+        });
+      });
+    });
+  });
+
+  /**
+   * 読み込みに失敗するファイルの前提条件グループ。
+   *
+   * 読み込み失敗の理由をユーザーが把握できるよう、logger.warn でファイル名と理由が出力されることを検証する。
+   */
+  describe('Given: 読み込みに失敗するファイル', () => {
+    /** prefilterFiles([file], { stats }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], { stats }) を呼び出す', () => {
+      /** logger.warn がファイル名と非空の理由を含めて呼ばれることを検証する。 */
+      describe('Then: T-FL-PFF-22 - logger.warn に理由とファイル名が出力される', () => {
+        it('T-FL-PFF-22-01: [Normal] logger.warn がファイル名と非空の理由を含めて呼ばれる', async () => {
+          const filePath = `${periodDir1}/missing-read-warn.md`;
+          const filename = 'missing-read-warn.md';
+          const loggerStub = makeLoggerStub();
+          const stats = _makeStats();
+
+          await prefilterFiles([filePath], { stats });
+          loggerStub.restore();
+
+          const warnLog = loggerStub.warnLogs.find((msg) => msg.includes(filename));
+          assert(warnLog !== undefined);
+          const reasonMatch = warnLog.match(/read failed \((.+)\): /);
+          assert(reasonMatch !== null && reasonMatch[1].length > 0);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/__tests__/functional/phase2-read-survivors.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/__tests__/functional/phase2-read-survivors.functional.spec.ts
@@ -8,7 +8,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertNotEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -109,15 +109,17 @@ describe('_phase2ReadSurvivors', () => {
     describe('When: _phase2ReadSurvivors([filePath]) を呼び出す', () => {
       /** readOk が空になり、readError に filePath が含まれることを検証する。 */
       describe('Then: T-FL-P2-03 - readError に DiscardFile が含まれる', () => {
-        it('T-FL-P2-03-01: readOk は空、readError[0] が filePath/filename/reason/decision を持つ', async () => {
+        it('T-FL-P2-03-01: readOk は空、readError[0] が filePath/filename/decision と実際のエラーメッセージを持つ reason を持つ', async () => {
           const filePath = `${periodDir1}/missing.md`;
 
           const { readOk, readError } = await _phase2ReadSurvivors([filePath]);
 
           assertEquals(readOk, []);
-          assertEquals(readError, [
-            { filePath, filename: 'missing.md', reason: '読み込み失敗', decision: FILTER_DECISIONS.ERROR },
-          ]);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, filePath);
+          assertEquals(readError[0].filename, 'missing.md');
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+          assertNotEquals(readError[0].reason, '読み込み失敗');
         });
       });
     });
@@ -142,14 +144,11 @@ describe('_phase2ReadSurvivors', () => {
 
           assertEquals(readOk.length, 1);
           assertEquals(readOk[0].filePath, validPath);
-          assertEquals(readError, [
-            {
-              filePath: missingPath,
-              filename: 'mixed-missing.md',
-              reason: '読み込み失敗',
-              decision: FILTER_DECISIONS.ERROR,
-            },
-          ]);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, missingPath);
+          assertEquals(readError[0].filename, 'mixed-missing.md');
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+          assertNotEquals(readError[0].reason, '読み込み失敗');
         });
       });
     });
@@ -166,21 +165,18 @@ describe('_phase2ReadSurvivors', () => {
     describe('When: _phase2ReadSurvivors([filePath]) を呼び出す', () => {
       /** readOk が空になり、readError に filePath が含まれることを検証する。 */
       describe('Then: T-FL-P2-07 - readError に DiscardFile が含まれる', () => {
-        it('T-FL-P2-07-01: readOk は空、readError[0] が filePath/filename/reason/decision を持つ', async () => {
+        it('T-FL-P2-07-01: readOk は空、readError[0] が filePath/filename/decision と実際のパースエラーメッセージを持つ reason を持つ', async () => {
           const filePath = `${periodDir1}/unclosed-frontmatter.md`;
           await Deno.writeTextFile(filePath, '---\ntitle: test\n本文...');
 
           const { readOk, readError } = await _phase2ReadSurvivors([filePath]);
 
           assertEquals(readOk, []);
-          assertEquals(readError, [
-            {
-              filePath,
-              filename: 'unclosed-frontmatter.md',
-              reason: '読み込み失敗',
-              decision: FILTER_DECISIONS.ERROR,
-            },
-          ]);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, filePath);
+          assertEquals(readError[0].filename, 'unclosed-frontmatter.md');
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+          assertNotEquals(readError[0].reason, '読み込み失敗');
         });
       });
     });
@@ -206,14 +202,11 @@ describe('_phase2ReadSurvivors', () => {
 
           assertEquals(readOk.length, 1);
           assertEquals(readOk[0].filePath, validPath);
-          assertEquals(readError, [
-            {
-              filePath: malformedPath,
-              filename: 'mixed-malformed.md',
-              reason: '読み込み失敗',
-              decision: FILTER_DECISIONS.ERROR,
-            },
-          ]);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, malformedPath);
+          assertEquals(readError[0].filename, 'mixed-malformed.md');
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+          assertNotEquals(readError[0].reason, '読み込み失敗');
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -144,31 +144,45 @@ export const _phase1PartitionByFilename = (
   return { fileList, discardFiles };
 };
 
+/** `_readEntry` の読み込み結果。読み込み成功（`ok`）か失敗確定（`error`）のいずれかを表す。 */
+type _ReadEntryResult =
+  | { kind: 'ok'; entry: ChatlogEntry }
+  | { kind: 'error'; result: DiscardFile };
+
 /**
- * 1 ファイルを読み込み `ChatlogEntry` を生成する。読み込み・パースに失敗した場合は `null` を返す。
+ * 1 ファイルを読み込み `ChatlogEntry` を生成する。
  *
  * ファイル読み込み失敗、および `ChatlogEntry` コンストラクタでのパース失敗（不正な frontmatter 等）の
- * いずれも「読み込み失敗」として扱う。
+ * いずれも失敗として扱い、実際のエラーメッセージを `reason` に格納した `DiscardFile` を返す。
  *
  * @param filePath - 読み込み対象のファイルパス
- * @returns 読み込み・パースに成功した場合は `ChatlogEntry`、失敗した場合は `null`
+ * @returns 読み込み・パースに成功した場合は `{ kind: 'ok', entry }`、失敗した場合は `{ kind: 'error', result }`
  */
-const _readEntry = async (filePath: string): Promise<ChatlogEntry | null> => {
+const _readEntry = async (filePath: string): Promise<_ReadEntryResult> => {
+  const filename = getFilename(filePath);
   const text = await readTextFile(filePath, { throwFileIoError: false });
   if (text instanceof Error) {
-    return null;
+    return {
+      kind: 'error',
+      result: { filePath, filename, reason: text.message, decision: FILTER_DECISIONS.ERROR },
+    };
   }
   try {
-    return new ChatlogEntry(text, { filePath });
-  } catch {
-    return null;
+    const entry = new ChatlogEntry(text, { filePath });
+    return { kind: 'ok', entry };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      kind: 'error',
+      result: { filePath, filename, reason: message, decision: FILTER_DECISIONS.ERROR },
+    };
   }
 };
 
 /**
  * ファイルリストの本文を並列に読み込み、frontmatter を除いた content を取り出す。
  *
- * 読み込みに失敗したファイルは `filePath` を `readError` に振り分ける。
+ * 読み込みに失敗したファイルは実際のエラーメッセージを `reason` に持つ `DiscardFile` として `readError` に振り分ける。
  *
  * @param survivors - 読み込み対象のファイルパス配列
  * @returns 読み込みに成功したファイル情報（`readOk`）と、読み込みに失敗したファイル情報（`readError`）
@@ -176,17 +190,15 @@ const _readEntry = async (filePath: string): Promise<ChatlogEntry | null> => {
 export const _phase2ReadSurvivors = async (
   survivors: string[],
 ): Promise<{ readOk: ChatlogEntry[]; readError: DiscardFile[] }> => {
-  const entries = await Promise.all(survivors.map((filePath) => _readEntry(filePath)));
+  const results = await Promise.all(survivors.map((filePath) => _readEntry(filePath)));
 
-  const readOk = entries.filter((entry): entry is ChatlogEntry => entry !== null);
-  const readError = survivors
-    .filter((_filePath, i) => entries[i] === null)
-    .map((filePath) => ({
-      filePath,
-      filename: getFilename(filePath),
-      reason: '読み込み失敗',
-      decision: FILTER_DECISIONS.ERROR,
-    }));
+  const readOk = results
+    .filter((r): r is { kind: 'ok'; entry: ChatlogEntry } => r.kind === 'ok')
+    .map((r) => r.entry);
+
+  const readError = results
+    .filter((r): r is { kind: 'error'; result: DiscardFile } => r.kind === 'error')
+    .map((r) => r.result);
 
   return { readOk, readError };
 };
@@ -271,6 +283,10 @@ export const _phase3PartitionByContent = (
 /**
  * 削除確定ファイルをバッチで削除し、stats を加算する。
  *
+ * `decision === FILTER_DECISIONS.DISCARD` のエントリのみを削除処理の対象とする。
+ * それ以外（`FILTER_DECISIONS.ERROR` 等）が誤って渡された場合は削除を試みず、
+ * そのまま戻り値に残す（呼び出し元が `toDelete` の組み立てを誤った場合の誤削除防止ガード）。
+ *
  * `dryRun === true` のときは削除を行わず `stats.skip` に加算してログ出力する（`files` をそのまま返す）。
  * `dryRun === false` のときは `removeFile()` を呼び、成功なら `stats.remove` に加算してログ出力し
  * 戻り値から除く。NotFound（`false`）を返した場合は `stats.error` に加算し、
@@ -280,15 +296,18 @@ export const _phase3PartitionByContent = (
  * @param files - 削除対象の `DiscardFile` 配列
  * @param dryRun - `true` のとき実削除を行わない
  * @param stats - 加算対象の処理統計オブジェクト
- * @returns 削除できなかった（未実施 or 失敗）ファイルの `DiscardFile` 配列
+ * @returns 削除できなかった（未実施 or 失敗）ファイル、および非 DISCARD エントリの `DiscardFile` 配列
  */
 export const _discardFiles = async (
   files: DiscardFile[],
   dryRun: boolean,
   stats: BaseStats,
 ): Promise<DiscardFile[]> => {
+  const toDiscard = files.filter((entry) => entry.decision === FILTER_DECISIONS.DISCARD);
+  const nonDiscard = files.filter((entry) => entry.decision !== FILTER_DECISIONS.DISCARD);
+
   const results = await Promise.all(
-    files.map(async (entry): Promise<DiscardFile | null> => {
+    toDiscard.map(async (entry): Promise<DiscardFile | null> => {
       const { filePath, filename, reason } = entry;
       if (dryRun) {
         logger.info(`  skipped (${reason}): ${filename}`);
@@ -305,7 +324,7 @@ export const _discardFiles = async (
       return null;
     }),
   );
-  return results.filter((entry): entry is DiscardFile => entry !== null);
+  return [...results.filter((entry): entry is DiscardFile => entry !== null), ...nonDiscard];
 };
 
 /**
@@ -335,6 +354,10 @@ export const prefilterFiles = async (
 
   const byRead = await _phase2ReadSurvivors(fileList);
   const byContent = _phase3PartitionByContent(byRead.readOk, minCharCount, minAssistantChars);
+
+  byRead.readError.forEach(({ filename, reason }) => {
+    logger.warn(`  read failed (${reason}): ${filename}`);
+  });
 
   const toDelete = [...discardFiles, ...byContent.results];
   stats.error += byRead.readError.length;


### PR DESCRIPTION
## Overview

**Summary**
Preserve actual read/parse error messages in prefilter and guard discard removal against non-DISCARD entries.

**Background / Motivation**
`prefilter.ts` used to swallow the real error and report a fixed string ("読み込み失敗") for any read or parse failure, making root-cause investigation hard. `_discardFiles` also removed entries without checking their `decision`, risking accidental deletion of `ERROR` entries. This PR returns the actual error reason via an explicit result type and adds a guard so only `DISCARD` entries are ever removed. It also removes the outdated `--report` option description from SKILL.md.

## Changes

### Core Changes

- `skills/filter-chatlogs/scripts/modules/prefilter.ts`
  - `_readEntry` now returns a `_ReadEntryResult` (`{ kind: 'ok' | 'error' }`) that carries the actual error message on failure, instead of `null`
  - `_phase2ReadSurvivors` simplified to match the new result type
  - `_discardFiles` now only removes entries with `decision === FILTER_DECISIONS.DISCARD`; non-DISCARD entries (e.g. `ERROR`) are left untouched
  - `prefilterFiles` logs read failures with their reason via `logger.warn`

### Test Updates

- `discard-files.functional.spec.ts`: verify `ERROR` entries are kept and only `DISCARD` entries are removed
- `prefilter.functional.spec.ts`: verify read failures stay in `passed`, cover mixed success/failure cases, verify warning logs include filename and reason
- `phase2-read-survivors.functional.spec.ts`: cover both success and failure paths, verify the actual error reason is preserved

### Removed

- `skills/filter-chatlogs/SKILL.md`: removed the unimplemented `--report` option (description, example, and notification format)

## Change Type (optional)

- [x] Bug fix
- [x] Documentation

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
