### PR TITLE
fix(exporter): resolve session id cache collisions

### DIFF
--- a/skills/export-chatlogs/scripts/__tests__/functional/parse-claude-session.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/parse-claude-session.functional.spec.ts
@@ -9,7 +9,7 @@
 // cspell:words sess
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertNotEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { assertNotNull, assertNull } from '../../../../_scripts/__tests__/helpers/assert.ts';
 
@@ -303,6 +303,55 @@ describe('parseClaudeSession', () => {
           const assistantText = result!.turns[1].content;
           assertEquals(assistantText.includes('前半'), true);
           assertEquals(assistantText.includes('後半'), true);
+        });
+      });
+    });
+  });
+
+  // ─── T-EC-PC-07: sessionId 欠落 → 一意な代替値が生成される ────────────────
+
+  /**
+   * sessionId が欠落した2つのセッションをパースするシナリオ。
+   * 同日・同slugのセッションで sessionId が欠落すると、単純な固定値フォールバックでは
+   * 出力ファイル名が衝突しキャッシュが誤って共有されてしまう。
+   * `resolveSessionId` により、欠落時は呼び出しごとに異なる代替値が生成されることを確認する。
+   */
+  describe('Given: sessionId が欠落した2つのJSONLセッション', () => {
+    /** `parseClaudeSession(filePath, allPeriod)` を各ファイルに対して呼び出したときの結果を検証する。 */
+    describe('When: 2つのファイルをそれぞれ parseClaudeSession(filePath, allPeriod) でパースする', () => {
+      let filePathA: string;
+      let filePathB: string;
+
+      beforeEach(async () => {
+        filePathA = `${tempDir}/missing-session-id-a.jsonl`;
+        filePathB = `${tempDir}/missing-session-id-b.jsonl`;
+        const _makeEntries = () => [
+          {
+            type: 'user',
+            isMeta: false,
+            timestamp: '2026-03-15T10:00:00.000Z',
+            cwd: '/home/user/projects/my-app',
+            message: { id: 'msg-u-001', content: [{ type: 'text', text: '質問です' }] },
+          },
+          {
+            type: 'assistant',
+            isMeta: false,
+            timestamp: '2026-03-15T10:00:05.000Z',
+            message: { id: 'msg-a-001', content: [{ type: 'text', text: '回答です。' }] },
+          },
+        ];
+        await writeJsonl(filePathA, _makeEntries());
+        await writeJsonl(filePathB, _makeEntries());
+      });
+
+      /** T-EC-PC-07: 2セッションの meta.sessionId が異なる値になる */
+      describe('Then: T-EC-PC-07 - 2セッションの meta.sessionId が異なる値になる', () => {
+        it('T-EC-PC-07-01: sessionA と sessionB の meta.sessionId が異なる（出力ファイル名衝突を回避する）', async () => {
+          const sessionA = await parseClaudeSession(filePathA, ALL_PERIOD);
+          const sessionB = await parseClaudeSession(filePathB, ALL_PERIOD);
+          assertNotNull(sessionA);
+          assertNotNull(sessionB);
+          assertNotEquals(sessionA!.meta.sessionId, sessionB!.meta.sessionId);
         });
       });
     });

--- a/skills/export-chatlogs/scripts/__tests__/functional/parse-codex-session.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/parse-codex-session.functional.spec.ts
@@ -9,7 +9,7 @@
 // cspell:words sess
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertNotEquals } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { assertNotNull, assertNull } from '../../../../_scripts/__tests__/helpers/assert.ts';
 
@@ -340,6 +340,63 @@ describe('parseCodexSession', () => {
         it('T-EC-PX-07-01: null を返す', async () => {
           const result = await parseCodexSession(filePath, ALL_PERIOD);
           assertNull(result);
+        });
+      });
+    });
+  });
+
+  // ─── T-EC-PX-08: payload.id 欠落 → 一意な代替値が生成される ───────────────
+
+  /**
+   * `payload.id` が欠落した2つのセッションをパースするシナリオ。
+   * 同日・同slugのセッションで sessionId が欠落すると、単純な固定値フォールバックでは
+   * 出力ファイル名が衝突しキャッシュが誤って共有されてしまう。
+   * `resolveSessionId` により、欠落時は呼び出しごとに異なる代替値が生成されることを確認する。
+   */
+  describe('Given: payload.id が欠落した2つのJSONLセッション', () => {
+    /** `parseCodexSession(filePath, allPeriod)` を各ファイルに対して呼び出したときの結果を検証する。 */
+    describe('When: 2つのファイルをそれぞれ parseCodexSession(filePath, allPeriod) でパースする', () => {
+      let filePathA: string;
+      let filePathB: string;
+
+      beforeEach(async () => {
+        filePathA = `${tempDir}/missing-session-id-a.jsonl`;
+        filePathB = `${tempDir}/missing-session-id-b.jsonl`;
+        const _makeEntries = () => [
+          {
+            timestamp: '2026-03-15T11:00:00.000Z',
+            type: 'session_meta',
+            payload: { cwd: '/home/user/projects/my-codex-app', model: 'o4-mini' },
+          },
+          {
+            timestamp: '2026-03-15T11:00:01.000Z',
+            type: 'response_item',
+            payload: {
+              role: 'user',
+              content: [{ type: 'input_text', text: '質問です' }],
+            },
+          },
+          {
+            timestamp: '2026-03-15T11:00:05.000Z',
+            type: 'response_item',
+            payload: {
+              role: 'assistant',
+              content: [{ type: 'output_text', text: '回答です。' }],
+            },
+          },
+        ];
+        await writeJsonl(filePathA, _makeEntries());
+        await writeJsonl(filePathB, _makeEntries());
+      });
+
+      /** T-EC-PX-08: 2セッションの meta.sessionId が異なる値になる */
+      describe('Then: T-EC-PX-08 - 2セッションの meta.sessionId が異なる値になる', () => {
+        it('T-EC-PX-08-01: sessionA と sessionB の meta.sessionId が異なる（出力ファイル名衝突を回避する）', async () => {
+          const sessionA = await parseCodexSession(filePathA, ALL_PERIOD);
+          const sessionB = await parseCodexSession(filePathB, ALL_PERIOD);
+          assertNotNull(sessionA);
+          assertNotNull(sessionB);
+          assertNotEquals(sessionA!.meta.sessionId, sessionB!.meta.sessionId);
         });
       });
     });

--- a/skills/export-chatlogs/scripts/__tests__/unit/resolve-session-id.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/resolve-session-id.unit.spec.ts
@@ -1,0 +1,52 @@
+// src: scripts/__tests__/unit/resolve-session-id.unit.spec.ts
+// @(#): sessionId 解決関数のユニットテスト
+//       対象: resolveSessionId
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertNotEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { resolveSessionId } from '../../libs/session-writer.ts';
+
+// ─── Tests
+
+/**
+ * `resolveSessionId` のユニットテストスイート。
+ *
+ * sessionId が存在する通常ケースでは値を変更せずそのまま返し、
+ * sessionId が欠落している場合のみ `generateHash` で一意な代替値を生成することを検証する。
+ *
+ * @see resolveSessionId
+ */
+describe('resolveSessionId', () => {
+  /** sessionId が存在する通常ケース。 */
+  describe('Given: sessionId が存在する', () => {
+    describe('When: resolveSessionId(sessionId) を呼び出す', () => {
+      describe('Then: T-EC-RS-01 - 渡した sessionId をそのまま返す', () => {
+        it('T-EC-RS-01-01: sessionId="sess-0001" → "sess-0001" が返る（値が変わらない）', async () => {
+          const result = await resolveSessionId('sess-0001');
+          assertEquals(result, 'sess-0001');
+        });
+      });
+    });
+  });
+
+  /** sessionId が欠落している場合に、呼び出しごとに異なる代替値を生成するケース。 */
+  describe('Given: sessionId が undefined', () => {
+    describe('When: resolveSessionId(undefined) を2回呼び出す', () => {
+      describe('Then: T-EC-RS-02 - 呼び出しごとに異なる代替値が生成される', () => {
+        it('T-EC-RS-02-01: 2回の呼び出し結果が異なる（フォールバック衝突を回避する）', async () => {
+          const result1 = await resolveSessionId(undefined);
+          const result2 = await resolveSessionId(undefined);
+          assertNotEquals(result1, result2);
+        });
+      });
+    });
+  });
+});

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
@@ -53,10 +53,9 @@ async function _writeConvFile(filePath: string, conversations: ChatGPTConversati
 //   skippedCount  : parseConversation が null を返した会話数（期間外・内容なし）
 //   errorCount    : ファイル読み込み失敗 または writeSession 例外 の件数
 //
-// ParseConversationProvider は同期関数:
-//   型: (conv: ChatGPTConversation, range: PeriodRange) => ExportedSession | null
-//   I/O・副作用なし。Promise.all の並列実行下でもシングルスレッド（Deno）のため安全。
-//   テスト内で Promise を返してはならない。
+// ParseConversationProvider は非同期関数:
+//   型: (conv: ChatGPTConversation, range: PeriodRange) => Promise<ExportedSession | null>
+//   sessionId 欠落時の resolveSessionId（generateHash）呼び出しに対応するため Promise を返す。
 
 // ─── Tests
 
@@ -125,8 +124,9 @@ describe('exportChatGPT', () => {
         const result = await exportChatGPT(config, {
           // FindFilesProvider: (baseDir: string) => Promise<string[]>
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([convFile]),
-          // ParseConversationProvider: 同期 (conv, range) => ExportedSession | null
-          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => validSession,
+          // ParseConversationProvider: (conv, range) => Promise<ExportedSession | null>
+          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve(validSession),
           // WriteSessionProvider: (outputDir, agent, session) => Promise<string>
           writeSession: (_outputDir: string, _agent: string, _session: ExportedSession): Promise<string> =>
             Promise.resolve('/fake/path.md'),
@@ -172,7 +172,8 @@ describe('exportChatGPT', () => {
         const result = await exportChatGPT(config, {
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([convFile]),
           // null を返す → skippedCount に計上される（仕様）
-          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => null,
+          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve(null),
           writeSession: (_outputDir: string, _agent: string, _session: ExportedSession): Promise<string> =>
             Promise.resolve('/fake/path.md'),
         });
@@ -206,7 +207,8 @@ describe('exportChatGPT', () => {
         const result = await exportChatGPT(config, {
           // 対象ファイルが0件 → 処理対象なし
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([]),
-          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => null,
+          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve(null),
           writeSession: (_outputDir: string, _agent: string, _session: ExportedSession): Promise<string> =>
             Promise.resolve('/fake/path.md'),
         });
@@ -278,7 +280,8 @@ describe('exportChatGPT', () => {
 
         const result = await exportChatGPT(config, {
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([convFile]),
-          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => validSession,
+          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve(validSession),
           // writeSession の例外は errorCount に計上され、outputPaths には追加されない（仕様）
           writeSession: (_outputDir: string, _agent: string, _session: ExportedSession): Promise<string> => {
             throw new Error('write error');
@@ -347,10 +350,11 @@ describe('exportChatGPT', () => {
         const result = await exportChatGPT(config, {
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([file1, file2, file3]),
           // conv.id ベースで sessionId を生成し、outputPaths で識別可能にする
-          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => ({
-            ...validSession,
-            meta: { ...validSession.meta, sessionId: `session-${conv.id}` },
-          }),
+          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve({
+              ...validSession,
+              meta: { ...validSession.meta, sessionId: `session-${conv.id}` },
+            }),
           writeSession: (_outputDir: string, _agent: string, session: ExportedSession): Promise<string> =>
             Promise.resolve(`/fake/${session.meta.sessionId}.md`),
         });
@@ -414,8 +418,8 @@ describe('exportChatGPT', () => {
         const result = await exportChatGPT(config, {
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([errorFile, validFile, skipFile]),
           // conv.id で同定（callCount は使わない — Promise.all 並列処理で呼び出し順序が不定になるため）
-          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => {
-            return conv.id === 'valid' ? validSession : null;
+          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> => {
+            return Promise.resolve(conv.id === 'valid' ? validSession : null);
           },
           writeSession: (_outputDir: string, _agent: string, _session: ExportedSession): Promise<string> =>
             Promise.resolve('/fake/path.md'),
@@ -487,10 +491,10 @@ describe('exportChatGPT', () => {
 
         const result = await exportChatGPT(config, {
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([file1, file2]),
-          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => {
-            if (conv.id === 'skip') { return null; }
-            if (conv.id === 'error') { return errorSession; }
-            return validSession;
+          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> => {
+            if (conv.id === 'skip') { return Promise.resolve(null); }
+            if (conv.id === 'error') { return Promise.resolve(errorSession); }
+            return Promise.resolve(validSession);
           },
           writeSession: (_outputDir: string, _agent: string, session: ExportedSession): Promise<string> => {
             if (session.meta.sessionId === 'conv-uuid-error') {
@@ -536,7 +540,8 @@ describe('exportChatGPT', () => {
               `${tempDir}/nonexistent-001.json`,
               `${tempDir}/nonexistent-002.json`,
             ]),
-          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => null,
+          parseConversation: (_conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve(null),
           writeSession: (_outputDir: string, _agent: string, _session: ExportedSession): Promise<string> =>
             Promise.resolve('/fake/path.md'),
         });
@@ -608,10 +613,11 @@ describe('exportChatGPT', () => {
           // findFiles は [fileX, fileY, fileZ] の順序で返す（入力順を固定）
           findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([fileX, fileY, fileZ]),
           // conv.id で sessionId を生成（並列処理でも各ファイルの conv は独立）
-          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): ExportedSession | null => ({
-            ...validSession,
-            meta: { ...validSession.meta, sessionId: `session-${conv.id}` },
-          }),
+          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve({
+              ...validSession,
+              meta: { ...validSession.meta, sessionId: `session-${conv.id}` },
+            }),
           // sessionId ベースでパスを返すことで outputPaths の内容が検証可能になる
           writeSession: (_outputDir: string, _agent: string, session: ExportedSession): Promise<string> =>
             Promise.resolve(`/fake/${session.meta.sessionId}.md`),

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts
@@ -9,12 +9,12 @@
 
 // cspell:words conv
 
-// parseChatGPTConversation は同期関数（I/O・副作用なし）。
-// ExportConfig → PeriodRange のフィルタと mapping トラバースのみ行う。
-// テスト内で await は不要。型として sync であることを明示する。
+// parseChatGPTConversation は非同期関数。
+// ExportConfig → PeriodRange のフィルタと mapping トラバースに加え、
+// sessionId 欠落時は resolveSessionId（generateHash）で代替値を生成するため await が必要。
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertNotEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 import { assertNotNull, assertNull } from '../../../../../_scripts/__tests__/helpers/assert.ts';
 
@@ -82,7 +82,7 @@ function _makeNormalConv(): ChatGPTConversation {
 /**
  * `parseChatGPTConversation` の機能テストスイート。
  *
- * 同期関数（I/O・副作用なし）として動作し、ChatGPTConversation と PeriodRange を受け取り、
+ * 非同期関数として動作し、ChatGPTConversation と PeriodRange を受け取り、
  * ExportedSession または null を返す関数を検証する。
  * period フィルタ・isSkippable 判定・current_node フォールバックの各仕様をカバーする。
  *
@@ -101,33 +101,33 @@ describe('parseChatGPTConversation', () => {
     describe('When: parseChatGPTConversation(conv, allPeriod) を呼び出す', () => {
       // ─── T-EC-GP-01-01: 非 null を返す ───────────────────────────────────
 
-      it('T-EC-GP-01-01: null でない ExportedSession を返す', () => {
+      it('T-EC-GP-01-01: null でない ExportedSession を返す', async () => {
         const conv = _makeNormalConv();
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertNotNull(result);
       });
 
       // ─── T-EC-GP-01-02: meta.sessionId === conv.conversation_id ──────────
 
-      it('T-EC-GP-01-02: meta.sessionId が conv.conversation_id と一致する', () => {
+      it('T-EC-GP-01-02: meta.sessionId が conv.conversation_id と一致する', async () => {
         const conv = _makeNormalConv();
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertEquals(result!.meta.sessionId, conv.conversation_id);
       });
 
       // ─── T-EC-GP-01-03: meta.project === conv.title ──────────────────────
 
-      it('T-EC-GP-01-03: meta.project が conv.title と一致する', () => {
+      it('T-EC-GP-01-03: meta.project が conv.title と一致する', async () => {
         const conv = _makeNormalConv();
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertEquals(result!.meta.project, conv.title);
       });
 
       // ─── T-EC-GP-01-04: turns.length が user+assistant の数 ──────────────
 
-      it('T-EC-GP-01-04: turns.length が 2（user1 + assistant1）', () => {
+      it('T-EC-GP-01-04: turns.length が 2（user1 + assistant1）', async () => {
         const conv = _makeNormalConv();
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertEquals(result!.turns.length, 2);
       });
     });
@@ -144,7 +144,7 @@ describe('parseChatGPTConversation', () => {
     /** `parseChatGPTConversation` を呼び出したときの戻り値を検証する。 */
     describe('When: parseChatGPTConversation(conv, allPeriod) を呼び出す', () => {
       // null 理由: all-turns-skipped（有効 user ターンなし）
-      it('T-EC-GP-02-01: null を返す', () => {
+      it('T-EC-GP-02-01: null を返す', async () => {
         const conv: ChatGPTConversation = {
           id: 'conv-skip',
           conversation_id: 'conv-uuid-skip',
@@ -166,7 +166,7 @@ describe('parseChatGPTConversation', () => {
           },
           current_node: 'user-1',
         };
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertNull(result);
       });
     });
@@ -183,11 +183,11 @@ describe('parseChatGPTConversation', () => {
     /** 指定期間でフィルタしたときの戻り値を検証する。 */
     describe('When: parsePeriod("2026-03") の期間でフィルタする', () => {
       // null 理由: period-filtered（create_time が期間外）
-      it('T-EC-GP-03-01: null を返す', () => {
+      it('T-EC-GP-03-01: null を返す', async () => {
         const marchRange = parsePeriod('2026-03');
         // create_time は 2025-03-14 頃（2026-03 期間外）
         const conv = _makeNormalConv();
-        const result = parseChatGPTConversation(conv, marchRange);
+        const result = await parseChatGPTConversation(conv, marchRange);
         assertNull(result);
       });
     });
@@ -203,7 +203,7 @@ describe('parseChatGPTConversation', () => {
   describe('Given: current_node が未設定の会話（children が空のノードからフォールバック）', () => {
     /** `parseChatGPTConversation` を呼び出したときの戻り値を検証する。 */
     describe('When: parseChatGPTConversation(conv, allPeriod) を呼び出す', () => {
-      it('T-EC-GP-04-01: ExportedSession を返す（null でない）', () => {
+      it('T-EC-GP-04-01: ExportedSession を返す（null でない）', async () => {
         const conv: ChatGPTConversation = {
           id: 'conv-no-current',
           conversation_id: 'conv-uuid-no-current',
@@ -235,7 +235,7 @@ describe('parseChatGPTConversation', () => {
           },
           // current_node を意図的に省略
         };
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertNotNull(result);
       });
     });
@@ -252,7 +252,7 @@ describe('parseChatGPTConversation', () => {
     /** `parseChatGPTConversation` を呼び出したときの戻り値を検証する。 */
     describe('When: parseChatGPTConversation(conv, allPeriod) を呼び出す', () => {
       // null 理由: invalid-mapping（有効な末尾ノードが特定できない）
-      it('T-EC-GP-04-02: null を返す', () => {
+      it('T-EC-GP-04-02: null を返す', async () => {
         const conv: ChatGPTConversation = {
           id: 'conv-no-leaf',
           conversation_id: 'conv-uuid-no-leaf',
@@ -275,8 +275,37 @@ describe('parseChatGPTConversation', () => {
           },
           // current_node を意図的に省略
         };
-        const result = parseChatGPTConversation(conv, ALL_PERIOD);
+        const result = await parseChatGPTConversation(conv, ALL_PERIOD);
         assertNull(result);
+      });
+    });
+  });
+
+  // ─── T-EC-GP-05: conversation_id 欠落 → 一意な代替値が生成される ─────────
+
+  /**
+   * `conversation_id` が欠落した2つの会話をパースするシナリオ。
+   * 同日・同タイトルの会話で sessionId が欠落すると、単純な固定値フォールバックでは
+   * 出力ファイル名が衝突しキャッシュが誤って共有されてしまう。
+   * `resolveSessionId` により、欠落時は呼び出しごとに異なる代替値が生成されることを確認する。
+   */
+  describe('Given: conversation_id が欠落した2つの会話オブジェクト', () => {
+    /** `parseChatGPTConversation` を各会話に対して呼び出したときの戻り値を検証する。 */
+    describe('When: 2つの会話をそれぞれ parseChatGPTConversation(conv, allPeriod) でパースする', () => {
+      it('T-EC-GP-05-01: convA と convB の meta.sessionId が異なる（出力ファイル名衝突を回避する）', async () => {
+        const _makeConvWithoutId = (id: string): ChatGPTConversation => ({
+          ..._makeNormalConv(),
+          id,
+          // conversation_id は string 型だが、欠落時の実データ（undefined）を意図的に再現する
+          conversation_id: undefined as unknown as string,
+        });
+        const convA = _makeConvWithoutId('conv-a');
+        const convB = _makeConvWithoutId('conv-b');
+        const sessionA = await parseChatGPTConversation(convA, ALL_PERIOD);
+        const sessionB = await parseChatGPTConversation(convB, ALL_PERIOD);
+        assertNotNull(sessionA);
+        assertNotNull(sessionB);
+        assertNotEquals(sessionA!.meta.sessionId, sessionB!.meta.sessionId);
       });
     });
   });

--- a/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
@@ -20,7 +20,7 @@ import { ConversationRole } from '../../../_scripts/types/conversation-role.cons
 // ─── Local modules ───────────────────────────────────────────────────────────
 // libs
 import { inPeriod, parsePeriod } from '../libs/period-filter.ts';
-import { writeSession } from '../libs/session-writer.ts';
+import { resolveSessionId, writeSession } from '../libs/session-writer.ts';
 import { isSkippable, isSkippableSession } from '../libs/skip-rules.ts';
 // types
 import type { Turn } from '../../../_scripts/types/conversation.types.ts';
@@ -125,10 +125,10 @@ export const traverseConversation = (
  * @param range parsePeriod() が生成した期間フィルタ
  * @returns ExportedSession または null
  */
-export const parseChatGPTConversation = (
+export const parseChatGPTConversation = async (
   conv: ChatGPTConversation,
   range: PeriodRange,
-): ExportedSession | null => {
+): Promise<ExportedSession | null> => {
   // 期間チェック
   const isoTimestamp = new Date(conv.create_time * 1000).toISOString();
   if (!inPeriod(isoTimestamp, range)) { return null; }
@@ -163,7 +163,7 @@ export const parseChatGPTConversation = (
   if (isSkippableSession(firstUserTurn.content)) { return null; }
 
   const meta: SessionMeta = {
-    sessionId: conv.conversation_id,
+    sessionId: await resolveSessionId(conv.conversation_id),
     date: isoToDate(isoTimestamp),
     project: conv.title,
     slug: '',
@@ -243,7 +243,7 @@ const _processFile = async (
 
   for (const conv of conversations) {
     try {
-      const session = parseConversation(conv, range);
+      const session = await parseConversation(conv, range);
       if (!session) {
         skippedCount++;
         continue;

--- a/skills/export-chatlogs/scripts/exporter/claude-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/claude-exporter.ts
@@ -19,7 +19,7 @@ import { ConversationRole } from '../../../_scripts/types/conversation-role.cons
 // ─── Local modules ───────────────────────────────────────────────────────────
 // libs
 import { inPeriod, parsePeriod } from '../libs/period-filter.ts';
-import { writeSession } from '../libs/session-writer.ts';
+import { resolveSessionId, writeSession } from '../libs/session-writer.ts';
 import { isSkippable, isSkippableSession } from '../libs/skip-rules.ts';
 // types
 import type { Turn } from '../../../_scripts/types/conversation.types.ts';
@@ -186,7 +186,7 @@ export const parseClaudeSession = async (
   const firstUserText = extractClaudeUserText(firstEntry.message?.content);
   if (isSkippableSession(firstUserText)) { return null; }
   const meta: SessionMeta = {
-    sessionId: firstEntry.sessionId ?? 'unknown',
+    sessionId: await resolveSessionId(firstEntry.sessionId),
     date: isoToDate(firstEntry.timestamp ?? ''),
     project,
     slug: firstEntry.slug ?? '',

--- a/skills/export-chatlogs/scripts/exporter/codex-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/codex-exporter.ts
@@ -19,7 +19,7 @@ import { ConversationRole } from '../../../_scripts/types/conversation-role.cons
 // ─── Local modules ───────────────────────────────────────────────────────────
 // libs
 import { inPeriod, parsePeriod } from '../libs/period-filter.ts';
-import { writeSession } from '../libs/session-writer.ts';
+import { resolveSessionId, writeSession } from '../libs/session-writer.ts';
 import { isSkippable, isSkippableSession } from '../libs/skip-rules.ts';
 // types
 import type { Turn } from '../../../_scripts/types/conversation.types.ts';
@@ -98,7 +98,7 @@ export const parseCodexSession = async (
   const metaEntry = entries.find((e) => e.type === 'session_meta');
   if (!metaEntry) { return null; }
 
-  const sessionId = metaEntry.payload.id ?? 'unknown';
+  const sessionId = await resolveSessionId(metaEntry.payload.id);
   const cwd = metaEntry.payload.cwd ?? '';
   const project = cwd ? normalizePath(cwd).split('/').pop()! : 'unknown';
   const sessionTimestamp = metaEntry.timestamp;

--- a/skills/export-chatlogs/scripts/exporter/types/chatgpt-provider.types.ts
+++ b/skills/export-chatlogs/scripts/exporter/types/chatgpt-provider.types.ts
@@ -15,11 +15,11 @@ import type { ChatGPTConversation } from './chatgpt-entry.types.ts';
 /** 指定ディレクトリから conversations-*.json ファイルパス一覧を返す Provider */
 export type FindFilesProvider = (baseDir: string) => Promise<string[]>;
 
-/** ChatGPT 会話オブジェクトを ExportedSession に変換する Provider（同期） */
+/** ChatGPT 会話オブジェクトを ExportedSession に変換する Provider */
 export type ParseConversationProvider = (
   conv: ChatGPTConversation,
   range: PeriodRange,
-) => ExportedSession | null;
+) => Promise<ExportedSession | null>;
 
 /** ExportedSession を Markdown ファイルに書き出し、パスを返す Provider */
 export type WriteSessionProvider = (outputDir: string, agent: string, session: ExportedSession) => Promise<string>;

--- a/skills/export-chatlogs/scripts/libs/session-writer.ts
+++ b/skills/export-chatlogs/scripts/libs/session-writer.ts
@@ -8,6 +8,7 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
+import { generateHash } from '../../../_scripts/libs/io/hash.ts';
 import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 import { textToSlug } from '../../../_scripts/libs/text/slug-utils.ts';
@@ -19,6 +20,13 @@ import { ConversationRole } from '../../../_scripts/types/conversation-role.cons
 // types
 import type { Turn } from '../../../_scripts/types/conversation.types.ts';
 import type { ExportedSession, SessionMeta } from '../types/session.types.ts';
+
+/** sessionId が欠落している場合に使用するフォールバックのハッシュ生成ベース文字列。 */
+const SESSION_ID_FALLBACK = 'unknown';
+
+/** sessionId が欠落している場合、generateHash で一意な代替値を生成する。 */
+export const resolveSessionId = async (sessionId: string | undefined): Promise<string> =>
+  sessionId ? sessionId : await generateHash(SESSION_ID_FALLBACK);
 
 /** セッションの Markdown ファイル出力パスを生成する。 */
 export const buildOutputPath = (


### PR DESCRIPTION
## Overview

**Summary**
Fix session export cache collisions by generating a unique fallback ID for sessions without a native session ID.

**Background / Motivation**
Sessions without a native session ID fell back to the same static string `'unknown'`. This caused sessions to collide in the export cache and overwrite each other. `resolveSessionId()` now generates a unique hash-based fallback ID per session when the native ID is missing.

## Changes

### Core Changes

- `skills/export-chatlogs/scripts/libs/session-writer.ts`: add `resolveSessionId()`, returning the existing session ID as-is, or a unique hash-based fallback when missing.
- `skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts`: use `resolveSessionId()` instead of the static `'unknown'` fallback; `parseChatGPTConversation` is now async.
- `skills/export-chatlogs/scripts/exporter/claude-exporter.ts`: use `resolveSessionId()` instead of `firstEntry.sessionId ?? 'unknown'`.
- `skills/export-chatlogs/scripts/exporter/codex-exporter.ts`: use `resolveSessionId()` for the `metaEntry.payload.id` fallback.
- `skills/export-chatlogs/scripts/exporter/types/chatgpt-provider.types.ts`: change `ParseConversationProvider`'s return type to `Promise<ExportedSession | null>`.

### Test Updates

- `resolve-session-id.unit.spec.ts`: unit tests for `resolveSessionId` (existing ID kept, unique fallback generated).
- `parse-claude-session.functional.spec.ts`: verify two sessions with missing `sessionId` get distinct IDs.
- `parse-codex-session.functional.spec.ts`: verify two sessions with missing `payload.id` get distinct IDs.
- `parse-chatgpt-conversation.functional.spec.ts`: updated to async; verify two conversations with missing `conversation_id` get distinct IDs.
- `export-chatgpt.functional.spec.ts`: updated `ParseConversationProvider` mocks to return a `Promise`.

### Removed

- None

## Change Type (optional)

- [x] Bug fix
- [x] Refactor

## Related Issues

> Related to #326

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`ParseConversationProvider`'s return type changed from sync to `Promise`-wrapped. This is an internal exporter-provider interface; all callers in this repo have been updated.
