### PR TITLE
refactor(filter-chatlogs): build config from args, apply prefilter

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
@@ -25,23 +25,34 @@ import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../../_scripts/constants/defaults.constants.ts';
-import { NOISE_FILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // e2e helpers
 import { assertFileExist, assertFileNotExist } from '../../../../_scripts/__tests__/helpers/assert.ts';
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
-import { makePeriodDir, makeRepeatedContent, makeTestDirs } from '../_helpers/fixtures.ts';
+import { makePeriodDir, makeRepeatedContent, makeTestDirs, makeValidContent } from '../_helpers/fixtures.ts';
 // helpers
 import { resetProjectRoot } from '../../../../_scripts/libs/path-utils/dir-utils.ts';
 
 // ─── Internal Helpers
+
+// constants
+
+/**
+ * `main`（prefilterFiles → processNoiseFiles）を通過する最小テキスト長（文字数）。
+ *
+ * `main()` は `prefilterFiles` の `minCharCount`（デフォルト 1000）を経由するため、
+ * `processNoiseFiles` 単体のテストで使う `NOISE_FILTER_MIN_CONTENT_LENGTH`（300）では
+ * 事前フィルタで除外されてしまう。`makeRepeatedContent(N)` は本文長 `2N+46` 程度になるため、
+ * N=500 で `minCharCount`（1000）と `minAssistantChars`（300）の両方を満たす。
+ */
+const _MAIN_MIN_CONTENT_LENGTH = 500;
 
 // functions
 
 /** `_makeTestDirs` のラッパー。デフォルト引数付きで `makeTestDirs` を呼び出す。 */
 const _makeTestDirs = (agent = 'claude', period = '2026-03') => makeTestDirs(agent, period);
 
-/** `_makeValidContent` のラッパー。`NOISE_FILTER_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
-const _makeValidContent = () => makeRepeatedContent(NOISE_FILTER_MIN_CONTENT_LENGTH);
+/** `_makeValidContent` のラッパー。`_MAIN_MIN_CONTENT_LENGTH` を固定して `makeRepeatedContent` を呼び出す。 */
+const _makeValidContent = () => makeRepeatedContent(_MAIN_MIN_CONTENT_LENGTH);
 
 /**
  * テスト用 `GlobalConfig` インスタンスを YAML 文字列から生成する。
@@ -165,6 +176,62 @@ describe('main (noise-filter) - 通常実行（削除あり）', () => {
 
           await assertFileNotExist(noisePath);
           assertEquals(await fileExists(validPath), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── T-PF-E2E-16: 内容が短いファイル → 事前フィルタで削除される ─────────────
+
+/**
+ * `main` 関数（noise-filter）の E2E テストスイート（事前フィルタによる内容ベース削除）。
+ *
+ * ファイル名はノイズパターンに一致しないが本文が `minCharCount`（デフォルト 1000）未満の
+ * ファイルが、`processNoiseFiles`（会話内容判定）に到達する前に `prefilterFiles` の
+ * 内容チェックで削除されることを検証する。
+ *
+ * テスト ID 範囲: T-PF-E2E-16
+ *
+ * @see main
+ */
+describe('main (noise-filter) - 事前フィルタによる内容ベース削除', () => {
+  /**
+   * ファイル名は正常だが本文が `minCharCount` 未満の短い会話ファイルが存在する前提。
+   *
+   * ファイル名パターンでは除外されないが、内容が短すぎるため事前フィルタで削除されることを確認する。
+   */
+  describe('Given: ファイル名は正常だが本文が短すぎるファイル', () => {
+    /** `main(["claude", "--input-dir", chatlogsDir])` を呼び出すとき。 */
+    describe('When: main(["claude", "--input-dir", chatlogsDir]) を呼び出す', () => {
+      /** ファイルが `processNoiseFiles` に到達する前に事前フィルタで削除されること。 */
+      describe('Then: T-PF-E2E-16 - 内容が短いファイルが事前フィルタで削除される', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        it('T-PF-E2E-16-01: 本文が短すぎるファイルが削除される', async () => {
+          const shortPath = `${chatlogsDir}/short-content.md`;
+          // Assistant応答は100文字以上（processNoiseFiles 単体の MIN_ASSISTANT_CHARS を通過する）が、
+          // 本文全体は minCharCount（デフォルト1000）未満のため、prefilterFiles で削除される想定。
+          const question = 'これは通常の質問文です。'.repeat(3);
+          const answer = 'これは通常の回答文です。'.repeat(15);
+          await Deno.writeTextFile(shortPath, makeValidContent('テスト', question, answer));
+
+          await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+          await assertFileNotExist(shortPath);
         });
       });
     });
@@ -368,6 +435,10 @@ describe('main (noise-filter) - 存在しない inputDir', () => {
     describe('When: main(["claude", "--input-dir", "/nonexistent/path"]) を呼び出す', () => {
       /** `ChatlogError` が throw され `main` が reject されること。 */
       describe('Then: T-PF-E2E-08 - main が ChatlogError で reject される', () => {
+        afterEach(() => {
+          GlobalConfig.resetInstance();
+        });
+
         it('T-PF-E2E-08-01: ChatlogError で main が reject される', async () => {
           await assertRejects(
             () => main(['claude', '--input-dir', '/nonexistent/path']),

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 // ─── Test target
 import { buildConfig } from '../../../filter-chatlogs.ts';
 // types
-import type { FilterConfig, FilterParsedConfig } from '../../../types/filter.types.ts';
+import type { FilterConfig } from '../../../types/filter.types.ts';
 
 // ─── Helpers
 // constants
@@ -44,9 +44,6 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
   });
 };
 
-/** 空の FilterParsedConfig。 */
-const _EMPTY_PARSED: FilterParsedConfig = {};
-
 /** `DEFAULT_FILTER_CONFIG` と異なる値を持つカスタムデフォルト設定。`defaults` パラメータの注入テストに使用する。 */
 const _CUSTOM_DEFAULTS: FilterConfig = {
   ...DEFAULT_FILTER_CONFIG,
@@ -58,19 +55,20 @@ const _CUSTOM_DEFAULTS: FilterConfig = {
 /**
  * `buildConfig` 関数の機能テストスイート。
  *
- * `buildConfig(parsed, globalConfig, defaults?)` は
- * `FilterParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `FilterConfig` を構築する。
+ * `buildConfig(args, defaults?)` は CLI 引数・GlobalConfig・デフォルト値の 3 層から
+ * `FilterConfig` を構築する（内部で共通ライブラリ `parseArgs` が
+ * 「CLI > GlobalConfig > defaults」の優先度マージを行う）。
  *
  * ## 優先順位ルール
- * - `agent`      : parsed > globalConfig > defaults
- * - `chatlogsDir`: globalConfig.chatlogsDir（基準ディレクトリ）
- * - `inputDir`   : parsed.inputDir（指定時のみ設定される）
- * - `dryRun`     : parsed > defaults (false)
- * - `period`     : parsed のみ（GlobalConfig 連携なし）
+ * - `agent`      : CLI > GlobalConfig > defaults
+ * - `chatlogsDir`: GlobalConfig.chatlogsDir（基準ディレクトリ）
+ * - `inputDir`   : CLI の `--input-dir`（指定時のみ設定される）
+ * - `dryRun`     : CLI の `--dry-run` > defaults (false)
+ * - `period`     : CLI のみ（GlobalConfig 連携なし）
  * - `configFile` は FilterConfig に存在しないため結果に含まれない
  *
- * - `chunkSize`   : parsed > globalConfig.chunkSize > defaults
- * - `concurrency` : parsed > globalConfig.concurrency > defaults
+ * - `chunkSize`/`concurrency`/`minCharCount`/`minAssistantChars`/`discardThreshold` は
+ *   `_SCHEMA` に CLI オプション定義が無いため、GlobalConfig > defaults の優先順位のみ検証する。
  *
  * テスト ID 範囲: T-FL-BC-01 〜 T-FL-BC-32
  *
@@ -84,21 +82,20 @@ describe('buildConfig', () => {
   // ─── agent 優先順位 ─────────────────────────────────────────────────────────
 
   /**
-   * `parsed.agent` がセットされている前提条件グループ。
+   * CLI 引数で agent が指定されている前提条件グループ。
    *
    * CLI 引数が明示的にエージェントを指定したケースを表す。
-   * `globalConfig` に agent が設定されていても `parsed.agent` が優先されることを検証する。
+   * `globalConfig` に agent が設定されていても CLI 引数が優先されることを検証する。
    */
-  describe('Given: parsed.agent が指定されている', () => {
+  describe('Given: CLI 引数で agent が指定されている', () => {
     describe('When: GlobalConfig にも agent が設定されている', () => {
-      /** `parsed.agent` が `globalConfig.agent` より優先されることを検証する。 */
-      describe('Then: T-FL-BC-01 - parsed.agent が優先される', () => {
-        let globalConfig: GlobalConfig;
+      /** CLI 引数の agent が `globalConfig.agent` より優先されることを検証する。 */
+      describe('Then: T-FL-BC-01 - CLI 引数の agent が優先される', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: codex');
+          await _makeGlobalConfig('agent: codex');
         });
-        it('T-FL-BC-01: parsed.agent=chatgpt → result.agent === chatgpt', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, agent: 'chatgpt' }, globalConfig);
+        it('T-FL-BC-01: args=[chatgpt] → result.agent === chatgpt', () => {
+          const result = buildConfig(['chatgpt']);
           assertEquals(result.agent, 'chatgpt');
         });
       });
@@ -106,21 +103,20 @@ describe('buildConfig', () => {
   });
 
   /**
-   * `parsed.agent` が未指定の前提条件グループ。
+   * CLI 引数で agent が未指定の前提条件グループ。
    *
    * CLI 引数でエージェントが省略されたケースを表す。
    * GlobalConfig にある場合はその値が、ない場合はデフォルト値が使われることを検証する。
    */
-  describe('Given: parsed.agent が未指定', () => {
+  describe('Given: CLI 引数で agent が未指定', () => {
     describe('When: GlobalConfig に agent が設定されている', () => {
       /** GlobalConfig の agent が使われることを検証する。 */
       describe('Then: T-FL-BC-02 - GlobalConfig の agent が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: chatgpt');
+          await _makeGlobalConfig('agent: chatgpt');
         });
         it('T-FL-BC-02: globalConfig.agent=chatgpt → result.agent === chatgpt', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.agent, 'chatgpt');
         });
       });
@@ -129,12 +125,11 @@ describe('buildConfig', () => {
     describe('When: GlobalConfig にも agent が設定されていない', () => {
       /** DEFAULT_FILTER_CONFIG.agent が使われることを検証する。 */
       describe('Then: T-FL-BC-03 - DEFAULT_FILTER_CONFIG.agent が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /some/dir');
+          await _makeGlobalConfig('chatlogsDir: /some/dir');
         });
         it('T-FL-BC-03: agent 未設定 → result.agent === DEFAULT_FILTER_CONFIG.agent', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.agent, DEFAULT_FILTER_CONFIG.agent);
         });
       });
@@ -144,20 +139,19 @@ describe('buildConfig', () => {
   // ─── inputDir / chatlogsDir ─────────────────────────────────────────────────
 
   /**
-   * `parsed.inputDir` がセットされている前提条件グループ。
+   * CLI 引数で `--input-dir` が指定されている前提条件グループ。
    *
-   * `parsed.inputDir` が結果にそのまま反映されることを検証する。
+   * `--input-dir` が結果にそのまま反映されることを検証する。
    */
-  describe('Given: parsed.inputDir が指定されている', () => {
+  describe('Given: CLI 引数で --input-dir が指定されている', () => {
     describe('When: GlobalConfig にも chatlogsDir が設定されている', () => {
-      /** `parsed.inputDir` が結果に反映されることを検証する。 */
-      describe('Then: T-FL-BC-30 - parsed.inputDir が結果に反映される', () => {
-        let globalConfig: GlobalConfig;
+      /** `--input-dir` が結果に反映されることを検証する。 */
+      describe('Then: T-FL-BC-30 - --input-dir が結果に反映される', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
+          await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-FL-BC-30: parsed.inputDir=/custom → result.inputDir === /custom', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom' }, globalConfig);
+        it('T-FL-BC-30: args=[--input-dir, /custom] → result.inputDir === /custom', () => {
+          const result = buildConfig(['--input-dir', '/custom']);
           assertEquals(result.inputDir, '/custom');
         });
       });
@@ -165,20 +159,19 @@ describe('buildConfig', () => {
   });
 
   /**
-   * `parsed.inputDir` が未指定の前提条件グループ。
+   * CLI 引数で `--input-dir` が未指定の前提条件グループ。
    *
    * GlobalConfig.chatlogsDir がそのまま `chatlogsDir` として使われることを検証する。
    */
-  describe('Given: parsed.inputDir が未指定', () => {
+  describe('Given: CLI 引数で --input-dir が未指定', () => {
     describe('When: GlobalConfig に chatlogsDir が設定されている', () => {
       /** GlobalConfig.chatlogsDir が chatlogsDir に使われることを検証する。 */
       describe('Then: T-FL-BC-31 - GlobalConfig の chatlogsDir が chatlogsDir に使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
+          await _makeGlobalConfig('chatlogsDir: /global');
         });
         it('T-FL-BC-31: globalConfig.chatlogsDir=/global → result.chatlogsDir === /global', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.chatlogsDir, '/global');
         });
       });
@@ -187,12 +180,11 @@ describe('buildConfig', () => {
     describe('When: GlobalConfig にもデフォルトの chatlogsDir のみ設定されている', () => {
       /** DEFAULT_CHATLOGS_DIR が chatlogsDir に使われることを検証する。 */
       describe('Then: T-FL-BC-32 - DEFAULT_CHATLOGS_DIR が chatlogsDir に使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-32: chatlogsDir 未設定 → result.chatlogsDir === DEFAULT_CHATLOGS_DIR', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.chatlogsDir, DEFAULT_FILTER_CONFIG.chatlogsDir);
         });
       });
@@ -202,18 +194,17 @@ describe('buildConfig', () => {
   // ─── dryRun ─────────────────────────────────────────────────────────────────
 
   /**
-   * `parsed.dryRun` がセットされている前提条件グループ。
+   * CLI 引数で `--dry-run` が指定されている前提条件グループ。
    */
-  describe('Given: parsed.dryRun=true が指定されている', () => {
+  describe('Given: CLI 引数で --dry-run が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** `result.dryRun === true` になることを検証する。 */
       describe('Then: T-FL-BC-07 - result.dryRun === true', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
-        it('T-FL-BC-07: parsed.dryRun=true → result.dryRun === true', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, dryRun: true }, globalConfig);
+        it('T-FL-BC-07: args=[--dry-run] → result.dryRun === true', () => {
+          const result = buildConfig(['--dry-run']);
           assertEquals(result.dryRun, true);
         });
       });
@@ -221,291 +212,188 @@ describe('buildConfig', () => {
   });
 
   /**
-   * `parsed.dryRun` が未指定の前提条件グループ。
+   * CLI 引数で `--dry-run` が未指定の前提条件グループ。
    */
-  describe('Given: parsed.dryRun が未指定', () => {
+  describe('Given: CLI 引数で --dry-run が未指定', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** デフォルト値 false が使われることを検証する。 */
       describe('Then: T-FL-BC-08 - result.dryRun === false', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-08: dryRun 未指定 → result.dryRun === false', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.dryRun, false);
         });
       });
     });
   });
 
-  // ─── period (parsed のみ) ────────────────────────────────────────────────────
+  // ─── period (CLI のみ) ───────────────────────────────────────────────────────
 
   /**
-   * `parsed.period` の引き継ぎを検証するグループ。
+   * CLI 引数で period が結果に反映されることを検証するグループ。
+   *
+   * period は GlobalConfig と連携しない。
    */
-  describe('Given: parsed.period が指定されている', () => {
+  describe('Given: CLI 引数で period が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** `result.period` に parsed の値が反映されることを検証する。 */
-      describe('Then: T-FL-BC-09 - result.period === parsed.period', () => {
-        let globalConfig: GlobalConfig;
+      /** `result.period` に CLI の period が設定されることを検証する。 */
+      describe('Then: T-FL-BC-09 - result.period === CLI の period', () => {
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
-        it('T-FL-BC-09: parsed.period=2026-03 → result.period === 2026-03', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, period: '2026-03' }, globalConfig);
+        it('T-FL-BC-09: args=[claude, 2026-03] → result.period === 2026-03', () => {
+          const result = buildConfig(['claude', '2026-03']);
           assertEquals(result.period, '2026-03');
         });
       });
     });
   });
 
-  describe('Given: parsed.period が未指定', () => {
+  describe('Given: CLI 引数で period が未指定', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** `result.period === undefined` になることを検証する。 */
       describe('Then: T-FL-BC-10 - result.period === undefined', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-10: period 未指定 → result.period === undefined', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.period, undefined);
         });
       });
     });
   });
 
-  // ─── chunkSize 優先順位 ──────────────────────────────────────────────────────
+  // ─── chunkSize 優先順位（GlobalConfig 経由。CLI スキーマ未定義） ─────────────
 
   /**
-   * `parsed.chunkSize` がセットされている前提条件グループ。
+   * GlobalConfig に chunkSize が設定されている前提条件グループ。
    *
-   * CLI 引数が明示的に chunkSize を指定したケースを表す。
-   * GlobalConfig に chunkSize が設定されていても `parsed.chunkSize` が優先されることを検証する。
+   * `_SCHEMA` に chunkSize の CLI オプション定義が無いため、
+   * GlobalConfig の値がそのまま結果に反映されることを検証する。
    */
-  describe('Given: parsed.chunkSize が指定されている', () => {
-    describe('When: GlobalConfig にも chunkSize が設定されている', () => {
-      /** `parsed.chunkSize` が GlobalConfig より優先されることを検証する。 */
-      describe('Then: T-FL-BC-11 - parsed.chunkSize が優先される', () => {
-        let globalConfig: GlobalConfig;
+  describe('Given: GlobalConfig に chunkSize が設定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** GlobalConfig の chunkSize が使われることを検証する。 */
+      describe('Then: T-FL-BC-12 - GlobalConfig の chunkSize が使われる', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chunkSize: 8');
+          await _makeGlobalConfig('chunkSize: 8');
         });
-        it('T-FL-BC-11: parsed.chunkSize=5 → result.chunkSize === 5', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, chunkSize: 5 }, globalConfig);
-          assertEquals(result.chunkSize, 5);
+        it('T-FL-BC-12: globalConfig.chunkSize=8 → result.chunkSize === 8', () => {
+          const result = buildConfig([]);
+          assertEquals(result.chunkSize, 8);
         });
       });
     });
   });
 
-  /**
-   * `parsed.chunkSize` が未指定の前提条件グループ。
-   *
-   * GlobalConfig に chunkSize がある場合はその値が、ない場合はデフォルト値が使われることを検証する。
-   */
-  describe('Given: parsed.chunkSize が未指定', () => {
-    describe('When: GlobalConfig に chunkSize が設定されている', () => {
-      /** GlobalConfig の chunkSize が使われることを検証する。 */
-      describe('Then: T-FL-BC-12 - GlobalConfig の chunkSize が使われる', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chunkSize: 8');
-        });
-        it('T-FL-BC-12: globalConfig.chunkSize=8 → result.chunkSize === 8', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.chunkSize, 8);
-        });
-      });
-    });
-
-    describe('When: GlobalConfig にも chunkSize が設定されていない', () => {
+  describe('Given: GlobalConfig にも chunkSize が設定されていない', () => {
+    describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig の DEFAULT_CONFIG_VALUES.chunkSize が使われることを検証する。 */
       describe('Then: T-FL-BC-11b - GlobalConfig のデフォルト chunkSize が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-11b: chunkSize 未設定 → result.chunkSize === GlobalConfig デフォルト値', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.chunkSize, DEFAULT_FILTER_CONFIG.chunkSize);
         });
       });
     });
   });
 
-  // ─── concurrency 優先順位 ─────────────────────────────────────────────────────
+  // ─── concurrency 優先順位（GlobalConfig 経由） ───────────────────────────────
 
-  /**
-   * `parsed.concurrency` がセットされている前提条件グループ。
-   *
-   * CLI 引数が明示的に concurrency を指定したケースを表す。
-   * GlobalConfig に concurrency が設定されていても `parsed.concurrency` が優先されることを検証する。
-   */
-  describe('Given: parsed.concurrency が指定されている', () => {
-    describe('When: GlobalConfig にも concurrency が設定されている', () => {
-      /** `parsed.concurrency` が GlobalConfig より優先されることを検証する。 */
-      describe('Then: T-FL-BC-14 - parsed.concurrency が優先される', () => {
-        let globalConfig: GlobalConfig;
+  describe('Given: GlobalConfig に concurrency が設定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** GlobalConfig の concurrency が使われることを検証する。 */
+      describe('Then: T-FL-BC-15 - GlobalConfig の concurrency が使われる', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('concurrency: 6');
+          await _makeGlobalConfig('concurrency: 6');
         });
-        it('T-FL-BC-14: parsed.concurrency=2 → result.concurrency === 2', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, concurrency: 2 }, globalConfig);
-          assertEquals(result.concurrency, 2);
+        it('T-FL-BC-15: globalConfig.concurrency=6 → result.concurrency === 6', () => {
+          const result = buildConfig([]);
+          assertEquals(result.concurrency, 6);
         });
       });
     });
   });
 
-  /**
-   * `parsed.concurrency` が未指定の前提条件グループ。
-   *
-   * GlobalConfig に concurrency がある場合はその値が、ない場合はデフォルト値が使われることを検証する。
-   */
-  describe('Given: parsed.concurrency が未指定', () => {
-    describe('When: GlobalConfig に concurrency が設定されている', () => {
-      /** GlobalConfig の concurrency が使われることを検証する。 */
-      describe('Then: T-FL-BC-15 - GlobalConfig の concurrency が使われる', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('concurrency: 6');
-        });
-        it('T-FL-BC-15: globalConfig.concurrency=6 → result.concurrency === 6', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.concurrency, 6);
-        });
-      });
-    });
-
-    describe('When: GlobalConfig にも concurrency が設定されていない', () => {
+  describe('Given: GlobalConfig にも concurrency が設定されていない', () => {
+    describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig の DEFAULT_CONFIG_VALUES.concurrency が使われることを検証する。 */
       describe('Then: T-FL-BC-16 - GlobalConfig のデフォルト concurrency が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-16: concurrency 未設定 → result.concurrency === GlobalConfig デフォルト値', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.concurrency, DEFAULT_FILTER_CONFIG.concurrency);
         });
       });
     });
   });
 
-  // ─── minCharCount 優先順位 ───────────────────────────────────────────────────
+  // ─── minCharCount 優先順位（GlobalConfig 経由） ──────────────────────────────
 
-  /**
-   * `parsed.minCharCount` がセットされている前提条件グループ。
-   *
-   * CLI 引数または呼び出しコードが明示的に minCharCount を指定したケースを表す。
-   * GlobalConfig に minCharCount が設定されていても `parsed.minCharCount` が優先されることを検証する。
-   */
-  describe('Given: parsed.minCharCount が指定されている', () => {
-    describe('When: GlobalConfig にも minCharCount が設定されている', () => {
-      /** `parsed.minCharCount` が GlobalConfig より優先されることを検証する。 */
-      describe('Then: T-FL-BC-21 - parsed.minCharCount が優先される', () => {
-        let globalConfig: GlobalConfig;
+  describe('Given: GlobalConfig に minCharCount が設定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** GlobalConfig の minCharCount が使われることを検証する。 */
+      describe('Then: T-FL-BC-22 - GlobalConfig の minCharCount が使われる', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('minCharCount: 2000');
+          await _makeGlobalConfig('minCharCount: 2000');
         });
-        it('T-FL-BC-21: parsed.minCharCount=500 → result.minCharCount === 500', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, minCharCount: 500 }, globalConfig);
-          assertEquals(result.minCharCount, 500);
+        it('T-FL-BC-22: globalConfig.minCharCount=2000 → result.minCharCount === 2000', () => {
+          const result = buildConfig([]);
+          assertEquals(result.minCharCount, 2000);
         });
       });
     });
   });
 
-  /**
-   * `parsed.minCharCount` が未指定の前提条件グループ。
-   *
-   * GlobalConfig に minCharCount がある場合はその値が、ない場合はデフォルト値が使われることを検証する。
-   */
-  describe('Given: parsed.minCharCount が未指定', () => {
-    describe('When: GlobalConfig に minCharCount が設定されている', () => {
-      /** GlobalConfig の minCharCount が使われることを検証する。 */
-      describe('Then: T-FL-BC-22 - GlobalConfig の minCharCount が使われる', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('minCharCount: 2000');
-        });
-        it('T-FL-BC-22: globalConfig.minCharCount=2000 → result.minCharCount === 2000', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.minCharCount, 2000);
-        });
-      });
-    });
-
-    describe('When: GlobalConfig にも minCharCount が設定されていない', () => {
+  describe('Given: GlobalConfig にも minCharCount が設定されていない', () => {
+    describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig の DEFAULT_CONFIG_VALUES.minCharCount が使われることを検証する。 */
       describe('Then: T-FL-BC-23 - GlobalConfig のデフォルト minCharCount が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-23: minCharCount 未設定 → result.minCharCount === DEFAULT_FILTER_CONFIG.minCharCount', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.minCharCount, DEFAULT_FILTER_CONFIG.minCharCount);
         });
       });
     });
   });
 
-  // ─── minAssistantChars 優先順位 ──────────────────────────────────────────────
+  // ─── minAssistantChars 優先順位（GlobalConfig 経由） ─────────────────────────
 
-  /**
-   * `parsed.minAssistantChars` がセットされている前提条件グループ。
-   *
-   * CLI 引数または呼び出しコードが明示的に minAssistantChars を指定したケースを表す。
-   * GlobalConfig に minAssistantChars が設定されていても `parsed.minAssistantChars` が優先されることを検証する。
-   */
-  describe('Given: parsed.minAssistantChars が指定されている', () => {
-    describe('When: GlobalConfig にも minAssistantChars が設定されている', () => {
-      /** `parsed.minAssistantChars` が GlobalConfig より優先されることを検証する。 */
-      describe('Then: T-FL-BC-24 - parsed.minAssistantChars が優先される', () => {
-        let globalConfig: GlobalConfig;
+  describe('Given: GlobalConfig に minAssistantChars が設定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** GlobalConfig の minAssistantChars が使われることを検証する。 */
+      describe('Then: T-FL-BC-25 - GlobalConfig の minAssistantChars が使われる', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('minAssistantChars: 600');
+          await _makeGlobalConfig('minAssistantChars: 600');
         });
-        it('T-FL-BC-24: parsed.minAssistantChars=100 → result.minAssistantChars === 100', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, minAssistantChars: 100 }, globalConfig);
-          assertEquals(result.minAssistantChars, 100);
+        it('T-FL-BC-25: globalConfig.minAssistantChars=600 → result.minAssistantChars === 600', () => {
+          const result = buildConfig([]);
+          assertEquals(result.minAssistantChars, 600);
         });
       });
     });
   });
 
-  /**
-   * `parsed.minAssistantChars` が未指定の前提条件グループ。
-   *
-   * GlobalConfig に minAssistantChars がある場合はその値が、ない場合はデフォルト値が使われることを検証する。
-   */
-  describe('Given: parsed.minAssistantChars が未指定', () => {
-    describe('When: GlobalConfig に minAssistantChars が設定されている', () => {
-      /** GlobalConfig の minAssistantChars が使われることを検証する。 */
-      describe('Then: T-FL-BC-25 - GlobalConfig の minAssistantChars が使われる', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('minAssistantChars: 600');
-        });
-        it('T-FL-BC-25: globalConfig.minAssistantChars=600 → result.minAssistantChars === 600', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
-          assertEquals(result.minAssistantChars, 600);
-        });
-      });
-    });
-
-    describe('When: GlobalConfig にも minAssistantChars が設定されていない', () => {
+  describe('Given: GlobalConfig にも minAssistantChars が設定されていない', () => {
+    describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig の DEFAULT_CONFIG_VALUES.minAssistantChars が使われることを検証する。 */
       describe('Then: T-FL-BC-26 - GlobalConfig のデフォルト minAssistantChars が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-26: minAssistantChars 未設定 → result.minAssistantChars === DEFAULT_FILTER_CONFIG.minAssistantChars', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.minAssistantChars, DEFAULT_FILTER_CONFIG.minAssistantChars);
         });
       });
@@ -523,12 +411,11 @@ describe('buildConfig', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig の discardThreshold が使われることを検証する。 */
       describe('Then: T-FL-BC-27 - GlobalConfig の discardThreshold が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('discardThreshold: 0.85');
+          await _makeGlobalConfig('discardThreshold: 0.85');
         });
         it('T-FL-BC-27: globalConfig.discardThreshold=0.85 → result.discardThreshold === 0.85', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.discardThreshold, 0.85);
         });
       });
@@ -544,12 +431,11 @@ describe('buildConfig', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig が defaults より優先されることを検証する。 */
       describe('Then: T-FL-BC-28 - GlobalConfig が defaults より優先される', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('discardThreshold: 0.85');
+          await _makeGlobalConfig('discardThreshold: 0.85');
         });
         it('T-FL-BC-28: globalConfig=0.85, defaults=0.6 → result.discardThreshold === 0.85', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig, { ..._CUSTOM_DEFAULTS, discardThreshold: 0.6 });
+          const result = buildConfig([], { ..._CUSTOM_DEFAULTS, discardThreshold: 0.6 });
           assertEquals(result.discardThreshold, 0.85);
         });
       });
@@ -565,12 +451,11 @@ describe('buildConfig', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** DEFAULT_FILTER_CONFIG.discardThreshold が使われることを検証する。 */
       describe('Then: T-FL-BC-29 - DEFAULT_FILTER_CONFIG.discardThreshold が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
         it('T-FL-BC-29: discardThreshold 未設定 → result.discardThreshold === DEFAULT_FILTER_CONFIG.discardThreshold', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.discardThreshold, DEFAULT_FILTER_CONFIG.discardThreshold);
         });
       });
@@ -580,48 +465,20 @@ describe('buildConfig', () => {
   // ─── configFile が結果に含まれない ───────────────────────────────────────────
 
   /**
-   * `parsed.configFile` が結果に含まれないことを検証するグループ。
+   * CLI 引数で `--config` が指定されている前提条件グループ。
    *
    * `configFile` は `FilterConfig` に存在しないため、buildConfig の結果に含まれてはならない。
    */
-  describe('Given: parsed.configFile が指定されている', () => {
+  describe('Given: CLI 引数で --config が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** `result` に `configFile` フィールドが含まれないことを検証する。 */
       describe('Then: T-FL-BC-13 - result に configFile フィールドが含まれない', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
+          await GlobalConfig.getInstance();
         });
-        it('T-FL-BC-13: parsed.configFile=cfg.yaml → configFile in result === false', () => {
-          const result: FilterConfig = buildConfig(
-            { ..._EMPTY_PARSED, configFile: 'cfg.yaml' },
-            globalConfig,
-          );
+        it('T-FL-BC-13: args=[--config, cfg.yaml] → configFile in result === false', () => {
+          const result: FilterConfig = buildConfig(['--config', 'cfg.yaml']);
           assertEquals('configFile' in result, false);
-        });
-      });
-    });
-  });
-
-  /**
-   * `parsed.inputDir` が結果に含まれることを検証するグループ。
-   *
-   * `inputDir` は `FilterConfig` に追加されたため、buildConfig の結果に含まれる。
-   */
-  describe('Given: parsed.inputDir が指定されている', () => {
-    describe('When: buildConfig を呼び出す', () => {
-      /** `result` に `inputDir` フィールドが含まれることを検証する。 */
-      describe('Then: T-FL-BC-19 - result に inputDir フィールドが含まれる', () => {
-        let globalConfig: GlobalConfig;
-        beforeEach(async () => {
-          globalConfig = await GlobalConfig.getInstance();
-        });
-        it('T-FL-BC-19: parsed.inputDir=/base → result.inputDir === /base', () => {
-          const result: FilterConfig = buildConfig(
-            { ..._EMPTY_PARSED, inputDir: '/base' },
-            globalConfig,
-          );
-          assertEquals(result.inputDir, '/base');
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -319,13 +319,13 @@ describe('prefilterFiles', () => {
    * ファイル名パターン除外 1 件・本文短すぎ 1 件・正常 1 件が混在するファイルを入力とする前提条件グループ。
    *
    * `dryRun: true` を指定したときも削除予定ファイルのログ出力・`stats.skip` 計上が行われ、
-   * 実削除しないため `passed` に全ファイルが含まれることを検証する。
+   * DISCARD 確定ファイルは実削除しなくても `passed` から除外されることを検証する。
    */
   describe('Given: 3 ファイル（ファイル名パターン除外 1 + 本文短すぎ 1 + 正常 1）', () => {
     /** dryRun: true を渡して prefilterFiles を呼び出すとき。 */
     describe('When: dryRun: true を渡して prefilterFiles を呼び出す', () => {
-      /** dryRun でも削除予定ファイルはログ出力・stats.skip に計上され、passed には全ファイルが含まれることを検証する。 */
-      describe('Then: T-FL-PFF-09 - 削除予定がログ出力され、passed に全ファイルが含まれる', () => {
+      /** dryRun でも削除予定ファイルはログ出力・stats.skip に計上され、DISCARD 確定分は passed から除外されることを検証する。 */
+      describe('Then: T-FL-PFF-09 - 削除予定がログ出力され、DISCARD 確定分は passed から除外される', () => {
         it('T-FL-PFF-09-01: [Normal] dryRun: true のとき削除予定ファイルの logger.info が呼ばれる', async () => {
           const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
           const shortPath = `${periodDir1}/short-body.md`;
@@ -341,7 +341,7 @@ describe('prefilterFiles', () => {
           assertEquals(loggerStub.infoLogs.length, 2);
         });
 
-        it('T-FL-PFF-09-02: [Normal] dryRun: true では passed に全ファイルが含まれ、削除予定分は stats.skip に計上される', async () => {
+        it('T-FL-PFF-09-02: [Normal] dryRun: true でも DISCARD 確定分は passed から除外され、stats.skip に計上される', async () => {
           const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
           const shortPath = `${periodDir1}/short-body.md`;
           const validPath = `${periodDir1}/valid.md`;
@@ -359,7 +359,7 @@ describe('prefilterFiles', () => {
           const resultNormal = await prefilterFiles([excludedPath, shortPath, validPath], { stats: statsNormal });
           loggerStub.restore();
 
-          assertEquals(resultDryRun, [excludedPath, shortPath, validPath]);
+          assertEquals(resultDryRun, [validPath]);
           assertEquals(resultNormal, [validPath]);
           assertEquals(statsNormal.remove, 2);
           assertEquals(statsDryRun.remove, 0);

--- a/skills/filter-chatlogs/scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/noise-filter/build-config.functional.spec.ts
@@ -13,8 +13,6 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { buildConfig } from '../../../configs/noise-filter-config.ts';
-// types
-import type { NoiseFilterConfig, NoiseFilterParsedConfig } from '../../../types/noise-filter.types.ts';
 
 // ─── Helpers
 // classes
@@ -44,30 +42,20 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
   });
 };
 
-/** 空の NoiseFilterParsedConfig。 */
-const _EMPTY_PARSED: NoiseFilterParsedConfig = {};
-
-/** `DEFAULT_NOISE_FILTER_CONFIG` と異なる値を持つカスタムデフォルト設定。`defaults` パラメータの注入テストに使用する。 */
-const _CUSTOM_DEFAULTS: NoiseFilterConfig = {
-  ...DEFAULT_NOISE_FILTER_CONFIG,
-  agent: 'chatgpt',
-  chatlogsDir: '/custom-default',
-};
-
 // ─── Tests
 
 /**
  * `buildConfig` 関数の機能テストスイート。
  *
- * `buildConfig(parsed, globalConfig, defaults?)` は
- * `NoiseFilterParsedConfig`・`GlobalConfig`・デフォルト値の 3 層から `NoiseFilterConfig` を構築する。
+ * `buildConfig(args, defaults?)` は CLI 引数・GlobalConfig・デフォルト値の 3 層から
+ * `NoiseFilterConfig` を構築する。
  *
  * ## 優先順位ルール
- * - `agent`      : parsed > globalConfig > defaults
- * - `chatlogsDir`: globalConfig.chatlogsDir（基準ディレクトリ）
- * - `inputDir`   : parsed.inputDir（指定時のみ設定される）
- * - `period`     : parsed のみ（GlobalConfig 連携なし）
- * - `dryRun`     : parsed > defaults (false)
+ * - `agent`      : CLI > GlobalConfig > defaults
+ * - `chatlogsDir`: GlobalConfig.chatlogsDir（基準ディレクトリ）
+ * - `inputDir`   : CLI の `--input-dir`（指定時のみ設定される）
+ * - `period`     : CLI のみ（GlobalConfig 連携なし）
+ * - `dryRun`     : CLI の `--dry-run` > defaults (false)
  * - `configFile` は NoiseFilterConfig に存在しないため結果に含まれない
  *
  * テスト ID 範囲: T-PF-BC-06 〜 T-PF-BC-16
@@ -82,21 +70,20 @@ describe('buildConfig (noise-filter functional)', () => {
   // ─── agent 優先順位 ─────────────────────────────────────────────────────────
 
   /**
-   * `parsed.agent` がセットされている前提条件グループ。
+   * CLI 引数で agent が指定されている前提条件グループ。
    *
    * CLI 引数が明示的にエージェントを指定したケースを表す。
-   * `globalConfig` に agent が設定されていても `parsed.agent` が優先されることを検証する。
+   * `globalConfig` に agent が設定されていても CLI 引数が優先されることを検証する。
    */
-  describe('Given: parsed.agent が指定されている', () => {
+  describe('Given: CLI 引数で agent が指定されている', () => {
     describe('When: GlobalConfig にも agent が設定されている', () => {
-      /** `parsed.agent` が `globalConfig.agent` より優先されることを検証する。 */
-      describe('Then: T-PF-BC-06 - parsed.agent が優先される', () => {
-        let globalConfig: GlobalConfig;
+      /** CLI 引数の agent が `globalConfig.agent` より優先されることを検証する。 */
+      describe('Then: T-PF-BC-06 - CLI 引数の agent が優先される', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: codex');
+          await _makeGlobalConfig('agent: codex');
         });
-        it('T-PF-BC-06: parsed.agent=chatgpt → result.agent === chatgpt', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, agent: 'chatgpt' }, globalConfig);
+        it('T-PF-BC-06: args=[chatgpt] → result.agent === chatgpt', () => {
+          const result = buildConfig(['chatgpt']);
           assertEquals(result.agent, 'chatgpt');
         });
       });
@@ -104,21 +91,20 @@ describe('buildConfig (noise-filter functional)', () => {
   });
 
   /**
-   * `parsed.agent` が未指定の前提条件グループ。
+   * CLI 引数で agent が未指定の前提条件グループ。
    *
    * CLI 引数でエージェントが省略されたケースを表す。
    * GlobalConfig にある場合はその値が、ない場合はデフォルト値が使われることを検証する。
    */
-  describe('Given: parsed.agent が未指定', () => {
+  describe('Given: CLI 引数で agent が未指定', () => {
     describe('When: GlobalConfig に agent が設定されている', () => {
       /** GlobalConfig の agent が使われることを検証する。 */
       describe('Then: T-PF-BC-07 - GlobalConfig の agent が使われる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: chatgpt');
+          await _makeGlobalConfig('agent: chatgpt');
         });
         it('T-PF-BC-07: globalConfig.agent=chatgpt → result.agent === chatgpt', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.agent, 'chatgpt');
         });
       });
@@ -127,12 +113,11 @@ describe('buildConfig (noise-filter functional)', () => {
     describe('When: GlobalConfig にも agent が設定されていない', () => {
       /** DEFAULT_NOISE_FILTER_CONFIG.agent が使われることを検証する。 */
       describe('Then: T-PF-BC-08 - defaults.agent にフォールバック', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /some/dir');
+          await _makeGlobalConfig('chatlogsDir: /some/dir');
         });
         it('T-PF-BC-08: agent 未設定 → result.agent === DEFAULT_NOISE_FILTER_CONFIG.agent', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.agent, DEFAULT_NOISE_FILTER_CONFIG.agent);
         });
       });
@@ -150,12 +135,11 @@ describe('buildConfig (noise-filter functional)', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** GlobalConfig.chatlogsDir が chatlogsDir に使われることを検証する。 */
       describe('Then: T-PF-BC-10 - GlobalConfig の chatlogsDir が chatlogsDir になる', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
+          await _makeGlobalConfig('chatlogsDir: /global');
         });
         it('T-PF-BC-10: globalConfig.chatlogsDir=/global → result.chatlogsDir === /global', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.chatlogsDir, '/global');
         });
       });
@@ -171,12 +155,11 @@ describe('buildConfig (noise-filter functional)', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir が使われることを検証する。 */
       describe('Then: T-PF-BC-11 - defaults.chatlogsDir にフォールバック', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: claude');
+          await _makeGlobalConfig('agent: claude');
         });
         it('T-PF-BC-11: chatlogsDir 未設定 → result.chatlogsDir === DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.chatlogsDir, DEFAULT_NOISE_FILTER_CONFIG.chatlogsDir);
         });
       });
@@ -186,20 +169,19 @@ describe('buildConfig (noise-filter functional)', () => {
   // ─── inputDir ───────────────────────────────────────────────────────────────
 
   /**
-   * `parsed.inputDir` がセットされている前提条件グループ。
+   * CLI 引数で `--input-dir` が指定されている前提条件グループ。
    *
-   * `parsed.inputDir` が結果にそのまま反映されることを検証する。
+   * `--input-dir` が結果にそのまま反映されることを検証する。
    */
-  describe('Given: parsed.inputDir が指定されている', () => {
+  describe('Given: CLI 引数で --input-dir が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** `parsed.inputDir` が結果に反映されることを検証する。 */
-      describe('Then: T-PF-BC-16 - parsed.inputDir が結果に反映される', () => {
-        let globalConfig: GlobalConfig;
+      /** `--input-dir` が結果に反映されることを検証する。 */
+      describe('Then: T-PF-BC-16 - --input-dir が結果に反映される', () => {
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
+          await _makeGlobalConfig('chatlogsDir: /global');
         });
-        it('T-PF-BC-16-01: parsed.inputDir=/custom → result.inputDir === /custom', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, inputDir: '/custom' }, globalConfig);
+        it('T-PF-BC-16-01: args=[--input-dir, /custom] → result.inputDir === /custom', () => {
+          const result = buildConfig(['--input-dir', '/custom']);
           assertEquals(result.inputDir, '/custom');
         });
       });
@@ -207,43 +189,41 @@ describe('buildConfig (noise-filter functional)', () => {
   });
 
   /**
-   * `parsed.inputDir` が未指定の前提条件グループ。
+   * CLI 引数で `--input-dir` が未指定の前提条件グループ。
    *
    * `result.inputDir` が `undefined` のままであることを検証する。
    */
-  describe('Given: parsed.inputDir が未指定', () => {
+  describe('Given: CLI 引数で --input-dir が未指定', () => {
     describe('When: buildConfig を呼び出す', () => {
       /** `result.inputDir` が `undefined` になることを検証する。 */
       describe('Then: T-PF-BC-16-02 - result.inputDir === undefined', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('chatlogsDir: /global');
+          await _makeGlobalConfig('chatlogsDir: /global');
         });
         it('T-PF-BC-16-02: inputDir 未指定 → result.inputDir === undefined', () => {
-          const result = buildConfig(_EMPTY_PARSED, globalConfig);
+          const result = buildConfig([]);
           assertEquals(result.inputDir, undefined);
         });
       });
     });
   });
 
-  // ─── period (parsed のみ) ────────────────────────────────────────────────────
+  // ─── period (CLI のみ) ───────────────────────────────────────────────────────
 
   /**
-   * `parsed.period` が結果に反映されることを検証するグループ。
+   * CLI 引数で period が結果に反映されることを検証するグループ。
    *
    * period は GlobalConfig と連携しない。
    */
-  describe('Given: parsed.period が指定されている', () => {
+  describe('Given: CLI 引数で period が指定されている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      /** `result.period` に `parsed.period` が設定されることを検証する。 */
+      /** `result.period` に CLI の period が設定されることを検証する。 */
       describe('Then: T-PF-BC-15 - 結果の period に反映される（GlobalConfig 無関係）', () => {
-        let globalConfig: GlobalConfig;
         beforeEach(async () => {
-          globalConfig = await _makeGlobalConfig('agent: claude');
+          await _makeGlobalConfig('agent: claude');
         });
-        it('T-PF-BC-15: parsed.period=2026-03 → result.period === 2026-03', () => {
-          const result = buildConfig({ ..._EMPTY_PARSED, period: '2026-03' }, globalConfig);
+        it('T-PF-BC-15: args=[claude, 2026-03] → result.period === 2026-03', () => {
+          const result = buildConfig(['claude', '2026-03']);
           assertEquals(result.period, '2026-03');
         });
       });

--- a/skills/filter-chatlogs/scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/configs/__tests__/unit/noise-filter-config.unit.spec.ts
 // @(#): noise-filter-config.ts のユニットテスト
-//       対象: parseArgs / buildConfig
+//       対象: buildConfig
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -9,127 +9,18 @@
 
 // ─── BDD modules
 import { assert, assertEquals, assertFalse, assertThrows } from '@std/assert';
-import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+import { beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { buildConfig, parseArgs } from '../../../configs/noise-filter-config.ts';
+import { buildConfig } from '../../../configs/noise-filter-config.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 // constants
 import { DEFAULT_CHATLOGS_DIR } from '../../../../../_scripts/constants/defaults.constants.ts';
-// types
-import { resetProjectRoot } from '../../../../../_scripts/libs/path-utils/dir-utils.ts';
 
 // ─── Tests
-
-// ─────────────────────────────────────────────────────────────────────────────
-// parseArgs (noise-filter)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * `parseArgs` のユニットテストスイート。
- *
- * デフォルト値・agent/period/フラグ/オプション形式・エラーケースを検証する。
- *
- * テスト ID 範囲: T-PF-PA-01 〜 T-PF-PA-14
- *
- * @see parseArgs
- */
-describe('parseArgs (noise-filter)', () => {
-  beforeEach(() => {
-    GlobalConfig.resetInstance();
-  });
-
-  /** 引数なし・agent/period・フラグ・オプション形式の正常ケース。 */
-  describe('When: 正常系', () => {
-    it('[Normal] T-PF-PA-01-01: agent が GlobalConfig のデフォルト値 "claude" になる', () => {
-      assertEquals(parseArgs([]).agent, 'claude');
-    });
-
-    it('[Normal] T-PF-PA-01-02: dryRun が false になる', () => {
-      assertFalse(parseArgs([]).dryRun);
-    });
-
-    it('[Normal] T-PF-PA-01-03: chatlogsDir が GlobalConfig のデフォルト値になる', () => {
-      assertEquals(parseArgs([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
-    });
-
-    it('[Normal] T-PF-PA-01-04: period が undefined になる', () => {
-      assertEquals(parseArgs([]).period, undefined);
-    });
-
-    it('[Normal] T-PF-PA-02-01: agent が "codex" になる', () => {
-      assertEquals(parseArgs(['codex']).agent, 'codex');
-    });
-
-    it('[Normal] T-PF-PA-04-01: agent="claude", period="2026-03" が正しく解析される', () => {
-      const result = parseArgs(['claude', '2026-03']);
-
-      assertEquals(result.agent, 'claude');
-      assertEquals(result.period, '2026-03');
-    });
-
-    it('[Normal] T-PF-PA-05-01: dryRun が true になる', () => {
-      assert(parseArgs(['--dry-run']).dryRun);
-    });
-
-    it('[Normal] T-PF-PA-10-01: 全フィールドが正しく解析される', () => {
-      const result = parseArgs(['codex', '2026-03', '--dry-run', '--input-dir', '/path/to/input']);
-
-      assertEquals(result.agent, 'codex');
-      assertEquals(result.period, '2026-03');
-      assert(result.dryRun);
-      assertEquals(result.inputDir, '/path/to/input');
-    });
-
-    it('[Normal] T-PF-PA-14-01: inputDir が "/path/to/input" になる', () => {
-      assertEquals(parseArgs(['--input-dir', '/path/to/input']).inputDir, '/path/to/input');
-    });
-
-    it('[Normal] T-PF-PA-14-02: --input-dir=value 形式のパース', () => {
-      assertEquals(parseArgs(['--input-dir=/path/to/input']).inputDir, '/path/to/input');
-    });
-
-    it('[Normal] T-PF-PA-12-01: inputDir が "/path/to/chatlogs" になる', () => {
-      assertEquals(parseArgs(['--input-dir', '/path/to/chatlogs']).inputDir, '/path/to/chatlogs');
-    });
-  });
-
-  /** 未知オプション・不正値のエラーケース。 */
-  describe('When: 異常系', () => {
-    it('[Error] T-PF-PA-11-01: ChatlogError(InvalidArgs) がスローされる', () => {
-      assertThrows(
-        () => parseArgs(['--unknown']),
-        ChatlogError,
-        'Invalid Args',
-      );
-    });
-
-    it('[Error] T-PF-PA-11-02: --input を渡すと ChatlogError(InvalidArgs) がスローされる', () => {
-      assertThrows(
-        () => parseArgs(['--input', '/path/to/input']),
-        ChatlogError,
-        'Invalid Args',
-      );
-    });
-
-    it('[Error] T-PF-PA-13-01: --input-dir にパスでない値 → ChatlogError がスローされる', () => {
-      assertThrows(
-        () => parseArgs(['--input-dir', 'notapath']),
-        ChatlogError,
-      );
-    });
-
-    it('[Error] T-PF-PA-03-01: period 単独指定（agent 省略）→ ChatlogError(InvalidArgs) がスローされる', () => {
-      assertThrows(
-        () => parseArgs(['2026-03']),
-        ChatlogError,
-      );
-    });
-  });
-});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // buildConfig
@@ -138,65 +29,101 @@ describe('parseArgs (noise-filter)', () => {
 /**
  * `buildConfig` のユニットテストスイート。
  *
- * 空 Args のデフォルト値・agent 指定・フラグ反映・chatlogsDir 指定を検証する。
+ * デフォルト値・agent/period・フラグ/オプション形式・エラーケースを検証する。
  *
- * テスト ID 範囲: T-PF-BC-01 〜 T-PF-BC-04
+ * テスト ID 範囲: T-PF-BC-20 〜 T-PF-BC-33
  *
  * @see buildConfig
  */
-describe('buildConfig', () => {
-  /**
-   * 空の GlobalConfig インスタンスを生成する。
-   *
-   * `GlobalConfig.resetInstance()` でリセットしてから
-   * `resetProjectRoot` でプロジェクトルートをシードして初期化する。
-   *
-   * @returns 初期化済みの `GlobalConfig` インスタンス（空設定）
-   */
-  const _makeEmptyGlobalConfig = (): GlobalConfig => {
-    resetProjectRoot('/home/user/project');
-    GlobalConfig.resetInstance();
-    return GlobalConfig.getInstance({
-      readTextFileProvider: () => '{}',
-      configFile: 'dummy.yaml',
-      schema: {},
-    });
-  };
-
-  let globalConfig: GlobalConfig;
+describe('buildConfig (noise-filter)', () => {
   beforeEach(() => {
-    globalConfig = _makeEmptyGlobalConfig();
-  });
-  afterEach(() => {
     GlobalConfig.resetInstance();
   });
 
-  /** 空 Args・agent/chatlogsDir 指定・フラグ反映の正常ケース。 */
+  /** 引数なし・agent/period・フラグ・オプション形式の正常ケース。 */
   describe('When: 正常系', () => {
-    it('[Normal] T-PF-BC-01-01: agent が "claude" になる', () => {
-      assertEquals(buildConfig({ dryRun: false }, globalConfig).agent, 'claude');
+    it('[Normal] T-PF-BC-20-01: agent が GlobalConfig のデフォルト値 "claude" になる', () => {
+      assertEquals(buildConfig([]).agent, 'claude');
     });
 
-    it('[Normal] T-PF-BC-01-02: chatlogsDir が "./chatlogs" になる', () => {
-      assertEquals(buildConfig({ dryRun: false }, globalConfig).chatlogsDir, './chatlogs');
+    it('[Normal] T-PF-BC-20-02: dryRun が false になる', () => {
+      assertFalse(buildConfig([]).dryRun);
     });
 
-    it('[Normal] T-PF-BC-01-03: dryRun が false になる', () => {
-      assertFalse(buildConfig({ dryRun: false }, globalConfig).dryRun);
+    it('[Normal] T-PF-BC-20-03: chatlogsDir が GlobalConfig のデフォルト値になる', () => {
+      assertEquals(buildConfig([]).chatlogsDir, DEFAULT_CHATLOGS_DIR);
     });
 
-    it('[Normal] T-PF-BC-02-01: agent が "codex" になる', () => {
-      assertEquals(buildConfig({ agent: 'codex', dryRun: false }, globalConfig).agent, 'codex');
+    it('[Normal] T-PF-BC-20-04: period が undefined になる', () => {
+      assertEquals(buildConfig([]).period, undefined);
     });
 
-    it('[Normal] T-PF-BC-03-01: dryRun が true になる', () => {
-      assert(buildConfig({ dryRun: true }, globalConfig).dryRun);
+    it('[Normal] T-PF-BC-21-01: agent が "codex" になる', () => {
+      assertEquals(buildConfig(['codex']).agent, 'codex');
     });
 
-    it('[Normal] T-PF-BC-04-01: inputDir が "/chat" になる', () => {
-      assertEquals(
-        buildConfig({ inputDir: '/chat', dryRun: false }, globalConfig).inputDir,
-        '/chat',
+    it('[Normal] T-PF-BC-22-01: agent="claude", period="2026-03" が正しく解析される', () => {
+      const result = buildConfig(['claude', '2026-03']);
+
+      assertEquals(result.agent, 'claude');
+      assertEquals(result.period, '2026-03');
+    });
+
+    it('[Normal] T-PF-BC-23-01: dryRun が true になる', () => {
+      assert(buildConfig(['--dry-run']).dryRun);
+    });
+
+    it('[Normal] T-PF-BC-24-01: 全フィールドが正しく解析される', () => {
+      const result = buildConfig(['codex', '2026-03', '--dry-run', '--input-dir', '/path/to/input']);
+
+      assertEquals(result.agent, 'codex');
+      assertEquals(result.period, '2026-03');
+      assert(result.dryRun);
+      assertEquals(result.inputDir, '/path/to/input');
+    });
+
+    it('[Normal] T-PF-BC-25-01: inputDir が "/path/to/input" になる', () => {
+      assertEquals(buildConfig(['--input-dir', '/path/to/input']).inputDir, '/path/to/input');
+    });
+
+    it('[Normal] T-PF-BC-25-02: --input-dir=value 形式のパース', () => {
+      assertEquals(buildConfig(['--input-dir=/path/to/input']).inputDir, '/path/to/input');
+    });
+
+    it('[Normal] T-PF-BC-26-01: inputDir が "/path/to/chatlogs" になる', () => {
+      assertEquals(buildConfig(['--input-dir', '/path/to/chatlogs']).inputDir, '/path/to/chatlogs');
+    });
+  });
+
+  /** 未知オプション・不正値のエラーケース。 */
+  describe('When: 異常系', () => {
+    it('[Error] T-PF-BC-30-01: ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => buildConfig(['--unknown']),
+        ChatlogError,
+        'Invalid Args',
+      );
+    });
+
+    it('[Error] T-PF-BC-30-02: --input を渡すと ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => buildConfig(['--input', '/path/to/input']),
+        ChatlogError,
+        'Invalid Args',
+      );
+    });
+
+    it('[Error] T-PF-BC-31-01: --input-dir にパスでない値 → ChatlogError がスローされる', () => {
+      assertThrows(
+        () => buildConfig(['--input-dir', 'notapath']),
+        ChatlogError,
+      );
+    });
+
+    it('[Error] T-PF-BC-32-01: period 単独指定（agent 省略）→ ChatlogError(InvalidArgs) がスローされる', () => {
+      assertThrows(
+        () => buildConfig(['2026-03']),
+        ChatlogError,
       );
     });
   });

--- a/skills/filter-chatlogs/scripts/configs/noise-filter-config.ts
+++ b/skills/filter-chatlogs/scripts/configs/noise-filter-config.ts
@@ -11,8 +11,6 @@
 import { parseArgs as parseArgsToConfig } from '../../../_scripts/libs/io/parse-args.ts';
 // types
 import type { ArgSchema } from '../../../_scripts/types/args-schema.types.ts';
-// classes
-import { GlobalConfig } from '../../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── internal ───
 // constants
@@ -21,44 +19,26 @@ import { DEFAULT_NOISE_FILTER_CONFIG } from '../constants/common.constants.ts';
 import type { NoiseFilterConfig, NoiseFilterParsedConfig } from '../types/noise-filter.types.ts';
 
 // ─────────────────────────────────────────────
-// 引数解析
+// 設定構築
 // ─────────────────────────────────────────────
 
 /** noise-filter-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgSchema<NoiseFilterParsedConfig> = [];
 
-export const parseArgs = (args: string[]): NoiseFilterParsedConfig => {
-  const _parsed = parseArgsToConfig<NoiseFilterParsedConfig>(args, _SCHEMA);
-  _parsed.dryRun ??= false;
-  return {
-    ..._parsed,
-  };
-};
-
-// ─────────────────────────────────────────────
-// 設定構築
-// ─────────────────────────────────────────────
-
 /**
- * NoiseFilterParsedConfig・GlobalConfig・デフォルト値から完全な NoiseFilterConfig を構築する。
- * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - chatlogsDir: `globalConfig.get('chatlogsDir')`（基準ディレクトリ）
- * - inputDir: `parsed.inputDir`（指定時のみ設定される。フルパス直接指定の短絡パラメータ）
- * - `configFile` は NoiseFilterConfig に存在しないため結果に含まれない。
+ * CLI 引数から完全な NoiseFilterConfig を構築する。
+ * - `parseArgsToConfig`（共通ライブラリの `parseArgs`）が CLI 引数・GlobalConfig・defaults を
+ *   「CLI > GlobalConfig > defaults」の優先度で内部マージ済みの設定を返すため、
+ *   GlobalConfig の値を個別に再取得しない。
+ * - `dryRun` は未指定時 `false` になる。
+ * - `configFile` は NoiseFilterConfig に存在しないため結果から除外する。
  */
 export const buildConfig = (
-  parsed: NoiseFilterParsedConfig,
-  globalConfig: GlobalConfig,
+  args: string[],
   defaults: NoiseFilterConfig = DEFAULT_NOISE_FILTER_CONFIG,
 ): NoiseFilterConfig => {
-  const _agent = parsed.agent ?? globalConfig.get('agent') as string;
-  const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
-  const { configFile: _configFile, ...rest } = parsed;
-  return {
-    ...defaults,
-    ...rest,
-    agent: _agent,
-    chatlogsDir: _chatlogsDir,
-    inputDir: parsed.inputDir,
-  };
+  const _parsed = parseArgsToConfig<NoiseFilterParsedConfig>(args, _SCHEMA, defaults);
+  _parsed.dryRun ??= false;
+  const { configFile: _configFile, ...rest } = _parsed;
+  return { ...rest } as NoiseFilterConfig;
 };

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -31,6 +31,9 @@ export const DEFAULT_NOISE_FILTER_CONFIG: NoiseFilterConfig = {
   agent: DEFAULT_AGENT,
   chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dryRun: false,
+  // config.yaml only
+  minCharCount: DEFAULT_CONFIG_VALUES.minCharCount,
+  minAssistantChars: DEFAULT_CONFIG_VALUES.minAssistantChars,
 };
 
 /** filter-chatlogs の parseArgs で未指定のフィールドに適用するデフォルト設定。 */

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -21,7 +21,6 @@
 // classes
 import { ChatlogCache } from '../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
-import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 // functions
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
@@ -59,40 +58,19 @@ const _SCHEMA: ArgSchema<FilterParsedConfig> = [];
 // ─────────────────────────────────────────────
 
 /**
- * FilterParsedConfig・GlobalConfig・デフォルト値から完全な FilterConfig を構築する。
- * - agent 優先順位: `parsed.agent` > `globalConfig.get('agent')` > `defaults.agent`
- * - chatlogsDir: `globalConfig.get('chatlogsDir')`（基準ディレクトリ）
- * - inputDir: `parsed.inputDir`（指定時のみ設定される。フルパス直接指定の短絡パラメータ）
- * - dryRun: `parsed.dryRun` > `defaults.dryRun`（false）
- * - period: `parsed` のみ（GlobalConfig 連携なし）
- * - discardThreshold: `globalConfig.get('discardThreshold')` > `defaults.discardThreshold`
- * - `configFile` は FilterConfig に存在しないため結果に含まれない。
+ * CLI 引数から完全な FilterConfig を構築する。
+ * - `parseArgs`（共通ライブラリ）が CLI 引数・GlobalConfig・defaults を
+ *   「CLI > GlobalConfig > defaults」の優先度で内部マージ済みの設定を返すため、
+ *   GlobalConfig の値を個別に再取得しない。
+ * - `configFile` は FilterConfig に存在しないため結果から除外する。
  */
 export const buildConfig = (
-  parsed: FilterParsedConfig,
-  globalConfig: GlobalConfig,
+  args: string[],
   defaults: FilterConfig = DEFAULT_FILTER_CONFIG,
 ): FilterConfig => {
-  const _agent = parsed.agent ?? globalConfig.get('agent') as string;
-  const _chatlogsDir = globalConfig.get('chatlogsDir') as string;
-  const _chunkSize = parsed.chunkSize ?? globalConfig.get('chunkSize') as number;
-  const _concurrency = parsed.concurrency ?? globalConfig.get('concurrency') as number;
-  const _minCharCount = parsed.minCharCount ?? globalConfig.get('minCharCount') as number;
-  const _minAssistantChars = parsed.minAssistantChars ?? globalConfig.get('minAssistantChars') as number;
-  const _discardThreshold = globalConfig.get('discardThreshold') as number;
-  const { configFile: _cf, ...rest } = parsed;
-  return {
-    ...defaults,
-    ...rest,
-    agent: _agent,
-    chatlogsDir: _chatlogsDir,
-    inputDir: parsed.inputDir,
-    chunkSize: _chunkSize,
-    concurrency: _concurrency,
-    minCharCount: _minCharCount,
-    minAssistantChars: _minAssistantChars,
-    discardThreshold: _discardThreshold,
-  };
+  const _parsed = parseArgs<FilterParsedConfig>(args, _SCHEMA, defaults);
+  const { configFile: _configFile, ...rest } = _parsed;
+  return { ...rest } as FilterConfig;
 };
 
 // ─────────────────────────────────────────────
@@ -100,9 +78,7 @@ export const buildConfig = (
 // ─────────────────────────────────────────────
 
 export const main = async (args?: string[]): Promise<void> => {
-  const _parsed = parseArgs<FilterParsedConfig>(args ?? Deno.args, _SCHEMA, DEFAULT_FILTER_CONFIG);
-  const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
-  const _config = buildConfig(_parsed, _globalConfig);
+  const _config = buildConfig(args ?? Deno.args);
 
   const _searchDir = resolveChatlogsDir({
     chatlogsDir: _config.chatlogsDir,

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -364,11 +364,13 @@ export const prefilterFiles = async (
 
   const notDeleted = await _discardFiles(toDelete, dryRun, stats);
 
-  const notDeletedPaths = new Set(notDeleted.map((entry) => entry.filePath));
-  const deletedPaths = new Set(
-    toDelete.map((entry) => entry.filePath).filter((filePath) => !notDeletedPaths.has(filePath)),
+  const errorPaths = new Set(
+    notDeleted.filter((entry) => entry.decision === FILTER_DECISIONS.ERROR).map((entry) => entry.filePath),
   );
-  const passed = files.filter((filePath) => !deletedPaths.has(filePath));
+  const excludedPaths = new Set(
+    toDelete.map((entry) => entry.filePath).filter((filePath) => !errorPaths.has(filePath)),
+  );
+  const passed = files.filter((filePath) => !excludedPaths.has(filePath));
 
   if (!dryRun) {
     logger.info(

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -11,15 +11,20 @@
  *
  * Claude API呼び出し前に、正規表現・テキストパターンで
  * 明らかなノイズファイルを削除候補として絞り込む。
+ * 処理は2段階構成: 事前フィルタ（prefilterFiles）→ ノイズ判定（processNoiseFiles）。
  *
- * 対象パターン:
+ * 事前フィルタ段階（prefilterFiles）:
  *   1. ファイル名パターン  : say-ok, command-message-* 等
- *   2. Git操作ログのみ    : ===== GIT LOGS/DIFF ===== で始まるUser入力
- *   3. スキル呼び出し     : ---\nname: commit-message-generator 等のYAML先頭
- *   4. 定型APIプロンプト  : idd-framework の補助呼び出し（100-150文字生成等）
- *   5. スラッシュコマンド : /export-log, /deckrd 等のみのUser入力
- *   6. システムタグのみ   : <system-reminder> 等
- *   7. 短すぎる応答      : Assistantが100文字未満（1ターン限定）
+ *   2. 本文の最小文字数    : minCharCount 未満（デフォルト1000文字）
+ *   3. Assistant応答の最小文字数 : User1ターン時、minAssistantChars 未満（デフォルト300文字）
+ *
+ * ノイズ判定段階（processNoiseFiles）:
+ *   1. Git操作ログのみ    : ===== GIT LOGS/DIFF ===== で始まるUser入力
+ *   2. スキル呼び出し     : ---\nname: commit-message-generator 等のYAML先頭
+ *   3. 定型APIプロンプト  : idd-framework の補助呼び出し（100-150文字生成等）
+ *   4. スラッシュコマンド : /export-log, /deckrd 等のみのUser入力
+ *   5. システムタグのみ   : <system-reminder> 等
+ *   6. 短すぎる応答      : Assistantが100文字未満（1ターン限定、MIN_ASSISTANT_CHARS）
  *
  * 使い方:
  *   deno run --allow-read --allow-write scripts/noise-filter-chatlogs.ts
@@ -36,7 +41,6 @@ import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 // classes
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
-import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── internal ───
 // constants
@@ -44,17 +48,16 @@ import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.con
 // types
 import type { NoiseFilterStats } from './types/stats.types.ts';
 // functions
-import { buildConfig, parseArgs } from './configs/noise-filter-config.ts';
+import { buildConfig } from './configs/noise-filter-config.ts';
 import { processNoiseFiles } from './modules/noise-filter/process-noise-files.ts';
+import { prefilterFiles } from './modules/prefilter.ts';
 
 // ─────────────────────────────────────────────
 // メイン
 // ─────────────────────────────────────────────
 
 export const main = async (args: string[] = Deno.args): Promise<void> => {
-  const _parsed = parseArgs(args);
-  const _globalConfig = GlobalConfig.getInstance({ configFile: _parsed.configFile });
-  const { agent, period, chatlogsDir, inputDir, dryRun } = buildConfig(_parsed, _globalConfig);
+  const { agent, period, chatlogsDir, inputDir, dryRun, minCharCount, minAssistantChars } = buildConfig(args);
   const _searchDir = resolveChatlogsDir({
     chatlogsDir,
     agent,
@@ -74,7 +77,15 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
   }
 
   const stats: NoiseFilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
-  await processNoiseFiles(files, stats, { dryRun });
+
+  const targetFiles = await prefilterFiles(files, {
+    minCharCount,
+    minAssistantChars,
+    stats,
+    dryRun,
+  });
+
+  await processNoiseFiles(targetFiles, stats, { dryRun });
 
   const suffix = dryRun ? ' (dry-run)' : '';
   logger.info(

--- a/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
@@ -18,6 +18,10 @@ export type NoiseFilterConfig = DefaultArgFields & {
   chatlogsDir: string;
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */
   dryRun: boolean;
+  /** 本文の最小文字数（GlobalConfig の minCharCount 由来）。 */
+  minCharCount: number;
+  /** User ターンが 1 件のとき、Assistant 応答の最小文字数（GlobalConfig の minAssistantChars 由来）。 */
+  minAssistantChars: number;
 };
 
 /** `noise-filter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */


### PR DESCRIPTION
## Overview

**Summary**
Simplify config building in filter-chatlogs scripts and add a prefilter step to noise-filter.

**Background / Motivation**
Code review feedback pointed out that `filter-chatlogs.ts` and `noise-filter-chatlogs.ts`
built their config through an unnecessary `ParsedConfig` + `GlobalConfig` step. `buildConfig`
now takes CLI args directly instead. While refactoring, we also added a prefilter pass in
`noise-filter-chatlogs` that skips files below a minimum content length before running the
more expensive noise-filtering logic.

## Changes

### Core Changes

- `filter-chatlogs.ts`: `buildConfig` now takes CLI args directly; removed the `GlobalConfig`
  import and the separate `parseArgs` call in `main`.
- `noise-filter-chatlogs.ts`: pass CLI args directly to `buildConfig`; run `prefilterFiles`
  before noise filtering and feed the prefiltered list into `processNoiseFiles`.
- `configs/noise-filter-config.ts`: build config directly from CLI args; removed the
  `parseArgs` export; defaults are now passed to `parseArgsToConfig`.
- `types/noise-filter.types.ts`: added `minCharCount` and `minAssistantChars` fields to
  `NoiseFilterConfig`.
- `constants/common.constants.ts`: added `minCharCount` / `minAssistantChars` defaults to
  `DEFAULT_NOISE_FILTER_CONFIG`.

### Test Updates

- `filter/build-config.functional.spec.ts`: updated to call `buildConfig` with CLI args
  instead of `parsed`/`GlobalConfig`.
- `noise-filter/build-config.functional.spec.ts`: same update for noise-filter `buildConfig`.
- `noise-filter-config.unit.spec.ts`: updated to use `buildConfig`; removed
  `parseArgs`-specific tests.
- `noise-filter.main.e2e.spec.ts`: added coverage for the prefilter skipping short-content
  files before noise filtering runs.

### Removed

- `parseArgs` export from `filter-chatlogs.ts` and `noise-filter-config.ts` (no consumers
  outside their own test files).

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Pure refactor plus one small behavioral addition (prefiltering by content length in
noise-filter-chatlogs). No new CLI flags. No breaking changes to CLI-facing behavior.
