### PR TITLE
fix(classify-config): derive projects dictionary path from dicsDir

### DIFF
--- a/skills/classify-chatlogs/SKILL.md
+++ b/skills/classify-chatlogs/SKILL.md
@@ -126,7 +126,7 @@ tags:
 
 ## 辞書ファイル
 
-- `.config/chatlog-exporter/projects.dic`: プロジェクト名の選択肢（GlobalConfig の `projectsDic` で変更可能）
+- `.config/chatlog-exporter/dics/projects.dic`: プロジェクト名の選択肢（GlobalConfig の `dicsDir` 配下。`projectsDic` 明示指定で変更可能）
 
 ## 関連スキル
 

--- a/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -63,7 +63,7 @@ async function _makeTestDirs(agent = 'claude', period = '2026-03'): Promise<{
   const year = period.slice(0, 4);
   const monthDir = `${inputDir}/originalLogs/${agent}/${year}/${period}`;
   await Deno.mkdir(monthDir, { recursive: true });
-  await Deno.writeTextFile(configFile, `dicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`);
+  await Deno.writeTextFile(configFile, `dicsDir: "${configsDir}"\n`);
   await Deno.writeTextFile(
     `${configsDir}/projects.dic`,
     'app1:\n  def: Test project 1\napp2:\n  def: Test project 2\n',
@@ -462,7 +462,7 @@ describe('main - InputNotFound エラー', () => {
         beforeEach(async () => {
           configsDir = normalizePath(await Deno.makeTempDir());
           configFile = `${configsDir}/defaults.yaml`;
-          await Deno.writeTextFile(configFile, `dicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`);
+          await Deno.writeTextFile(configFile, `dicsDir: "${configsDir}"\n`);
           await Deno.writeTextFile(
             `${configsDir}/projects.dic`,
             'app1:\n  def: Test project 1\n',
@@ -572,7 +572,7 @@ describe('main - 期間フィルタ', () => {
           // chatlogsDir を GlobalConfig 経由で inputDir に設定し、period による通常解決経路を通す
           await Deno.writeTextFile(
             configFile,
-            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`,
+            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\n`,
           );
           // 2026-03 の対象ファイル
           await Deno.writeTextFile(
@@ -662,7 +662,7 @@ describe('main - 存在しない period ディレクトリ → InputNotFound', (
           // chatlogsDir を GlobalConfig 経由で inputDir に設定し、resolveChatlogsDir の通常解決経路を通す
           await Deno.writeTextFile(
             configFile,
-            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\n`,
+            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\n`,
           );
           GlobalConfig.resetInstance();
         });

--- a/skills/classify-chatlogs/scripts/constants/classify.constants.ts
+++ b/skills/classify-chatlogs/scripts/constants/classify.constants.ts
@@ -30,7 +30,7 @@ export const DEFAULT_CLASSIFY_CONFIG: ClassifyConfig = {
   agent: DEFAULT_AGENT,
   dryRun: false,
   chatlogsDir: DEFAULT_CHATLOGS_DIR,
-  /** 型定義上の整合性のためだけの値（classify-chatlogs は projectsDic のみを実際の辞書読み込みに使用する） */
+  /** projects.dic の既定配置。buildConfig で projectsDic 未指定時の導出元として使用する。 */
   dicsDir: 'dics',
   model: DEFAULT_AI_MODEL,
   chunkSize: DEFAULT_CHUNK_SIZE,

--- a/skills/classify-chatlogs/scripts/modules/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/functional/build-config.functional.spec.ts
@@ -328,14 +328,14 @@ describe('buildConfig', () => {
 
   describe('Given: GlobalConfig に projectsDic が設定されていない', () => {
     describe('When: buildConfig を呼び出す', () => {
-      describe('Then: T-CL-BC-18 - GlobalConfig のデフォルト projectsDic が使われる', () => {
+      describe('Then: T-CL-BC-18 - dicsDir 配下の projects.dic が使われる', () => {
         let globalConfig: GlobalConfig;
         beforeEach(async () => {
           globalConfig = await GlobalConfig.getInstance();
         });
-        it('T-CL-BC-18-01: projectsDic 未設定 → result.projectsDic === globalConfig.get("projectsDic")', () => {
+        it('T-CL-BC-18-01: projectsDic 未設定 → result.projectsDic === `${dicsDir}/projects.dic`', () => {
           const result = buildConfig([]);
-          assertEquals(result.projectsDic, globalConfig.get('projectsDic'));
+          assertEquals(result.projectsDic, `${globalConfig.get('dicsDir')}/projects.dic`);
         });
       });
     });
@@ -403,15 +403,14 @@ describe('buildConfig', () => {
 
   describe('Given: GlobalConfig の dicsDir が yaml で上書きされている', () => {
     describe('When: buildConfig を呼び出す', () => {
-      describe('Then: T-CL-BC-19 - dicsDir を変えても projectsDic は独立して変わらない', () => {
-        let globalConfig: GlobalConfig;
+      describe('Then: T-CL-BC-19 - projectsDic 未指定時は dicsDir 配下の projects.dic が使われる', () => {
         beforeEach(async () => {
           GlobalConfig.resetInstance();
-          globalConfig = await GlobalConfig.getInstance({ yaml: 'dicsDir: /custom/dics' });
+          await GlobalConfig.getInstance({ yaml: 'dicsDir: /custom/dics' });
         });
-        it('T-CL-BC-19-01: dicsDir=/custom/dics → projectsDic === globalConfig.get("projectsDic")（dicsDir に依存しない）', () => {
+        it('T-CL-BC-19-01: dicsDir=/custom/dics, projectsDic 未指定 → projectsDic === /custom/dics/projects.dic', () => {
           const result = buildConfig([]);
-          assertEquals(result.projectsDic, globalConfig.get('projectsDic'));
+          assertEquals(result.projectsDic, '/custom/dics/projects.dic');
         });
       });
     });
@@ -428,11 +427,11 @@ describe('buildConfig', () => {
           const result = buildConfig([]);
           assertEquals(result.projectsDic, '/custom/projects.dic');
         });
-        it('T-CL-BC-23-02: projectsDic 未設定 → result.projectsDic === .config/chatlog-exporter/projects.dic', async () => {
+        it('T-CL-BC-23-02: projectsDic 未設定かつ既定 dicsDir → result.projectsDic === dics/projects.dic', async () => {
           GlobalConfig.resetInstance();
           await GlobalConfig.getInstance();
           const result = buildConfig([]);
-          assertEquals(result.projectsDic, '.config/chatlog-exporter/dics/projects.dic');
+          assertEquals(result.projectsDic, 'dics/projects.dic');
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/modules/classify-config.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-config.ts
@@ -9,6 +9,7 @@
 
 // ─── Shared scripts
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
 import { isValidModel } from '../../../_scripts/libs/ai/model-utils.ts';
 import { parseArgs } from '../../../_scripts/libs/io/parse-args.ts';
 // types
@@ -28,6 +29,21 @@ const _SCHEMA: ArgSchema<Partial<ClassifyConfig>> = [
 ];
 
 /**
+ * projectsDic が既定値のままなら dicsDir 配下の projects.dic に寄せる。
+ * パス解決（configDir との結合）は行わず、生のパス文字列を格納する。
+ * 実際のパス解決は `loadProjectDic` 内の `resolveConfigPath` に一元化されている。
+ */
+const _deriveProjectsDic = (config: ClassifyConfig): ClassifyConfig => {
+  if (config.projectsDic !== DEFAULT_CONFIG_VALUES.projectsDic) {
+    return config;
+  }
+  return {
+    ...config,
+    projectsDic: `${config.dicsDir}/projects.dic`,
+  };
+};
+
+/**
  * CLI 引数から完全な ClassifyConfig を構築する。
  * - `parseArgsToConfig`（共通ライブラリの `parseArgs`）が CLI 引数・GlobalConfig・defaults を
  *   「CLI > GlobalConfig > defaults」の優先度で内部マージ済みの `ClassifyParsedConfig` を返すため、
@@ -45,5 +61,5 @@ export const buildConfig = (
   if (!isValidModel(_model)) {
     throw new ChatlogError('InvalidArgs', 'InvalidModel', `不正なモデル名: ${parsed.model}`);
   }
-  return parsed;
+  return _deriveProjectsDic(parsed);
 };


### PR DESCRIPTION
## Overview

**Summary**
Derive `projectsDic` from `dicsDir` instead of using an independent default path.

**Background / Motivation**
`projectsDic` previously had its own default path unrelated to `dicsDir`, so the projects
dictionary could end up outside the configured dictionary directory. This change makes
`buildConfig` derive `projectsDic` as `<dicsDir>/projects.dic` whenever `projectsDic` is left
at its default, keeping it alongside the other dictionary files. Explicit `projectsDic`
overrides are unaffected.

## Changes

### Core Changes

- `skills/classify-chatlogs/scripts/modules/classify-config.ts`
  Add `_deriveProjectsDic`, which resolves `projectsDic` to `<dicsDir>/projects.dic` when it is
  still at its default value. `buildConfig` now returns `_deriveProjectsDic(parsed)`.

### Test Updates

- `skills/classify-chatlogs/scripts/modules/__tests__/functional/build-config.functional.spec.ts`
  Update expected `projectsDic` for a custom `dicsDir` and for the default case.
- `skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts`
  Remove the now-unnecessary explicit `projectsDic` setting from the e2e test config.

### Removed

- None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Also updates `skills/classify-chatlogs/SKILL.md` and the `dicsDir` default comment in
`skills/classify-chatlogs/scripts/constants/classify.constants.ts` to reflect the new default
path (`.config/chatlog-exporter/dics/projects.dic`).
