### PR TITLE
fix(filter): skip chunks after abort instead of erroring

### DIFF
--- a/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
+++ b/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
@@ -119,8 +119,8 @@ describe('withConcurrency', () => {
 
   describe('Given: 先頭タスクが ctl.abort() を呼び、後続タスクは呼び出し有無を記録する', () => {
     describe('When: withConcurrency(tasks, 1) を実行する（limit=1 で決定的な実行順にする）', () => {
-      describe('Then: T-LIB-C-18 - abort 後も未着手タスクが呼ばれ続け結果配列に穴が空かない', () => {
-        it('T-LIB-C-18-01: 全タスクが呼ばれ calls が [0, 1, 2] になる', async () => {
+      describe('Then: T-LIB-C-18 - abort 後は未着手タスクが呼ばれず結果配列に穴が残る', () => {
+        it('T-LIB-C-18-01: 先頭タスクが abort() を呼ぶと後続タスクは呼ばれず calls が [0] になる', async () => {
           const _calls: number[] = [];
           const _tasks = [0, 1, 2].map((n) => (ctl: AbortController) => {
             _calls.push(n);
@@ -128,16 +128,18 @@ describe('withConcurrency', () => {
             return Promise.resolve(n * 10);
           });
           await withConcurrency(_tasks, 1);
-          assertEquals(_calls, [0, 1, 2]);
+          assertEquals(_calls, [0]);
         });
 
-        it('T-LIB-C-18-02: 結果配列に穴が空かず [0, 10, 20] になる', async () => {
+        it('T-LIB-C-18-02: 結果配列は未着手インデックスが穴のまま残る', async () => {
           const _tasks = [0, 1, 2].map((n) => (ctl: AbortController) => {
             if (n === 0) { ctl.abort(); }
             return Promise.resolve(n * 10);
           });
           const _results = await withConcurrency(_tasks, 1);
-          assertEquals(_results, [0, 10, 20]);
+          assertEquals(0 in _results, true);
+          assertEquals(1 in _results, false);
+          assertEquals(2 in _results, false);
         });
       });
     });

--- a/skills/_scripts/libs/parallel/concurrency.ts
+++ b/skills/_scripts/libs/parallel/concurrency.ts
@@ -16,6 +16,9 @@ export type { Task } from '../../types/common.types.ts';
 
 /**
  * 非同期タスク配列を並列度 `limit` で実行し、入力順の結果配列を返す。
+ *
+ * `ctl.abort()` が呼ばれた後は未着手タスクを実行せず、結果配列の該当インデックスは
+ * 穴（未代入）のまま残る。
  */
 export const withConcurrency = async <T>(
   tasks: Task<T>[],
@@ -25,7 +28,7 @@ export const withConcurrency = async <T>(
   const ctl = new AbortController();
   let idx = 0;
   const _worker = async (): Promise<void> => {
-    while (idx < tasks.length) {
+    while (idx < tasks.length && !ctl.signal.aborted) {
       const i = idx++;
       results[i] = await tasks[i](ctl);
     }

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -42,7 +42,7 @@ import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../../../_scripts/constants/defaul
 import { FILTER_DECISIONS } from '../../types/filter-decision.const.types.ts';
 import { FILTER_MIN_CONTENT_LENGTH } from '../_helpers/constants.ts';
 // types
-import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type { CommandMockHandle, DenoCommandLike } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 // e2e helpers
 import { assertFileNotExist } from '../../../../_scripts/__tests__/helpers/assert.ts';
@@ -77,6 +77,51 @@ const _makeGlobalConfig = async (yaml: string): Promise<GlobalConfig> => {
     readTextFileProvider: () => yaml,
     configFile: 'dummy.yaml',
   });
+};
+
+/**
+ * 1 回目の呼び出しをレートリミット（stderr にレートリミット文言、非ゼロ終了）で失敗させ、
+ * 2 回目以降は `[]`（空判定結果）で成功させる `DenoCommandLike` を返す。
+ *
+ * `runAI` はレートリミット検出のため `stderr` を参照するため、`stderr` フィールドを持つ
+ * 完全な `Deno.CommandOutput` を返す必要があり、共通モックの `BaseMockCommand` は使わない。
+ *
+ * @param counter - 呼び出し回数を記録するカウンター
+ * @returns Deno.Command 互換のモッククラス
+ */
+const _makeRateLimitThenEmptyMock = (counter: { calls: number }): DenoCommandLike => {
+  return class {
+    private readonly isFirstCall: boolean;
+
+    constructor(_cmd: string, _opts: unknown) {
+      counter.calls++;
+      this.isFirstCall = counter.calls === 1;
+    }
+
+    spawn() {
+      return {
+        stdin: { getWriter: () => ({ write: () => Promise.resolve(), close: () => Promise.resolve() }) },
+        output: () => this.output(),
+      };
+    }
+
+    output(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+      if (this.isFirstCall) {
+        return Promise.resolve({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode('rate limit exceeded'),
+        });
+      }
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: new TextEncoder().encode('[]'),
+        stderr: new Uint8Array(),
+      });
+    }
+  } as unknown as DenoCommandLike;
 };
 
 // ─── Tests
@@ -1165,6 +1210,402 @@ describe('main - dry-run 時のゾンビファイル', () => {
             await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
             assertEquals(await fileExists(`${chatlogsDir}/zombie-dry.md`), true);
+          });
+        });
+      });
+    });
+  });
+});
+
+// ─── T-FL-E2E-16: レートリミット abort → 未実行チャンクが stats.skip に計上される ─
+
+/**
+ * `main` 関数の E2E テストスイート（レートリミットによる未実行チャンク）。
+ *
+ * `chunkSize=1, concurrency=1` の下で 3 件のファイルを処理する際、
+ * 1 チャンク目でレートリミットが発生し `ctl.abort()` が呼ばれた場合、
+ * 未着手の 2 チャンク（2 ファイル）が `stats.skip` に加算され、
+ * レートリミットを検出したチャンク自体は `stats.error` に計上される
+ * （二重計上されない）ことを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-16
+ *
+ * @see main
+ */
+describe('main - レートリミットによる未実行チャンク', () => {
+  /**
+   * 3 件の .md ファイルが存在し、claude CLI の 1 回目呼び出しがレートリミットで失敗する前提。
+   *
+   * chunkSize=1, concurrency=1 のため、1 ファイル = 1 チャンクとして扱われる。
+   * 1 チャンク目でレートリミットが発生し以降のチャンクが未実行になることを確認する。
+   */
+  describe('Given: 3 件の .md ファイルと chunkSize=1・concurrency=1・レートリミットモック', () => {
+    /** `main([...args])` を dryRun=false で呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** 未実行チャンク分のファイル数が stats.skip に計上され、警告ログが 1 回出力されること。 */
+      describe('Then: T-FL-E2E-16 - 未実行チャンクが stats.skip に計上され警告ログが出る', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let counter: { calls: number };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(_makeRateLimitThenEmptyMock(counter));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: file1.md, file2.md, file3.md を chatlogsDir に配置し chunkSize=1・concurrency=1 を設定', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/file1.md`, _makeValidContent('file1'));
+            await Deno.writeTextFile(`${chatlogsDir}/file2.md`, _makeValidContent('file2'));
+            await Deno.writeTextFile(`${chatlogsDir}/file3.md`, _makeValidContent('file3'));
+            // 判定結果キャッシュを tempDir 配下に隔離し、他テストの残留キャッシュの影響を防ぐ
+            await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'\nchunkSize: 1\nconcurrency: 1`);
+          });
+
+          it('T-FL-E2E-16-01: 未実行チャンク分の 2 ファイルが stats.skip に計上される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('skip=2')), true);
+          });
+
+          it('T-FL-E2E-16-02: レートリミットを検出したチャンクは stats.error に計上される（二重計上なし）', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('error=1')), true);
+          });
+
+          it('T-FL-E2E-16-03: 未実行チャンク発生時に警告ログが 1 回出力される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            const matched = loggerStub.warnLogs.filter((l) => l.includes('チャンク') && l.includes('取りやめ'));
+            assertEquals(matched.length, 1);
+          });
+        });
+      });
+    });
+  });
+});
+
+// ─── T-FL-E2E-17: 全チャンク正常実行 → 判定対象数と判定済み数が一致 ─────────
+
+/**
+ * `main` 関数の E2E テストスイート（判定集計ログ・正常系）。
+ *
+ * RateLimit なしで全チャンクが正常実行された場合、判定候補数・判定対象数・判定済み数が
+ * ログに出力され、判定対象数と判定済み数が一致することを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-17
+ *
+ * @see main
+ */
+describe('main - 判定集計ログ（正常系）', () => {
+  /**
+   * 1 件の .md ファイルが存在し、claude CLI が正常に空の判定結果を返す前提。
+   *
+   * 全チャンクが正常実行されるため、判定対象数と判定済み数が一致することを確認する。
+   */
+  describe('Given: 1 件の .md ファイルと正常応答モック', () => {
+    /** `main([...args])` を dryRun=false で呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** 判定候補数・判定対象数・判定済み数がログに出力され、判定対象数と判定済み数が一致すること。 */
+      describe('Then: T-FL-E2E-17 - 判定候補数・判定対象数・判定済み数がログに出力される', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode('[]')),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: chat.md を chatlogsDir に配置', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/chat.md`, _makeValidContent());
+            // 判定結果キャッシュを tempDir 配下に隔離し、他テストの残留キャッシュの影響を防ぐ
+            await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'`);
+          });
+
+          it('T-FL-E2E-17-01: 判定候補数（candidates=1）がログに出力される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('candidates=1')), true);
+          });
+
+          it('T-FL-E2E-17-02: 判定済み数（judged=1）がログに出力される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('judged=1')), true);
+          });
+        });
+      });
+    });
+  });
+});
+
+// ─── T-FL-E2E-18: レートリミット abort → 判定済み数が判定対象数を下回る ─────
+
+/**
+ * `main` 関数の E2E テストスイート（判定集計ログ・レートリミット）。
+ *
+ * RateLimit により一部チャンクが未実行になった場合、判定済み数が判定対象数より
+ * 小さくなり、その差分が未実行チャンクのファイル数と一致することを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-18
+ *
+ * @see main
+ */
+describe('main - 判定集計ログ（レートリミット）', () => {
+  /**
+   * 3 件の .md ファイルが存在し、claude CLI の 1 回目呼び出しがレートリミットで失敗する前提。
+   *
+   * chunkSize=1, concurrency=1 のため、1 チャンク目でレートリミットが発生し
+   * 残り 2 チャンク（2 ファイル）が未実行になる。判定済み数は 1 件になる。
+   */
+  describe('Given: 3 件の .md ファイルと chunkSize=1・concurrency=1・レートリミットモック', () => {
+    /** `main([...args])` を dryRun=false で呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** 判定済み数が判定対象数より小さく、差分が未実行チャンクのファイル数と一致すること。 */
+      describe('Then: T-FL-E2E-18 - 判定済み数が判定対象数を下回る', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let counter: { calls: number };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(_makeRateLimitThenEmptyMock(counter));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: file1.md, file2.md, file3.md を chatlogsDir に配置し chunkSize=1・concurrency=1 を設定', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/file1.md`, _makeValidContent('file1'));
+            await Deno.writeTextFile(`${chatlogsDir}/file2.md`, _makeValidContent('file2'));
+            await Deno.writeTextFile(`${chatlogsDir}/file3.md`, _makeValidContent('file3'));
+            // 判定結果キャッシュを tempDir 配下に隔離し、他テストの残留キャッシュの影響を防ぐ
+            await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'\nchunkSize: 1\nconcurrency: 1`);
+          });
+
+          it('T-FL-E2E-18-01: 判定候補数（candidates=3）がログに出力される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('candidates=3')), true);
+          });
+
+          it('T-FL-E2E-18-02: 判定済み数（judged=1）がログに出力される（判定対象数 3 から未実行 2 件を差し引いた値）', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('judged=1')), true);
+          });
+        });
+      });
+    });
+  });
+});
+
+// ─── T-FL-E2E-19: 判定対象なし → 判定候補数のみログに出力される ─────────────
+
+/**
+ * `main` 関数の E2E テストスイート（判定集計ログ・判定対象なし）。
+ *
+ * `prefilterFiles` 通過後の判定対象が 0 件の場合でも、`total === 0` の早期分岐より前に
+ * 全体数・判定候補数がログに出力されることを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-19
+ *
+ * @see main
+ */
+describe('main - 判定集計ログ（判定対象なし）', () => {
+  /**
+   * `.md` ファイルが 0 件のディレクトリが存在する前提。
+   *
+   * 判定候補数（candidates=0）が `total === 0` の早期分岐より前にログ出力されることを確認する。
+   */
+  describe('Given: .md ファイルが存在しないディレクトリ', () => {
+    /** `main([...args])` を呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** 判定候補数（candidates=0）がログに出力されること。 */
+      describe('Then: T-FL-E2E-19 - 判定候補数（candidates=0）がログに出力される', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode('[]')),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        it('T-FL-E2E-19-01: 判定候補数（candidates=0）がログに出力される', async () => {
+          await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+          assertEquals(loggerStub.infoLogs.some((l) => l.includes('candidates=0')), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── T-FL-E2E-20: dry-run → 判定済み数が 0 になる ────────────────────────────
+
+/**
+ * `main` 関数の E2E テストスイート（判定集計ログ・dry-run）。
+ *
+ * `--dry-run` フラグ指定時は claude CLI を呼び出さないため、判定済み数が 0 に
+ * なることを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-20
+ *
+ * @see main
+ */
+describe('main - 判定集計ログ（dry-run）', () => {
+  /**
+   * 1 件の `.md` ファイルが存在し、`--dry-run` フラグを指定する前提。
+   *
+   * dry-run モードでは claude CLI 判定を実施しないため、判定済み数が 0 になることを確認する。
+   */
+  describe('Given: 1 件の .md ファイルと --dry-run 指定', () => {
+    /** `main([...args, "--dry-run"])` を呼び出すとき。 */
+    describe('When: main([...args, "--dry-run"]) を呼び出す', () => {
+      /** 判定済み数（judged=0）がログに出力されること。 */
+      describe('Then: T-FL-E2E-20 - 判定済み数（judged=0）がログに出力される', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let counter: { calls: number };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(makeCountingMock('[]', counter));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: chat.md を chatlogsDir に配置', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/chat.md`, _makeValidContent());
+          });
+
+          it('T-FL-E2E-20-01: 判定済み数（judged=0）がログに出力される', async () => {
+            await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('judged=0')), true);
+          });
+        });
+      });
+    });
+  });
+});
+
+// ─── T-FL-E2E-21: 全ファイルキャッシュ済み → 判定候補数が 0 になる ──────────
+
+/**
+ * `main` 関数の E2E テストスイート（判定集計ログ・全ファイルキャッシュ済み）。
+ *
+ * 全ファイルがキャッシュ済み（KEEP/DISCARD 確定）で `_targetEntries` が空の場合、
+ * 判定候補数（candidates=0）がログに出力されることを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-21
+ *
+ * @see main
+ */
+describe('main - 判定集計ログ（全ファイルキャッシュ済み）', () => {
+  /**
+   * `keep.md` がキャッシュ上 KEEP 確定済みで、他に新規判定対象ファイルがない前提。
+   *
+   * 全ファイルがキャッシュ済みのため `_targetEntries` が空になり、
+   * 判定候補数（candidates=0）がログに出力されることを確認する。
+   */
+  describe('Given: cacheDir に keep.md の KEEP キャッシュエントリのみが存在する', () => {
+    /** `main([...args])` を呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** 判定候補数（candidates=0）がログに出力されること。 */
+      describe('Then: T-FL-E2E-21 - 判定候補数（candidates=0）がログに出力される', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let counter: { calls: number };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(makeCountingMock('[]', counter));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: keep.md を chatlogsDir に配置し、cacheDir に KEEP エントリを書き込む', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/keep.md`, _makeValidContent());
+
+            const cacheDir = `${tempDir}/cache/filter-cache`;
+            await Deno.mkdir(cacheDir, { recursive: true });
+            await Deno.writeTextFile(
+              `${cacheDir}/keep.json`,
+              JSON.stringify({ decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' }),
+            );
+
+            await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'`);
+          });
+
+          it('T-FL-E2E-21-01: 判定候補数（candidates=0）がログに出力される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('candidates=0')), true);
           });
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/unit/filter/count-unexecuted-chunk-files.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/unit/filter/count-unexecuted-chunk-files.unit.spec.ts
@@ -1,0 +1,65 @@
+// src: scripts/__tests__/unit/filter/count-unexecuted-chunk-files.unit.spec.ts
+// @(#): count-unexecuted-chunk-files.ts のユニットテスト
+//       対象: countUnexecutedChunkFiles
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { countUnexecutedChunkFiles } from '../../../modules/filter/count-unexecuted-chunk-files.ts';
+
+// ─── Tests
+
+/**
+ * `countUnexecutedChunkFiles` のユニットテストスイート。
+ *
+ * `runChunked` の戻り値（穴を含みうる配列）から、未実行チャンクに含まれる
+ * ファイル数の合計を正しく集計することを検証する。
+ *
+ * テスト ID 範囲: T-FL-CUCF-01 〜 T-FL-CUCF-04
+ *
+ * @see countUnexecutedChunkFiles
+ */
+describe('countUnexecutedChunkFiles', () => {
+  describe('When: 正常系・エッジケース', () => {
+    it('T-FL-CUCF-01: items が空配列 → 0 を返す', () => {
+      const result = countUnexecutedChunkFiles([], 2, []);
+
+      assertEquals(result, 0);
+    });
+
+    it('T-FL-CUCF-02: 全チャンクが実行済み（穴なし） → 0 を返す', () => {
+      const items = ['a.md', 'b.md', 'c.md', 'd.md'];
+      const chunkResults = [undefined, undefined];
+
+      const result = countUnexecutedChunkFiles(items, 2, chunkResults);
+
+      assertEquals(result, 0);
+    });
+
+    it('T-FL-CUCF-03: 一部チャンクが未実行（穴あり） → 穴チャンクのファイル数合計を返す', () => {
+      const items = ['a.md', 'b.md', 'c.md', 'd.md', 'e.md'];
+      const chunkResults: unknown[] = [undefined];
+      // インデックス 1, 2 は穴（未代入）のまま残す
+
+      const result = countUnexecutedChunkFiles(items, 2, chunkResults);
+
+      assertEquals(result, 3);
+    });
+
+    it('T-FL-CUCF-04: 全チャンクが未実行（穴のみ） → 全ファイル数を返す', () => {
+      const items = ['a.md', 'b.md', 'c.md'];
+      const chunkResults: unknown[] = [];
+
+      const result = countUnexecutedChunkFiles(items, 1, chunkResults);
+
+      assertEquals(result, 3);
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -36,6 +36,7 @@ import type { ArgSchema } from '../../_scripts/types/args-schema.types.ts';
 
 // ─── internal ───
 // functions
+import { countUnexecutedChunkFiles } from './modules/filter/count-unexecuted-chunk-files.ts';
 import { processChunk } from './modules/filter/process-chunk.ts';
 import { sweepDiscards } from './modules/filter/sweep-discards.ts';
 import { prefilterFiles } from './modules/prefilter.ts';
@@ -118,6 +119,9 @@ export const main = async (args?: string[]): Promise<void> => {
   // キャッシュ済み KEEP 件数を集計
   stats.keep += allFiles.filter(_isCachedKeep).length;
 
+  // 全体数・判定候補数（キャッシュ除外後）を集計ログとして出力する
+  logger.info(`対象集計: total=${allFiles.length} candidates=${_targetEntries.length}`);
+
   const targetFiles = await prefilterFiles(_targetEntries, {
     minCharCount: _config.minCharCount,
     minAssistantChars: _config.minAssistantChars,
@@ -135,14 +139,26 @@ export const main = async (args?: string[]): Promise<void> => {
       logger.info('dry-run モード: claude CLI を呼び出さず対象ファイルを一覧表示します');
       targetFiles.forEach((filePath) => logger.info(`対象: ${filePath}`));
       stats.skip += targetFiles.length;
+      logger.info('判定済み: judged=0（dry-run）');
     } else {
       // チャンク分割して並列処理（判定結果はキャッシュに書き込むのみ。削除は後続のスイープで行う）
-      await runChunked(
+      const chunkResults = await runChunked(
         targetFiles,
         _config.chunkSize,
         (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl),
         _config.concurrency,
       );
+
+      // レートリミット等で abort された後、未着手のまま残ったチャンクのファイル数を skip に計上する
+      const unexecutedFileCount = countUnexecutedChunkFiles(targetFiles, _config.chunkSize, chunkResults);
+      if (unexecutedFileCount > 0) {
+        stats.skip += unexecutedFileCount;
+        logger.warn(
+          `レートリミットのため ${unexecutedFileCount} 件のチャンク未実行ファイルの実行を取りやめました（次回再判定対象）`,
+        );
+      }
+
+      logger.info(`判定済み: judged=${targetFiles.length - unexecutedFileCount}`);
     }
   }
 
@@ -156,6 +172,7 @@ export const main = async (args?: string[]): Promise<void> => {
   );
 };
 
+// --- main routine ---
 if (import.meta.main) {
   try {
     await main(Deno.args);

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -427,6 +427,23 @@ describe('processChunk', () => {
 
           assertEquals(cache.read(file1), {});
         });
+
+        it('T-FL-PCK-05-04: error 扱いになった各ファイル名がログに出力される', async () => {
+          const file1 = await _createTempFile('f5.md');
+          const file2 = await _createTempFile('f6.md');
+          commandHandle = installCommandMock(makeFailMock(1));
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+
+          await processChunk([file1, file2], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
+          errStub.restore();
+
+          const logged = errStub.calls.map((c) => c.args.join(' ')).join('\n');
+          assertEquals(logged.includes('f5.md'), true);
+          assertEquals(logged.includes('f6.md'), true);
+        });
       });
     });
   });
@@ -532,6 +549,25 @@ describe('processChunk', () => {
           errStub.restore();
 
           assertEquals(cache.read(filePath), {});
+        });
+
+        it('T-FL-PCK-06-04: error 扱いになった各ファイル名がログに出力される', async () => {
+          const file1 = await _createTempFile('g4.md');
+          const file2 = await _createTempFile('g5.md');
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+
+          await processChunk([file1, file2], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
+          errStub.restore();
+
+          const logged = errStub.calls.map((c) => c.args.join(' ')).join('\n');
+          assertEquals(logged.includes('g4.md'), true);
+          assertEquals(logged.includes('g5.md'), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -119,9 +119,8 @@ function _makeRateLimitMock(): DenoCommandLike {
  * - ファイル名不一致 → 判定不能として stats.skip に計上（cache へは書き込まず、次回再判定される）
  * - CLI エラー（`ChatlogError`）・JSON パース失敗 → 全件 `stats.error` に計上し `ChatlogError` を返す（cache へは書き込まない）。RateLimit の場合は `ctl.abort()` を呼ぶ
  * - 非 `ChatlogError`（CLI バイナリ不在等）→ 握りつぶさず throw する
- * - 呼び出し前から `ctl.signal.aborted` が true → AI 呼び出しをせず即座に `stats.error` へ計上する
  *
- * テスト ID 範囲: T-FL-PCK-01 〜 T-FL-PCK-11
+ * テスト ID 範囲: T-FL-PCK-01 〜 T-FL-PCK-10
  *
  * @see processChunk
  */
@@ -632,43 +631,6 @@ describe('processChunk', () => {
           assertEquals(cache.read(filePath).decision, FILTER_DECISIONS.DISCARD);
           assertEquals(stats.remove, 0);
           assertEquals(stats.keep, 0);
-        });
-      });
-    });
-  });
-
-  /**
-   * 呼び出し前から `ctl.signal.aborted` が true な前提条件グループ（RateLimit 後の未着手チャンク相当）。
-   *
-   * AI 呼び出しを一切行わず、即座に stats.error へ計上して return することを検証する。
-   */
-  describe('Given: 呼び出し前から ctl.signal.aborted が true', () => {
-    /** processChunk([file], stats, threshold, cache, ctl) を呼び出すとき。 */
-    describe('When: processChunk([file], stats, threshold, cache, ctl) を呼び出す', () => {
-      /** AI 呼び出しをせず stats.error に計上して return することを検証する。 */
-      describe('Then: T-FL-PCK-11 - AI 呼び出しをせず stats.error に計上する', () => {
-        it('T-FL-PCK-11-01: stats.error が 1 になる', async () => {
-          const filePath = await _createTempFile('k.md');
-          const stats = _makeStats();
-          const cache = await _makeEmptyCache();
-          const ctl = new AbortController();
-          ctl.abort();
-
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
-
-          assertEquals(stats.error, 1);
-        });
-
-        it('T-FL-PCK-11-02: cache へは書き込まれない', async () => {
-          const filePath = await _createTempFile('k2.md');
-          const stats = _makeStats();
-          const cache = await _makeEmptyCache();
-          const ctl = new AbortController();
-          ctl.abort();
-
-          await processChunk([filePath], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
-
-          assertEquals(cache.read(filePath), {});
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/filter/count-unexecuted-chunk-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/count-unexecuted-chunk-files.ts
@@ -1,0 +1,38 @@
+// src: scripts/modules/filter/count-unexecuted-chunk-files.ts
+// @(#): レートリミット abort により未実行のまま残ったチャンクのファイル数を集計する
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─────────────────────────────────────────────
+// 未実行チャンク集計
+// ─────────────────────────────────────────────
+
+/**
+ * `runChunked` の結果配列を検査し、未実行（穴）のまま残ったチャンクに含まれる
+ * ファイル数の合計を返す。
+ *
+ * `withConcurrency` は `ctl.abort()` 後の未着手タスクを実行しないため、結果配列の
+ * 該当インデックスは未代入（穴）のまま残る。`i in chunkResults` で判定できる
+ * （`true`=実行済み、`false`=穴＝未実行）。
+ *
+ * `items` は `createChunkedTasks`（concurrency.ts）と同じ規則
+ * （`items.slice(i * chunkSize, (i + 1) * chunkSize)`）でチャンク化して対応付ける。
+ *
+ * @param items - チャンク分割前の全ファイルパス配列
+ * @param chunkSize - チャンクサイズ
+ * @param chunkResults - `runChunked` の戻り値（穴を含みうる配列）
+ * @returns 未実行チャンクに含まれるファイル数の合計
+ */
+export const countUnexecutedChunkFiles = <R>(
+  items: string[],
+  chunkSize: number,
+  chunkResults: R[],
+): number => {
+  const chunkCount = Math.ceil(items.length / chunkSize);
+  return Array.from({ length: chunkCount })
+    .map((_, i) => (i in chunkResults ? 0 : items.slice(i * chunkSize, (i + 1) * chunkSize).length))
+    .reduce((sum, count) => sum + count, 0);
+};

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -47,12 +47,6 @@ export const processChunk = async (
   cache: ChatlogCache<CLEResult>,
   ctl: AbortController,
 ): Promise<ChatlogError | undefined> => {
-  if (ctl.signal.aborted) {
-    logger.warn(`  レートリミット中のためスキップ。チャンク内ファイルをすべて error 扱い`);
-    stats.error += chunkFiles.length;
-    return;
-  }
-
   const batchPrompt = await buildBatchPrompt(chunkFiles);
 
   let rawResult: string;

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -56,6 +56,7 @@ export const processChunk = async (
     if (!(e instanceof ChatlogError)) { throw e; }
     logger.warn(`  claude CLI 実行失敗。チャンク内ファイルをすべて error 扱い`);
     logger.warn(`  error: ${e.message}`);
+    chunkFiles.forEach((filePath) => logger.warn(`  error扱い: ${getFilename(filePath)}`));
     stats.error += chunkFiles.length;
     if (e.subindex === 'RateLimit') { ctl.abort(); }
     return e;
@@ -65,6 +66,7 @@ export const processChunk = async (
   if (!parsed) {
     logger.warn(`  JSON パース失敗。チャンク内ファイルをすべて error 扱い`);
     logger.warn(`  raw output: ${rawResult.slice(0, 200)}`);
+    chunkFiles.forEach((filePath) => logger.warn(`  error扱い: ${getFilename(filePath)}`));
     stats.error += chunkFiles.length;
     return new ChatlogError('InvalidFormat', 'JsonParse', `raw output: ${rawResult.slice(0, 200)}`);
   }


### PR DESCRIPTION
## Overview

**Summary**
Stop counting unexecuted chunks as errors after a rate-limit abort; skip them for retry instead.

**Background / Motivation**
When `filter-chatlogs` hit a rate limit mid-run, `withConcurrency` kept starting new chunk
tasks even after `ctl.abort()` was called. Chunks left unexecuted were then miscounted as
`error` by a pre-check inside `processChunk`, even though the real cause was the abort, not a
per-file failure. This PR stops new tasks from starting after abort and reclassifies files in
unexecuted chunks as `skip` (retryable next run) instead of `error`. It also adds file-level
logs for chunks that fail due to a CLI error or invalid JSON, and adds target/candidate/judged
count logs for better run visibility.

## Changes

### Core Changes

- `skills/_scripts/libs/parallel/concurrency.ts`: worker loop also checks
  `!ctl.signal.aborted`, so no new tasks start after abort; the result array keeps holes for
  unstarted indices.
- `skills/filter-chatlogs/scripts/modules/filter/count-unexecuted-chunk-files.ts` (new):
  `countUnexecutedChunkFiles` scans the `runChunked` result array for holes and sums the file
  counts of unexecuted chunks.
- `skills/filter-chatlogs/scripts/filter-chatlogs.ts`: adds unexecuted files to `stats.skip`
  (with a warning log) using `countUnexecutedChunkFiles`, and adds target/candidate/judged
  count logs.
- `skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts`: removes the
  `ctl.signal.aborted` pre-check (now handled upstream), and logs each chunk file name when a
  chunk is marked `error` due to a CLI failure or JSON parse failure.

### Test Updates

- `skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts`: updated abort
  expectations — unstarted tasks are not called and holes remain in the result array.
- `skills/filter-chatlogs/scripts/__tests__/unit/filter/count-unexecuted-chunk-files.unit.spec.ts`
  (new): unit tests for empty input, fully executed chunks, chunks with holes, and fully
  unexecuted chunks.
- `skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts`:
  removed aborted-precheck cases and added coverage for error-handled chunk file name logging.
- `skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts`: added coverage for
  skipped/error counts after a rate-limit interruption, unexecuted-chunk warnings, and
  target/candidate/judged count logs across normal, rate-limit, dry-run, empty-candidate, and
  cached-file scenarios.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Unexecuted chunk files are now treated as retryable (`skip`) rather than failed (`error`),
since the underlying cause is a rate limit, not a per-file processing failure — they remain
candidates for re-judgment on the next run.
