### PR TITLE
refactor(noise-filter): split noise filtering into phases

### DIFF
--- a/skills/filter-chatlogs/SKILL.md
+++ b/skills/filter-chatlogs/SKILL.md
@@ -44,7 +44,7 @@ allowed-tools: Bash, Glob
 - `agent`（例: `chatgpt`）→ 指定 agent の全体
 - `agent YYYY-MM`（例: `chatgpt 2026-03`）→ 指定 agent・指定月
 - `path`（例: `chatlogs\claude\2026\2026-04`）→ 指定パスをそのまま渡す（agent/period の代わり）
-- `--dry-run` → 削除せず、ノイズ候補のパスを標準出力に表示
+- `--dry-run` → 削除せず、ノイズ候補のパスと判定理由をログ出力
 
 ## ステップ1: スクリプトパスの解決
 
@@ -89,19 +89,20 @@ deno run --allow-read --allow-write "$NOISE_FILTER_PATH" $REST_ARGS
 ### filter サブコマンドまたはサブコマンドなしの場合
 
 先頭トークンが `filter` なら除去し、それ以外（サブコマンドなし）はそのまま `$ARGS` として使用する。
-解決した `SCRIPT_PATH` を使い、Bash で実行する（`--input` は**追加しない**）:
+解決した `SCRIPT_PATH` を使い、Bash で実行する（`--input` は**追加しない**）。
+`ChatlogCache` の初期化で `TEMP` 環境変数を参照するため `--allow-env` が必須:
 
 ```bash
-deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" $ARGS
+deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" $ARGS
 ```
 
 引数からオプションを組み立てるルール:
 
-- 引数なし → `deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH"`
-- `agent` のみ → `deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" chatgpt`
-- `YYYY-MM` のみ → `deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" 2026-03`
-- `agent YYYY-MM` → `deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" chatgpt 2026-03`
-- `agent YYYY-MM project` → `deno run --allow-read --allow-run --allow-write "$SCRIPT_PATH" chatgpt 2026-03 aplys`
+- 引数なし → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH"`
+- `agent` のみ → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt`
+- `YYYY-MM` のみ → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" 2026-03`
+- `agent YYYY-MM` → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt 2026-03`
+- `agent YYYY-MM project` → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt 2026-03 aplys`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
 
 スクリプトは以下の基準でKEEP/DISCARDを判定し、DISCARDかつ confidence >= 0.7 のファイルを削除する:

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
@@ -84,8 +84,8 @@ describe('main (noise-filter) - dry-run モード', () => {
   describe('Given: ノイズファイル名の .md ファイルと --dry-run フラグ', () => {
     /** `main(["claude", "--dry-run", "--input-dir", chatlogsDir])` を呼び出すとき。 */
     describe('When: main(["claude", "--dry-run", "--input-dir", chatlogsDir]) を呼び出す', () => {
-      /** ファイルが削除されず、stdout にノイズファイルのパスが出力されること。 */
-      describe('Then: T-PF-E2E-01 - ファイルが削除されずパスが stdout に出力される', () => {
+      /** ファイルが削除されず、info ログにノイズファイルのパスが出力されること。 */
+      describe('Then: T-PF-E2E-01 - ファイルが削除されずパスが info ログに出力される', () => {
         let tempDir: string;
         let chatlogsDir: string;
         let loggerStub: LoggerStub;
@@ -101,14 +101,14 @@ describe('main (noise-filter) - dry-run モード', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        it('T-PF-E2E-01-01: ファイルが削除されずに残り、stdout にパスが出力される', async () => {
+        it('T-PF-E2E-01-01: ファイルが削除されずに残り、info ログにパスが出力される', async () => {
           const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, _makeValidContent());
 
           await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
           assertEquals(await fileExists(filePath), true);
-          assertEquals(loggerStub.logLogs.some((line) => line.includes('say-ok-and-nothing-else.md')), true);
+          assertEquals(loggerStub.infoLogs.some((line) => line.includes('say-ok-and-nothing-else.md')), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/libs/classify-file.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/libs/classify-file.functional.spec.ts
@@ -14,251 +14,65 @@ import { describe, it } from '@std/testing/bdd';
 // ─── Test target
 import { classifyFile } from '../../../libs/classify-file.ts';
 
-// ─── Helpers
-import { makeRepeatedContent } from '../../_helpers/fixtures.ts';
-// constants
-import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
-
 // ─── Tests
 
 /**
  * `classifyFile` 関数の機能テストスイート。
  *
- * `classifyFile(filename, text)` はファイル名パターン・User ターンのノイズパターン・
- * Assistant 応答長の 3 段階でノイズを判定し、`{ isNoise, reason }` を返す。
+ * `classifyFile(file)` は単一ファイルの `filename` にファイル名パターン一致チェックを適用し、
+ * マッチした場合のみ `NoiseDiscardFile` を返す。マッチしない場合は `null` を返す。
  *
- * ## 判定優先順位
- * 1. ファイル名パターン一致 → `isNoise=true`（後段チェックをスキップ）
- * 2. User ターンがシステムタグのみ → `isNoise=true`
- * 3. Assistant 応答が短すぎる（< 100 文字）→ `isNoise=true`
- * 4. 上記いずれにも該当しない → `isNoise=false`
- *
- * テスト ID 範囲: T-PF-CL-01 〜 T-PF-CL-09
+ * テスト ID 範囲: T-PF-CL-01
  *
  * @see classifyFile
  */
 describe('classifyFile', () => {
   /**
-   * 除外パターンに一致するファイル名（`say-ok-and-nothing-else.md`）と有効な内容の前提条件グループ。
+   * 除外パターンに一致するファイル名（`say-ok-and-nothing-else.md`）の前提条件グループ。
    *
-   * 内容に関係なく、ファイル名だけで `isNoise=true` になることを検証する。
+   * ファイル名だけで判定対象になることを検証する。
    */
-  describe('Given: "say-ok-and-nothing-else.md" と有効な内容テキスト', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** isNoise=true かつ reason にファイル名パターンの説明が含まれることを検証する。 */
-      describe('Then: T-PF-CL-01 - isNoise=true が返される', () => {
-        it('T-PF-CL-01-01: isNoise が true になる', () => {
-          const { isNoise } = classifyFile(
-            'say-ok-and-nothing-else.md',
-            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
-          );
+  describe('Given: "say-ok-and-nothing-else.md" というファイル', () => {
+    /** classifyFile(file) を呼び出すとき。 */
+    describe('When: classifyFile(file) を呼び出す', () => {
+      /** 戻り値が該当ファイルの NoiseDiscardFile となり、reason にファイル名パターンの説明が含まれることを検証する。 */
+      describe('Then: T-PF-CL-01 - 該当ファイルが NoiseDiscardFile として返される', () => {
+        it('T-PF-CL-01-01: 戻り値が該当ファイルの NoiseDiscardFile になる', () => {
+          const result = classifyFile({
+            filePath: '/a/say-ok-and-nothing-else.md',
+            filename: 'say-ok-and-nothing-else.md',
+          });
 
-          assertEquals(isNoise, true);
+          assertEquals(result?.filePath, '/a/say-ok-and-nothing-else.md');
+          assertEquals(result?.filename, 'say-ok-and-nothing-else.md');
         });
 
         it('T-PF-CL-01-02: reason に "ファイル名パターン:" が含まれる', () => {
-          const { reason } = classifyFile(
-            'say-ok-and-nothing-else.md',
-            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
-          );
+          const result = classifyFile({
+            filePath: '/a/say-ok-and-nothing-else.md',
+            filename: 'say-ok-and-nothing-else.md',
+          });
 
-          assertEquals(reason.includes('ファイル名パターン:'), true);
+          assertEquals(result?.reason.includes('ファイル名パターン:'), true);
         });
       });
     });
   });
 
   /**
-   * 通常ファイル名かつ User ターンが `<system-reminder>` タグのみの前提条件グループ。
+   * ファイル名パターンに一致しない通常ファイル名の前提条件グループ。
    *
-   * 有意な User 発話がなく、`isNoise=true` になることを検証する。
+   * 戻り値が `null` になることを検証する。
    */
-  describe('Given: 通常ファイル名 + <system-reminder> のみの User ターン', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** isNoise=true が返されることを検証する。 */
-      describe('Then: T-PF-CL-02 - isNoise=true が返される', () => {
-        it('T-PF-CL-02-01: isNoise が true になる', () => {
-          const text = '### User\n<system-reminder>システムメッセージ</system-reminder>\n\n### Assistant\n'
-            + 'a'.repeat(200) + '\n';
-          const { isNoise } = classifyFile('normal-file.md', text);
+  describe('Given: 通常ファイル名のファイル', () => {
+    /** classifyFile(file) を呼び出すとき。 */
+    describe('When: classifyFile(file) を呼び出す', () => {
+      /** 戻り値が `null` であることを検証する。 */
+      describe('Then: T-PF-CL-01 - null が返される', () => {
+        it('T-PF-CL-01-03: 戻り値が null になる', () => {
+          const result = classifyFile({ filePath: '/a/valid-chat.md', filename: 'valid-chat.md' });
 
-          assertEquals(isNoise, true);
-        });
-      });
-    });
-  });
-
-  /**
-   * 通常ファイル名 + 正常 User ターン + 30 文字の短い Assistant ターンの前提条件グループ。
-   *
-   * Assistant 応答が 100 文字未満のため `isNoise=true` になることを検証する。
-   */
-  describe('Given: 通常ファイル名 + 1 件 User ターン + 30 文字の Assistant ターン', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** isNoise=true かつ reason に「短すぎる」が含まれることを検証する。 */
-      describe('Then: T-PF-CL-03 - isNoise=true が返される', () => {
-        it('T-PF-CL-03-01: isNoise が true になる', () => {
-          const text = '### User\n' + 'u'.repeat(200) + '\n\n### Assistant\n短い\n';
-          const { isNoise } = classifyFile('normal-file.md', text);
-
-          assertEquals(isNoise, true);
-        });
-
-        it('T-PF-CL-03-02: reason に "短すぎる" が含まれる', () => {
-          const text = '### User\n' + 'u'.repeat(200) + '\n\n### Assistant\n短い\n';
-          const { reason } = classifyFile('normal-file.md', text);
-
-          assertEquals(reason.includes('短すぎる'), true);
-        });
-      });
-    });
-  });
-
-  /**
-   * 通常ファイル名 + 十分な長さの User/Assistant ターンの前提条件グループ。
-   *
-   * すべての除外条件に該当せず、`isNoise=false` になることを検証する。
-   */
-  describe('Given: 通常ファイル名 + 十分な User/Assistant ターン', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** isNoise=false かつ reason が空文字列であることを検証する。 */
-      describe('Then: T-PF-CL-04 - isNoise=false が返される', () => {
-        it('T-PF-CL-04-01: isNoise が false になる', () => {
-          const { isNoise } = classifyFile('valid-chat.md', makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH));
-
-          assertEquals(isNoise, false);
-        });
-
-        it('T-PF-CL-04-02: reason が空文字列になる', () => {
-          const { reason } = classifyFile('valid-chat.md', makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH));
-
-          assertEquals(reason, '');
-        });
-      });
-    });
-  });
-
-  /**
-   * frontmatter あり・本文が正常な会話の前提条件グループ。
-   *
-   * `ChatlogEntry` が frontmatter を除いた content のみを会話解析に渡すため、
-   * frontmatter の内容に関わらず `isNoise=false` になることを検証する。
-   */
-  describe('Given: frontmatter 付きの通常会話テキスト', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** frontmatter は会話解析対象外のため isNoise=false であることを検証する。 */
-      describe('Then: T-PF-CL-05 - isNoise=false が返される（frontmatter は会話解析対象外）', () => {
-        it('T-PF-CL-05-01: isNoise が false になる', () => {
-          const text = [
-            '---',
-            'title: テスト会話',
-            'date: 2026-01-01',
-            '---',
-            '',
-            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
-          ].join('\n');
-          const { isNoise } = classifyFile('valid-chat.md', text);
-
-          assertEquals(isNoise, false);
-        });
-      });
-    });
-  });
-
-  /**
-   * frontmatter の閉じ区切りがない不正フォーマットの前提条件グループ。
-   *
-   * `classifyFile` が `ChatlogEntry` の `InvalidFormat` エラーをキャッチし、
-   * エラーをスローせず安全に処理することを検証する。
-   */
-  describe('Given: frontmatter の閉じ区切りがない不正フォーマットテキスト', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** エラーをスローせず isNoise=false が返されることを検証する。 */
-      describe('Then: T-PF-CL-07 - エラーをスローせず isNoise=false が返される', () => {
-        it('T-PF-CL-07-01: エラーをスローしない', () => {
-          const text = [
-            '---',
-            'title: 不正フォーマット',
-            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
-          ].join('\n');
-          let threw = false;
-          try {
-            classifyFile('malformed.md', text);
-          } catch {
-            threw = true;
-          }
-
-          assertEquals(threw, false);
-        });
-
-        it('T-PF-CL-07-02: isNoise が false になる（削除対象にしない）', () => {
-          const text = [
-            '---',
-            'title: 不正フォーマット',
-            makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH),
-          ].join('\n');
-          const { isNoise } = classifyFile('malformed.md', text);
-
-          assertEquals(isNoise, false);
-        });
-      });
-    });
-  });
-
-  /**
-   * frontmatter あり・本文がノイズ会話の前提条件グループ。
-   *
-   * `ChatlogEntry` が frontmatter を除いた content を渡すため、
-   * ノイズパターンが content から正しく検出されることを検証する。
-   */
-  describe('Given: frontmatter 付きのノイズ会話テキスト', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** isNoise=true かつ reason が空でないことを検証する。 */
-      describe('Then: T-PF-CL-08 - isNoise=true が返される', () => {
-        it('T-PF-CL-08-01: isNoise が true になる', () => {
-          const text = [
-            '---',
-            'title: ノイズ会話',
-            '---',
-            '',
-            '### User',
-            '=== GIT LOGS ===\ngit log --oneline',
-            '',
-            '### Assistant',
-            '了解',
-            '',
-          ].join('\n');
-          const { isNoise } = classifyFile('noise-chat.md', text);
-
-          assertEquals(isNoise, true);
-        });
-      });
-    });
-  });
-
-  /**
-   * ファイル名が除外パターン一致かつ User がシステムタグのみの前提条件グループ。
-   *
-   * ファイル名チェックが最優先で評価され、User コンテンツチェックに到達しないことを検証する。
-   */
-  describe('Given: ファイル名が除外パターン一致 かつ User がシステムタグのみ', () => {
-    /** classifyFile(filename, text) を呼び出すとき。 */
-    describe('When: classifyFile(filename, text) を呼び出す', () => {
-      /** reason がファイル名パターンの説明のみを含み、User チェックの reason ではないことを検証する。 */
-      describe('Then: T-PF-CL-06 - reason が "ファイル名パターン:" のみを含む', () => {
-        it('T-PF-CL-06-01: reason が "ファイル名パターン:" を含む（checkUserContent の reason ではない）', () => {
-          const text = '### User\n<system-reminder>msg</system-reminder>\n\n### Assistant\n'
-            + 'a'.repeat(200) + '\n';
-          const { reason } = classifyFile('say-ok-and-nothing-else.md', text);
-
-          assertEquals(reason.includes('ファイル名パターン:'), true);
+          assertEquals(result, null);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/integration/noise-filter/noise-filter.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/noise-filter/noise-filter.integration.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/__tests__/integration/noise-filter/noise-filter.integration.spec.ts
 // @(#): noise-filter-chatlogs.ts の統合テスト
-//       findMdFiles → classifyFile パイプライン
+//       findMdFiles → checkFilename/classifyConversation パイプライン
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -10,12 +10,13 @@ import { assertEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // test target
-import { classifyFile } from '../../../libs/classify-file.ts';
+import { checkFilename, classifyConversation, readConversation } from '../../../libs/classify-file.ts';
 
 // ─── Helpers
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { resolveChatlogsDir } from '../../../../../_scripts/libs/file-io/resolve-directory.ts';
 import { findFiles } from '../../../../../_scripts/libs/file-ops/find-files.ts';
+import { getFilename } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 import { makeRepeatedContent } from '../../_helpers/fixtures.ts';
 // constants
 import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../../_helpers/constants.ts';
@@ -50,29 +51,31 @@ const _runPipeline = async (
 ): Promise<{ noise: number; keep: number }> => {
   const _searchDir = resolveChatlogsDir({ chatlogsDir, agent, period });
   const files = await findFiles(_searchDir);
-  let noise = 0;
-  let keep = 0;
 
-  for (const filePath of files) {
-    const filename = filePath.split(/[/\\]/).pop()!;
-    const text = await readTextFile(filePath);
-    const { isNoise } = classifyFile(filename, text);
-    if (isNoise) { noise++; }
-    else { keep++; }
-  }
+  const results = await Promise.all(
+    files.map(async (filePath): Promise<boolean> => {
+      const filename = getFilename(filePath);
+      if (checkFilename(filename) !== null) { return true; }
+      const text = await readTextFile(filePath);
+      return classifyConversation(readConversation(text)) !== null;
+    }),
+  );
 
-  return { noise, keep };
+  return {
+    noise: results.filter((isNoise) => isNoise).length,
+    keep: results.filter((isNoise) => !isNoise).length,
+  };
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-// findMdFiles → classifyFile パイプライン
+// findMdFiles → checkFilename/classifyConversation パイプライン
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('findMdFiles → classifyFile パイプライン', () => {
+describe('findMdFiles → checkFilename/classifyConversation パイプライン', () => {
   // ─── T-PF-INT-01: 混在ディレクトリ → noise/keep を正しく分類 ────────────────
 
   describe('Given: ノイズと正常ファイルが混在するディレクトリ', () => {
-    describe('When: findMdFiles → classifyFile パイプラインを実行', () => {
+    describe('When: findMdFiles → checkFilename/classifyConversation パイプラインを実行', () => {
       describe('Then: T-PF-INT-01 - noise=3, keep=2 になる', () => {
         it('T-PF-INT-01-01: noise 判定が 3 件、keep 判定が 2 件になる', async () => {
           const baseDir = `${tempDir}/claude/2026/2026-03`;
@@ -102,7 +105,7 @@ describe('findMdFiles → classifyFile パイプライン', () => {
   // ─── T-PF-INT-02: period 指定 → 指定月のみパイプラインを通過 ─────────────────
 
   describe('Given: 2026-03 と 2026-04 に各 1 件の正常ファイル', () => {
-    describe('When: findMdFiles(tempDir, "claude", "2026-03") → classifyFile パイプライン', () => {
+    describe('When: findMdFiles(tempDir, "claude", "2026-03") → checkFilename/classifyConversation パイプライン', () => {
       describe('Then: T-PF-INT-02 - 2026-03 の 1 件のみが処理される', () => {
         it('T-PF-INT-02-01: パイプラインに渡されるのは 2026-03 の 1 件のみ', async () => {
           await _makeTestFile(`${tempDir}/claude/2026/2026-03/chat.md`, _makeValidContent());
@@ -133,7 +136,7 @@ describe('findMdFiles → classifyFile パイプライン', () => {
   // ─── T-PF-INT-03: 全ファイルが正常 → 全件 keep ───────────────────────────────
 
   describe('Given: 3 件の正常ファイル', () => {
-    describe('When: findMdFiles → classifyFile パイプラインを実行', () => {
+    describe('When: findMdFiles → checkFilename/classifyConversation パイプラインを実行', () => {
       describe('Then: T-PF-INT-03 - 全 3 件が keep になる', () => {
         it('T-PF-INT-03-01: noise=0, keep=3 になる', async () => {
           const baseDir = `${tempDir}/claude/2026/2026-03`;
@@ -153,7 +156,7 @@ describe('findMdFiles → classifyFile パイプライン', () => {
   // ─── T-PF-INT-04: 全ファイルがノイズ → 全件 noise ────────────────────────────
 
   describe('Given: 3 件の除外パターンファイル名ファイル', () => {
-    describe('When: findMdFiles → classifyFile パイプラインを実行', () => {
+    describe('When: findMdFiles → checkFilename/classifyConversation パイプラインを実行', () => {
       describe('Then: T-PF-INT-04 - 全 3 件が noise になる', () => {
         it('T-PF-INT-04-01: noise=3, keep=0 になる', async () => {
           const baseDir = `${tempDir}/claude/2026/2026-03`;
@@ -173,7 +176,7 @@ describe('findMdFiles → classifyFile パイプライン', () => {
   // ─── T-PF-INT-05: ディレクトリなし → パイプラインが空を処理 ─────────────────
 
   describe('Given: agent ディレクトリが存在しない', () => {
-    describe('When: findMdFiles → classifyFile パイプラインを実行', () => {
+    describe('When: findMdFiles → checkFilename/classifyConversation パイプラインを実行', () => {
       describe('Then: T-PF-INT-05 - findMdFiles が空配列を返す', () => {
         it('T-PF-INT-05-01: noise=0, keep=0 になる', async () => {
           const { noise, keep } = await _runPipeline(tempDir, 'claude');

--- a/skills/filter-chatlogs/scripts/libs/__tests__/unit/classify-file.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/libs/__tests__/unit/classify-file.unit.spec.ts
@@ -8,7 +8,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assert } from '@std/assert';
+import { assert, assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 import { assertNotNull, assertNull } from '../../../../../_scripts/__tests__/helpers/assert.ts';
 
@@ -19,6 +19,8 @@ import {
   checkFilename,
   checkPromptContent,
   checkUserContent,
+  classifyConversation,
+  readConversation,
 } from '../../../libs/classify-file.ts';
 
 // ─── Helpers
@@ -801,6 +803,153 @@ describe('checkPromptContent', () => {
 
       assertNull(result);
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// readConversation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `readConversation` のユニットテストスイート。
+ *
+ * frontmatter 付きテキストの会話パース、および frontmatter の閉じ区切りがない
+ * 不正フォーマットに対する修復フォールバックを検証する。
+ *
+ * テスト ID 範囲: T-PF-RC-01 〜 T-PF-RC-02
+ *
+ * @see readConversation
+ */
+describe('readConversation', () => {
+  /** frontmatter を除いた content から会話ターンが正しく解析されるケース。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-PF-RC-01-01: frontmatter 付きテキスト → content 部分の User/Assistant ターンが解析される', () => {
+      const text = [
+        '---',
+        'title: テスト会話',
+        '---',
+        '',
+        '### User',
+        '質問テキスト',
+        '',
+        '### Assistant',
+        '応答テキスト',
+        '',
+      ].join('\n');
+
+      const conversation = readConversation(text);
+
+      assertEquals(conversation.length, 2);
+      assertEquals(conversation[0].content, '質問テキスト');
+      assertEquals(conversation[1].content, '応答テキスト');
+    });
+  });
+
+  /** frontmatter の閉じ区切りがない不正フォーマットに対する修復フォールバックのケース。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-PF-RC-02-01: frontmatter の閉じ区切りがない → 例外をスローせず会話を返す', () => {
+      const text = [
+        '---',
+        'title: 不正フォーマット',
+        '',
+        '### User',
+        '質問テキスト',
+        '',
+        '### Assistant',
+        '応答テキスト',
+        '',
+      ].join('\n');
+
+      let threw = false;
+      let conversation: Turn[] = [];
+      try {
+        conversation = readConversation(text) as Turn[];
+      } catch {
+        threw = true;
+      }
+
+      assertEquals(threw, false);
+      assert(conversation.length > 0);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classifyConversation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `classifyConversation` のユニットテストスイート。
+ *
+ * checkUserContent → checkConversationPattern → checkPromptContent → checkAssistantContent
+ * の優先順位で最初に一致した reason を返すこと、いずれも一致しない場合に null を返すことを検証する。
+ *
+ * テスト ID 範囲: T-PF-CC-01 〜 T-PF-CC-02
+ *
+ * @see classifyConversation
+ */
+describe('classifyConversation', () => {
+  /** @param turns - ロール・テキストペアから Turn[] を生成するヘルパー。 */
+  function _makeTurns(turns: Array<{ role: 'user' | 'assistant'; content: string }>): Turn[] {
+    return turns;
+  }
+
+  /** 複数チェックに一致しうる会話で、より優先度の高い checkUserContent の reason が返るケース。 */
+  describe('When: 正常系', () => {
+    it(
+      '[Normal] T-PF-CC-01-01: Userターン不在（checkUserContent該当） → checkUserContentのreasonを返す',
+      () => {
+        const turns = _makeTurns([{ role: 'assistant', content: '回答' }]);
+
+        const result = classifyConversation(turns);
+
+        assertNotNull(result);
+        assert(result!.includes('Userターンが存在しない'));
+      },
+    );
+
+    it('[Normal] T-PF-CC-01-02: 通常の会話 → null を返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: 'この機能の設計についてどう思いますか？' },
+        { role: 'assistant', content: 'a'.repeat(MIN_ASSISTANT_CHARS) },
+      ]);
+
+      const result = classifyConversation(turns);
+
+      assertNull(result);
+    });
+  });
+
+  /** checkUserContent は一致せず checkConversationPattern が一致するケース（優先順位の検証）。 */
+  describe('When: エッジケース', () => {
+    it(
+      '[Edge] T-PF-CC-02-01: Git操作ログパターン（checkConversationPattern該当）→ そのreasonを返す',
+      () => {
+        const turns = _makeTurns([
+          { role: 'user', content: '=== GIT LOGS ===\ngit log --oneline' },
+          { role: 'assistant', content: 'a'.repeat(MIN_ASSISTANT_CHARS) },
+        ]);
+
+        const result = classifyConversation(turns);
+
+        assertNotNull(result);
+      },
+    );
+
+    it(
+      '[Edge] T-PF-CC-03-01: checkUserContent と checkAssistantContent の両方が該当 → checkUserContentのreasonを優先する',
+      () => {
+        const turns = _makeTurns([
+          { role: 'user', content: '<system-reminder>x</system-reminder>' },
+          { role: 'assistant', content: '短い' },
+        ]);
+
+        const result = classifyConversation(turns);
+
+        assertNotNull(result);
+        assert(result!.includes('システムTag'));
+      },
+    );
   });
 });
 

--- a/skills/filter-chatlogs/scripts/libs/classify-file.ts
+++ b/skills/filter-chatlogs/scripts/libs/classify-file.ts
@@ -35,6 +35,8 @@ import {
   SYSTEM_TAG_REGEX,
 } from '../constants/patterns.constants.ts';
 // types
+import { FILTER_DECISIONS } from '../types/filter-decision.const.types.ts';
+import type { NoiseDiscardFile } from '../types/noise-filter.types.ts';
 import { ENTRY_CONTROL } from '../types/patterns.types.ts';
 import type {
   ConversationEntry,
@@ -171,40 +173,52 @@ export const checkAssistantContent = (conversation: Conversation): string | null
 // メイン判定関数
 // ─────────────────────────────────────────────
 
-export const classifyFile = (filename: string, text: string): { isNoise: boolean; reason: string } => {
-  // 1. ファイル名チェック
-  const filenameReason = checkFilename(filename);
-  if (filenameReason) { return { isNoise: true, reason: filenameReason }; }
-
-  // 2. ChatlogEntry インスタンス生成（frontmatter + content 読み込み）
-  //    不正フォーマット（閉じ区切りなし）の場合は先頭の区切り行を除去して再生成する
+/**
+ * テキストから `ChatlogEntry` を生成し、本文を会話ターンに解析する。
+ *
+ * frontmatter の閉じ区切りがない不正フォーマットの場合は、先頭の区切り行を除去して再生成する。
+ *
+ * @param text - チャットログの生テキスト（frontmatter + content）
+ * @returns 解析済みの会話ターン配列
+ */
+export const readConversation = (text: string): Conversation => {
   let _entry: ChatlogEntry;
   try {
     _entry = new ChatlogEntry(text);
   } catch {
     _entry = new ChatlogEntry(text.replace(/^---\n/, ''));
   }
+  return parseConversation(_entry.content);
+};
 
-  // 3. 会話ターン解析
-  const conversation = parseConversation(_entry.content);
+/**
+ * 会話に対して User本文・会話パターン・プロンプトパターン・Assistant応答長のチェックを順に適用する。
+ *
+ * @param conversation - 解析済みの会話ターン配列
+ * @returns 最初に一致したチェックの reason。いずれも一致しない場合は `null`
+ */
+export const classifyConversation = (conversation: Conversation): string | null =>
+  checkUserContent(conversation)
+    ?? checkConversationPattern(conversation)
+    ?? checkPromptContent(conversation)
+    ?? checkAssistantContent(conversation);
 
-  // 4. User本文チェック
-  const userReason = checkUserContent(conversation);
-  if (userReason) { return { isNoise: true, reason: userReason }; }
-
-  // 5. 会話パターンチェック
-  const conversationReason = checkConversationPattern(conversation);
-  if (conversationReason) { return { isNoise: true, reason: conversationReason }; }
-
-  // 6. プロンプトパターンチェック
-  const promptReason = checkPromptContent(conversation);
-  if (promptReason) { return { isNoise: true, reason: promptReason }; }
-
-  // 7. Assistant応答の長さチェック
-  const assistantReason = checkAssistantContent(conversation);
-  if (assistantReason) { return { isNoise: true, reason: assistantReason }; }
-
-  return { isNoise: false, reason: '' };
+/**
+ * ファイル名パターンのみでノイズ判定を行い、一致した場合は `NoiseDiscardFile` を返す。
+ *
+ * 会話内容の判定は行わない。呼び出し元が別途 `classifyConversation` を呼び出す想定。
+ * 複数ファイルに対するループ処理は呼び出し元が行う。
+ *
+ * @param file - ファイルパスとファイル名
+ * @returns ファイル名パターンに一致した場合は `NoiseDiscardFile`、一致しない場合は `null`
+ */
+export const classifyFile = (
+  file: { filePath: string; filename: string },
+): NoiseDiscardFile | null => {
+  const reason = checkFilename(file.filename);
+  return reason === null
+    ? null
+    : { filePath: file.filePath, filename: file.filename, reason, decision: FILTER_DECISIONS.DISCARD };
 };
 
 // テスト用エクスポート（本番コードでは使用しない）

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase1-read-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase1-read-files.functional.spec.ts
@@ -1,0 +1,185 @@
+// src: scripts/modules/noise-filter/__tests__/functional/phase1-read-files.functional.spec.ts
+// @(#): process-noise-files.ts の機能テスト
+//       対象: _phase1ReadFiles — ファイル並列読み込み・成功/失敗振り分け
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertNotEquals, assertRejects } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+// stub
+import { stub } from '@std/testing/mock';
+
+// ─── Test target
+import { _phase1ReadFiles } from '../../process-noise-files.ts';
+
+// ─── Helpers
+import { makeLoggerStub } from '../../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { getUserTurns } from '../../../../../../_scripts/libs/chatlogs/conversation-utils.ts';
+import { makeRepeatedContent } from '../../../../__tests__/_helpers/fixtures.ts';
+// types
+import type { LoggerStub } from '../../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+// constants
+import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../../../../__tests__/_helpers/constants.ts';
+import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
+
+// ─── Tests
+
+/**
+ * `_phase1ReadFiles` 関数の機能テストスイート。
+ *
+ * ファイルパス配列を並列に読み込み、成功エントリ（`filePath`/`filename`/`conversation`）と
+ * 失敗エントリ（`NoiseDiscardFile`、`decision: FILTER_DECISIONS.ERROR`）に振り分ける。
+ *
+ * テスト ID 範囲: T-PF-P1-01 〜 T-PF-P1-07
+ *
+ * @see _phase1ReadFiles
+ */
+describe('_phase1ReadFiles', () => {
+  /** テスト用一時ディレクトリ。 */
+  let tempDir: string;
+
+  /** logger stub。 */
+  let loggerStub: LoggerStub;
+
+  beforeEach(async () => {
+    tempDir = await Deno.makeTempDir();
+    loggerStub = makeLoggerStub();
+  });
+
+  afterEach(async () => {
+    loggerStub.restore();
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  // ─── T-PF-P1-01: 実在する単一ファイル → readOk に格納 ────────────────────────
+
+  describe('Given: 実在する単一ファイル', () => {
+    describe('When: _phase1ReadFiles([filePath]) を呼び出す', () => {
+      describe('Then: T-PF-P1-01 - readOk に filePath/filename/conversation が含まれる', () => {
+        it('T-PF-P1-01-01: readOk[0] が filePath/filename/conversation を持ち readError は空になる', async () => {
+          const filePath = `${tempDir}/valid.md`;
+          const content = makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH);
+          await Deno.writeTextFile(filePath, content);
+
+          const { readOk, readError } = await _phase1ReadFiles([filePath]);
+
+          assertEquals(readOk.length, 1);
+          assertEquals(readOk[0].filePath, filePath);
+          assertEquals(readOk[0].filename, 'valid.md');
+          assertEquals(getUserTurns(readOk[0].conversation)[0].content, 'u'.repeat(NOISE_FILTER_MIN_CONTENT_LENGTH));
+          assertEquals(readError, []);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P1-02: 存在しないファイル → readError に振り分け ───────────────────
+
+  describe('Given: 存在しないファイル', () => {
+    describe('When: _phase1ReadFiles([filePath]) を呼び出す', () => {
+      describe('Then: T-PF-P1-02 - readError に NoiseDiscardFile が含まれる', () => {
+        it('T-PF-P1-02-01: readOk は空、readError[0] が filePath/filename/decision=ERROR を持つ', async () => {
+          const filePath = `${tempDir}/non-existent.md`;
+
+          const { readOk, readError } = await _phase1ReadFiles([filePath]);
+
+          assertEquals(readOk, []);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, filePath);
+          assertEquals(readError[0].filename, 'non-existent.md');
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+          assertNotEquals(readError[0].reason, '');
+        });
+      });
+
+      // ─── T-PF-P1-06: 読み込み失敗があってもログ副作用を持たない ────────────────
+
+      describe('Then: T-PF-P1-06 - ログ出力を一切行わない', () => {
+        it('T-PF-P1-06-01: readError に振り分けられても loggerStub.errorLogs は空のまま', async () => {
+          const filePath = `${tempDir}/no-log.md`;
+
+          await _phase1ReadFiles([filePath]);
+
+          assertEquals(loggerStub.errorLogs, []);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P1-03: 正常ファイル1件と読み込み失敗ファイル1件が混在 ──────────────
+
+  describe('Given: 正常ファイル1件と読み込み失敗ファイル1件が混在するファイルリスト', () => {
+    describe('When: _phase1ReadFiles([validPath, missingPath]) を呼び出す', () => {
+      describe('Then: T-PF-P1-03 - 正常分と失敗分が振り分けられる', () => {
+        it('T-PF-P1-03-01: readOk に正常分のみ、readError に失敗分のみが含まれる', async () => {
+          const validPath = `${tempDir}/mixed-valid.md`;
+          const missingPath = `${tempDir}/mixed-missing.md`;
+          await Deno.writeTextFile(validPath, makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH));
+
+          const { readOk, readError } = await _phase1ReadFiles([validPath, missingPath]);
+
+          assertEquals(readOk.length, 1);
+          assertEquals(readOk[0].filePath, validPath);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, missingPath);
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P1-04: 空配列 ───────────────────────────────────────────────────────
+
+  describe('Given: files が空配列', () => {
+    describe('When: _phase1ReadFiles([]) を呼び出す', () => {
+      describe('Then: T-PF-P1-04 - readOk・readError ともに空配列を返す', () => {
+        it('T-PF-P1-04-01: readOk: [], readError: [] を返す', async () => {
+          const { readOk, readError } = await _phase1ReadFiles([]);
+
+          assertEquals(readOk, []);
+          assertEquals(readError, []);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P1-05: ファイル I/O 起因ではない例外 → catch せず伝播 ──────────────
+
+  describe('Given: readTextFile がファイル I/O 起因ではない例外を throw する', () => {
+    describe('When: _phase1ReadFiles([filePath]) を呼び出す', () => {
+      describe('Then: T-PF-P1-05 - 例外を catch せずそのまま伝播する', () => {
+        it('T-PF-P1-05-01: 素の Error が throw される場合、_phase1ReadFiles も reject する', async () => {
+          using _readStub = stub(Deno, 'readTextFile', () => Promise.reject(new Error('unexpected bug')));
+          const filePath = `${tempDir}/any.md`;
+
+          await assertRejects(() => _phase1ReadFiles([filePath]), Error, 'unexpected bug');
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P1-07: readConversation が ChatlogError を throw する不正フォーマット → readError に振り分け ──
+
+  describe('Given: readConversation が ChatlogError を throw する不正フォーマットファイル', () => {
+    describe('When: _phase1ReadFiles([filePath]) を呼び出す', () => {
+      describe('Then: T-PF-P1-07 - readError に NoiseDiscardFile が含まれる', () => {
+        it('T-PF-P1-07-01: readOk は空、readError[0] が filePath/decision=ERROR/非空 reason を持つ', async () => {
+          const filePath = `${tempDir}/invalid-frontmatter.md`;
+          await Deno.writeTextFile(filePath, '---');
+
+          const { readOk, readError } = await _phase1ReadFiles([filePath]);
+
+          assertEquals(readOk, []);
+          assertEquals(readError.length, 1);
+          assertEquals(readError[0].filePath, filePath);
+          assertEquals(readError[0].decision, FILTER_DECISIONS.ERROR);
+          assertNotEquals(readError[0].reason, '');
+        });
+      });
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
@@ -1,0 +1,126 @@
+// src: scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
+// @(#): process-noise-files.ts の機能テスト
+//       対象: _phase3DiscardOrSkip — ノイズ確定ファイルの削除/dry-run 実行
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { _phase3DiscardOrSkip } from '../../process-noise-files.ts';
+
+// ─── Helpers
+import { makeLoggerStub } from '../../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { fileExists } from '../../../../../../_scripts/libs/file-ops/exists-utils.ts';
+// types
+import type { LoggerStub } from '../../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+// constants
+import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
+
+// ─── Tests
+
+/**
+ * `_phase3DiscardOrSkip` 関数の機能テストスイート。
+ *
+ * ノイズ判定確定ファイル（`NoiseDiscardFile[]`）を受け取り、`dryRun` に応じて
+ * 実削除または dry-run ログ出力を行い、`stats` を加算する。
+ *
+ * テスト ID 範囲: T-PF-P3-01 〜 T-PF-P3-03
+ *
+ * @see _phase3DiscardOrSkip
+ */
+describe('_phase3DiscardOrSkip', () => {
+  /** テスト用一時ディレクトリ。 */
+  let tempDir: string;
+
+  /** logger stub。 */
+  let loggerStub: LoggerStub;
+
+  beforeEach(async () => {
+    tempDir = await Deno.makeTempDir();
+    loggerStub = makeLoggerStub();
+  });
+
+  afterEach(async () => {
+    loggerStub.restore();
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  // ─── T-PF-P3-01: 通常モード → 実削除され stats.remove 加算 ──────────────────
+
+  describe('Given: ノイズ確定ファイル 1 件と dryRun=false', () => {
+    describe('When: _phase3DiscardOrSkip(discardFiles, stats, false) を呼び出す', () => {
+      describe('Then: T-PF-P3-01 - ファイルが削除され stats.remove が 1 になる', () => {
+        it('T-PF-P3-01-01: ファイルが削除され stats.remove=1、logger.info に "deleted:" が出力される', async () => {
+          const filePath = `${tempDir}/noise.md`;
+          await Deno.writeTextFile(filePath, 'dummy');
+          const discardFiles = [
+            { filePath, filename: 'noise.md', reason: 'テスト理由', decision: FILTER_DECISIONS.DISCARD },
+          ];
+          const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
+
+          await _phase3DiscardOrSkip(discardFiles, stats, false);
+
+          assertEquals(await fileExists(filePath), false);
+          assertEquals(stats.remove, 1);
+          assertEquals(loggerStub.infoLogs.some((line) => line.includes(`deleted: ${filePath}`)), true);
+          assertEquals(loggerStub.infoLogs.some((line) => line.includes('テスト理由')), true);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P3-02: dry-run モード → 削除されずログ出力、stats.skip 加算 ────────
+
+  describe('Given: ノイズ確定ファイル 1 件と dryRun=true', () => {
+    describe('When: _phase3DiscardOrSkip(discardFiles, stats, true) を呼び出す', () => {
+      describe('Then: T-PF-P3-02 - ファイルが削除されず stats.skip が 1 になる', () => {
+        it('T-PF-P3-02-01: ファイルが削除されずに残り stats.skip=1、logger.log には出力されず logger.info にファイルパスと reason が出力される', async () => {
+          const filePath = `${tempDir}/noise.md`;
+          await Deno.writeTextFile(filePath, 'dummy');
+          const discardFiles = [
+            { filePath, filename: 'noise.md', reason: 'テスト理由', decision: FILTER_DECISIONS.DISCARD },
+          ];
+          const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
+
+          await _phase3DiscardOrSkip(discardFiles, stats, true);
+
+          assertEquals(await fileExists(filePath), true);
+          assertEquals(stats.skip, 1);
+          assertEquals(loggerStub.logLogs, []);
+          assertEquals(
+            loggerStub.infoLogs.some((line) => line.includes(filePath) && line.includes('テスト理由')),
+            true,
+          );
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P3-03: 削除対象ファイルが実削除前に既に存在しない → stats.error 加算 ─
+
+  describe('Given: ノイズ確定ファイルが実削除前に既に存在しない', () => {
+    describe('When: _phase3DiscardOrSkip(discardFiles, stats, false) を呼び出す', () => {
+      describe('Then: T-PF-P3-03 - stats.error が 1 になる', () => {
+        it('T-PF-P3-03-01: removeFile 失敗 → stats.error=1, stats.remove=0', async () => {
+          const filePath = `${tempDir}/vanished.md`;
+          const discardFiles = [
+            { filePath, filename: 'vanished.md', reason: 'テスト理由', decision: FILTER_DECISIONS.DISCARD },
+          ];
+          const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
+
+          await _phase3DiscardOrSkip(discardFiles, stats, false);
+
+          assertEquals(stats.error, 1);
+          assertEquals(stats.remove, 0);
+          assertEquals(loggerStub.warnLogs.some((line) => line.includes(filePath)), true);
+        });
+      });
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -140,13 +140,13 @@ describe('processNoiseFiles', () => {
   /**
    * ノイズファイルが dry-run モードで処理される前提グループ。
    *
-   * ファイルが削除されず、パスがログに出力されることを検証する。
+   * ファイルが削除されず、パスが info ログに出力されることを検証する。
    */
   describe('Given: ノイズファイル 1 件と dryRun=true', () => {
     /** `processNoiseFiles(files, counts, { dryRun: true })` を呼び出すとき。 */
     describe('When: processNoiseFiles を dry-run モードで呼び出す', () => {
-      /** ファイルが削除されず、ログにファイルパスが含まれること。 */
-      describe('Then: T-PF-PNF-03 - ファイルが削除されずパスがログに出力される', () => {
+      /** ファイルが削除されず、info ログにファイルパスが含まれること。 */
+      describe('Then: T-PF-PNF-03 - ファイルが削除されずパスが info ログに出力される', () => {
         it('T-PF-PNF-03-01: ファイルが削除されずに残る', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
@@ -157,14 +157,14 @@ describe('processNoiseFiles', () => {
           assertEquals(await fileExists(filePath), true);
         });
 
-        it('T-PF-PNF-03-02: logLogs にファイルパスが含まれる', async () => {
+        it('T-PF-PNF-03-02: infoLogs にファイルパスが含まれる', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           await Deno.writeTextFile(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([filePath], counts, { dryRun: true });
 
-          assertEquals(loggerStub.logLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
+          assertEquals(loggerStub.infoLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
         });
 
         it('T-PF-PNF-03-03: counts.skip が 1 になる', async () => {
@@ -201,6 +201,16 @@ describe('processNoiseFiles', () => {
           assertEquals(counts.error, 1);
           assertEquals(counts.remove, 0);
           assertEquals(counts.keep, 0);
+        });
+
+        it('[Error] T-PF-PNF-07-01: 読み込み失敗ファイル名を含むエラーログが出力される', async () => {
+          const filename = 'non-existent-file2.md';
+          const nonExistentPath = `${tempDir}/${filename}`;
+          const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
+
+          await processNoiseFiles([nonExistentPath], counts, { dryRun: false });
+
+          assertEquals(loggerStub.errorLogs.some((line) => line.includes(filename)), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/unit/phase0-classify-by-filename.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/unit/phase0-classify-by-filename.unit.spec.ts
@@ -1,0 +1,112 @@
+// src: scripts/modules/noise-filter/__tests__/unit/phase0-classify-by-filename.unit.spec.ts
+// @(#): process-noise-files.ts のユニットテスト
+//       対象: _phase0ClassifyByFilename — classifyFile によるファイル名ノイズ/通過分類
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { _phase0ClassifyByFilename } from '../../process-noise-files.ts';
+
+// ─── Helpers
+// constants
+import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
+
+// ─── Internal Helpers
+
+// constants
+/** ファイル名パターンでノイズ判定されるファイル名。 */
+const _NOISE_FILENAME = 'say-ok-and-nothing-else.md';
+
+/** ファイル名パターンに一致しない通常のファイル名。 */
+const _KEEP_FILENAME = 'valid-chat.md';
+
+// ─── Tests
+
+/**
+ * `_phase0ClassifyByFilename` のユニットテストスイート。
+ *
+ * ファイルパス配列を `classifyFile` でファイル名パターン判定し、
+ * ノイズ判定確定ファイル（`discardFiles`）と通過ファイル（`passFiles`）に振り分ける
+ * 純粋関数の動作を検証する。全件ノイズ・全件通過・混在・空配列を網羅する。
+ *
+ * テスト ID 範囲: T-PF-P0-01 〜 T-PF-P0-04
+ *
+ * @see _phase0ClassifyByFilename
+ */
+describe('_phase0ClassifyByFilename', () => {
+  // ─── T-PF-P0-01: 全件ファイル名ノイズ判定 ──────────────────────────────────────
+
+  describe('Given: ファイル名パターンに一致するファイルのみの配列', () => {
+    describe('When: _phase0ClassifyByFilename(files) を呼び出す', () => {
+      describe('Then: T-PF-P0-01 - discardFiles に全件、passFiles は空', () => {
+        it('T-PF-P0-01-01: 全件が discardFiles に入り passFiles は空になる', () => {
+          const files = [`/a/${_NOISE_FILENAME}`];
+
+          const result = _phase0ClassifyByFilename(files);
+
+          assertEquals(result.passFiles, []);
+          assertEquals(result.discardFiles.length, 1);
+          assertEquals(result.discardFiles[0].filePath, `/a/${_NOISE_FILENAME}`);
+          assertEquals(result.discardFiles[0].decision, FILTER_DECISIONS.DISCARD);
+          assertEquals(result.discardFiles[0].reason.length > 0, true);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P0-02: 全件ファイル名パターン不一致 ──────────────────────────────────
+
+  describe('Given: ファイル名パターンに一致しないファイルのみの配列', () => {
+    describe('When: _phase0ClassifyByFilename(files) を呼び出す', () => {
+      describe('Then: T-PF-P0-02 - passFiles に全件、discardFiles は空', () => {
+        it('T-PF-P0-02-01: 全件が passFiles に入り discardFiles は空になる', () => {
+          const files = [`/a/${_KEEP_FILENAME}`];
+
+          const result = _phase0ClassifyByFilename(files);
+
+          assertEquals(result.passFiles, [`/a/${_KEEP_FILENAME}`]);
+          assertEquals(result.discardFiles, []);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P0-03: ノイズと通過が混在 ────────────────────────────────────────────
+
+  describe('Given: ファイル名ノイズ判定と通過が混在する配列', () => {
+    describe('When: _phase0ClassifyByFilename(files) を呼び出す', () => {
+      describe('Then: T-PF-P0-03 - それぞれ正しい配列に振り分けられる', () => {
+        it('T-PF-P0-03-01: 通過1件+ノイズ1件 → passFiles/discardFiles に正しく分類される', () => {
+          const files = [`/a/${_KEEP_FILENAME}`, `/b/${_NOISE_FILENAME}`];
+
+          const result = _phase0ClassifyByFilename(files);
+
+          assertEquals(result.passFiles, [`/a/${_KEEP_FILENAME}`]);
+          assertEquals(result.discardFiles.map((d) => d.filePath), [`/b/${_NOISE_FILENAME}`]);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P0-04: 空配列 ─────────────────────────────────────────────────────────
+
+  describe('Given: 空のファイルパス配列', () => {
+    describe('When: _phase0ClassifyByFilename([]) を呼び出す', () => {
+      describe('Then: T-PF-P0-04 - discardFiles/passFiles ともに空配列', () => {
+        it('T-PF-P0-04-01: discardFiles と passFiles がともに空配列になる', () => {
+          const result = _phase0ClassifyByFilename([]);
+
+          assertEquals(result.discardFiles, []);
+          assertEquals(result.passFiles, []);
+        });
+      });
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/unit/phase2-classify-conversations.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/unit/phase2-classify-conversations.unit.spec.ts
@@ -1,0 +1,122 @@
+// src: scripts/modules/noise-filter/__tests__/unit/phase2-classify-conversations.unit.spec.ts
+// @(#): process-noise-files.ts のユニットテスト
+//       対象: _phase2ClassifyConversations — classifyConversation による内容ノイズ/keep 分類
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { _phase2ClassifyConversations } from '../../process-noise-files.ts';
+
+// ─── Helpers
+import { readConversation } from '../../../../libs/classify-file.ts';
+// constants
+import { FILTER_DECISIONS } from '../../../../types/filter-decision.const.types.ts';
+
+// ─── Internal Helpers
+
+// constants
+/** ノイズ判定されるファイル名相当（内容判定専用のため、ここでは通常のファイル名を使う）。 */
+const _NOISE_FILENAME = 'noise-chat.md';
+
+/** keep 判定されるファイル名。 */
+const _KEEP_FILENAME = 'valid-chat.md';
+
+/** KEEP 判定を通過する会話（読み込み済み）。 */
+const _VALID_CONVERSATION = readConversation(`### User\n${'u'.repeat(300)}\n\n### Assistant\n${'a'.repeat(300)}\n`);
+
+/** 内容判定でノイズ確定する会話（読み込み済み、Assistant応答が短すぎる）。 */
+const _NOISE_CONVERSATION = readConversation(`### User\n${'u'.repeat(300)}\n\n### Assistant\n短い\n`);
+
+// ─── Tests
+
+/**
+ * `_phase2ClassifyConversations` のユニットテストスイート。
+ *
+ * `_phase1ReadFiles` の読み込み成功エントリを `classifyConversation` で分類し、
+ * ノイズ判定確定ファイル（`discardFiles`）と通過ファイル（`keepFiles`）に振り分ける
+ * 純粋関数の動作を検証する。全件ノイズ・全件 keep・混在・空配列を網羅する。
+ *
+ * テスト ID 範囲: T-PF-P2-01 〜 T-PF-P2-04
+ *
+ * @see _phase2ClassifyConversations
+ */
+describe('_phase2ClassifyConversations', () => {
+  // ─── T-PF-P2-01: 全件ノイズ判定 ───────────────────────────────────────────────
+
+  describe('Given: 内容がノイズ判定されるエントリ配列', () => {
+    describe('When: _phase2ClassifyConversations(entries) を呼び出す', () => {
+      describe('Then: T-PF-P2-01 - discardFiles に全件、keepFiles は空', () => {
+        it('T-PF-P2-01-01: 全件が discardFiles に入り keepFiles は空になる', () => {
+          const entries = [{ filePath: '/a/noise.md', filename: _NOISE_FILENAME, conversation: _NOISE_CONVERSATION }];
+
+          const result = _phase2ClassifyConversations(entries);
+
+          assertEquals(result.keepFiles, []);
+          assertEquals(result.discardFiles.length, 1);
+          assertEquals(result.discardFiles[0].filePath, '/a/noise.md');
+          assertEquals(result.discardFiles[0].decision, FILTER_DECISIONS.DISCARD);
+          assertEquals(result.discardFiles[0].reason.length > 0, true);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P2-02: 全件 keep 判定 ───────────────────────────────────────────────
+
+  describe('Given: keep 判定されるファイルのみのエントリ配列', () => {
+    describe('When: _phase2ClassifyConversations(entries) を呼び出す', () => {
+      describe('Then: T-PF-P2-02 - keepFiles に全件、discardFiles は空', () => {
+        it('T-PF-P2-02-01: 全件が keepFiles に入り discardFiles は空になる', () => {
+          const entries = [{ filePath: '/a/keep.md', filename: _KEEP_FILENAME, conversation: _VALID_CONVERSATION }];
+
+          const result = _phase2ClassifyConversations(entries);
+
+          assertEquals(result.keepFiles, ['/a/keep.md']);
+          assertEquals(result.discardFiles, []);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P2-03: ノイズと keep が混在 ────────────────────────────────────────
+
+  describe('Given: 内容ノイズ判定と keep 判定が混在するエントリ配列', () => {
+    describe('When: _phase2ClassifyConversations(entries) を呼び出す', () => {
+      describe('Then: T-PF-P2-03 - それぞれ正しい配列に振り分けられる', () => {
+        it('T-PF-P2-03-01: keep 1件+ノイズ1件 → keepFiles/discardFiles に正しく分類される', () => {
+          const entries = [
+            { filePath: '/a/keep.md', filename: _KEEP_FILENAME, conversation: _VALID_CONVERSATION },
+            { filePath: '/b/noise.md', filename: _NOISE_FILENAME, conversation: _NOISE_CONVERSATION },
+          ];
+
+          const result = _phase2ClassifyConversations(entries);
+
+          assertEquals(result.keepFiles, ['/a/keep.md']);
+          assertEquals(result.discardFiles.map((d) => d.filePath), ['/b/noise.md']);
+        });
+      });
+    });
+  });
+
+  // ─── T-PF-P2-04: 空配列 ───────────────────────────────────────────────────────
+
+  describe('Given: 空のエントリ配列', () => {
+    describe('When: _phase2ClassifyConversations([]) を呼び出す', () => {
+      describe('Then: T-PF-P2-04 - keepFiles/discardFiles ともに空配列', () => {
+        it('T-PF-P2-04-01: keepFiles と discardFiles がともに空配列になる', () => {
+          const result = _phase2ClassifyConversations([]);
+
+          assertEquals(result.keepFiles, []);
+          assertEquals(result.discardFiles, []);
+        });
+      });
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
@@ -11,53 +11,215 @@
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import { removeFile } from '../../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../../_scripts/libs/io/logger.ts';
+import { runConcurrent } from '../../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../../_scripts/libs/path-utils/path-utils.ts';
+// constants
+import { DEFAULT_CONCURRENCY } from '../../../../_scripts/constants/defaults.constants.ts';
+// types
+import type { Conversation } from '../../../../_scripts/types/conversation.types.ts';
 
 // ─── internal ───
 // types
+import type { NoiseDiscardFile } from '../../types/noise-filter.types.ts';
 import type { NoiseFilterStats } from '../../types/stats.types.ts';
 // functions
-import { classifyFile } from '../../libs/classify-file.ts';
+import { classifyConversation, classifyFile, readConversation } from '../../libs/classify-file.ts';
+// constants
+import { FILTER_DECISIONS } from '../../types/filter-decision.const.types.ts';
+// classes
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 
 // ─────────────────────────────────────────────
 // ファイルリスト処理
 // ─────────────────────────────────────────────
 
+/** `_phase1ReadFiles` の読み込み成功エントリ。 */
+interface _ReadFileEntry {
+  filePath: string;
+  filename: string;
+  conversation: Conversation;
+}
+
+/**
+ * ファイルパス配列を `classifyFile` でファイル名パターン判定し、ノイズ確定/通過に分類する。
+ *
+ * ファイル名パターンに一致したファイルは `NoiseDiscardFile`（`decision: FILTER_DECISIONS.DISCARD`）
+ * として `discardFiles` に、一致しなかったファイルは `filePath` のみ `passFiles` に振り分ける純粋関数。
+ *
+ * @param files - 判定対象のファイルパス配列
+ * @returns ファイル名ノイズ判定確定ファイル（`discardFiles`）と、通過ファイルパス（`passFiles`）
+ */
+export const _phase0ClassifyByFilename = (
+  files: string[],
+): { discardFiles: NoiseDiscardFile[]; passFiles: string[] } => {
+  const classified = files.map((filePath) => ({
+    filePath,
+    discard: classifyFile({ filePath, filename: getFilename(filePath) }),
+  }));
+
+  const discardFiles = classified
+    .filter((c): c is { filePath: string; discard: NoiseDiscardFile } => c.discard !== null)
+    .map((c) => c.discard);
+
+  const passFiles = classified
+    .filter((c) => c.discard === null)
+    .map((c) => c.filePath);
+
+  return { discardFiles, passFiles };
+};
+
+/**
+ * ファイルリストを並列に読み込み、会話ターン配列にパースしたうえで成功/失敗エントリに振り分ける。
+ *
+ * 読み込みに失敗したファイル、および `readConversation` がパース失敗で `ChatlogError` を
+ * throw したファイルは、実際のエラーメッセージを `reason` に持つ
+ * `NoiseDiscardFile`（`decision: FILTER_DECISIONS.ERROR`）として `readError` に振り分ける。
+ * `ChatlogError` 以外の予期しない例外は catch せずそのまま伝播する。
+ *
+ * @param files - 読み込み対象のファイルパス配列
+ * @returns 読み込み・パースに成功したファイル情報（`readOk`）と、読み込み・パースに失敗したファイル情報（`readError`）
+ */
+export const _phase1ReadFiles = async (
+  files: string[],
+): Promise<{ readOk: _ReadFileEntry[]; readError: NoiseDiscardFile[] }> => {
+  const results = await runConcurrent(
+    files,
+    async (filePath): Promise<
+      { kind: 'ok'; entry: _ReadFileEntry } | { kind: 'error'; result: NoiseDiscardFile }
+    > => {
+      const filename = getFilename(filePath);
+      const text = await readTextFile(filePath, { throwFileIoError: false });
+      if (text instanceof Error) {
+        return {
+          kind: 'error',
+          result: { filePath, filename, reason: text.message, decision: FILTER_DECISIONS.ERROR },
+        };
+      }
+      try {
+        return { kind: 'ok', entry: { filePath, filename, conversation: readConversation(text) } };
+      } catch (e) {
+        if (e instanceof ChatlogError) {
+          return {
+            kind: 'error',
+            result: { filePath, filename, reason: e.message, decision: FILTER_DECISIONS.ERROR },
+          };
+        }
+        // ChatlogError は想定内のパース失敗として readError に吸収する。OOM 等の想定外の
+        // ランタイム例外は握りつぶさずそのまま伝播させる（fail-first）。
+        throw e;
+      }
+    },
+    DEFAULT_CONCURRENCY,
+  );
+
+  const readOk = results
+    .filter((r): r is { kind: 'ok'; entry: _ReadFileEntry } => r.kind === 'ok')
+    .map((r) => r.entry);
+
+  const readError = results
+    .filter((r): r is { kind: 'error'; result: NoiseDiscardFile } => r.kind === 'error')
+    .map((r) => r.result);
+
+  return { readOk, readError };
+};
+
+/**
+ * 読み込み済み会話を `classifyConversation` の判定でノイズ確定/keep に分類する。
+ *
+ * 会話内容がノイズ判定された（`reason !== null`）ファイルは `NoiseDiscardFile`
+ * （`decision: FILTER_DECISIONS.DISCARD`、`reason` は `classifyConversation` の判定理由）として
+ * `discardFiles` に、それ以外は `filePath` のみ `keepFiles` に振り分ける純粋関数。
+ *
+ * @param entries - `_phase1ReadFiles` で読み込み・パース済みのファイル情報
+ * @returns ノイズ判定確定ファイル（`discardFiles`）と、通過ファイルパス（`keepFiles`）
+ */
+export const _phase2ClassifyConversations = (
+  entries: _ReadFileEntry[],
+): { discardFiles: NoiseDiscardFile[]; keepFiles: string[] } => {
+  const classified = entries.map((entry) => ({
+    entry,
+    reason: classifyConversation(entry.conversation),
+  }));
+
+  const discardFiles = classified
+    .filter((c): c is { entry: _ReadFileEntry; reason: string } => c.reason !== null)
+    .map((c) => ({
+      filePath: c.entry.filePath,
+      filename: c.entry.filename,
+      reason: c.reason,
+      decision: FILTER_DECISIONS.DISCARD,
+    }));
+
+  const keepFiles = classified
+    .filter((c) => c.reason === null)
+    .map((c) => c.entry.filePath);
+
+  return { discardFiles, keepFiles };
+};
+
+/**
+ * ノイズ判定確定ファイルを並列に削除（または dry-run 出力）し、stats を加算する。
+ *
+ * `dryRun === true` のときは削除を行わず、ファイルパスと判定理由を `logger.info`（stderr）に
+ * 出力したうえで `stats.skip` に加算する。`dryRun === false` のときは `removeFile()` を呼び、
+ * 成功なら `stats.remove` に加算してファイルパスと判定理由を `logger.info` に出力し、失敗
+ * （ファイルが既に存在しない等）なら `removeFile()` 内部で `logger.warn` にエラー内容が
+ * 出力された上で `stats.error` に加算する。
+ *
+ * @param discardFiles - ノイズ判定確定ファイル（`NoiseDiscardFile[]`）
+ * @param stats - 加算対象の処理統計オブジェクト
+ * @param dryRun - `true` のとき実削除を行わない
+ */
+export const _phase3DiscardOrSkip = async (
+  discardFiles: NoiseDiscardFile[],
+  stats: NoiseFilterStats,
+  dryRun: boolean,
+): Promise<void> => {
+  await Promise.all(
+    discardFiles.map(async ({ filePath, reason }) => {
+      if (dryRun) {
+        logger.info(`<<dry-run>> skip: ${filePath} (${reason})`);
+        stats.skip++;
+        return;
+      }
+      if (await removeFile(filePath, { throwFileIoError: false })) {
+        logger.info(`deleted: ${filePath} (${reason})`);
+        stats.remove++;
+      } else {
+        // log output in removeFIle() already, so just count up stats.error
+        stats.error++;
+      }
+    }),
+  );
+};
+
+/**
+ * ファイルリストを分類・読み込み・分類し、ノイズ判定確定ファイルを削除（または dry-run 出力）する。
+ *
+ * `_phase0ClassifyByFilename` → `_phase1ReadFiles` → `_phase2ClassifyConversations` → `_phase3DiscardOrSkip`
+ * の順にフェーズ関数を適用するオーケストレーション関数。ファイル名判定と内容判定それぞれの
+ * ノイズ確定ファイルを結合して `_phase3DiscardOrSkip` に渡す。読み込み失敗分は `logger.error` に
+ * まとめて出力したうえで `stats.error` に、分類で残った（ノイズでない）ファイル数は `stats.keep` に加算する。
+ *
+ * @param files - 処理対象のファイルパス配列
+ * @param stats - 加算対象の処理統計オブジェクト
+ * @param options.dryRun - `true` のとき、ノイズ判定確定ファイルを実削除せず `stats.skip` に計上する
+ */
 export const processNoiseFiles = async (
   files: string[],
   stats: NoiseFilterStats,
   options: { dryRun: boolean },
 ): Promise<void> => {
-  const { dryRun } = options;
+  const { discardFiles: filenameDiscardFiles, passFiles } = _phase0ClassifyByFilename(files);
+  const { readOk, readError } = await _phase1ReadFiles(passFiles);
+  const { discardFiles: contentDiscardFiles, keepFiles } = _phase2ClassifyConversations(readOk);
 
-  for (const filePath of files) {
-    const filename = getFilename(filePath);
+  readError.forEach(({ filename, reason }) => {
+    logger.error(`  error (${filename}): ${reason}`);
+  });
 
-    let text: string;
-    try {
-      text = await readTextFile(filePath);
-    } catch (e) {
-      logger.error(`  error (${filename}): ${e}`);
-      stats.error++;
-      continue;
-    }
+  stats.error += readError.length;
+  stats.keep += keepFiles.length;
 
-    const { isNoise, reason: _reason } = classifyFile(filename, text);
-
-    if (isNoise) {
-      if (dryRun) {
-        logger.log(filePath);
-        stats.skip++;
-      } else {
-        if (await removeFile(filePath, { throwFileIoError: false })) {
-          logger.info(`deleted: ${filePath}`);
-          stats.remove++;
-        } else {
-          stats.error++;
-        }
-      }
-    } else {
-      stats.keep++;
-    }
-  }
+  await _phase3DiscardOrSkip([...filenameDiscardFiles, ...contentDiscardFiles], stats, options.dryRun);
 };

--- a/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
@@ -8,6 +8,7 @@
 
 // types
 import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
+import type { FilterDecision } from './filter-decision.const.types.ts';
 
 /** `noise-filter-chatlogs` の `main` が使用する設定。すべてのフィールドに値が入る。 */
 export type NoiseFilterConfig = DefaultArgFields & {
@@ -21,6 +22,20 @@ export type NoiseFilterConfig = DefaultArgFields & {
 
 /** `noise-filter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */
 export type NoiseFilterParsedConfig = Partial<NoiseFilterConfig>;
+
+// ─────────────────────────────────────────────
+// ノイズ判定確定ファイル型
+// ─────────────────────────────────────────────
+
+/** ノイズ判定確定ファイル。`processNoiseFiles` のフェーズ関数間で受け渡す削除対象単位。 */
+export interface NoiseDiscardFile {
+  filePath: string;
+  filename: string;
+  /** ノイズ判定理由（`classifyFile`/`classifyConversation` が返す判定理由）。 */
+  reason: string;
+  /** 区別用の判定種別。ノイズ判定確定は `FILTER_DECISIONS.DISCARD`、読み込み失敗は `FILTER_DECISIONS.ERROR`。 */
+  decision: FilterDecision;
+}
 
 /** T が ArgValue 互換であることをコンパイル時に強制するための恒等型。 */
 type _Assert<T extends Partial<ParsedArgs>> = T;


### PR DESCRIPTION
## Overview

**Summary**
Split the noise filter into four explicit phases for clarity and testability.

**Background / Motivation**
`process-noise-files.ts` handled filename checks, file reading, conversation
classification, and discard/skip decisions in a single loop. This made each
step hard to test in isolation. Splitting into phases lets filename-based
discards skip file reading entirely, and makes each stage independently
testable.

## Changes

### Core Changes

- `process-noise-files.ts`: split into phase0 (filename classification),
  phase1 (read files), phase2 (classify conversations), phase3
  (discard-or-skip). Read/parse failures become `ERROR` discard entries;
  unexpected errors still propagate. Discard reasons are now logged in
  dry-run and discard output.
- `classify-file.ts`: split into `readConversation` and `classifyConversation`
  helpers; `classifyFile` now returns filename discard results.
- `noise-filter.types.ts`: add `NoiseDiscardFile` type for passing discard
  entries between phases.
- `SKILL.md`: document `--allow-env` and the `TEMP` environment variable used
  by `ChatlogCache`.

### Test Updates

- Add unit specs for phase0 and phase2.
- Add functional specs for phase1 and phase3.
- Update `classify-file` specs for the new function split.
- Update the noise-filter integration spec for the new pipeline.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is an internal refactor. No change to the skill's CLI interface or
discard semantics.
