### PR TITLE
fix: add missing reason codes to ChatlogError

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -14,6 +14,9 @@
 !agents/**
 !rules/
 !rules/**
+!commands/
+!commands/**
+commands/_libs/*
 
 # deckrd settings
 !rules/

--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,6 @@ coverage*/
 !.claude/agents/**
 !.claude/rules/
 !.claude/rules/**
-!.claude/commands/
-!.claude/commands/**
 
 # MCP server dependency files
 .cocoindex_code/

--- a/skills/_scripts/classes/GlobalConfig.class.ts
+++ b/skills/_scripts/classes/GlobalConfig.class.ts
@@ -157,7 +157,11 @@ export class GlobalConfig {
       _text = _readTextFile(_resolved);
     } catch (e) {
       if (e instanceof Deno.errors.NotFound) {
-        throw new ChatlogError('FileDirNotFound', `設定ファイル/ディレクトリが見つかりません: ${_resolved}`);
+        throw new ChatlogError(
+          'FileDirNotFound',
+          'ConfigNotFound',
+          `設定ファイル/ディレクトリが見つかりません: ${_resolved}`,
+        );
       }
       throw e;
     }

--- a/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assertEquals, assertFalse, assertStrictEquals, assertThrows } from '@std/assert';
+import { assert, assertEquals, assertFalse, assertStrictEquals, assertThrows } from '@std/assert';
 import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -473,6 +473,7 @@ describe('GlobalConfig', () => {
           ChatlogError,
         );
         assertEquals(_err.kind, 'FileDirNotFound');
+        assert(_err.message.includes('/mock/missing.yaml'));
       });
 
       it('[Error] T-CLS-GC-35: 不正な YAML 文字列 → ChatlogError の kind が InvalidYaml でスローされる', () => {

--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -131,6 +131,7 @@ describe('_setByTypeForTest (negated)', () => {
       const _entry = { option: '--dry-run', field: 'dryRun', type: 'flag' as const };
       const _err = _setByTypeForTest(_config, _entry, 'true', true);
       assertEquals(_err instanceof ChatlogError, true);
+      assert((_err as ChatlogError).message.includes('フラグに値は指定できません'));
     });
 
     it('[Error] T-PA-ST-N-03: string 型 + negated=true → ChatlogError が返る', () => {
@@ -138,6 +139,7 @@ describe('_setByTypeForTest (negated)', () => {
       const _entry = { option: '--output', field: 'outputDir', type: 'string' as const };
       const _err = _setByTypeForTest(_config, _entry, undefined, true);
       assertEquals(_err instanceof ChatlogError, true);
+      assert((_err as ChatlogError).message.includes('--no- は flag 型にのみ使用できます'));
     });
   });
 });
@@ -374,11 +376,11 @@ describe('parseArgsToConfig', () => {
   describe('Given: 不明な -- オプション', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-09 - ChatlogError(InvalidArgs) がスローされる', () => {
-        it('T-PA-09-01: --unknown → ChatlogError がスローされる', () => {
+        it('T-PA-09-01: --unknown → ChatlogError がスローされる（不明なオプション の詳細を含む）', () => {
           assertThrows(
             () => parseArgs<TestConfig>(['--unknown'], TEST_SCHEMA),
             ChatlogError,
-            'Invalid Args',
+            '不明なオプション: --unknown',
           );
         });
       });
@@ -390,11 +392,11 @@ describe('parseArgsToConfig', () => {
   describe('Given: 不明な位置引数', () => {
     describe('When: parseArgs(args) を呼び出す', () => {
       describe('Then: T-PA-10 - ChatlogError(InvalidArgs) がスローされる', () => {
-        it('T-PA-10-01: "unknown-arg" → ChatlogError がスローされる', () => {
+        it('T-PA-10-01: "unknown-arg" → ChatlogError がスローされる（不明な引数 の詳細を含む）', () => {
           assertThrows(
             () => parseArgs<TestConfig>(['unknown-arg'], TEST_SCHEMA),
             ChatlogError,
-            'Invalid Args',
+            '不明な引数: unknown-arg',
           );
         });
       });
@@ -406,11 +408,11 @@ describe('parseArgsToConfig', () => {
   describe('Given: 値なしのキー付きオプション', () => {
     describe('When: parseArgs(["--output"]) を呼び出す', () => {
       describe('Then: T-PA-11 - ChatlogError(InvalidArgs) がスローされる', () => {
-        it('T-PA-11-01: --output のみ → ChatlogError がスローされる', () => {
+        it('T-PA-11-01: --output のみ → ChatlogError がスローされる（値が空です の詳細を含む）', () => {
           assertThrows(
             () => parseArgs<TestConfig>(['--output'], TEST_SCHEMA),
             ChatlogError,
-            'Invalid Args',
+            '値が空です',
           );
         });
       });
@@ -513,11 +515,11 @@ describe('parseArgsToConfig', () => {
     ];
 
     describe('When: 異常系', () => {
-      it('[Error] T-PA-17-01: --period invalid-format → ChatlogError(InvalidArgs) がスローされる', () => {
+      it('[Error] T-PA-17-01: --period invalid-format → ChatlogError(InvalidArgs) がスローされる（期間形式ではありません の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfig>(['--period', 'invalid-format'], _SCHEMA_WITH_PERIOD),
           ChatlogError,
-          'Invalid Args',
+          '期間形式ではありません',
         );
       });
     });
@@ -567,11 +569,11 @@ describe('parseArgsToConfig', () => {
     ];
 
     describe('When: 異常系', () => {
-      it('[Error] T-PA-19-01: --agent unknown-bot → ChatlogError(InvalidArgs) がスローされる', () => {
+      it('[Error] T-PA-19-01: --agent unknown-bot → ChatlogError(InvalidArgs) がスローされる（不明なエージェント の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfig>(['--agent', 'unknown-bot'], _SCHEMA_WITH_AGENT),
           ChatlogError,
-          'Invalid Args',
+          '不明なエージェント: unknown-bot',
         );
       });
     });
@@ -594,11 +596,11 @@ describe('parseArgsToConfig', () => {
     ];
 
     describe('When: 異常系', () => {
-      it('[Error] T-PA-20-01: --limit abc → ChatlogError(InvalidArgs) がスローされる', () => {
+      it('[Error] T-PA-20-01: --limit abc → ChatlogError(InvalidArgs) がスローされる（整数ではありません の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfig & { limit?: string }>(['--limit', 'abc'], _SCHEMA_WITH_INTEGER),
           ChatlogError,
-          'Invalid Args',
+          '整数ではありません: abc',
         );
       });
     });
@@ -621,11 +623,11 @@ describe('parseArgsToConfig', () => {
     ];
 
     describe('When: 異常系', () => {
-      it('[Error] T-PA-21-01: --ratio xyz → ChatlogError(InvalidArgs) がスローされる', () => {
+      it('[Error] T-PA-21-01: --ratio xyz → ChatlogError(InvalidArgs) がスローされる（数値ではありません の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfig & { ratio?: string }>(['--ratio', 'xyz'], _SCHEMA_WITH_NUMBER),
           ChatlogError,
-          'Invalid Args',
+          '数値ではありません: xyz',
         );
       });
     });
@@ -803,11 +805,11 @@ describe('parseArgsToConfig', () => {
           'Invalid Args',
         );
       });
-      it('[Error] T-PA-29-02: --no-dry-run=true → ChatlogError(InvalidArgs) がスローされる (=値指定不可)', () => {
+      it('[Error] T-PA-29-02: --no-dry-run=true → ChatlogError(InvalidArgs) がスローされる (=値指定不可、--no- フラグに値は指定できません の詳細を含む)', () => {
         assertThrows(
           () => parseArgs<TestConfig>(['--no-dry-run=true'], TEST_SCHEMA),
           ChatlogError,
-          'Invalid Args',
+          '--no- フラグに値は指定できません',
         );
       });
     });
@@ -866,11 +868,11 @@ describe('parseArgsToConfig', () => {
 
     /** ディレクトリ形式でない値を渡す異常系。 */
     describe('When: 異常系', () => {
-      it('[Error] T-PA-31-02: --cache-dir plain-value → ChatlogError(InvalidArgs) がスローされる', () => {
+      it('[Error] T-PA-31-02: --cache-dir plain-value → ChatlogError(InvalidArgs) がスローされる（ディレクトリ形式ではありません の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfigWithCache>(['--cache-dir', 'plain-value'], _SCHEMA_WITH_CACHE),
           ChatlogError,
-          'Invalid Args',
+          'ディレクトリ形式ではありません',
         );
       });
     });
@@ -926,11 +928,11 @@ describe('parseArgsToConfig', () => {
    */
   describe('Given: agent の次に agent 名を渡す（idx1 が period 形式でない）', () => {
     describe('When: 異常系', () => {
-      it('[Error] T-PA-33-01: "claude" "chatgpt" → idx1 が period 形式でないため ChatlogError(InvalidArgs)', () => {
+      it('[Error] T-PA-33-01: "claude" "chatgpt" → idx1 が period 形式でないため ChatlogError(InvalidArgs)（2番目の引数は期間形式である必要があります の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfig>(['claude', 'chatgpt'], TEST_SCHEMA),
           ChatlogError,
-          'Invalid Args',
+          '2番目の引数は期間形式である必要があります',
         );
       });
     });
@@ -982,11 +984,11 @@ describe('parseArgsToConfig', () => {
         assertEquals(result.inputDir, 'in');
         assertEquals(result.outputDir, 'out');
       });
-      it('[Error] T-PA-POS-03: ["./in", "./out", "./extra"] → 3個目で ChatlogError(InvalidArgs)', () => {
+      it('[Error] T-PA-POS-03: ["./in", "./out", "./extra"] → 3個目で ChatlogError(InvalidArgs)（位置引数が多すぎます の詳細を含む）', () => {
         assertThrows(
           () => parseArgs<TestConfig>(['./in', './out', './extra'], TEST_SCHEMA),
           ChatlogError,
-          'Invalid Args',
+          '位置引数が多すぎます',
         );
       });
     });

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -74,69 +74,73 @@ const _setByType = (
   // flag は rawValue 不要。rawValue が渡された場合はエラー
   if (entry.type === 'flag') {
     if (rawValue !== undefined) {
-      return new ChatlogError('InvalidArgs', `フラグに値は指定できません: ${entry.option}`);
+      return new ChatlogError('InvalidArgs', 'FlagValueNotAllowed', `フラグに値は指定できません: ${entry.option}`);
     }
     config[entry.field] = !negated;
     return null;
   }
   // flag 以外に negated を指定した場合はエラー
   if (negated) {
-    return new ChatlogError('InvalidArgs', `--no- は flag 型にのみ使用できます: ${entry.option}`);
+    return new ChatlogError('InvalidArgs', 'NegatedNonFlag', `--no- は flag 型にのみ使用できます: ${entry.option}`);
   }
   switch (entry.type) {
     case 'string':
       if (rawValue === undefined || rawValue === '') {
-        return new ChatlogError('InvalidArgs', `値が空です: ${entry.option}`);
+        return new ChatlogError('InvalidArgs', 'EmptyValue', `値が空です: ${entry.option}`);
       }
       config[entry.field] = rawValue;
       return null;
     case 'agent':
       if (rawValue === undefined || rawValue === '') {
-        return new ChatlogError('InvalidArgs', `値が空です: ${entry.option}`);
+        return new ChatlogError('InvalidArgs', 'EmptyValue', `値が空です: ${entry.option}`);
       }
       if (!isKnownAgent(rawValue)) {
-        return new ChatlogError('InvalidArgs', `不明なエージェント: ${rawValue}`);
+        return new ChatlogError('InvalidArgs', 'UnknownAgent', `不明なエージェント: ${rawValue}`);
       }
       config[entry.field] = rawValue;
       return null;
     case 'integer': {
       if (rawValue === undefined || rawValue === '') {
-        return new ChatlogError('InvalidArgs', `値が空です: ${entry.option}`);
+        return new ChatlogError('InvalidArgs', 'EmptyValue', `値が空です: ${entry.option}`);
       }
       const _n = parseInt(rawValue, 10);
       if (isNaN(_n)) {
-        return new ChatlogError('InvalidArgs', `整数ではありません: ${rawValue}`);
+        return new ChatlogError('InvalidArgs', 'NotAnInteger', `整数ではありません: ${rawValue}`);
       }
       config[entry.field] = _n;
       return null;
     }
     case 'number': {
       if (rawValue === undefined || rawValue === '') {
-        return new ChatlogError('InvalidArgs', `値が空です: ${entry.option}`);
+        return new ChatlogError('InvalidArgs', 'EmptyValue', `値が空です: ${entry.option}`);
       }
       const _n = parseFloat(rawValue);
       if (isNaN(_n)) {
-        return new ChatlogError('InvalidArgs', `数値ではありません: ${rawValue}`);
+        return new ChatlogError('InvalidArgs', 'NotANumber', `数値ではありません: ${rawValue}`);
       }
       config[entry.field] = _n;
       return null;
     }
     case 'period': {
       if (rawValue === undefined || rawValue === '') {
-        return new ChatlogError('InvalidArgs', `値が空です: ${entry.option}`);
+        return new ChatlogError('InvalidArgs', 'EmptyValue', `値が空です: ${entry.option}`);
       }
       if (!isArgPeriod(rawValue)) {
-        return new ChatlogError('InvalidArgs', `期間形式ではありません（YYYY または YYYY-MM）: ${rawValue}`);
+        return new ChatlogError(
+          'InvalidArgs',
+          'InvalidPeriodFormat',
+          `期間形式ではありません（YYYY または YYYY-MM）: ${rawValue}`,
+        );
       }
       config[entry.field] = rawValue;
       return null;
     }
     case 'directory': {
       if (rawValue === undefined || rawValue === '') {
-        return new ChatlogError('InvalidArgs', `値が空です: ${entry.option}`);
+        return new ChatlogError('InvalidArgs', 'EmptyValue', `値が空です: ${entry.option}`);
       }
       if (!isArgDirectory(rawValue)) {
-        return new ChatlogError('InvalidArgs', `ディレクトリ形式ではありません: ${rawValue}`);
+        return new ChatlogError('InvalidArgs', 'InvalidDirectoryFormat', `ディレクトリ形式ではありません: ${rawValue}`);
       }
       const _dir = normalizePath(rawValue);
       config[entry.field] = _dir;
@@ -162,7 +166,7 @@ const _assignEntry = (
 ): void => {
   const _entry = schemaMap.get(optionKey);
   if (_entry === undefined) {
-    throw new ChatlogError('InvalidArgs', `スキーマに存在しないエントリです: ${optionKey}`);
+    throw new ChatlogError('InvalidArgs', 'UnknownSchemaEntry', `スキーマに存在しないエントリです: ${optionKey}`);
   }
   const err = _setByType(config, _entry, rawValue);
   if (err) { throw err; }
@@ -183,7 +187,11 @@ const _assignOutputDirEntry = (
   rawValue: string,
 ): void => {
   if ('outputDir' in config) {
-    throw new ChatlogError('InvalidArgs', `位置引数が多すぎます（output-dir は1個のみ指定可能）: ${rawValue}`);
+    throw new ChatlogError(
+      'InvalidArgs',
+      'TooManyOutputDir',
+      `位置引数が多すぎます（output-dir は1個のみ指定可能）: ${rawValue}`,
+    );
   }
   _assignEntry(config, schemaMap, '--output-dir', rawValue);
 };
@@ -222,6 +230,7 @@ const _parsePositionals = (
         if (!isArgPeriod(positionals[idx + 1])) {
           throw new ChatlogError(
             'InvalidArgs',
+            'InvalidPeriodPosition',
             `2番目の引数は期間形式である必要があります（YYYY または YYYY-MM）: ${positionals[idx + 1]}`,
           );
         }
@@ -233,7 +242,7 @@ const _parsePositionals = (
 
     if (idx === 0) {
       // idx0 が directory でも agent でもない -> 即エラー
-      throw new ChatlogError('InvalidArgs', `不明な引数: ${_arg}`);
+      throw new ChatlogError('InvalidArgs', 'UnknownPositional', `不明な引数: ${_arg}`);
     }
 
     // idx1以降はすべて output-dir(directory, 1個のみ許容)
@@ -267,12 +276,12 @@ export const parseOptions = <T>(
       const _lookupKey = _isNegation ? '--' + _optionName.slice('--no-'.length) : _optionName;
 
       if (_isNegation && _eqIdx !== -1) {
-        throw new ChatlogError('InvalidArgs', `--no- フラグに値は指定できません: ${arg}`);
+        throw new ChatlogError('InvalidArgs', 'NegationWithValue', `--no- フラグに値は指定できません: ${arg}`);
       }
 
       const _entry = _schemaMap.get(_lookupKey);
       if (_entry === undefined) {
-        throw new ChatlogError('InvalidArgs', `不明なオプション: ${arg}`);
+        throw new ChatlogError('InvalidArgs', 'UnknownOption', `不明なオプション: ${arg}`);
       }
 
       let _rawValue: string | undefined;

--- a/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts
@@ -41,10 +41,10 @@ const _FALLBACK_PROPS = {
 
 const _resolveToFixture = (_opts: ResolveConfigPathOptions): string => _FIXTURE_DIC_PATH;
 const _resolveFileDirNotFound = (_opts: ResolveConfigPathOptions): string => {
-  throw new ChatlogError('FileDirNotFound', 'テスト用: ファイル不在');
+  throw new ChatlogError('FileDirNotFound', 'TestStub', 'テスト用: ファイル不在');
 };
 const _resolveGitNotFound = (_opts: ResolveConfigPathOptions): string => {
-  throw new ChatlogError('GitNotFound', 'テスト用: git が見つからない');
+  throw new ChatlogError('GitNotFound', 'TestStub', 'テスト用: git が見つからない');
 };
 
 const _readPermissionError = (_path: string) =>

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -21,6 +21,7 @@ import type { Stub } from '@std/testing/mock';
 // ─── Test target
 import { main } from '../../filter-chatlogs.ts';
 // classes
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 // constants
 import { LOGGER_HEADER } from '../../../../_scripts/constants/logger-header.constants.ts';
@@ -679,7 +680,7 @@ describe('main - Claude CLI 異常終了', () => {
  * `main` 関数の E2E テストスイート（存在しない period ディレクトリ）。
  *
  * period を指定したとき、その月ディレクトリが存在しない場合に
- * InputNotFound エラーになることを検証する。
+ * `ChatlogError` が throw され、`main` が reject されることを検証する。
  *
  * テスト ID 範囲: T-FL-E2E-11
  *
@@ -689,17 +690,15 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
   /**
    * agent ディレクトリは存在するが、period ディレクトリ（2026-99）が存在しない前提。
    *
-   * period 込みで存在確認を行い、存在しない場合は InputNotFound エラーと
-   * Deno.exit(1) が発生することを確認する。
+   * period 込みで存在確認を行い、存在しない場合は `ChatlogError` が throw されることを確認する。
    */
   describe('Given: agent ディレクトリは存在するが period ディレクトリが存在しない', () => {
     /** `main(["claude", "2026-99"])` を呼び出すとき（GlobalConfig に chatlogsDir を設定）。 */
     describe('When: main(["claude", "2026-99"]) を呼び出す', () => {
-      /** InputNotFound エラーが発生し Deno.exit(1) が呼ばれること。 */
-      describe('Then: T-FL-E2E-11 - InputNotFound → exit(1)', () => {
+      /** `ChatlogError` が throw され `main` が reject されること。 */
+      describe('Then: T-FL-E2E-11 - main が ChatlogError で reject される', () => {
         let tempDir: string;
         let loggerStub: LoggerStub;
-        let exitStub: Stub;
 
         beforeEach(async () => {
           // agent ディレクトリは存在するが、2026-99 月ディレクトリは存在しない
@@ -710,33 +709,18 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
           await Deno.mkdir(originalLogsAgentDir, { recursive: true });
           await _makeGlobalConfig(`chatlogsDir: '${tempDir}'`);
           loggerStub = makeLoggerStub();
-          exitStub = stub(Deno, 'exit');
         });
 
         afterEach(async () => {
           loggerStub.restore();
-          exitStub.restore();
           GlobalConfig.resetInstance();
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        it('T-FL-E2E-11-01: Deno.exit が 1 で呼ばれる', async () => {
-          try {
-            await main(['claude', '2026-99']);
-          } catch { /* ChatlogError が漏れた場合も継続 */ }
-
-          assertEquals(exitStub.calls.length >= 1, true, 'Deno.exit が呼ばれていない');
-          assertEquals(exitStub.calls[0].args[0], 1);
-        });
-
-        it('T-FL-E2E-11-02: errorLogs に "入力ディレクトリが見つかりません" が含まれる', async () => {
-          try {
-            await main(['claude', '2026-99']);
-          } catch { /* ChatlogError が漏れた場合も継続 */ }
-
-          assertEquals(
-            loggerStub.errorLogs.some((l) => l.includes('入力ディレクトリが見つかりません')),
-            true,
+        it('T-FL-E2E-11-01: ChatlogError で main が reject される', async () => {
+          await assertRejects(
+            () => main(['claude', '2026-99']),
+            ChatlogError,
           );
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
@@ -11,7 +11,7 @@
 // This software is released under the MIT License.
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -19,6 +19,7 @@ import { main } from '../../noise-filter-chatlogs.ts';
 
 // ─── Helpers
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 // types
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -338,6 +339,48 @@ describe('main (noise-filter) - period 絞り込み', () => {
 
           await assertFileNotExist(noisePath03);
           assertEquals(await fileExists(noisePath04), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── T-PF-E2E-08: 存在しない inputDir → ChatlogError で reject される ───────
+
+/**
+ * `main` 関数（noise-filter）の E2E テストスイート（存在しない inputDir）。
+ *
+ * 入力ディレクトリが存在しない場合に `ChatlogError` が throw され、
+ * `main` が reject されることを検証する。
+ *
+ * テスト ID 範囲: T-PF-E2E-08
+ *
+ * @see main
+ */
+describe('main (noise-filter) - 存在しない inputDir', () => {
+  /**
+   * 存在しないディレクトリパスを `--input-dir` に指定する前提。
+   *
+   * 入力ディレクトリが見つからない場合に `ChatlogError` が throw されることを確認する。
+   */
+  describe('Given: 存在しない inputDir を指定', () => {
+    /** `main(["claude", "--input-dir", "/nonexistent/path"])` を呼び出すとき。 */
+    describe('When: main(["claude", "--input-dir", "/nonexistent/path"]) を呼び出す', () => {
+      /** `ChatlogError` が throw され `main` が reject されること。 */
+      describe('Then: T-PF-E2E-08 - main が ChatlogError で reject される', () => {
+        it('T-PF-E2E-08-01: ChatlogError で main が reject される', async () => {
+          await assertRejects(
+            () => main(['claude', '--input-dir', '/nonexistent/path']),
+            ChatlogError,
+          );
+        });
+
+        it('T-PF-E2E-08-02: エラーメッセージにパスの詳細が含まれる', async () => {
+          const error = await assertRejects(
+            () => main(['claude', '--input-dir', '/nonexistent/path']),
+            ChatlogError,
+          );
+          assertEquals(error.message.includes('/nonexistent/path'), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -100,85 +100,89 @@ export const buildConfig = (
 // ─────────────────────────────────────────────
 
 export const main = async (args?: string[]): Promise<void> => {
-  try {
-    const _parsed = parseArgs<FilterParsedConfig>(args ?? Deno.args, _SCHEMA, DEFAULT_FILTER_CONFIG);
-    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
-    const _config = buildConfig(_parsed, _globalConfig);
+  const _parsed = parseArgs<FilterParsedConfig>(args ?? Deno.args, _SCHEMA, DEFAULT_FILTER_CONFIG);
+  const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
+  const _config = buildConfig(_parsed, _globalConfig);
 
-    const _searchDir = resolveChatlogsDir({
-      chatlogsDir: _config.chatlogsDir,
-      agent: _config.agent,
-      period: _config.period,
-      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
-      override: _config.inputDir,
-    });
+  const _searchDir = resolveChatlogsDir({
+    chatlogsDir: _config.chatlogsDir,
+    agent: _config.agent,
+    period: _config.period,
+    addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+    override: _config.inputDir,
+  });
 
-    // 入力ディレクトリ確認
-    if (!await dirExists(_searchDir)) {
-      throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_searchDir}`);
-    }
+  // 入力ディレクトリ確認
+  if (!await dirExists(_searchDir)) {
+    throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_searchDir}`);
+  }
 
-    logger.info(`対象 agent: ${_config.agent}`);
-    if (_config.period) { logger.info(`対象期間: ${_config.period}`); }
+  logger.info(`対象 agent: ${_config.agent}`);
+  if (_config.period) { logger.info(`対象期間: ${_config.period}`); }
 
-    // ファイル列挙
-    const allFiles = await findFiles(_searchDir);
+  // ファイル列挙
+  const allFiles = await findFiles(_searchDir);
 
-    // 判定結果キャッシュ
-    const _cache = new ChatlogCache<CLEResult>('filter-cache');
-    await _cache.ready;
+  // 判定結果キャッシュ
+  const _cache = new ChatlogCache<CLEResult>('filter-cache');
+  await _cache.ready;
 
-    // 事前フィルタ
-    const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
+  // 事前フィルタ
+  const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-    // キャッシュ済み判定が KEEP かどうかを判定する
-    const _isCachedKeep = (filePath: string): boolean => _cache.read(filePath).decision === FILTER_DECISIONS.KEEP;
+  // キャッシュ済み判定が KEEP かどうかを判定する
+  const _isCachedKeep = (filePath: string): boolean => _cache.read(filePath).decision === FILTER_DECISIONS.KEEP;
 
-    // キャッシュ済み判定が DISCARD とマークされているかどうかを判定する
-    const _isCachedDiscard = (filePath: string): boolean => _cache.read(filePath).decision === FILTER_DECISIONS.DISCARD;
+  // キャッシュ済み判定が DISCARD とマークされているかどうかを判定する
+  const _isCachedDiscard = (filePath: string): boolean => _cache.read(filePath).decision === FILTER_DECISIONS.DISCARD;
 
-    // キャッシュ上 KEEP 済み・DISCARD マーク済みのファイルを処理対象から除外する
-    const _targetEntries = allFiles.filter((filePath) => !_isCachedKeep(filePath) && !_isCachedDiscard(filePath));
+  // キャッシュ上 KEEP 済み・DISCARD マーク済みのファイルを処理対象から除外する
+  const _targetEntries = allFiles.filter((filePath) => !_isCachedKeep(filePath) && !_isCachedDiscard(filePath));
 
-    // キャッシュ済み KEEP 件数を集計
-    stats.keep += allFiles.filter(_isCachedKeep).length;
+  // キャッシュ済み KEEP 件数を集計
+  stats.keep += allFiles.filter(_isCachedKeep).length;
 
-    const targetFiles = await prefilterFiles(_targetEntries, {
-      minCharCount: _config.minCharCount,
-      minAssistantChars: _config.minAssistantChars,
-      stats,
-      dryRun: _config.dryRun,
-    });
+  const targetFiles = await prefilterFiles(_targetEntries, {
+    minCharCount: _config.minCharCount,
+    minAssistantChars: _config.minAssistantChars,
+    stats,
+    dryRun: _config.dryRun,
+  });
 
-    const total = targetFiles.length;
-    if (total === 0) {
-      logger.info(`${LOGGER_HEADER.NO_FILE_FOUND}: 対象ファイルなし`);
+  const total = targetFiles.length;
+  if (total === 0) {
+    logger.info(`${LOGGER_HEADER.NO_FILE_FOUND}: 対象ファイルなし`);
+  } else {
+    logger.info(`判定対象ファイル数: ${total}`);
+
+    if (_config.dryRun) {
+      logger.info('dry-run モード: claude CLI を呼び出さず対象ファイルを一覧表示します');
+      targetFiles.forEach((filePath) => logger.info(`対象: ${filePath}`));
+      stats.skip += targetFiles.length;
     } else {
-      logger.info(`判定対象ファイル数: ${total}`);
-
-      if (_config.dryRun) {
-        logger.info('dry-run モード: claude CLI を呼び出さず対象ファイルを一覧表示します');
-        targetFiles.forEach((filePath) => logger.info(`対象: ${filePath}`));
-        stats.skip += targetFiles.length;
-      } else {
-        // チャンク分割して並列処理（判定結果はキャッシュに書き込むのみ。削除は後続のスイープで行う）
-        await runChunked(
-          targetFiles,
-          _config.chunkSize,
-          (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl),
-          _config.concurrency,
-        );
-      }
+      // チャンク分割して並列処理（判定結果はキャッシュに書き込むのみ。削除は後続のスイープで行う）
+      await runChunked(
+        targetFiles,
+        _config.chunkSize,
+        (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl),
+        _config.concurrency,
+      );
     }
+  }
 
-    // DISCARD マーク済み（今回マーク分 + 前回削除されずに残ったゾンビファイル）をまとめて削除する
-    await sweepDiscards(allFiles, _cache, stats, _config.dryRun);
+  // DISCARD マーク済み（今回マーク分 + 前回削除されずに残ったゾンビファイル）をまとめて削除する
+  await sweepDiscards(allFiles, _cache, stats, _config.dryRun);
 
-    // サマリー
-    const drySuffix = _config.dryRun ? ' (dry-run)' : '';
-    logger.info(
-      `\n完了${drySuffix}: total=${allFiles.length} keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
-    );
+  // サマリー
+  const drySuffix = _config.dryRun ? ' (dry-run)' : '';
+  logger.info(
+    `\n完了${drySuffix}: total=${allFiles.length} keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
+  );
+};
+
+if (import.meta.main) {
+  try {
+    await main(Deno.args);
   } catch (e) {
     if (e instanceof ChatlogError) {
       logger.error(e.message);
@@ -186,8 +190,4 @@ export const main = async (args?: string[]): Promise<void> => {
     }
     throw e;
   }
-};
-
-if (import.meta.main) {
-  await main(Deno.args);
 }

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -52,35 +52,39 @@ import { processNoiseFiles } from './modules/noise-filter/process-noise-files.ts
 // ─────────────────────────────────────────────
 
 export const main = async (args: string[] = Deno.args): Promise<void> => {
+  const _parsed = parseArgs(args);
+  const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
+  const { agent, period, chatlogsDir, inputDir, dryRun } = buildConfig(_parsed, _globalConfig);
+  const _searchDir = resolveChatlogsDir({
+    chatlogsDir,
+    agent,
+    period,
+    addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+    override: inputDir,
+  });
+
+  if (!await dirExists(_searchDir)) {
+    throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_searchDir}`);
+  }
+
+  const files = await findFiles(_searchDir);
+  logger.info(`対象ファイル数: ${files.length}`);
+  if (dryRun) {
+    logger.info('dry-run モード: ファイルは削除しません');
+  }
+
+  const stats: NoiseFilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
+  await processNoiseFiles(files, stats, { dryRun });
+
+  const suffix = dryRun ? ' (dry-run)' : '';
+  logger.info(
+    `\n完了${suffix}: keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
+  );
+};
+
+if (import.meta.main) {
   try {
-    const _parsed = parseArgs(args);
-    const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
-    const { agent, period, chatlogsDir, inputDir, dryRun } = buildConfig(_parsed, _globalConfig);
-    const _searchDir = resolveChatlogsDir({
-      chatlogsDir,
-      agent,
-      period,
-      addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
-      override: inputDir,
-    });
-
-    if (!await dirExists(_searchDir)) {
-      throw new ChatlogError('InputNotFound', `入力ディレクトリが見つかりません: ${_searchDir}`);
-    }
-
-    const files = await findFiles(_searchDir);
-    logger.info(`対象ファイル数: ${files.length}`);
-    if (dryRun) {
-      logger.info('dry-run モード: ファイルは削除しません');
-    }
-
-    const stats: NoiseFilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
-    await processNoiseFiles(files, stats, { dryRun });
-
-    const suffix = dryRun ? ' (dry-run)' : '';
-    logger.info(
-      `\n完了${suffix}: keep=${stats.keep} skip=${stats.skip} remove=${stats.remove} error=${stats.error}`,
-    );
+    await main();
   } catch (e) {
     if (e instanceof ChatlogError) {
       logger.error(e.message);
@@ -88,8 +92,4 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
     }
     throw e;
   }
-};
-
-if (import.meta.main) {
-  await main();
 }


### PR DESCRIPTION
## Overview

**Summary**
Add missing reason codes to ChatlogError call sites.

**Background / Motivation**
Some `ChatlogError` throw sites in `parse-args.ts` and `GlobalConfig.class.ts` had no `reason` argument, so the specific failure cause could not be identified from the error alone. This PR adds the missing reason codes and moves error handling in `filter-chatlogs.ts` and `noise-filter-chatlogs.ts` from inside `main()` to the `import.meta.main` entrypoint, so e2e tests can assert rejections with `assertRejects` instead of checking `Deno.exit` and logs.

## Changes

### Core Changes

- `skills/_scripts/libs/io/parse-args.ts`: add reason codes to all `ChatlogError(InvalidArgs)` call sites
- `skills/_scripts/classes/GlobalConfig.class.ts`: add `ConfigNotFound` reason when the config file or directory is missing
- `skills/filter-chatlogs/scripts/filter-chatlogs.ts`: move error handling from `main()` to the `import.meta.main` entrypoint
- `skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts`: move error handling to the entrypoint; add `NotFound` reason for a missing input directory

### Test Updates

- `skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts`: assert error detail messages
- `skills/_scripts/classes/__tests__/unit/GlobalConfig.unit.spec.ts`: assert the missing config path is included in the error message
- `skills/classify-chatlogs/scripts/libs/__tests__/unit/load-project-dic.unit.spec.ts`: update stubs for the new reason argument
- `skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts`: use `assertRejects` instead of `Deno.exit`/log checks
- `skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts`: add e2e coverage for a missing input directory

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #311

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Reason codes follow the existing `ChatlogError` reason conventions already used elsewhere in the codebase; no new error taxonomy was introduced.
