### PR TITLE
feat(classify-chatlogs): reuse cached AI classification results

### DIFF
--- a/skills/classify-chatlogs/scripts/__tests__/_helpers/classify-test-helpers.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/_helpers/classify-test-helpers.ts
@@ -8,9 +8,10 @@
 // https://opensource.org/licenses/MIT
 
 // ─── Helpers
+import { ChatlogCache } from '../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { renderFrontmatter } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
-import type { ClassifyStats } from '../../types/classify.types.ts';
+import type { ClassifyResult, ClassifyStats } from '../../types/classify.types.ts';
 // types
 import type { FrontmatterFields } from '../../../../_scripts/types/frontmatter.types.ts';
 
@@ -47,4 +48,37 @@ export const _makeEntry = (
 ): ChatlogEntry => {
   const _text = renderFrontmatter(frontmatter) + content;
   return new ChatlogEntry(_text, { filePath });
+};
+
+/**
+ * テスト用の空 `ChatlogCache<ClassifyResult>`（バッファバック）を生成する。
+ *
+ * ファイル I/O をせずにインメモリバッファで動作するキャッシュを返す。
+ *
+ * @returns 初期化済みの空キャッシュ
+ */
+export const _makeEmptyClassifyCache = async (): Promise<ChatlogCache<ClassifyResult>> => {
+  const buf = new Map<string, string>();
+  const cache = new ChatlogCache<ClassifyResult>(
+    'classify-cache',
+    '/fake/cache',
+    undefined,
+    {
+      cache: {
+        readTextFile: (path) => {
+          const data = buf.get(path);
+          if (data === undefined) { return Promise.reject(new Error('not found')); }
+          return Promise.resolve(data);
+        },
+        writeTextFile: (path, data) => {
+          buf.set(path, data);
+          return Promise.resolve();
+        },
+        mkdir: () => Promise.resolve(),
+        glob: () => Promise.resolve([]),
+      },
+    },
+  );
+  await cache.ready;
+  return cache;
 };

--- a/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -63,7 +63,10 @@ async function _makeTestDirs(agent = 'claude', period = '2026-03'): Promise<{
   const year = period.slice(0, 4);
   const monthDir = `${inputDir}/originalLogs/${agent}/${year}/${period}`;
   await Deno.mkdir(monthDir, { recursive: true });
-  await Deno.writeTextFile(configFile, `dicsDir: "${configsDir}"\n`);
+  await Deno.writeTextFile(
+    configFile,
+    `dicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\ncacheDir: "${configsDir}/cache"\n`,
+  );
   await Deno.writeTextFile(
     `${configsDir}/projects.dic`,
     'app1:\n  def: Test project 1\napp2:\n  def: Test project 2\n',
@@ -338,12 +341,12 @@ describe('main - project 設定済みファイルの実移動', () => {
   });
 });
 
-// ─── T-CL-E2E-09: 既に正しいサブディレクトリにある → skipped ────────────────
+// ─── T-CL-E2E-09: サブディレクトリ内のファイルは走査対象外（直下1階層のみ走査） ─
 
-describe('main - 既に正しいサブディレクトリにあるファイル → skipped', () => {
-  describe('Given: project=app1 のファイルが月ディレクトリ/app1/ に存在', () => {
+describe('main - サブディレクトリ内のファイルは走査対象外', () => {
+  describe('Given: project=app1 のファイルが月ディレクトリ/app1/ に存在（月ディレクトリ直下には .md なし）', () => {
     describe('When: main([...args]) を呼び出す', () => {
-      describe('Then: T-CL-E2E-09 - 二重ネストせず skipped になる', () => {
+      describe('Then: T-CL-E2E-09 - 直下1階層のみ走査され、対象ファイルなしとして完了する', () => {
         let inputDir: string;
         let configsDir: string;
         let configFile: string;
@@ -355,7 +358,7 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
 
         beforeEach(async () => {
           ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
-          // 既に app1/ サブディレクトリに配置済み
+          // 既に app1/ サブディレクトリに配置済み（月ディレクトリ直下には .md ファイルなし）
           const app1Dir = `${inputDir}/originalLogs/claude/2026/2026-03/app1`;
           await Deno.mkdir(app1Dir, { recursive: true });
           await Deno.writeTextFile(
@@ -384,16 +387,19 @@ describe('main - 既に正しいサブディレクトリにあるファイル �
           await Deno.remove(configsDir, { recursive: true });
         });
 
-        it('T-CL-E2E-09-01: 完了ログに skipped=1 が含まれる（二重ネストしない）', async () => {
+        it('T-CL-E2E-09-01: 完了ログに moved=0 movedByAI=0 skipped=0 error=0 が含まれる（サブディレクトリは走査対象外）', async () => {
           await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
-          assertEquals(errLogs.some((l) => l.includes('skipped=1')), true);
+          assertEquals(errLogs.some((l) => l.includes('moved=0 movedByAI=0 skipped=0 error=0')), true);
         });
 
-        it('T-CL-E2E-09-02: app1/app1/ ディレクトリが作成されない', async () => {
+        it('T-CL-E2E-09-02: app1/ 内のファイルは移動されず、そのまま残る', async () => {
           await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
 
-          assertEquals(await fileOrDirExists(`${inputDir}/originalLogs/claude/2026/2026-03/app1/app1`), false);
+          assertEquals(
+            await fileOrDirExists(`${inputDir}/originalLogs/claude/2026/2026-03/app1/chat.md`),
+            true,
+          );
         });
       });
     });
@@ -572,7 +578,7 @@ describe('main - 期間フィルタ', () => {
           // chatlogsDir を GlobalConfig 経由で inputDir に設定し、period による通常解決経路を通す
           await Deno.writeTextFile(
             configFile,
-            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\n`,
+            `chatlogsDir: "${inputDir}"\ndicsDir: "${configsDir}"\nprojectsDic: "${configsDir}/projects.dic"\ncacheDir: "${configsDir}/cache"\n`,
           );
           // 2026-03 の対象ファイル
           await Deno.writeTextFile(
@@ -822,6 +828,84 @@ describe('main - 非 ChatlogError 例外の再スロー', () => {
           } catch { /* TypeError が再スローされる想定 */ }
 
           assertEquals(exitStub.calls.length, 0, 'Deno.exit が呼ばれてはいけない');
+        });
+      });
+    });
+  });
+});
+
+// ─── T-CL-E2E-13: キャッシュ済みファイル → claude CLI 未呼び出し ─────────────
+
+/**
+ * `main` 関数の E2E テストスイート（キャッシュ済み AI 分類判定）。
+ *
+ * `classify-cache` に対象ファイルの判定結果（`project`）が既に書き込まれている場合、
+ * `processClassify` が AI 呼び出し前にそのファイルを除外し、claude CLI を呼ばずに
+ * キャッシュの `project` でファイルを移動することを検証する。
+ *
+ * テスト ID 範囲: T-CL-E2E-13
+ *
+ * @see main
+ */
+describe('main - キャッシュ済み AI 分類判定', () => {
+  /**
+   * `chat.md` に対する分類結果として `project: 'app1'` が `classify-cache` に既に書き込まれている前提。
+   *
+   * キャッシュ済みファイルは claude CLI 呼び出し前に除外され、キャッシュの project で移動されることを確認する。
+   */
+  describe('Given: classify-cache に chat.md の判定結果（project: app1）を配置', () => {
+    /** `main(["claude", "2026-03", "--input-dir", monthDir, "--config", configFile])` を呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す（dryRun=false）', () => {
+      /** claude CLI が呼び出されず、ファイルが app1/ サブディレクトリに移動されること。 */
+      describe('Then: T-CL-E2E-13 - claude CLI 未呼び出し・キャッシュの project で移動される', () => {
+        let inputDir: string;
+        let configsDir: string;
+        let configFile: string;
+        let monthDir: string;
+        let commandHandle: CommandMockHandle;
+        let counter: { calls: number };
+        let errStub: Stub;
+
+        beforeEach(async () => {
+          ({ inputDir, configsDir, configFile, monthDir } = await _makeTestDirs());
+          await Deno.writeTextFile(
+            `${monthDir}/chat.md`,
+            '---\ntitle: テスト\ncategory: development\n---\n本文',
+          );
+
+          const cacheDir = `${configsDir}/cache/classify-cache`;
+          await Deno.mkdir(cacheDir, { recursive: true });
+          await Deno.writeTextFile(
+            `${cacheDir}/chat.json`,
+            JSON.stringify({ project: 'app1', confidence: 0.9, reason: 'cached decision' }),
+          );
+
+          counter = { calls: 0 };
+          resetProjectRoot(inputDir);
+          commandHandle = installCommandMock(makeCountingMock('[]', counter));
+          errStub = stub(console, 'error', () => {});
+          GlobalConfig.resetInstance();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          resetProjectRoot();
+          errStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(inputDir, { recursive: true });
+          await Deno.remove(configsDir, { recursive: true });
+        });
+
+        it('T-CL-E2E-13-01: claude CLI が呼び出されない', async () => {
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
+
+          assertEquals(counter.calls, 0);
+        });
+
+        it('T-CL-E2E-13-02: ファイルが app1/ サブディレクトリに移動している', async () => {
+          await main(['claude', '2026-03', '--input-dir', monthDir, '--config', configFile]);
+
+          assertEquals(await fileExists(`${monthDir}/app1/chat.md`), true);
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/__tests__/unit/process-classify.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/unit/process-classify.unit.spec.ts
@@ -9,25 +9,33 @@
 
 // ─── BDD modules
 import { assertEquals } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { afterEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { processClassify } from '../../classify-chatlogs.ts';
 
 // ─── Helpers
-import { _makeEntry } from '../_helpers/classify-test-helpers.ts';
+import { _makeClassifyChatlogEntry, _makeEmptyClassifyCache } from '../_helpers/classify-test-helpers.ts';
+// classes
+import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
-import type { ClassifyBuffer, ProjectDicEntry } from '../../types/classify.types.ts';
+import type { ClassifyPartition, ProjectDicEntry } from '../../types/classify.types.ts';
 // constants
 import { CLASSIFY_ACTIONS } from '../../types/classify.types.ts';
 
 // ─── Internal Helpers
+import {
+  installCommandMock,
+  makeCountingMock,
+} from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+// types
+import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
 // constants
 /** プロジェクト辞書（AI を呼び出さないテスト用に proj-a のみ定義）。 */
 const _PROJECTS: ProjectDicEntry = { 'proj-a': {} };
 
-/** processClassify に渡す最小 config（AI 分類は空配列になるので実際には使われない）。 */
+/** processClassify に渡す最小 config。 */
 const _CONFIG = { chunkSize: 10, concurrency: 1, model: 'opus' };
 
 // ─── Tests
@@ -35,8 +43,9 @@ const _CONFIG = { chunkSize: 10, concurrency: 1, model: 'opus' };
 /**
  * `processClassify` のユニットテストスイート。
  *
- * AI なし事前分類 → AI 分類のパイプラインを検証する。
- * テスト対象を `_remaining=[]` になるケースに限定し、実 AI CLI を呼ばない。
+ * `ClassifyPartition` を受け取り、`uncached` のみを AI 分類に委譲し、
+ * `resolved`・`cached`・AI 分類結果を結合して返す contract を検証する。
+ * `partitionClassifyEntries` 側の責務（preclassify・キャッシュ振り分け）は検証しない。
  *
  * テスト ID 範囲: T-CL-PC-01 〜 T-CL-PC-02
  *
@@ -44,42 +53,59 @@ const _CONFIG = { chunkSize: 10, concurrency: 1, model: 'opus' };
  */
 describe('processClassify', () => {
   /**
-   * 正常系: AI なし事前分類ですべて解決するケース。
+   * `resolved`/`cached` はそのまま結果に含まれ、AI 分類は行われないケース。
    */
   describe('When: 正常系', () => {
-    it('[Normal] T-CL-PC-01: frontmatter に project あり(MOVE) + 本文短小(FALLBACK MOVE) → result.length=2, 両方 MOVE', async () => {
-      // frontmatter に project: 'proj-a' あり、パスは proj-a サブディレクトリ外 → MOVE
-      const _entryMove = _makeEntry('/tmp/input/test.md', { project: 'proj-a' }, '');
-      // frontmatter なし、本文が短い (5文字 < 50) → FALLBACK MOVE
-      const _entryShort = _makeEntry('/tmp/input/short.md', {}, 'short');
+    it('[Normal] T-CL-PC-01: uncached が空 → resolved と cached がそのまま結合されて返る', async () => {
+      const _resolvedEntry = {
+        file: new ChatlogEntry('', { filePath: '/tmp/input/resolved.md' }),
+        action: CLASSIFY_ACTIONS.MOVE,
+      };
+      const _cachedEntry = {
+        file: new ChatlogEntry('', { filePath: '/tmp/input/cached.md' }),
+        project: 'proj-a',
+        action: CLASSIFY_ACTIONS.MOVEBYAI,
+      };
+      const _partition: ClassifyPartition = { resolved: [_resolvedEntry], cached: [_cachedEntry], uncached: [] };
+      const _cache = await _makeEmptyClassifyCache();
 
-      const _buffer: ClassifyBuffer = [
-        { file: _entryMove, filePath: _entryMove.filePath! },
-        { file: _entryShort, filePath: _entryShort.filePath! },
-      ];
+      const result = await processClassify(_partition, _PROJECTS, _CONFIG, _cache);
 
-      const result = await processClassify(_buffer, _PROJECTS, _CONFIG);
-
-      assertEquals(result.length, 2);
-      assertEquals(result[0].action, CLASSIFY_ACTIONS.MOVE);
-      assertEquals(result[1].action, CLASSIFY_ACTIONS.MOVE);
+      assertEquals(result, [_resolvedEntry, _cachedEntry]);
     });
   });
 
   /**
-   * エッジケース: already-in-subdir でスキップになるケース。
+   * `uncached` の件数分だけ `classifyByAI` に委譲され、claude CLI が呼び出されることを検証する。
    */
-  describe('When: エッジケース', () => {
-    it('[Edge] T-CL-PC-02: frontmatter に project あり、パスが proj-a サブディレクトリ内 → result.length=1, SKIP', async () => {
-      // srcDir '/tmp/input/proj-a' は '/proj-a' で終わる → SKIP
-      const _entrySkip = _makeEntry('/tmp/input/proj-a/test.md', { project: 'proj-a' }, '');
+  describe('When: uncached エントリの AI 分類委譲', () => {
+    let mockHandle: CommandMockHandle;
+    let counter: { calls: number };
 
-      const _buffer: ClassifyBuffer = [{ file: _entrySkip, filePath: _entrySkip.filePath! }];
+    afterEach(() => {
+      mockHandle.restore();
+    });
 
-      const result = await processClassify(_buffer, _PROJECTS, _CONFIG);
+    it('[Normal] T-CL-PC-02: uncached に1件 → claude CLI が1回呼び出され、AI 分類結果が結果に含まれる', async () => {
+      counter = { calls: 0 };
+      const response = JSON.stringify([
+        { file: 'uncached.md', project: 'proj-a', confidence: 0.8, reason: 'matched' },
+      ]);
+      mockHandle = installCommandMock(makeCountingMock(response, counter));
 
+      const _entryUncached = _makeClassifyChatlogEntry('uncached.md');
+      const _partition: ClassifyPartition = {
+        resolved: [],
+        cached: [],
+        uncached: [{ file: _entryUncached, action: CLASSIFY_ACTIONS.REMAINING }],
+      };
+      const _cache = await _makeEmptyClassifyCache();
+
+      const result = await processClassify(_partition, _PROJECTS, _CONFIG, _cache);
+
+      assertEquals(counter.calls, 1);
       assertEquals(result.length, 1);
-      assertEquals(result[0].action, CLASSIFY_ACTIONS.SKIP);
+      assertEquals(result[0].action, CLASSIFY_ACTIONS.MOVEBYAI);
     });
   });
 });

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -17,6 +17,7 @@
 // cspell:words noai
 
 // ─── Shared scripts
+import { ChatlogCache } from '../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
@@ -28,31 +29,38 @@ import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.con
 import { loadProjectDic } from './libs/load-project-dic.ts';
 import { classifyByAI } from './modules/classify-ai.ts';
 import { buildConfig } from './modules/classify-config.ts';
-import { processPreclassify } from './modules/classify-noai.ts';
 import { moveClassified } from './modules/file-ops.ts';
-import { findBufferEntries } from './modules/find-buffer-entries.ts';
+import { partitionClassifyEntries } from './modules/partition-classify-entries.ts';
 // types
-import type { ClassifyBuffer, ClassifyConfig, ClassifyStats, ProjectDicEntry } from './types/classify.types.ts';
+import type {
+  ClassifyBuffer,
+  ClassifyConfig,
+  ClassifyPartition,
+  ClassifyResult,
+  ClassifyStats,
+  ProjectDicEntry,
+} from './types/classify.types.ts';
 // constants
 import { FALLBACK_PROJECT } from './constants/classify.constants.ts';
-import { CLASSIFY_ACTIONS } from './types/classify.types.ts';
 
 // ─────────────────────────────────────────────
 // processClassify
 // ─────────────────────────────────────────────
 
 /**
- * 分類バッファに対して AI なし事前分類・AI 分類を実行し、結合した分類済みバッファを返す。
+ * 分類候補エントリの分割結果に対して AI 分類を実行し、結合した分類済みバッファを返す。
+ *
+ * `partition.uncached`（未キャッシュの REMAINING エントリ）のみを `classifyByAI` に渡し、
+ * `resolved`・`cached` と結合した結果を返す。
  */
 export const processClassify = async (
-  allEntries: ClassifyBuffer,
+  partition: ClassifyPartition,
   projects: ProjectDicEntry,
   config: Pick<ClassifyConfig, 'chunkSize' | 'concurrency' | 'model'>,
+  cache: ChatlogCache<ClassifyResult>,
 ): Promise<ClassifyBuffer> => {
-  const _preClassified = processPreclassify(allEntries);
-  const _resolved = _preClassified.filter((e) => e.action !== CLASSIFY_ACTIONS.REMAINING);
-  const _aiClassified = await classifyByAI(_preClassified, projects, config);
-  return [..._resolved, ..._aiClassified];
+  const _aiClassified = await classifyByAI(partition.uncached, projects, config, cache);
+  return [...partition.resolved, ...partition.cached, ..._aiClassified];
 };
 
 // ─────────────────────────────────────────────
@@ -102,16 +110,20 @@ export const main = async (argv?: string[]): Promise<void> => {
 
   const stats: ClassifyStats = { moved: 0, movedByAI: 0, skipped: 0, error: 0, remaining: 0 };
 
-  // Step 1: バッファ取得
-  const _buffer = await findBufferEntries(_searchDir, undefined, stats);
-  if (_buffer.length === 0) {
+  // 判定結果キャッシュ
+  const _cache = new ChatlogCache<ClassifyResult>('classify-cache');
+  await _cache.ready;
+
+  // Step 1: バッファ取得 + AI なし事前分類 + キャッシュ振り分け
+  const _partition = await partitionClassifyEntries(_searchDir, _cache, undefined, stats);
+  if (_partition.resolved.length === 0 && _partition.cached.length === 0 && _partition.uncached.length === 0) {
     logger.info('対象ファイルなし');
     logger.info('完了: moved=0 movedByAI=0 skipped=0 error=0');
     return;
   }
 
-  // Step 2: 分類（AI なし + AI あり）
-  const _classified = await processClassify(_buffer, projects, _config);
+  // Step 2: 分類（AI あり）
+  const _classified = await processClassify(_partition, projects, _config, _cache);
 
   // Step 3: ファイル移動
   await moveClassified(_classified, _searchDir, _config.dryRun, stats);

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
@@ -18,6 +18,7 @@ import { parse as parseYaml } from '@std/yaml';
 import { preClassify } from '../../classify-noai.ts';
 
 // ─── Helpers
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
 import type { FrontmatterFields } from '../../../../../_scripts/types/frontmatter.types.ts';
 import type { ClassifyAction, ClassifyBufferEntry } from '../../../types/classify.types.ts';
@@ -75,7 +76,7 @@ const _loadFixture = async (dir: string): Promise<{ input: _FixtureInput; expect
 /**
  * `_FixtureInput` から `ClassifyBufferEntry` を構築する。
  *
- * `action: error` の場合は `file: null` のエントリを返す。
+ * `action: error` の場合は filePath のみ保持する空の `ChatlogEntry` のエントリを返す。
  * それ以外は frontmatter と content から `ClassifyChatlogEntry` を構築する。
  *
  * @param input - `input.yaml` から読み込んだデータ
@@ -84,14 +85,13 @@ const _loadFixture = async (dir: string): Promise<{ input: _FixtureInput; expect
 const _buildEntry = (input: _FixtureInput): ClassifyBufferEntry => {
   if (input.action === 'error') {
     return {
-      file: null,
-      filePath: input.filePath,
+      file: new ChatlogEntry('', { filePath: input.filePath }),
       action: 'error',
       reason: input.reason,
     };
   }
   const _entry = _makeEntry(input.filePath, input.frontmatter ?? {}, input.content ?? '');
-  return { file: _entry, filePath: input.filePath };
+  return { file: _entry };
 };
 
 // ─── Tests

--- a/skills/classify-chatlogs/scripts/modules/__tests__/functional/classify-by-ai.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/functional/classify-by-ai.functional.spec.ts
@@ -87,12 +87,10 @@ describe('classifyByAI', () => {
       const allEntries: ClassifyBuffer = [
         {
           file: _makeClassifyChatlogEntry('a.md'),
-          filePath: '/tmp/input/a.md',
           action: CLASSIFY_ACTIONS.REMAINING,
         },
         {
           file: _makeClassifyChatlogEntry('b.md'),
-          filePath: '/tmp/input/b.md',
           action: CLASSIFY_ACTIONS.REMAINING,
         },
       ];
@@ -112,7 +110,6 @@ describe('classifyByAI', () => {
 
       const allEntries: ClassifyBuffer = ['a.md', 'b.md', 'c.md'].map((filename) => ({
         file: _makeClassifyChatlogEntry(filename),
-        filePath: `/tmp/input/${filename}`,
         action: CLASSIFY_ACTIONS.REMAINING,
       }));
 
@@ -134,18 +131,17 @@ describe('classifyByAI', () => {
       const allEntries: ClassifyBuffer = [
         {
           file: _makeClassifyChatlogEntry('a.md'),
-          filePath: '/tmp/input/a.md',
           action: CLASSIFY_ACTIONS.REMAINING,
         },
-        { file: null, filePath: '/tmp/input/b.md', action: CLASSIFY_ACTIONS.SKIP },
-        { file: null, filePath: '/tmp/input/c.md', action: CLASSIFY_ACTIONS.MOVE },
-        { file: null, filePath: '/tmp/input/d.md', action: CLASSIFY_ACTIONS.ERROR, reason: 'load failed' },
+        { file: _makeClassifyChatlogEntry('b.md'), action: CLASSIFY_ACTIONS.SKIP },
+        { file: _makeClassifyChatlogEntry('c.md'), action: CLASSIFY_ACTIONS.MOVE },
+        { file: _makeClassifyChatlogEntry('d.md'), action: CLASSIFY_ACTIONS.ERROR, reason: 'load failed' },
       ];
 
       const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig(), cache);
 
       assertEquals(buffer.length, 1);
-      assertEquals(buffer[0].filePath, '/tmp/input/a.md');
+      assertEquals(buffer[0].file.filePath, '/tmp/input/a.md');
     });
 
     it('[Normal] T-CL-CBA-05-01: AI 判定成功 → cache に判定結果が書き込まれる', async () => {
@@ -157,7 +153,6 @@ describe('classifyByAI', () => {
       const allEntries: ClassifyBuffer = [
         {
           file: _makeClassifyChatlogEntry('a.md'),
-          filePath: '/tmp/input/a.md',
           action: CLASSIFY_ACTIONS.REMAINING,
         },
       ];
@@ -188,8 +183,8 @@ describe('classifyByAI', () => {
 
     it('[Edge] T-CL-CBA-04-01: REMAINING 以外のみ → 空配列を返し claude CLI は呼び出されない', async () => {
       const allEntries: ClassifyBuffer = [
-        { file: null, filePath: '/tmp/input/a.md', action: CLASSIFY_ACTIONS.SKIP },
-        { file: null, filePath: '/tmp/input/b.md', action: CLASSIFY_ACTIONS.MOVE },
+        { file: _makeClassifyChatlogEntry('a.md'), action: CLASSIFY_ACTIONS.SKIP },
+        { file: _makeClassifyChatlogEntry('b.md'), action: CLASSIFY_ACTIONS.MOVE },
       ];
 
       const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig(), cache);

--- a/skills/classify-chatlogs/scripts/modules/__tests__/functional/classify-by-ai.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/functional/classify-by-ai.functional.spec.ts
@@ -17,7 +17,8 @@ import { classifyByAI } from '../../classify-ai.ts';
 
 // ─── Helpers
 // types
-import type { ClassifyBuffer, ClassifyConfig, ProjectDicEntry } from '../../../types/classify.types.ts';
+import type { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
+import type { ClassifyBuffer, ClassifyConfig, ClassifyResult, ProjectDicEntry } from '../../../types/classify.types.ts';
 // constants
 import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
@@ -28,7 +29,10 @@ import {
   makeCountingMock,
   makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import { _makeClassifyChatlogEntry } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+import {
+  _makeClassifyChatlogEntry,
+  _makeEmptyClassifyCache,
+} from '../../../__tests__/_helpers/classify-test-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
@@ -63,6 +67,11 @@ describe('classifyByAI', () => {
    */
   describe('When: 正常系', () => {
     let mockHandle: CommandMockHandle;
+    let cache: ChatlogCache<ClassifyResult>;
+
+    beforeEach(async () => {
+      cache = await _makeEmptyClassifyCache();
+    });
 
     afterEach(() => {
       mockHandle.restore();
@@ -88,7 +97,7 @@ describe('classifyByAI', () => {
         },
       ];
 
-      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig());
+      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig(), cache);
 
       assertEquals(buffer.length, 2);
       assertEquals(buffer.every((e) => e.action === CLASSIFY_ACTIONS.MOVEBYAI), true);
@@ -107,7 +116,7 @@ describe('classifyByAI', () => {
         action: CLASSIFY_ACTIONS.REMAINING,
       }));
 
-      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig({ chunkSize: 1 }));
+      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig({ chunkSize: 1 }), cache);
 
       // chunkSize=1 で 3件 → 3チャンクに分割され、claude CLI が 3回呼び出される
       assertEquals(counter.calls, 3);
@@ -133,10 +142,29 @@ describe('classifyByAI', () => {
         { file: null, filePath: '/tmp/input/d.md', action: CLASSIFY_ACTIONS.ERROR, reason: 'load failed' },
       ];
 
-      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig());
+      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig(), cache);
 
       assertEquals(buffer.length, 1);
       assertEquals(buffer[0].filePath, '/tmp/input/a.md');
+    });
+
+    it('[Normal] T-CL-CBA-05-01: AI 判定成功 → cache に判定結果が書き込まれる', async () => {
+      const response = JSON.stringify([
+        { file: 'a.md', project: 'app1', confidence: 0.9, reason: 'matched' },
+      ]);
+      mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(response)));
+
+      const allEntries: ClassifyBuffer = [
+        {
+          file: _makeClassifyChatlogEntry('a.md'),
+          filePath: '/tmp/input/a.md',
+          action: CLASSIFY_ACTIONS.REMAINING,
+        },
+      ];
+
+      await classifyByAI(allEntries, _PROJECTS, _makeConfig(), cache);
+
+      assertEquals(cache.read('/tmp/input/a.md'), { project: 'app1', confidence: 0.9, reason: 'matched' });
     });
   });
 
@@ -146,10 +174,12 @@ describe('classifyByAI', () => {
   describe('When: エッジケース', () => {
     let mockHandle: CommandMockHandle;
     let counter: { calls: number };
+    let cache: ChatlogCache<ClassifyResult>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       counter = { calls: 0 };
       mockHandle = installCommandMock(makeCountingMock('[]', counter));
+      cache = await _makeEmptyClassifyCache();
     });
 
     afterEach(() => {
@@ -162,14 +192,14 @@ describe('classifyByAI', () => {
         { file: null, filePath: '/tmp/input/b.md', action: CLASSIFY_ACTIONS.MOVE },
       ];
 
-      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig());
+      const buffer = await classifyByAI(allEntries, _PROJECTS, _makeConfig(), cache);
 
       assertEquals(buffer, []);
       assertEquals(counter.calls, 0);
     });
 
     it('[Edge] T-CL-CBA-04-02: allEntries が空配列 → 空配列を返し claude CLI は呼び出されない', async () => {
-      const buffer = await classifyByAI([], _PROJECTS, _makeConfig());
+      const buffer = await classifyByAI([], _PROJECTS, _makeConfig(), cache);
 
       assertEquals(buffer, []);
       assertEquals(counter.calls, 0);

--- a/skills/classify-chatlogs/scripts/modules/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/functional/process-chunk.functional.spec.ts
@@ -17,8 +17,9 @@ import { processChunk } from '../../classify-ai.ts';
 
 // ─── Helpers
 // types
-import type { ProjectDicEntry } from '../../../types/classify.types.ts';
+import type { ClassifyResult, ProjectDicEntry } from '../../../types/classify.types.ts';
 // classes
+import type { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // constants
 import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
@@ -32,7 +33,10 @@ import {
   makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
-import { _makeClassifyChatlogEntry } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+import {
+  _makeClassifyChatlogEntry,
+  _makeEmptyClassifyCache,
+} from '../../../__tests__/_helpers/classify-test-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -57,10 +61,12 @@ describe('processChunk', () => {
     let mockHandle: CommandMockHandle;
     let loggerStub: LoggerStub;
     let model: string;
+    let cache: ChatlogCache<ClassifyResult>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       model = DEFAULT_AI_MODEL;
       loggerStub = makeLoggerStub();
+      cache = await _makeEmptyClassifyCache();
       const response = JSON.stringify([
         { file: 'a.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
@@ -78,7 +84,7 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, app2: {}, misc: {} };
 
-      const buffer = await processChunk(metas, projects, model);
+      const buffer = await processChunk(metas, projects, model, cache);
 
       assertEquals(buffer.length, 1);
       assertEquals(buffer[0].action, CLASSIFY_ACTIONS.MOVEBYAI);
@@ -89,13 +95,22 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, app2: {}, misc: {} };
 
-      await processChunk(metas, projects, model);
+      await processChunk(metas, projects, model, cache);
 
       assertEquals(
         loggerStub.infoLogs.some((l) => l.includes('classify:')),
         true,
         'classify ログが infoLogs に記録されていない',
       );
+    });
+
+    it('[Normal] T-CL-PC-07-01: AI 判定成功 → cache に project/confidence/reason が書き込まれる', async () => {
+      const metas = [_makeClassifyChatlogEntry('a.md')];
+      const projects: ProjectDicEntry = { app1: {}, app2: {}, misc: {} };
+
+      await processChunk(metas, projects, model, cache);
+
+      assertEquals(cache.read('/tmp/input/a.md'), { project: 'app1', confidence: 0.9, reason: 'matched' });
     });
   });
 
@@ -106,10 +121,12 @@ describe('processChunk', () => {
     let mockHandle: CommandMockHandle;
     let loggerStub: LoggerStub;
     let model: string;
+    let cache: ChatlogCache<ClassifyResult>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       model = DEFAULT_AI_MODEL;
       loggerStub = makeLoggerStub();
+      cache = await _makeEmptyClassifyCache();
       mockHandle = installCommandMock(makeFailMock(1));
     });
 
@@ -122,7 +139,7 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md'), _makeClassifyChatlogEntry('b.md')];
       const projects: ProjectDicEntry = { app1: {}, misc: {} };
 
-      const buffer = await processChunk(metas, projects, model);
+      const buffer = await processChunk(metas, projects, model, cache);
 
       assertEquals(buffer.length, 2);
       assertEquals(buffer.every((e) => e.action === CLASSIFY_ACTIONS.ERROR), true);
@@ -132,13 +149,22 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, misc: {} };
 
-      await processChunk(metas, projects, model);
+      await processChunk(metas, projects, model, cache);
 
       assertEquals(
         loggerStub.warnLogs.some((l) => l.includes('claude CLI 実行失敗')),
         true,
         '警告ログが warnLogs に記録されていない',
       );
+    });
+
+    it('[Error] T-CL-PC-02-03: CLI エラー → cache へは書き込まれない', async () => {
+      const metas = [_makeClassifyChatlogEntry('a.md')];
+      const projects: ProjectDicEntry = { app1: {}, misc: {} };
+
+      await processChunk(metas, projects, model, cache);
+
+      assertEquals(cache.read('/tmp/input/a.md'), {});
     });
 
     it('[Error] T-CL-PC-03-01: JSON パース失敗 → buffer に action: ERROR エントリが返される', async () => {
@@ -152,7 +178,7 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, misc: {} };
 
-      const buffer = await processChunk(metas, projects, model);
+      const buffer = await processChunk(metas, projects, model, cache);
 
       assertEquals(buffer.length, 1);
       assertEquals(buffer[0].action, CLASSIFY_ACTIONS.ERROR);
@@ -169,13 +195,29 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, misc: {} };
 
-      await processChunk(metas, projects, model);
+      await processChunk(metas, projects, model, cache);
 
       assertEquals(
         loggerStub.warnLogs.some((l) => l.includes('JSON パース失敗')),
         true,
         '警告ログが warnLogs に記録されていない',
       );
+    });
+
+    it('[Error] T-CL-PC-03-03: JSON パース失敗 → cache へは書き込まれない', async () => {
+      mockHandle.restore();
+      loggerStub.restore();
+      loggerStub = makeLoggerStub();
+      mockHandle = installCommandMock(
+        makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+      );
+
+      const metas = [_makeClassifyChatlogEntry('a.md')];
+      const projects: ProjectDicEntry = { app1: {}, misc: {} };
+
+      await processChunk(metas, projects, model, cache);
+
+      assertEquals(cache.read('/tmp/input/a.md'), {});
     });
   });
 
@@ -186,10 +228,12 @@ describe('processChunk', () => {
     let mockHandle: CommandMockHandle;
     let loggerStub: LoggerStub;
     let model: string;
+    let cache: ChatlogCache<ClassifyResult>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       model = DEFAULT_AI_MODEL;
       loggerStub = makeLoggerStub();
+      cache = await _makeEmptyClassifyCache();
       // "b.md" の結果を返すが、対象ファイルは "a.md"
       const response = JSON.stringify([
         { file: 'b.md', project: 'app1', confidence: 0.9, reason: 'matched' },
@@ -208,7 +252,7 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, misc: {} };
 
-      const buffer = await processChunk(metas, projects, model);
+      const buffer = await processChunk(metas, projects, model, cache);
 
       assertEquals(buffer.length, 1);
       assertEquals(buffer[0].project, FALLBACK_PROJECT);
@@ -218,7 +262,7 @@ describe('processChunk', () => {
       const metas: ChatlogEntry[] = [];
       const projects: ProjectDicEntry = { app1: {}, misc: {} };
 
-      const buffer = await processChunk(metas, projects, model);
+      const buffer = await processChunk(metas, projects, model, cache);
 
       assertEquals(buffer.length, 0);
     });
@@ -238,7 +282,7 @@ describe('processChunk', () => {
       const metas = [_makeClassifyChatlogEntry('a.md')];
       const projects: ProjectDicEntry = { app1: {}, app2: {}, misc: {} };
 
-      const buffer = await processChunk(metas, projects, model);
+      const buffer = await processChunk(metas, projects, model, cache);
 
       assertEquals(buffer.length, 1);
       assertEquals(buffer[0].project, 'app1');

--- a/skills/classify-chatlogs/scripts/modules/__tests__/integration/move-classified.integration.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/integration/move-classified.integration.spec.ts
@@ -53,7 +53,6 @@ describe('moveClassified', () => {
         it('T-CL-MC-10-01: stats.error が 1 になる', async () => {
           const _buffer: ClassifyBuffer = [{
             file: entry,
-            filePath: entry.filePath!,
             project: 'app1',
             action: CLASSIFY_ACTIONS.MOVE,
           }];
@@ -67,7 +66,6 @@ describe('moveClassified', () => {
         it('T-CL-MC-10-02: stats.moved は 0 のままである', async () => {
           const _buffer: ClassifyBuffer = [{
             file: entry,
-            filePath: entry.filePath!,
             project: 'app1',
             action: CLASSIFY_ACTIONS.MOVE,
           }];

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-noai.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-noai.unit.spec.ts
@@ -17,6 +17,7 @@ import { describe, it } from '@std/testing/bdd';
 import { preClassify, processPreclassify } from '../../classify-noai.ts';
 
 // ─── Helpers
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
 import type { ClassifyBufferEntry } from '../../../types/classify.types.ts';
 // constants
@@ -46,7 +47,7 @@ describe('preClassify', () => {
     it('[Normal] T-CL-PRE-01: project フィールドあり + 既に正しいディレクトリ内 → action=skip', () => {
       const _entry = _makeEntry('/tmp/chatlogs/app1/test.md', { project: 'app1' }, '本文テキスト');
 
-      const result = preClassify({ file: _entry, filePath: _entry.filePath! });
+      const result = preClassify({ file: _entry });
 
       assertEquals(result.action, CLASSIFY_ACTIONS.SKIP);
       assertEquals(result.project, 'app1');
@@ -55,7 +56,7 @@ describe('preClassify', () => {
     it('[Normal] T-CL-PRE-02: project フィールドあり + ディレクトリが違う → action=move', () => {
       const _entry = _makeEntry('/tmp/chatlogs/test.md', { project: 'app1' }, '本文テキスト');
 
-      const result = preClassify({ file: _entry, filePath: _entry.filePath! });
+      const result = preClassify({ file: _entry });
 
       assertEquals(result.action, CLASSIFY_ACTIONS.MOVE);
       assertEquals(result.project, 'app1');
@@ -64,7 +65,7 @@ describe('preClassify', () => {
     it('[Normal] T-CL-PRE-03: project フィールドなし + hasMeta=false + 短い → FALLBACK_PROJECT, action=move', () => {
       const _entry = _makeEntry('/tmp/chatlogs/test.md', {}, 'short');
 
-      const result = preClassify({ file: _entry, filePath: _entry.filePath! });
+      const result = preClassify({ file: _entry });
 
       assertEquals(result.action, CLASSIFY_ACTIONS.MOVE);
       assertEquals(result.project, FALLBACK_PROJECT);
@@ -77,7 +78,7 @@ describe('preClassify', () => {
         'short',
       );
 
-      const result = preClassify({ file: _entry, filePath: _entry.filePath! });
+      const result = preClassify({ file: _entry });
 
       assertEquals(result.action, CLASSIFY_ACTIONS.REMAINING);
     });
@@ -86,7 +87,7 @@ describe('preClassify', () => {
       const _longContent = 'a'.repeat(100);
       const _entry = _makeEntry('/tmp/chatlogs/test.md', {}, _longContent);
 
-      const result = preClassify({ file: _entry, filePath: _entry.filePath! });
+      const result = preClassify({ file: _entry });
 
       assertEquals(result.action, CLASSIFY_ACTIONS.REMAINING);
     });
@@ -96,10 +97,10 @@ describe('preClassify', () => {
    * エッジケース: `action === 'error'` のエントリはそのまま返す。
    */
   describe('When: エッジケース', () => {
-    it('[Edge] T-CL-PRE-06: action=error のエントリ → そのまま返す（file は null のまま）', () => {
+    it('[Edge] T-CL-PRE-06: action=error のエントリ → そのまま返す（file は変更されない）', () => {
+      const _errorFile = new ChatlogEntry('', { filePath: '/tmp/chatlogs/broken.md' });
       const _errorEntry: ClassifyBufferEntry = {
-        file: null,
-        filePath: '/tmp/chatlogs/broken.md',
+        file: _errorFile,
         action: CLASSIFY_ACTIONS.ERROR,
         reason: 'InvalidFormat',
       };
@@ -107,7 +108,7 @@ describe('preClassify', () => {
       const result = preClassify(_errorEntry);
 
       assertEquals(result.action, CLASSIFY_ACTIONS.ERROR);
-      assertEquals(result.file, null);
+      assertEquals(result.file, _errorFile);
       assertEquals(result.reason, 'InvalidFormat');
     });
   });
@@ -133,9 +134,9 @@ describe('processPreclassify', () => {
       const _entryLong = _makeEntry('/tmp/dir/c.md', {}, 'a'.repeat(100));
 
       const _buffer: ClassifyBufferEntry[] = [
-        { file: _entryWithProject, filePath: _entryWithProject.filePath! },
-        { file: _entryShort, filePath: _entryShort.filePath! },
-        { file: _entryLong, filePath: _entryLong.filePath! },
+        { file: _entryWithProject },
+        { file: _entryShort },
+        { file: _entryLong },
       ];
 
       const _result = processPreclassify(_buffer);
@@ -155,7 +156,7 @@ describe('processPreclassify', () => {
   describe('When: エッジケース', () => {
     it('[Edge] T-CL-PCL-03: 単一エントリ（project あり）を渡す → action=skip を返す', () => {
       const _entry = _makeEntry('/tmp/dir/app1/a.md', { project: 'app1' }, '本文');
-      const _buffer: ClassifyBufferEntry[] = [{ file: _entry, filePath: _entry.filePath! }];
+      const _buffer: ClassifyBufferEntry[] = [{ file: _entry }];
 
       const _result = processPreclassify(_buffer);
 

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/find-buffer-entries.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/find-buffer-entries.unit.spec.ts
@@ -12,17 +12,19 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { findBufferEntries } from '../../find-buffer-entries.ts';
+import { findBufferEntries, findChatlogFilePaths, loadClassifyEntries } from '../../find-buffer-entries.ts';
 
 // ─── Helpers
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
+import type { FrontmatterFields } from '../../../../../_scripts/types/frontmatter.types.ts';
 import type { ClassifyBufferEntry, FindBufferEntriesOptions } from '../../../types/classify.types.ts';
 
 // constants
 import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
 
 // ─── Internal Helpers
-import { _makeEntry, _makeStats } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+import { _makeEmptyClassifyCache, _makeEntry, _makeStats } from '../../../__tests__/_helpers/classify-test-helpers.ts';
 
 // functions
 
@@ -53,9 +55,13 @@ const _makeLoadMeta = (
 (path: string): Promise<ClassifyBufferEntry> => {
   callCounter.count++;
   if (errorPaths.has(path)) {
-    return Promise.resolve({ file: null, filePath: path, action: CLASSIFY_ACTIONS.ERROR, reason: 'load failed' });
+    return Promise.resolve({
+      file: new ChatlogEntry('', { filePath: path }),
+      action: CLASSIFY_ACTIONS.ERROR,
+      reason: 'load failed',
+    });
   }
-  return Promise.resolve({ file: _makeEntry(path), filePath: path });
+  return Promise.resolve({ file: _makeEntry(path) });
 };
 
 // ─── Tests
@@ -82,7 +88,7 @@ describe('findBufferEntries', () => {
 
       const _result = await findBufferEntries('/tmp/input', _opts, _stats);
 
-      assertEquals(_result.map((e) => e.filePath).sort(), _paths);
+      assertEquals(_result.map((e) => e.file.filePath).sort(), _paths);
       assertEquals(_stats.error, 0);
     });
   });
@@ -100,7 +106,7 @@ describe('findBufferEntries', () => {
 
       const _result = await findBufferEntries('/tmp/input', _opts, _stats);
 
-      assertEquals(_result.map((e) => e.filePath).sort(), ['/tmp/input/a.md', '/tmp/input/c.md']);
+      assertEquals(_result.map((e) => e.file.filePath).sort(), ['/tmp/input/a.md', '/tmp/input/c.md']);
       assertEquals(_stats.error, 1);
     });
 
@@ -130,7 +136,7 @@ describe('findBufferEntries', () => {
 
       const _result = await findBufferEntries('/tmp/input', _opts);
 
-      assertEquals(_result.map((e) => e.filePath), ['/tmp/input/a.md']);
+      assertEquals(_result.map((e) => e.file.filePath), ['/tmp/input/a.md']);
     });
 
     it('[Edge] T-CL-FBE-05: 対象ディレクトリに .md ファイルが1件もない → 空配列が返り loadMeta は呼び出されない', async () => {
@@ -146,6 +152,150 @@ describe('findBufferEntries', () => {
       assertEquals(_result, []);
       assertEquals(_callCounter.count, 0);
       assertEquals(_stats.error, 0);
+    });
+  });
+});
+
+/**
+ * `findChatlogFilePaths` のユニットテストスイート。
+ *
+ * ディレクトリ直下の `.md` ファイルパス一覧取得を検証する。
+ *
+ * テスト ID 範囲: T-CL-FCP-01 〜 T-CL-FCP-02
+ *
+ * @see findChatlogFilePaths
+ */
+describe('findChatlogFilePaths', () => {
+  describe('When: 正常系', () => {
+    it('[Normal] T-CL-FCP-01: glob が複数パスを返す → そのままファイルパス配列として返る', async () => {
+      const _paths = ['/tmp/input/a.md', '/tmp/input/b.md'];
+
+      const _result = await findChatlogFilePaths('/tmp/input', { glob: _makeGlob(_paths) });
+
+      assertEquals(_result, _paths);
+    });
+  });
+
+  describe('When: エッジケース', () => {
+    it('[Edge] T-CL-FCP-02: 対象ディレクトリに .md ファイルが1件もない → 空配列が返る', async () => {
+      const _result = await findChatlogFilePaths('/tmp/input', { glob: _makeGlob([]) });
+
+      assertEquals(_result, []);
+    });
+  });
+});
+
+/**
+ * `loadClassifyEntries` のユニットテストスイート。
+ *
+ * ファイルパス一覧から `ChatlogEntry` を読み込み、既存 project frontmatter があれば
+ * キャッシュへ書き込み、読み込み失敗エントリはキャッシュへエラー記録のうえ除外する振る舞いを検証する。
+ *
+ * テスト ID 範囲: T-CL-LCE-01 〜 T-CL-LCE-05
+ *
+ * @see loadClassifyEntries
+ */
+describe('loadClassifyEntries', () => {
+  describe('When: 正常系', () => {
+    it('[Normal] T-CL-LCE-01: frontmatter に project あり → cache に project が書き込まれ戻り値に含まれる', async () => {
+      const _cache = await _makeEmptyClassifyCache();
+      const _filePath = '/tmp/input/a.md';
+      const _opts: FindBufferEntriesOptions = {
+        loadMeta: () =>
+          Promise.resolve({
+            file: _makeEntry(_filePath, { project: 'proj-a' }),
+          }),
+      };
+
+      const _result = await loadClassifyEntries([_filePath], _cache, _opts);
+
+      assertEquals(_result.map((e) => e.filePath), [_filePath]);
+      assertEquals(_cache.read(_filePath).project, 'proj-a');
+    });
+
+    it('[Normal] T-CL-LCE-04: frontmatter に project なし → cache に書き込まれず戻り値に含まれる', async () => {
+      const _cache = await _makeEmptyClassifyCache();
+      const _filePath = '/tmp/input/a.md';
+      const _opts: FindBufferEntriesOptions = {
+        loadMeta: () => Promise.resolve({ file: _makeEntry(_filePath, {}) }),
+      };
+
+      const _result = await loadClassifyEntries([_filePath], _cache, _opts);
+
+      assertEquals(_result.map((e) => e.filePath), [_filePath]);
+      assertEquals(_cache.read(_filePath).project, undefined);
+    });
+
+    it('[Normal] T-CL-LCE-05: 正常/異常混在 → 正常分のみ順序を保って戻り値に含まれ、各cache書き込みとstats.errorが個別に反映される', async () => {
+      const _cache = await _makeEmptyClassifyCache();
+      const _withProject = '/tmp/input/with-project.md';
+      const _errorPath = '/tmp/input/error.md';
+      const _noProject = '/tmp/input/no-project.md';
+      const _opts: FindBufferEntriesOptions = {
+        loadMeta: (path: string) => {
+          if (path === _errorPath) {
+            return Promise.resolve({
+              file: new ChatlogEntry('', { filePath: path }),
+              action: CLASSIFY_ACTIONS.ERROR,
+              reason: 'load failed',
+            });
+          }
+          const _frontmatter: FrontmatterFields = path === _withProject ? { project: 'proj-a' } : {};
+          return Promise.resolve({ file: _makeEntry(path, _frontmatter) });
+        },
+      };
+      const _stats = _makeStats();
+
+      const _result = await loadClassifyEntries(
+        [_withProject, _errorPath, _noProject],
+        _cache,
+        _opts,
+        _stats,
+      );
+
+      assertEquals(_result.map((e) => e.filePath), [_withProject, _noProject]);
+      assertEquals(_cache.read(_withProject).project, 'proj-a');
+      assertEquals(_cache.read(_errorPath).status, CLASSIFY_ACTIONS.ERROR);
+      assertEquals(_cache.read(_noProject).project, undefined);
+      assertEquals(_stats.error, 1);
+    });
+  });
+
+  describe('When: エッジケース', () => {
+    it('[Edge] T-CL-LCE-02: loadMeta が ERROR エントリを返す → cache に status: error が書き込まれ戻り値から除外・stats.error がインクリメントされる', async () => {
+      const _cache = await _makeEmptyClassifyCache();
+      const _filePath = '/tmp/input/b.md';
+      const _opts: FindBufferEntriesOptions = {
+        loadMeta: () =>
+          Promise.resolve({
+            file: new ChatlogEntry('', { filePath: _filePath }),
+            action: CLASSIFY_ACTIONS.ERROR,
+            reason: 'load failed',
+          }),
+      };
+      const _stats = _makeStats();
+
+      const _result = await loadClassifyEntries([_filePath], _cache, _opts, _stats);
+
+      assertEquals(_result, []);
+      assertEquals(_cache.read(_filePath).status, CLASSIFY_ACTIONS.ERROR);
+      assertEquals(_stats.error, 1);
+    });
+
+    it('[Edge] T-CL-LCE-03: デフォルト読み込み（loadClassifyEntry）経由のフロントマターパースエラー → cache に status: error が書き込まれ戻り値から除外される', async () => {
+      const _tempDir = await Deno.makeTempDir();
+      try {
+        const _cache = await _makeEmptyClassifyCache();
+        const _filePath = `${_tempDir}/bad-yaml.md`;
+        await Deno.writeTextFile(_filePath, '---\ntitle: [unclosed\n---\n本文');
+
+        const _result = await loadClassifyEntries([_filePath], _cache);
+
+        assertEquals(_result, []);
+        assertEquals(_cache.read(_filePath).status, CLASSIFY_ACTIONS.ERROR);
+      } finally {
+        await Deno.remove(_tempDir, { recursive: true });
+      }
     });
   });
 });

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/move-classified.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/move-classified.unit.spec.ts
@@ -17,6 +17,7 @@ import { describe, it } from '@std/testing/bdd';
 import { moveClassified } from '../../file-ops.ts';
 
 // ─── Helpers
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
 import type { ClassifyBuffer } from '../../../types/classify.types.ts';
 
@@ -47,7 +48,6 @@ describe('moveClassified', () => {
       const _entry = _makeEntry('/tmp/input/test.md');
       const _buffer: ClassifyBuffer = [{
         file: _entry,
-        filePath: _entry.filePath!,
         project: 'app1',
         action: CLASSIFY_ACTIONS.SKIP,
       }];
@@ -78,7 +78,6 @@ describe('moveClassified', () => {
       const _entry = _makeEntry('/tmp/input/test.md');
       const _buffer: ClassifyBuffer = [{
         file: _entry,
-        filePath: _entry.filePath!,
         action: CLASSIFY_ACTIONS.REMAINING,
       }];
       const _stats = _makeStats();
@@ -94,7 +93,7 @@ describe('moveClassified', () => {
 
     it('[Normal] T-CL-MC-06: action=undefined → stats.remaining++', async () => {
       const _entry = _makeEntry('/tmp/input/test.md');
-      const _buffer: ClassifyBuffer = [{ file: _entry, filePath: _entry.filePath! }];
+      const _buffer: ClassifyBuffer = [{ file: _entry }];
       const _stats = _makeStats();
 
       await moveClassified(_buffer, '/tmp/output', false, _stats);
@@ -108,8 +107,7 @@ describe('moveClassified', () => {
 
     it('[Normal] T-CL-MC-09: action=error → stats.error++ のみ、ファイル移動なし', async () => {
       const _buffer: ClassifyBuffer = [{
-        file: null,
-        filePath: '/tmp/input/broken.md',
+        file: new ChatlogEntry('', { filePath: '/tmp/input/broken.md' }),
         action: CLASSIFY_ACTIONS.ERROR,
         reason: 'AI 分類失敗',
       }];
@@ -133,7 +131,6 @@ describe('moveClassified', () => {
       const _entry = _makeEntry('/tmp/input/test.md');
       const _buffer: ClassifyBuffer = [{
         file: _entry,
-        filePath: _entry.filePath!,
         project: 'app1',
         action: CLASSIFY_ACTIONS.MOVE,
       }];
@@ -151,7 +148,6 @@ describe('moveClassified', () => {
       const _entry = _makeEntry('/tmp/input/test.md');
       const _buffer: ClassifyBuffer = [{
         file: _entry,
-        filePath: _entry.filePath!,
         project: 'app1',
         action: CLASSIFY_ACTIONS.MOVEBYAI,
       }];
@@ -168,7 +164,6 @@ describe('moveClassified', () => {
       const _entry = _makeEntry('/tmp/input/test.md');
       const _buffer: ClassifyBuffer = [{
         file: _entry,
-        filePath: _entry.filePath!,
         project: undefined,
         action: CLASSIFY_ACTIONS.MOVE,
       }];
@@ -188,7 +183,6 @@ describe('moveClassified', () => {
       const _entry = _makeEntry('/tmp/input/test.md');
       const _buffer: ClassifyBuffer = [{
         file: _entry,
-        filePath: _entry.filePath!,
         project: 'app1',
         action: CLASSIFY_ACTIONS.MOVE,
       }];

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/partition-classify-entries.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/partition-classify-entries.unit.spec.ts
@@ -1,0 +1,135 @@
+// src: scripts/modules/__tests__/unit/partition-classify-entries.unit.spec.ts
+// @(#): partitionClassifyEntries の単体テスト
+//       対象: partitionClassifyEntries
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { partitionClassifyEntries } from '../../partition-classify-entries.ts';
+
+// ─── Helpers
+import { _makeEmptyClassifyCache, _makeEntry, _makeStats } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+// types
+import type { ClassifyBufferEntry, FindBufferEntriesOptions } from '../../../types/classify.types.ts';
+// constants
+import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
+
+// ─── Internal Helpers
+
+// functions
+
+/**
+ * `opts.glob` 用のスタブを生成する。
+ *
+ * 渡された `paths` を、glob パターン引数を無視してそのまま返す。
+ *
+ * @param paths - 返却するファイルパス配列
+ * @returns `GlobProvider` 互換のスタブ関数
+ */
+const _makeGlob = (paths: string[]): FindBufferEntriesOptions['glob'] => (_pattern: string) => Promise.resolve(paths);
+
+/**
+ * `opts.loadMeta` 用のスタブを生成する。
+ *
+ * `path` に対応する `ClassifyBufferEntry` を `entries` マップから返す。
+ *
+ * @param entries - パスをキーとした `ClassifyBufferEntry` マップ
+ * @returns `path => Promise<ClassifyBufferEntry>` 互換のスタブ関数
+ */
+const _makeLoadMeta = (
+  entries: Map<string, ClassifyBufferEntry>,
+): FindBufferEntriesOptions['loadMeta'] =>
+(path: string): Promise<ClassifyBufferEntry> => Promise.resolve(entries.get(path)!);
+
+// ─── Tests
+
+/**
+ * `partitionClassifyEntries` のユニットテストスイート。
+ *
+ * ディレクトリ走査 → AI なし事前分類 → キャッシュ有無による REMAINING の振り分けを検証する。
+ *
+ * テスト ID 範囲: T-CL-PCE-01 〜 T-CL-PCE-03
+ *
+ * @see partitionClassifyEntries
+ */
+describe('partitionClassifyEntries', () => {
+  describe('When: 正常系', () => {
+    it('[Normal] T-CL-PCE-01: preclassify で全件 MOVE/SKIP に解決する → resolved に全件含まれ、cached/uncached は空', async () => {
+      // frontmatter に project あり、パスは proj-a サブディレクトリ外 → MOVE
+      const _entryMove = _makeEntry('/tmp/input/test.md', { project: 'proj-a' }, '');
+      // frontmatter に project あり、パスが proj-a サブディレクトリ内 → SKIP
+      const _entrySkip = _makeEntry('/tmp/input/proj-a/test.md', { project: 'proj-a' }, '');
+
+      const _entries = new Map<string, ClassifyBufferEntry>([
+        [_entryMove.filePath!, { file: _entryMove }],
+        [_entrySkip.filePath!, { file: _entrySkip }],
+      ]);
+      const _opts: FindBufferEntriesOptions = {
+        glob: _makeGlob([..._entries.keys()]),
+        loadMeta: _makeLoadMeta(_entries),
+      };
+      const _cache = await _makeEmptyClassifyCache();
+      const _stats = _makeStats();
+
+      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts, _stats);
+
+      assertEquals(result.resolved.length, 2);
+      assertEquals(result.resolved.map((e) => e.action).sort(), [CLASSIFY_ACTIONS.MOVE, CLASSIFY_ACTIONS.SKIP].sort());
+      assertEquals(result.cached, []);
+      assertEquals(result.uncached, []);
+    });
+  });
+
+  describe('When: エッジケース', () => {
+    it('[Edge] T-CL-PCE-02: REMAINING エントリのファイルがキャッシュ済み → cached に project/action: MOVEBYAI で含まれ uncached には含まれない', async () => {
+      const _entry = _makeEntry('/tmp/input/cached.md', {}, 'a'.repeat(100));
+      const _entries = new Map<string, ClassifyBufferEntry>([
+        [_entry.filePath!, { file: _entry }],
+      ]);
+      const _opts: FindBufferEntriesOptions = {
+        glob: _makeGlob([..._entries.keys()]),
+        loadMeta: _makeLoadMeta(_entries),
+      };
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(_entry.filePath!, { project: 'proj-a', confidence: 0.95, reason: 'cached decision' });
+
+      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts);
+
+      assertEquals(result.resolved, []);
+      assertEquals(result.uncached, []);
+      assertEquals(result.cached.length, 1);
+      assertEquals(result.cached[0].project, 'proj-a');
+      assertEquals(result.cached[0].action, CLASSIFY_ACTIONS.MOVEBYAI);
+    });
+
+    it('[Edge] T-CL-PCE-03: REMAINING エントリが一部のみキャッシュ済み → cache済み分は cached へ、未cache分は uncached へ振り分けられる', async () => {
+      const _entryCached = _makeEntry('/tmp/input/cached2.md', {}, 'a'.repeat(100));
+      const _entryUncached = _makeEntry('/tmp/input/uncached.md', {}, 'b'.repeat(100));
+      const _entries = new Map<string, ClassifyBufferEntry>([
+        [_entryCached.filePath!, { file: _entryCached }],
+        [_entryUncached.filePath!, { file: _entryUncached }],
+      ]);
+      const _opts: FindBufferEntriesOptions = {
+        glob: _makeGlob([..._entries.keys()]),
+        loadMeta: _makeLoadMeta(_entries),
+      };
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(_entryCached.filePath!, { project: 'proj-a', confidence: 0.9, reason: 'cached' });
+
+      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts);
+
+      assertEquals(result.cached.length, 1);
+      assertEquals(result.cached[0].file.filePath, _entryCached.filePath);
+      assertEquals(result.cached[0].project, 'proj-a');
+      assertEquals(result.uncached.length, 1);
+      assertEquals(result.uncached[0].file.filePath, _entryUncached.filePath);
+    });
+  });
+});

--- a/skills/classify-chatlogs/scripts/modules/classify-ai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-ai.ts
@@ -16,6 +16,7 @@ import { runChunked } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
 
 // ─── Local
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
 import type {
@@ -94,6 +95,7 @@ export const processChunk = async (
   chunkMetas: ChatlogEntry[],
   projects: ProjectDicEntry,
   model: string,
+  cache: ChatlogCache<ClassifyResult>,
 ): Promise<ClassifyBuffer> => {
   const _buffer: ClassifyBuffer = [];
 
@@ -110,7 +112,6 @@ export const processChunk = async (
     logger.warn(`  ${_reason}`);
     return chunkMetas.map((f) => ({
       file: f,
-      filePath: f.filePath!,
       action: CLASSIFY_ACTIONS.ERROR,
       reason: _reason,
     }));
@@ -122,7 +123,6 @@ export const processChunk = async (
     logger.warn(`  ${_reason}`);
     return chunkMetas.map((f) => ({
       file: f,
-      filePath: f.filePath!,
       action: CLASSIFY_ACTIONS.ERROR,
       reason: _reason,
     }));
@@ -132,7 +132,12 @@ export const processChunk = async (
     const result = parsed.find((r) => r.file === fileMeta.filename);
     const project = result?.project ?? FALLBACK_PROJECT;
     logger.info(`  classify: ${fileMeta.filename} → ${project} (conf=${result?.confidence ?? 0})`);
-    _buffer.push({ file: fileMeta, filePath: fileMeta.filePath!, project, action: CLASSIFY_ACTIONS.MOVEBYAI });
+    _buffer.push({ file: fileMeta, project, action: CLASSIFY_ACTIONS.MOVEBYAI });
+    await cache.write(fileMeta.filePath!, {
+      project,
+      confidence: result?.confidence ?? 0,
+      reason: result?.reason ?? '',
+    });
   }
 
   return _buffer;
@@ -149,6 +154,7 @@ export const classifyByAI = async (
   allEntries: ClassifyBuffer,
   projects: ProjectDicEntry,
   config: Pick<ClassifyConfig, 'chunkSize' | 'concurrency' | 'model'>,
+  cache: ChatlogCache<ClassifyResult>,
 ): Promise<ClassifyBuffer> => {
   // `e.file!` は安全: `findBufferEntries` が `action=error` を除外し、REMAINING エントリは常に file を持つ
   const _remaining = allEntries
@@ -159,7 +165,7 @@ export const classifyByAI = async (
   const _chunkBuffers = await runChunked<ChatlogEntry, ClassifyBuffer>(
     _remaining,
     config.chunkSize,
-    (chunk) => processChunk(chunk, projects, config.model),
+    (chunk) => processChunk(chunk, projects, config.model, cache),
     config.concurrency,
   );
 

--- a/skills/classify-chatlogs/scripts/modules/classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-noai.ts
@@ -38,7 +38,7 @@ export const loadClassifyEntry = async (filePath: string): Promise<ActionStatusE
   } catch (e) {
     const _reason = e instanceof Error ? e.message : String(e);
     return {
-      entry: new ChatlogEntry(''),
+      entry: new ChatlogEntry('', { filePath }),
       options: { filePath, action: ENTRY_ACTIONS.ERROR, status: ENTRY_STATUSES.ERROR, reason: _reason },
     };
   }

--- a/skills/classify-chatlogs/scripts/modules/file-ops.ts
+++ b/skills/classify-chatlogs/scripts/modules/file-ops.ts
@@ -87,7 +87,7 @@ export const moveClassified = async (
         stats.remaining++;
         break;
       case CLASSIFY_ACTIONS.ERROR:
-        logger.warn(`  AI 分類失敗: ${entry.filePath}`);
+        logger.warn(`  AI 分類失敗: ${entry.file.filePath}`);
         stats.error++;
         break;
       case CLASSIFY_ACTIONS.MOVE: {

--- a/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
+++ b/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
@@ -10,15 +10,18 @@
 // cspell:word noai
 
 // ─── Shared scripts
-import { findEntries } from '../../../_scripts/libs/file-ops/find-entries.ts';
+import { findFilesFlat } from '../../../_scripts/libs/file-ops/find-files.ts';
 
 // ─── Local
 import { loadClassifyEntry } from './classify-noai.ts';
 // types
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import type { ActionStatusEntry } from '../../../_scripts/types/action-status-entry.types.ts';
 import type {
   ClassifyBuffer,
   ClassifyBufferEntry,
+  ClassifyEntry,
+  ClassifyResult,
   ClassifyStats,
   FindBufferEntriesOptions,
 } from '../types/classify.types.ts';
@@ -30,15 +33,65 @@ import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
 const _toBufferEntry = (ase: ActionStatusEntry): ClassifyBufferEntry => {
   const _isError = ase.options.action === ENTRY_ACTIONS.ERROR;
   return {
-    file: _isError ? null : ase.entry,
-    filePath: ase.options.filePath,
+    file: ase.entry,
     action: _isError ? CLASSIFY_ACTIONS.ERROR : undefined,
     reason: ase.options.reason,
   };
 };
 
+/** `entry.file` の frontmatter から既存の `project` フィールド（非空文字列）を取得する。なければ `undefined`。 */
+const _getExistingProject = (entry: ClassifyBufferEntry): string | undefined => {
+  const _project = entry.file?.frontmatter.get('project');
+  return typeof _project === 'string' && _project ? _project : undefined;
+};
+
+/** 1件のファイルパスに対して `loadMeta`（省略時は `loadClassifyEntry`）を呼び出し、`ClassifyBufferEntry` を返す。 */
+const _loadEntry = async (
+  filePath: string,
+  loadMeta?: FindBufferEntriesOptions['loadMeta'],
+): Promise<ClassifyBufferEntry> =>
+  loadMeta ? await loadMeta(filePath) : _toBufferEntry(await loadClassifyEntry(filePath));
+
 /**
- * ディレクトリ配下の `.md` ファイルを収集し、メタデータを読み込んで分類バッファを返す。
+ * ディレクトリ直下（1階層目）の `.md` ファイルパス一覧を収集する。
+ */
+export const findChatlogFilePaths = (dir: string, opts?: FindBufferEntriesOptions): Promise<string[]> =>
+  findFilesFlat(dir, { ext: '.md', glob: opts?.glob });
+
+/**
+ * ファイルパス一覧からエントリを読み込み、`ClassifyEntry` 配列を返す。
+ * - 読み込み成功時、frontmatter に `project` があれば `cache` に `{ project }` を書き込む。
+ * - 読み込み失敗（`action: 'error'`）時は `cache` に `{ status: CLASSIFY_ACTIONS.ERROR }` を書き込み、
+ *   戻り値から除外し `stats.error` をインクリメントする。
+ */
+export const loadClassifyEntries = async (
+  filePaths: string[],
+  cache: ChatlogCache<ClassifyResult>,
+  opts?: FindBufferEntriesOptions,
+  stats?: ClassifyStats,
+): Promise<ClassifyEntry[]> => {
+  const _entries = await Promise.all(
+    filePaths.map((filePath) => _loadEntry(filePath, opts?.loadMeta)),
+  );
+
+  await Promise.all(
+    _entries.map((entry) => {
+      if (entry.action === CLASSIFY_ACTIONS.ERROR) {
+        if (stats) { stats.error++; }
+        return cache.write(entry.file.filePath!, { status: CLASSIFY_ACTIONS.ERROR });
+      }
+      const _project = _getExistingProject(entry);
+      return _project ? cache.write(entry.file.filePath!, { project: _project }) : Promise.resolve();
+    }),
+  );
+
+  return _entries
+    .filter((entry) => entry.action !== CLASSIFY_ACTIONS.ERROR)
+    .map((entry) => ({ file: entry.file, filePath: entry.file.filePath! }));
+};
+
+/**
+ * ディレクトリ直下（1階層目）の `.md` ファイルを収集し、メタデータを読み込んで分類バッファを返す。
  * - `loadMeta` が `action: 'error'` のエントリを返したファイルはスキップし、`stats.error` をインクリメントする。
  */
 export const findBufferEntries = async (
@@ -46,17 +99,11 @@ export const findBufferEntries = async (
   opts?: FindBufferEntriesOptions,
   stats?: ClassifyStats,
 ): Promise<ClassifyBuffer> => {
-  const _files = await findEntries([dir], '.md', { glob: opts?.glob });
+  const _files = await findFilesFlat(dir, { ext: '.md', glob: opts?.glob });
 
   const _entries = await Promise.all(
-    _files.map(async (filePath): Promise<ClassifyBufferEntry> => {
-      let _entry: ClassifyBufferEntry;
-      if (opts?.loadMeta) {
-        _entry = await opts.loadMeta(filePath);
-      } else {
-        const _ase = await loadClassifyEntry(filePath);
-        _entry = _toBufferEntry(_ase);
-      }
+    _files.map(async (filePath) => {
+      const _entry = await _loadEntry(filePath, opts?.loadMeta);
       if (_entry.action === CLASSIFY_ACTIONS.ERROR && stats) { stats.error++; }
       return _entry;
     }),

--- a/skills/classify-chatlogs/scripts/modules/partition-classify-entries.ts
+++ b/skills/classify-chatlogs/scripts/modules/partition-classify-entries.ts
@@ -1,0 +1,54 @@
+// src: scripts/modules/partition-classify-entries.ts
+// @(#): classify-chatlogs 分類候補エントリ分割モジュール
+//       対象: partitionClassifyEntries
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Local
+import { processPreclassify } from './classify-noai.ts';
+import { findBufferEntries } from './find-buffer-entries.ts';
+// types
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
+import type {
+  ClassifyBuffer,
+  ClassifyPartition,
+  ClassifyResult,
+  ClassifyStats,
+  FindBufferEntriesOptions,
+} from '../types/classify.types.ts';
+// constants
+import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
+
+/**
+ * ディレクトリを走査して分類対象ファイルを収集し、AI なし事前分類を適用したうえで
+ * `resolved`（解決済み）・`cached`（キャッシュ済み REMAINING）・`uncached`（未キャッシュ REMAINING）に分割する。
+ *
+ * REMAINING エントリのうち `cache` に判定結果が既に存在するファイルは `cached` に、
+ * キャッシュの `project` を用いて `action: MOVEBYAI` のエントリとして含める。
+ * 未キャッシュの REMAINING エントリは `uncached` にそのまま含める。
+ */
+export const partitionClassifyEntries = async (
+  searchDir: string,
+  cache: ChatlogCache<ClassifyResult>,
+  opts?: FindBufferEntriesOptions,
+  stats?: ClassifyStats,
+): Promise<ClassifyPartition> => {
+  const buffer = await findBufferEntries(searchDir, opts, stats);
+  const preClassified = processPreclassify(buffer);
+  const resolved = preClassified.filter((e) => e.action !== CLASSIFY_ACTIONS.REMAINING);
+  const remaining = preClassified.filter((e) => e.action === CLASSIFY_ACTIONS.REMAINING);
+
+  const { cached, uncached } = remaining.reduce<
+    { cached: ClassifyBuffer; uncached: ClassifyBuffer }
+  >((acc, e) => {
+    const _cachedProject = cache.read(e.file.filePath!).project;
+    return _cachedProject != null
+      ? { ...acc, cached: [...acc.cached, { ...e, project: _cachedProject, action: CLASSIFY_ACTIONS.MOVEBYAI }] }
+      : { ...acc, uncached: [...acc.uncached, e] };
+  }, { cached: [], uncached: [] });
+
+  return { resolved, cached, uncached };
+};

--- a/skills/classify-chatlogs/scripts/types/classify.types.ts
+++ b/skills/classify-chatlogs/scripts/types/classify.types.ts
@@ -35,6 +35,8 @@ export interface ClassifyResult {
   confidence: number;
   /** 分類根拠の説明文。 */
   reason: string;
+  /** ファイル読み込み失敗時のステータス（`CLASSIFY_ACTIONS.ERROR`）。 */
+  status?: ClassifyAction;
 }
 
 // ─────────────────────────────────────────────
@@ -104,10 +106,8 @@ export type ClassifyAction = typeof CLASSIFY_ACTIONS[keyof typeof CLASSIFY_ACTIO
 
 /** `preClassify` および `processChunk` が返す1件分のバッファエントリ。 */
 export type ClassifyBufferEntry = {
-  /** 分類対象のファイルエントリ。エラー時は `null`。 */
-  file: ChatlogEntry | null;
-  /** エントリのファイルパス。エラー時も参照できるよう `file` とは別に保持する。 */
-  filePath: string;
+  /** 分類対象のファイルエントリ。 */
+  file: ChatlogEntry;
   /** 割り当てるプロジェクト名。 */
   project?: string;
   /** 実行するアクション。`'move'` はファイル移動、`'skip'` はスキップ（カウントのみ）。 */
@@ -119,6 +119,16 @@ export type ClassifyBufferEntry = {
 /** `preClassify` および `processChunk` が返すバッファ。 */
 export type ClassifyBuffer = ClassifyBufferEntry[];
 
+/** `partitionClassifyEntries` が返す、分類候補ファイルエントリの分割結果。 */
+export type ClassifyPartition = {
+  /** preclassify で MOVE/SKIP/ERROR 相当に確定したエントリ。 */
+  resolved: ClassifyBuffer;
+  /** REMAINING のうちキャッシュ済み（前回以前の呼び出しでの AI 判定結果）。project 適用済み、action: MOVEBYAI。 */
+  cached: ClassifyBuffer;
+  /** REMAINING のうち未キャッシュ。AI 分類対象。 */
+  uncached: ClassifyBuffer;
+};
+
 // ─────────────────────────────────────────────
 // findBufferEntries オプション型
 // ─────────────────────────────────────────────
@@ -127,4 +137,16 @@ export type ClassifyBuffer = ClassifyBufferEntry[];
 export type FindBufferEntriesOptions = {
   glob?: GlobProvider;
   loadMeta?: (path: string) => Promise<ClassifyBufferEntry>;
+};
+
+// ─────────────────────────────────────────────
+// 分類エントリ型
+// ─────────────────────────────────────────────
+
+/** `loadClassifyEntries` が返す、読み込みに成功したエントリ。`file` は non-null。 */
+export type ClassifyEntry = {
+  /** 読み込み済みのファイルエントリ。 */
+  file: ChatlogEntry;
+  /** エントリのファイルパス。 */
+  filePath: string;
 };


### PR DESCRIPTION
## Overview

**Summary**
Cache AI classification results so already-classified entries are not re-sent to the AI.

**Background / Motivation**
Repeated classification runs used to call the AI for every entry, even ones already classified before. This is slow
and wastes AI calls. Entries are now split into resolved, cached, and uncached groups before calling the AI, so only
uncached entries are actually classified.

## Changes

### Core Changes

- `classify-chatlogs.ts`: split entries into resolved / cached / uncached before classification, reusing cached AI
  results.
- `modules/partition-classify-entries.ts` (new): partitions entries into resolved, cached, and uncached groups.
- `modules/find-buffer-entries.ts`: add helpers to find chatlog files, load entries, and write cache results.
- `modules/classify-ai.ts`: write AI classification results to the cache, keyed by `filePath`.
- `modules/classify-noai.ts`: keep the file path on load errors.
- `modules/file-ops.ts`: fix error log to use the nested `entry.file.filePath`.
- `types/classify.types.ts`: add `ClassifyPartition` and `ClassifyEntry` types; add `status` to `ClassifyResult`;
  remove the unused `filePath` property.

### Test Updates

- Add unit tests for `partition-classify-entries` and the new `find-buffer-entries` helpers.
- Add functional tests for cache writes during AI classification.
- Add a shared test helper for an in-memory classify cache.
- Update existing fixtures to the new nested `file.filePath` shape.
- Add an E2E test for the cached classification flow.

### Removed

- `filePath` property from `ClassifyBufferEntry` (replaced by nested `file.filePath`).

## Change Type (optional)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This change is scoped to `skills/classify-chatlogs`; no other skills or shared `_scripts/` modules are affected.
