### PR TITLE
refactor(classify): use ChatlogEntry directly across classify-chatlogs

### DIFF
--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -30,7 +30,8 @@ import { loadProjectDic } from './libs/load-project-dic.ts';
 import { classifyByAI } from './modules/classify-ai.ts';
 import { buildConfig } from './modules/classify-config.ts';
 import { applyClassifications } from './modules/file-ops.ts';
-import { partitionClassifyEntries } from './modules/partition-classify-entries.ts';
+import { findChatlogFilePaths, loadClassifyEntries } from './modules/find-buffer-entries.ts';
+import { partitionByPreclassify } from './modules/partition-classify-entries.ts';
 // types
 import type { ClassifyCache, ClassifyStats } from './types/classify.types.ts';
 // constants
@@ -49,15 +50,15 @@ export const main = async (argv?: string[]): Promise<void> => {
   const _config = buildConfig(argv ?? Deno.args);
 
   // 入力ディレクトリ確認
-  const _agentDir = resolveChatlogsDir({
+  const _originalLogsDir = resolveChatlogsDir({
     chatlogsDir: _config.chatlogsDir,
     agent: _config.agent,
     period: _config.period,
     addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
     override: _config.inputDir,
   });
-  if (!await dirExists(_agentDir)) {
-    throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_agentDir}`);
+  if (!await dirExists(_originalLogsDir)) {
+    throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_originalLogsDir}`);
   }
 
   // プロジェクト辞書読み込み
@@ -72,34 +73,28 @@ export const main = async (argv?: string[]): Promise<void> => {
   if (_config.dryRun) { logger.info('dry-run モード: ファイルは移動しません'); }
   logger.info(`プロジェクト候補: ${_projectNames.join(', ')}`);
 
-  // 対象ディレクトリ
-  const _searchDir = resolveChatlogsDir({
-    chatlogsDir: _config.chatlogsDir,
-    agent: _config.agent,
-    period: _config.period,
-    addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
-    override: _config.inputDir,
-  });
-
   const stats: ClassifyStats = { moved: 0, movedByAI: 0, skipped: 0, error: 0, remaining: 0 };
 
-  // 判定結果キャッシュ
-  const _cache = new ChatlogCache<ClassifyCache>('classify-cache');
-  await _cache.ready;
-
-  // Step 1: バッファ取得 + AI なし事前分類 + キャッシュ振り分け
-  const _partition = await partitionClassifyEntries(_searchDir, _cache);
-  if (_partition.filePaths.length === 0) {
+  // Step 0: ファイルリスト、キャッシュ取得
+  const _filePaths = await findChatlogFilePaths(_originalLogsDir);
+  if (_filePaths.length === 0) {
     logger.info('対象ファイルなし');
     logger.info('完了: moved=0 movedByAI=0 skipped=0 error=0');
     return;
   }
+  // 判定結果キャッシュ
+  const _cache = new ChatlogCache<ClassifyCache>('classify-cache');
+  await _cache.ready;
+
+  // Step 1: 分類候補エントリの読み込みと事前分類
+  const _loaded = await loadClassifyEntries(_filePaths, _cache);
+  const _partition = await partitionByPreclassify(_loaded, _cache);
 
   // Step 2: 分類（AI あり）
   await classifyByAI(_partition.uncached, projects, _config, _cache);
 
   // Step 3: ファイル移動
-  await applyClassifications(_partition.filePaths, _partition.entries, _cache, _searchDir, _config.dryRun, stats);
+  await applyClassifications(_partition.entries, _cache, _originalLogsDir, _config.dryRun, stats);
 
   // サマリー
   const drySuffix = _config.dryRun ? ' (dry-run)' : '';

--- a/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/fixtures/pre-classify.fixtures.spec.ts
@@ -19,8 +19,9 @@ import { preClassify } from '../../classify-noai.ts';
 
 // ─── Helpers
 // types
+import type { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import type { FrontmatterFields } from '../../../../../_scripts/types/frontmatter.types.ts';
-import type { ClassifyAction, ClassifyBufferEntry } from '../../../types/classify.types.ts';
+import type { ClassifyAction } from '../../../types/classify.types.ts';
 // functions
 import {
   findFixtureDirs,
@@ -71,16 +72,15 @@ const _loadFixture = async (dir: string): Promise<{ input: _FixtureInput; expect
 };
 
 /**
- * `_FixtureInput` から `ClassifyBufferEntry` を構築する。
+ * `_FixtureInput` から `ChatlogEntry` を構築する。
  *
  * frontmatter と content から `ChatlogEntry` を構築する。
  *
  * @param input - `input.yaml` から読み込んだデータ
- * @returns 構築した `ClassifyBufferEntry`
+ * @returns 構築した `ChatlogEntry`
  */
-const _buildEntry = (input: _FixtureInput): ClassifyBufferEntry => {
-  const _entry = _makeEntry(input.filePath, input.frontmatter ?? {}, input.content ?? '');
-  return { entry: _entry };
+const _buildEntry = (input: _FixtureInput): ChatlogEntry => {
+  return _makeEntry(input.filePath, input.frontmatter ?? {}, input.content ?? '');
 };
 
 // ─── Tests
@@ -94,7 +94,7 @@ const _fixtures = await Promise.all(
  * `preClassify` の fixtures テストスイート。
  *
  * fixtures-data/pre-classify/ 下の各ディレクトリを読み込み、
- * `input.yaml` から `ClassifyBufferEntry` を構築して `preClassify` に渡し、
+ * `input.yaml` から `ChatlogEntry` を構築して `preClassify` に渡し、
  * `cache` に書き込まれた結果を `expected.yaml` の期待値と照合する。
  *
  * @see preClassify

--- a/skills/classify-chatlogs/scripts/modules/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/functional/process-chunk.functional.spec.ts
@@ -47,7 +47,7 @@ import type { LoggerStub } from '../../../../../_scripts/__tests__/helpers/logge
  * `processChunk` の機能テストスイート。
  *
  * AI 呼び出しの成功・失敗・JSON パースエラー・ファイル名不一致を検証する。
- * 戻り値は `ClassifyBuffer`（副作用なし）。
+ * 戻り値は `ChatlogEntry[]`（副作用なし）。
  *
  * テスト ID 範囲: T-CL-PC-01 〜 T-CL-PC-04
  *

--- a/skills/classify-chatlogs/scripts/modules/__tests__/integration/move-classified.integration.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/integration/move-classified.integration.spec.ts
@@ -46,7 +46,7 @@ describe('applyClassifications', () => {
       );
     });
 
-    describe('When: applyClassifications(filePaths, entries, cache, tempDir, false, stats) を呼び出す', () => {
+    describe('When: applyClassifications(entries, cache, tempDir, false, stats) を呼び出す', () => {
       describe('Then: T-CL-MC-10 - classifyFile の実失敗が stats.error に伝播する', () => {
         it('T-CL-MC-10-01: stats.error が 1 になる', async () => {
           const _cache = await _makeEmptyClassifyCache();
@@ -54,8 +54,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
 
           await applyClassifications(
-            [`${tempDir}/missing.md`],
-            new Map([[`${tempDir}/missing.md`, entry]]),
+            [entry],
             _cache,
             tempDir,
             false,
@@ -71,8 +70,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
 
           await applyClassifications(
-            [`${tempDir}/missing.md`],
-            new Map([[`${tempDir}/missing.md`, entry]]),
+            [entry],
             _cache,
             tempDir,
             false,
@@ -88,8 +86,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
 
           await applyClassifications(
-            [`${tempDir}/missing.md`],
-            new Map([[`${tempDir}/missing.md`, entry]]),
+            [entry],
             _cache,
             tempDir,
             false,
@@ -112,7 +109,7 @@ describe('applyClassifications', () => {
       entry = new ChatlogEntry(`---\ntitle: Test\n---\n本文`, { filePath: srcPath });
     });
 
-    describe('When: applyClassifications(filePaths, entries, cache, destDir, false, stats) を呼び出す', () => {
+    describe('When: applyClassifications(entries, cache, destDir, false, stats) を呼び出す', () => {
       describe('Then: T-CL-MC-11 - ファイル移動成功後にキャッシュエントリが削除される', () => {
         it('T-CL-MC-11-01: stats.moved が 1 になる', async () => {
           const _cache = await _makeEmptyClassifyCache();
@@ -120,7 +117,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
           const destDir = `${tempDir}/out`;
 
-          await applyClassifications([srcPath], new Map([[srcPath, entry]]), _cache, destDir, false, _stats);
+          await applyClassifications([entry], _cache, destDir, false, _stats);
 
           assertEquals(_stats.moved, 1);
         });
@@ -131,7 +128,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
           const destDir = `${tempDir}/out`;
 
-          await applyClassifications([srcPath], new Map([[srcPath, entry]]), _cache, destDir, false, _stats);
+          await applyClassifications([entry], _cache, destDir, false, _stats);
 
           assertEquals(_cache.read(srcPath), {});
         });
@@ -140,7 +137,7 @@ describe('applyClassifications', () => {
   });
 
   describe('Given: キャッシュに SKIP/ERROR が登録済みのエントリと dryRun=false', () => {
-    describe('When: applyClassifications(filePaths, entries, cache, destDir, false, stats) を呼び出す', () => {
+    describe('When: applyClassifications(entries, cache, destDir, false, stats) を呼び出す', () => {
       describe('Then: T-CL-MC-12 - SKIP/ERROR はキャッシュが削除されず残る', () => {
         it('T-CL-MC-12-01: action=skip のキャッシュエントリは削除されない', async () => {
           const _cache = await _makeEmptyClassifyCache();
@@ -149,8 +146,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
 
           await applyClassifications(
-            [`${tempDir}/skip.md`],
-            new Map([[`${tempDir}/skip.md`, skipEntry]]),
+            [skipEntry],
             _cache,
             `${tempDir}/out`,
             false,
@@ -167,8 +163,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
 
           await applyClassifications(
-            [`${tempDir}/error.md`],
-            new Map([[`${tempDir}/error.md`, errorEntry]]),
+            [errorEntry],
             _cache,
             `${tempDir}/out`,
             false,

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-noai.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/classify-noai.unit.spec.ts
@@ -18,7 +18,7 @@ import { preClassify, processPreclassify } from '../../classify-noai.ts';
 
 // ─── Helpers
 // types
-import type { ClassifyBufferEntry } from '../../../types/classify.types.ts';
+import type { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // constants
 import { FALLBACK_PROJECT } from '../../../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
@@ -32,7 +32,7 @@ import { _makeEmptyClassifyCache, _makeEntry } from '../../../__tests__/_helpers
  * `preClassify` のユニットテストスイート。
  *
  * frontmatter の `project` フィールドと本文長に基づく事前分類ロジックを検証する。
- * `ClassifyBufferEntry` と `cache` を受け取り、判定結果を `cache.write` に書き込む。
+ * `ChatlogEntry` と `cache` を受け取り、判定結果を `cache.write` に書き込む。
  *
  * テスト ID 範囲: T-CL-PRE-01 〜 T-CL-PRE-05
  *
@@ -48,7 +48,7 @@ describe('preClassify', () => {
       const _entry = _makeEntry(_filePath, { project: 'app1' }, '本文テキスト');
       const cache = await _makeEmptyClassifyCache();
 
-      await preClassify({ entry: _entry }, cache);
+      await preClassify(_entry, cache);
 
       assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.SKIP);
       assertEquals(cache.read(_filePath).project, 'app1');
@@ -59,7 +59,7 @@ describe('preClassify', () => {
       const _entry = _makeEntry(_filePath, { project: 'app1' }, '本文テキスト');
       const cache = await _makeEmptyClassifyCache();
 
-      await preClassify({ entry: _entry }, cache);
+      await preClassify(_entry, cache);
 
       assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.MOVE);
       assertEquals(cache.read(_filePath).project, 'app1');
@@ -70,7 +70,7 @@ describe('preClassify', () => {
       const _entry = _makeEntry(_filePath, {}, 'short');
       const cache = await _makeEmptyClassifyCache();
 
-      await preClassify({ entry: _entry }, cache);
+      await preClassify(_entry, cache);
 
       assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.MOVE);
       assertEquals(cache.read(_filePath).project, FALLBACK_PROJECT);
@@ -85,7 +85,7 @@ describe('preClassify', () => {
       );
       const cache = await _makeEmptyClassifyCache();
 
-      await preClassify({ entry: _entry }, cache);
+      await preClassify(_entry, cache);
 
       assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.REMAINING);
     });
@@ -96,7 +96,7 @@ describe('preClassify', () => {
       const _entry = _makeEntry(_filePath, {}, _longContent);
       const cache = await _makeEmptyClassifyCache();
 
-      await preClassify({ entry: _entry }, cache);
+      await preClassify(_entry, cache);
 
       assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.REMAINING);
     });
@@ -106,7 +106,7 @@ describe('preClassify', () => {
 /**
  * `processPreclassify` のユニットテストスイート。
  *
- * `ClassifyBufferEntry[]` と `cache` を渡し、各エントリに `preClassify` を適用した
+ * `ChatlogEntry[]` と `cache` を渡し、各エントリに `preClassify` を適用した
  * 結果が `cache` に書き込まれることを検証する。
  *
  * テスト ID 範囲: T-CL-PCL-01 〜 T-CL-PCL-03
@@ -127,11 +127,7 @@ describe('processPreclassify', () => {
       const _entryLong = _makeEntry(_pathLong, {}, 'a'.repeat(100));
       const cache = await _makeEmptyClassifyCache();
 
-      const _buffer: ClassifyBufferEntry[] = [
-        { entry: _entryWithProject },
-        { entry: _entryShort },
-        { entry: _entryLong },
-      ];
+      const _buffer: ChatlogEntry[] = [_entryWithProject, _entryShort, _entryLong];
 
       const _result = await processPreclassify(_buffer, cache);
 
@@ -151,7 +147,7 @@ describe('processPreclassify', () => {
     it('[Edge] T-CL-PCL-03: 単一エントリ（project あり）を渡す → cache に action=skip が書き込まれる', async () => {
       const _filePath = '/tmp/dir/app1/a.md';
       const _entry = _makeEntry(_filePath, { project: 'app1' }, '本文');
-      const _buffer: ClassifyBufferEntry[] = [{ entry: _entry }];
+      const _buffer: ChatlogEntry[] = [_entry];
       const cache = await _makeEmptyClassifyCache();
 
       const _result = await processPreclassify(_buffer, cache);

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/find-buffer-entries.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/find-buffer-entries.unit.spec.ts
@@ -19,7 +19,7 @@ import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class
 // types
 import type { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import type { FrontmatterFields } from '../../../../../_scripts/types/frontmatter.types.ts';
-import type { ClassifyBufferEntry, ClassifyCache, FindBufferEntriesOptions } from '../../../types/classify.types.ts';
+import type { ClassifyCache, FindBufferEntriesOptions } from '../../../types/classify.types.ts';
 
 // constants
 import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
@@ -40,21 +40,21 @@ import { _makeEmptyClassifyCache, _makeEntry } from '../../../__tests__/_helpers
 const _makeGlob = (paths: string[]): FindBufferEntriesOptions['glob'] => (_pattern: string) => Promise.resolve(paths);
 
 /**
- * エラーとして扱う `ClassifyBufferEntry` を生成する。
+ * エラーとして扱う `ChatlogEntry` を生成する。
  *
  * 実装のローダーが担う「読み込み失敗時に `cache` へ `action: ERROR` を書き込む」責務を、
  * `loadMeta` スタブ側で `cache` への書き込みとして代替する。
  *
  * @param path - エラーとなったファイルパス
  * @param cache - 書き込み先の `ChatlogCache`
- * @returns `entry` のみを持つ読み込み結果
+ * @returns エラー扱いの `ChatlogEntry`
  */
 const _makeErrorResult = async (
   path: string,
   cache: ChatlogCache<ClassifyCache>,
-): Promise<ClassifyBufferEntry> => {
+): Promise<ChatlogEntry> => {
   await cache.write(path, { action: CLASSIFY_ACTIONS.ERROR, reason: 'load failed' });
-  return { entry: new ChatlogEntry('', { filePath: path }) };
+  return new ChatlogEntry('', { filePath: path });
 };
 
 // ─── Tests
@@ -93,7 +93,7 @@ describe('findChatlogFilePaths', () => {
  *
  * ファイルパス一覧から `ChatlogEntry` を読み込み、各エントリについて必ず `action`（既定値 `EMPTY`）を
  * キャッシュへ書き込み、既存 project frontmatter があれば同じ書き込みに含める。
- * 読み込み失敗エントリはキャッシュへエラー記録のうえ戻り値から除外する振る舞いを検証する。
+ * 読み込み失敗エントリはキャッシュへエラー記録したうえで、戻り値には含める振る舞いを検証する。
  *
  * テスト ID 範囲: T-CL-LCE-01 〜 T-CL-LCE-05
  *
@@ -105,15 +105,12 @@ describe('loadClassifyEntries', () => {
       const _cache = await _makeEmptyClassifyCache();
       const _filePath = '/tmp/input/a.md';
       const _opts: FindBufferEntriesOptions = {
-        loadMeta: () =>
-          Promise.resolve({
-            entry: _makeEntry(_filePath, { project: 'proj-a' }),
-          }),
+        loadMeta: () => Promise.resolve(_makeEntry(_filePath, { project: 'proj-a' })),
       };
 
       const _result = await loadClassifyEntries([_filePath], _cache, _opts);
 
-      assertEquals(_result.map((e) => e.entry.filePath), [_filePath]);
+      assertEquals(_result.map((e) => e.filePath), [_filePath]);
       assertEquals(_cache.read(_filePath).project, 'proj-a');
       assertEquals(_cache.read(_filePath).action, CLASSIFY_ACTIONS.EMPTY);
     });
@@ -122,17 +119,17 @@ describe('loadClassifyEntries', () => {
       const _cache = await _makeEmptyClassifyCache();
       const _filePath = '/tmp/input/a.md';
       const _opts: FindBufferEntriesOptions = {
-        loadMeta: () => Promise.resolve({ entry: _makeEntry(_filePath, {}) }),
+        loadMeta: () => Promise.resolve(_makeEntry(_filePath, {})),
       };
 
       const _result = await loadClassifyEntries([_filePath], _cache, _opts);
 
-      assertEquals(_result.map((e) => e.entry.filePath), [_filePath]);
+      assertEquals(_result.map((e) => e.filePath), [_filePath]);
       assertEquals(_cache.read(_filePath).project, undefined);
       assertEquals(_cache.read(_filePath).action, CLASSIFY_ACTIONS.EMPTY);
     });
 
-    it('[Normal] T-CL-LCE-05: 正常/異常混在 → 正常分のみ順序を保って戻り値に含まれ、正常分は action: EMPTY、エラー分は action: ERROR が個別に反映される', async () => {
+    it('[Normal] T-CL-LCE-05: 正常/異常混在 → 全件が順序を保って戻り値に含まれ、正常分は action: EMPTY、エラー分は action: ERROR が個別に反映される', async () => {
       const _cache = await _makeEmptyClassifyCache();
       const _withProject = '/tmp/input/with-project.md';
       const _errorPath = '/tmp/input/error.md';
@@ -143,7 +140,7 @@ describe('loadClassifyEntries', () => {
             return _makeErrorResult(path, _cache);
           }
           const _frontmatter: FrontmatterFields = path === _withProject ? { project: 'proj-a' } : {};
-          return Promise.resolve({ entry: _makeEntry(path, _frontmatter) });
+          return Promise.resolve(_makeEntry(path, _frontmatter));
         },
       };
 
@@ -153,7 +150,7 @@ describe('loadClassifyEntries', () => {
         _opts,
       );
 
-      assertEquals(_result.map((e) => e.entry.filePath), [_withProject, _noProject]);
+      assertEquals(_result.map((e) => e.filePath), [_withProject, _errorPath, _noProject]);
       assertEquals(_cache.read(_withProject).project, 'proj-a');
       assertEquals(_cache.read(_withProject).action, CLASSIFY_ACTIONS.EMPTY);
       assertEquals(_cache.read(_errorPath).action, CLASSIFY_ACTIONS.ERROR);
@@ -163,7 +160,7 @@ describe('loadClassifyEntries', () => {
   });
 
   describe('When: エッジケース', () => {
-    it('[Edge] T-CL-LCE-02: loadMeta が ERROR エントリを返す → cache に action: error が書き込まれ戻り値から除外される', async () => {
+    it('[Edge] T-CL-LCE-02: loadMeta が ERROR エントリを返す → cache に action: error が書き込まれるが戻り値には含まれる', async () => {
       const _cache = await _makeEmptyClassifyCache();
       const _filePath = '/tmp/input/b.md';
       const _opts: FindBufferEntriesOptions = {
@@ -172,11 +169,11 @@ describe('loadClassifyEntries', () => {
 
       const _result = await loadClassifyEntries([_filePath], _cache, _opts);
 
-      assertEquals(_result, []);
+      assertEquals(_result.map((e) => e.filePath), [_filePath]);
       assertEquals(_cache.read(_filePath).action, CLASSIFY_ACTIONS.ERROR);
     });
 
-    it('[Edge] T-CL-LCE-03: デフォルト読み込み（loadClassifyEntry）経由のフロントマターパースエラー → cache に action: error が書き込まれ戻り値から除外される', async () => {
+    it('[Edge] T-CL-LCE-03: デフォルト読み込み（loadClassifyEntry）経由のフロントマターパースエラー → cache に action: error が書き込まれるが戻り値には含まれる', async () => {
       const _tempDir = await Deno.makeTempDir();
       try {
         const _cache = await _makeEmptyClassifyCache();
@@ -185,7 +182,7 @@ describe('loadClassifyEntries', () => {
 
         const _result = await loadClassifyEntries([_filePath], _cache);
 
-        assertEquals(_result, []);
+        assertEquals(_result.map((e) => e.filePath), [_filePath]);
         assertEquals(_cache.read(_filePath).action, CLASSIFY_ACTIONS.ERROR);
       } finally {
         await Deno.remove(_tempDir, { recursive: true });

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/move-classified.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/move-classified.unit.spec.ts
@@ -49,8 +49,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         false,
@@ -63,11 +62,11 @@ describe('applyClassifications', () => {
       assertEquals(_stats.remaining, 0);
     });
 
-    it('[Normal] T-CL-MC-04: filePaths が空 → 何も起きない', async () => {
+    it('[Normal] T-CL-MC-04: entries が空 → 何も起きない', async () => {
       const _cache = await _makeEmptyClassifyCache();
       const _stats = _makeStats();
 
-      await applyClassifications([], new Map(), _cache, '/tmp/output', false, _stats);
+      await applyClassifications([], _cache, '/tmp/output', false, _stats);
 
       assertEquals(_stats.skipped, 0);
       assertEquals(_stats.moved, 0);
@@ -83,8 +82,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         false,
@@ -104,8 +102,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         false,
@@ -126,8 +123,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/broken.md'],
-        new Map([['/tmp/input/broken.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         false,
@@ -153,8 +149,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         true,
@@ -174,8 +169,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         true,
@@ -194,8 +188,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         true,
@@ -217,8 +210,7 @@ describe('applyClassifications', () => {
       const _stats = _makeStats();
 
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         'C:\\output',
         true,
@@ -241,8 +233,7 @@ describe('applyClassifications', () => {
       // dryRun=true で classifyFile 呼び出しのみ確認（実ファイル操作はしない）。
       // 実削除の検証は integration テストで実施する。
       await applyClassifications(
-        ['/tmp/input/test.md'],
-        new Map([['/tmp/input/test.md', _entry]]),
+        [_entry],
         _cache,
         '/tmp/output',
         true,

--- a/skills/classify-chatlogs/scripts/modules/__tests__/unit/partition-classify-entries.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/modules/__tests__/unit/partition-classify-entries.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: scripts/modules/__tests__/unit/partition-classify-entries.unit.spec.ts
-// @(#): partitionClassifyEntries の単体テスト
-//       対象: partitionClassifyEntries
+// @(#): partitionByPreclassify の単体テスト
+//       対象: partitionByPreclassify
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -12,86 +12,37 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { partitionClassifyEntries } from '../../partition-classify-entries.ts';
+import { partitionByPreclassify } from '../../partition-classify-entries.ts';
 
 // ─── Helpers
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { _makeEmptyClassifyCache, _makeEntry } from '../../../__tests__/_helpers/classify-test-helpers.ts';
-// types
-import type { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
-import type { ClassifyBufferEntry, ClassifyCache, FindBufferEntriesOptions } from '../../../types/classify.types.ts';
 // constants
 import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
-
-// ─── Internal Helpers
-
-// functions
-
-/**
- * `opts.glob` 用のスタブを生成する。
- *
- * 渡された `paths` を、glob パターン引数を無視してそのまま返す。
- *
- * @param paths - 返却するファイルパス配列
- * @returns `GlobProvider` 互換のスタブ関数
- */
-const _makeGlob = (paths: string[]): FindBufferEntriesOptions['glob'] => (_pattern: string) => Promise.resolve(paths);
-
-/**
- * `opts.loadMeta` 用のスタブを生成する。
- *
- * `path` に対応する `ClassifyBufferEntry` を `entries` マップから返す。
- * `errorPaths` に含まれるパスは、実装のローダーが担う「読み込み失敗時に `cache` へ
- * `action: ERROR` を書き込む」責務を代替して `cache` に書き込む。
- *
- * @param entries - パスをキーとした `ClassifyBufferEntry` マップ
- * @param cache - エラーパスの書き込み先 `ChatlogCache`
- * @param errorPaths - 読み込み失敗として扱うパスの集合
- * @returns `path => Promise<ClassifyBufferEntry>` 互換のスタブ関数
- */
-const _makeLoadMeta = (
-  entries: Map<string, ClassifyBufferEntry>,
-  cache: ChatlogCache<ClassifyCache>,
-  errorPaths: ReadonlySet<string> = new Set(),
-): FindBufferEntriesOptions['loadMeta'] =>
-async (path: string): Promise<ClassifyBufferEntry> => {
-  if (errorPaths.has(path)) {
-    await cache.write(path, { action: CLASSIFY_ACTIONS.ERROR, reason: 'invalid frontmatter' });
-  }
-  return entries.get(path)!;
-};
 
 // ─── Tests
 
 /**
- * `partitionClassifyEntries` のユニットテストスイート。
+ * `partitionByPreclassify` のユニットテストスイート。
  *
- * ディレクトリ走査 → AI なし事前分類 → キャッシュ有無による REMAINING の振り分けを検証する。
+ * AI なし事前分類 → キャッシュ有無による REMAINING の振り分けを検証する。
  *
- * テスト ID 範囲: T-CL-PCE-01 〜 T-CL-PCE-04
+ * テスト ID 範囲: T-CL-PCE-01 〜 T-CL-PCE-05
  *
- * @see partitionClassifyEntries
+ * @see partitionByPreclassify
  */
-describe('partitionClassifyEntries', () => {
+describe('partitionByPreclassify', () => {
   describe('When: 正常系', () => {
-    it('[Normal] T-CL-PCE-01: preclassify で全件 MOVE/SKIP に解決する → filePaths に全件含まれ, uncached は空', async () => {
+    it('[Normal] T-CL-PCE-01: preclassify で全件 MOVE/SKIP に解決する → uncached は空', async () => {
       // frontmatter に project あり、パスは proj-a サブディレクトリ外 → MOVE
       const _entryMove = _makeEntry('/tmp/input/move-test.md', { project: 'proj-a' }, '');
       // frontmatter に project あり、パスが proj-a サブディレクトリ内 → SKIP
       const _entrySkip = _makeEntry('/tmp/input/proj-a/skip-test.md', { project: 'proj-a' }, '');
 
-      const _entries = new Map<string, ClassifyBufferEntry>([
-        [_entryMove.filePath!, { entry: _entryMove }],
-        [_entrySkip.filePath!, { entry: _entrySkip }],
-      ]);
       const _cache = await _makeEmptyClassifyCache();
-      const _opts: FindBufferEntriesOptions = {
-        glob: _makeGlob([..._entries.keys()]),
-        loadMeta: _makeLoadMeta(_entries, _cache),
-      };
 
-      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts);
+      const result = await partitionByPreclassify([_entryMove, _entrySkip], _cache);
 
-      assertEquals(result.filePaths.sort(), [_entryMove.filePath!, _entrySkip.filePath!].sort());
       assertEquals(result.uncached, []);
       assertEquals(_cache.read(_entryMove.filePath!).action, CLASSIFY_ACTIONS.MOVE);
       assertEquals(_cache.read(_entrySkip.filePath!).action, CLASSIFY_ACTIONS.SKIP);
@@ -101,17 +52,10 @@ describe('partitionClassifyEntries', () => {
   describe('When: エッジケース', () => {
     it('[Edge] T-CL-PCE-02: REMAINING エントリのファイルがキャッシュ済み → uncached には含まれず cache に project/action: MOVEBYAI が書き込まれる', async () => {
       const _entry = _makeEntry('/tmp/input/cached.md', {}, 'a'.repeat(100));
-      const _entries = new Map<string, ClassifyBufferEntry>([
-        [_entry.filePath!, { entry: _entry }],
-      ]);
       const _cache = await _makeEmptyClassifyCache();
-      const _opts: FindBufferEntriesOptions = {
-        glob: _makeGlob([..._entries.keys()]),
-        loadMeta: _makeLoadMeta(_entries, _cache),
-      };
       await _cache.write(_entry.filePath!, { project: 'proj-a', confidence: 0.95, reason: 'cached decision' });
 
-      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts);
+      const result = await partitionByPreclassify([_entry], _cache);
 
       assertEquals(result.uncached, []);
       assertEquals(_cache.read(_entry.filePath!).action, CLASSIFY_ACTIONS.MOVEBYAI);
@@ -121,18 +65,10 @@ describe('partitionClassifyEntries', () => {
     it('[Edge] T-CL-PCE-03: REMAINING エントリが一部のみキャッシュ済み → cache済み分は cache 経由で MOVEBYAI, 未cache分は uncached に含まれる', async () => {
       const _entryCached = _makeEntry('/tmp/input/cached2.md', {}, 'a'.repeat(100));
       const _entryUncached = _makeEntry('/tmp/input/uncached.md', {}, 'b'.repeat(100));
-      const _entries = new Map<string, ClassifyBufferEntry>([
-        [_entryCached.filePath!, { entry: _entryCached }],
-        [_entryUncached.filePath!, { entry: _entryUncached }],
-      ]);
       const _cache = await _makeEmptyClassifyCache();
-      const _opts: FindBufferEntriesOptions = {
-        glob: _makeGlob([..._entries.keys()]),
-        loadMeta: _makeLoadMeta(_entries, _cache),
-      };
       await _cache.write(_entryCached.filePath!, { project: 'proj-a', confidence: 0.9, reason: 'cached' });
 
-      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts);
+      const result = await partitionByPreclassify([_entryCached, _entryUncached], _cache);
 
       assertEquals(_cache.read(_entryCached.filePath!).action, CLASSIFY_ACTIONS.MOVEBYAI);
       assertEquals(_cache.read(_entryCached.filePath!).project, 'proj-a');
@@ -140,32 +76,34 @@ describe('partitionClassifyEntries', () => {
       assertEquals(result.uncached[0].filePath, _entryUncached.filePath);
     });
 
-    it('[Edge] T-CL-PCE-04: entries Map に読み込み成功した全ファイルの filePath→ChatlogEntry が格納される', async () => {
+    it('[Edge] T-CL-PCE-04: entries Map に渡した全ファイルの filePath→ChatlogEntry が格納される', async () => {
       const _entryA = _makeEntry('/tmp/input/a.md', { project: 'proj-a' }, '');
       const _entryB = _makeEntry('/tmp/input/uncached.md', {}, 'b'.repeat(100));
-      const _entries = new Map<string, ClassifyBufferEntry>([
-        [_entryA.filePath!, { entry: _entryA }],
-        [_entryB.filePath!, { entry: _entryB }],
-      ]);
       const _cache = await _makeEmptyClassifyCache();
-      const _opts: FindBufferEntriesOptions = {
-        glob: _makeGlob([..._entries.keys()]),
-        loadMeta: _makeLoadMeta(_entries, _cache),
-      };
 
-      const result = await partitionClassifyEntries('/tmp/input', _cache, _opts);
+      const result = await partitionByPreclassify([_entryA, _entryB], _cache);
 
-      assertEquals(result.entries.size, 2);
-      assertEquals(result.entries.get(_entryA.filePath!), _entryA);
-      assertEquals(result.entries.get(_entryB.filePath!), _entryB);
+      assertEquals(result.entries, [_entryA, _entryB]);
+    });
+
+    it('[Edge] T-CL-PCE-05: action: ERROR 済みの読み込み失敗エントリ（空内容）を含む → entries には含まれるが、事前分類で上書きされず action: ERROR のまま維持され uncached にも含まれない', async () => {
+      const _errorEntry = new ChatlogEntry('', { filePath: '/tmp/input/error.md' });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(_errorEntry.filePath!, { action: CLASSIFY_ACTIONS.ERROR, reason: 'load failed' });
+
+      const result = await partitionByPreclassify([_errorEntry], _cache);
+
+      assertEquals(result.entries, [_errorEntry]);
+      assertEquals(result.uncached, []);
+      assertEquals(_cache.read(_errorEntry.filePath!).action, CLASSIFY_ACTIONS.ERROR);
     });
 
     it('[Edge] T-CL-PCE-05: 読み込み失敗(ERROR)ファイルは filePaths には残るが entries/uncached からは除外され cache.action が ERROR になる', async () => {
       const _entryOk = _makeEntry('/tmp/input/ok.md', {}, 'a'.repeat(100));
       const _errorPath = '/tmp/input/broken.md';
-      const _entries = new Map<string, ClassifyBufferEntry>([
-        [_entryOk.filePath!, { entry: _entryOk }],
-        [_errorPath, { entry: _makeEntry(_errorPath, {}, '') }],
+      const _entries = new Map<string, ChatlogEntry>([
+        [_entryOk.filePath!, _entryOk],
+        [_errorPath, _makeEntry(_errorPath, {}, '')],
       ]);
       const _cache = await _makeEmptyClassifyCache();
       const _opts: FindBufferEntriesOptions = {

--- a/skills/classify-chatlogs/scripts/modules/classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-noai.ts
@@ -19,7 +19,7 @@ import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import type { ActionStatusEntry } from '../../../_scripts/types/action-status-entry.types.ts';
-import type { ClassifyBufferEntry, ClassifyCache } from '../types/classify.types.ts';
+import type { ClassifyCache } from '../types/classify.types.ts';
 // constants
 import { ENTRY_ACTIONS, ENTRY_STATUSES } from '../../../_scripts/types/action-status.types.ts';
 import { FALLBACK_PROJECT, MIN_CLASSIFIABLE_LENGTH } from '../constants/classify.constants.ts';
@@ -59,10 +59,10 @@ export const loadClassifyEntry = async (
  * 戻り値は常に入力の `entry` をそのまま返す（cache への書き込みが主目的）。
  */
 export const preClassify = async (
-  entry: ClassifyBufferEntry,
+  entry: ChatlogEntry,
   cache: ChatlogCache<ClassifyCache>,
-): Promise<ClassifyBufferEntry> => {
-  const f = entry.entry!;
+): Promise<ChatlogEntry> => {
+  const f = entry;
   const _fm = f.frontmatter;
   const _existingProject = _fm.get('project');
 
@@ -101,6 +101,6 @@ export const preClassify = async (
  * バッファエントリ配列に対して `preClassify` を適用し、各判定結果を `cache` に書き込む。
  */
 export const processPreclassify = (
-  buffer: ClassifyBufferEntry[],
+  buffer: ChatlogEntry[],
   cache: ChatlogCache<ClassifyCache>,
-): Promise<ClassifyBufferEntry[]> => Promise.all(buffer.map((entry) => preClassify(entry, cache)));
+): Promise<ChatlogEntry[]> => Promise.all(buffer.map((entry) => preClassify(entry, cache)));

--- a/skills/classify-chatlogs/scripts/modules/file-ops.ts
+++ b/skills/classify-chatlogs/scripts/modules/file-ops.ts
@@ -100,14 +100,14 @@ const _applyMove = async (
  * - それ以外（`undefined` 等）→ `stats.remaining++`（ログなし）
  */
 export const applyClassifications = async (
-  filePaths: string[],
-  entries: Map<string, ChatlogEntry>,
+  entries: ChatlogEntry[],
   cache: ChatlogCache<ClassifyCache>,
   destDir: string,
   dryRun: boolean,
   stats: ClassifyStats,
 ): Promise<void> => {
-  await Promise.all(filePaths.map(async (filePath) => {
+  await Promise.all(entries.map(async (entry) => {
+    const filePath = entry.filePath!;
     const cached = cache.read(filePath);
     const action = cached.action ?? CLASSIFY_ACTIONS.REMAINING;
     switch (action) {
@@ -123,10 +123,10 @@ export const applyClassifications = async (
         stats.error++;
         break;
       case CLASSIFY_ACTIONS.MOVE:
-        await _applyMove(filePath, entries.get(filePath)!, cached, destDir, dryRun, cache, stats, 'moved');
+        await _applyMove(filePath, entry, cached, destDir, dryRun, cache, stats, 'moved');
         break;
       case CLASSIFY_ACTIONS.MOVEBYAI:
-        await _applyMove(filePath, entries.get(filePath)!, cached, destDir, dryRun, cache, stats, 'movedByAI');
+        await _applyMove(filePath, entry, cached, destDir, dryRun, cache, stats, 'movedByAI');
         break;
     }
   }));

--- a/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
+++ b/skills/classify-chatlogs/scripts/modules/find-buffer-entries.ts
@@ -16,34 +16,27 @@ import { findFilesFlat } from '../../../_scripts/libs/file-ops/find-files.ts';
 import { loadClassifyEntry } from './classify-noai.ts';
 // types
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
-import type { ActionStatusEntry } from '../../../_scripts/types/action-status-entry.types.ts';
-import type {
-  ClassifyBufferEntry,
-  ClassifyCache,
-  FindBufferEntriesOptions,
-} from '../types/classify.types.ts';
+import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import type { ClassifyCache, FindBufferEntriesOptions } from '../types/classify.types.ts';
 // constants
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
 
-/**
- * `ActionStatusEntry` を `ClassifyBufferEntry` に変換するアダプター。
- */
-const _toLoadResult = (ase: ActionStatusEntry): ClassifyBufferEntry => ({ entry: ase.entry });
-
-/** `entry.entry` の frontmatter から既存の `project` フィールド（非空文字列）を取得する。なければ `undefined`。 */
-const _getExistingProject = (entry: ClassifyBufferEntry): string | undefined => {
-  const _project = entry.entry?.frontmatter.get('project');
+/** `entry` の frontmatter から既存の `project` フィールド（非空文字列）を取得する。なければ `undefined`。 */
+const _getExistingProject = (entry: ChatlogEntry): string | undefined => {
+  const _project = entry?.frontmatter.get('project');
   return typeof _project === 'string' && _project ? _project : undefined;
 };
 
-/** 1件のファイルパスに対して `loadMeta`（省略時は `loadClassifyEntry`）を呼び出し、`ClassifyBufferEntry` を返す。 */
+/** 1件のファイルパスに対して `loadMeta`（省略時は `loadClassifyEntry`）を呼び出し、`ChatlogEntry` を返す。 */
 const _loadEntry = async (
   filePath: string,
   cache: ChatlogCache<ClassifyCache>,
   loadMeta?: FindBufferEntriesOptions['loadMeta'],
-): Promise<ClassifyBufferEntry> => {
-  const _fn = loadMeta ?? loadClassifyEntry;
-  return await _fn(filePath, cache);
+): Promise<ChatlogEntry> => {
+  if (loadMeta) {
+    return await loadMeta(filePath);
+  }
+  return (await loadClassifyEntry(filePath, cache)).entry;
 };
 /**
  * ディレクトリ直下（1階層目）の `.md` ファイルパス一覧を収集する。
@@ -52,26 +45,26 @@ export const findChatlogFilePaths = (dir: string, opts?: FindBufferEntriesOption
   findFilesFlat(dir, { ext: '.md', glob: opts?.glob });
 
 /**
- * ファイルパス一覧からエントリを読み込み、`ClassifyBufferEntry` 配列を返す。
+ * ファイルパス一覧からエントリを読み込み、`ChatlogEntry` 配列を返す。
  * - 読み込み（`loadMeta` または既定の `loadClassifyEntry`）時点で失敗したエントリは、
  *   ローダー自身が `cache` に `action: CLASSIFY_ACTIONS.ERROR` と `reason` を書き込む。
  * - 各エントリについて `cache` に `action`（ローダーが既に書き込んでいなければ `CLASSIFY_ACTIONS.EMPTY`）を
  *   マージ書き込みする。既存キャッシュ（例: 前回 AI 分類済みの `project`）を消さないよう `cache.update` を使う。
  * - frontmatter に `project` があれば同じ書き込みに含める。
- * - `cache` の `action` が `ERROR` のエントリは戻り値から除外する。
+ * - 読み込み失敗（`cache` の `action` が `ERROR`）のエントリも含めて全件を戻り値に含める。
  */
 export const loadClassifyEntries = async (
   filePaths: string[],
   cache: ChatlogCache<ClassifyCache>,
   opts?: FindBufferEntriesOptions,
-): Promise<ClassifyBufferEntry[]> => {
+): Promise<ChatlogEntry[]> => {
   const _results = await Promise.all(
     filePaths.map((filePath) => _loadEntry(filePath, cache, opts?.loadMeta)),
   );
 
   await Promise.all(
     _results.map((result) => {
-      const _filePath = result.entry.filePath!;
+      const _filePath = result.filePath!;
       const _project = _getExistingProject(result);
       // ローダーが既に action: ERROR を書き込んでいる場合はそれを維持し、未設定時のみ EMPTY を既定値にする。
       return cache.update(_filePath, {
@@ -81,6 +74,5 @@ export const loadClassifyEntries = async (
     }),
   );
 
-  return _results
-    .filter((result) => cache.read(result.entry.filePath!).action !== CLASSIFY_ACTIONS.ERROR);
+  return _results;
 };

--- a/skills/classify-chatlogs/scripts/modules/partition-classify-entries.ts
+++ b/skills/classify-chatlogs/scripts/modules/partition-classify-entries.ts
@@ -1,6 +1,6 @@
 // src: scripts/modules/partition-classify-entries.ts
 // @(#): classify-chatlogs 分類候補エントリ分割モジュール
-//       対象: partitionClassifyEntries
+//       対象: partitionByPreclassify
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -9,48 +9,49 @@
 
 // ─── Local
 import { processPreclassify } from './classify-noai.ts';
-import { findChatlogFilePaths, loadClassifyEntries } from './find-buffer-entries.ts';
 // types
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
-import type { ClassifyCache, ClassifyPartition, FindBufferEntriesOptions } from '../types/classify.types.ts';
+import type { ClassifyCache, ClassifyPartition } from '../types/classify.types.ts';
 // constants
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
 
 /**
- * ディレクトリを走査して分類対象ファイルを収集し、AI なし事前分類を適用したうえで
- * 今回発見した全ファイルパス（`filePaths`）・読み込み成功エントリの Map（`entries`）・
- * AI 分類が必要な未キャッシュエントリ（`uncached`）に分割する。
+ * 読み込み済みエントリに AI なし事前分類を適用したうえで、読み込み済みエントリ全件
+ * （`entries`、読み込み失敗分も含む）と AI 分類が必要な未キャッシュエントリ（`uncached`）に分割する。
  *
  * REMAINING エントリのうち `cache` に判定結果（`project`）が既に存在するファイルは、
  * `cache` に `action: MOVEBYAI` を書き込むのみで `uncached` には含めない。
  * 未キャッシュの REMAINING エントリは `uncached` にそのまま含める。
+ *
+ * 読み込み失敗（`cache` の `action` が既に `ERROR`）のエントリは、`processPreclassify` に渡すと
+ * 空内容ゆえに `too-short fallback` 等で `ERROR` が上書きされてしまうため、事前分類の対象から除外する。
  */
-export const partitionClassifyEntries = async (
-  searchDir: string,
+export const partitionByPreclassify = async (
+  loaded: ChatlogEntry[],
   cache: ChatlogCache<ClassifyCache>,
-  opts?: FindBufferEntriesOptions,
 ): Promise<ClassifyPartition> => {
-  const filePaths = await findChatlogFilePaths(searchDir, opts);
-  const loaded = await loadClassifyEntries(filePaths, cache, opts);
-  const entries = new Map<string, ChatlogEntry>(loaded.map((e) => [e.entry.filePath!, e.entry]));
+  const entries = loaded;
   // processPreclassify の REMAINING 判定は cache.write（上書き）で project を消してしまうため、
   // 前回 AI が確定済みの project は preclassify 実行前にスナップショットしておく。
-  const _cachedProjects = new Map(loaded.map((e) => [e.entry.filePath!, cache.read(e.entry.filePath!).project]));
+  const _cachedProjects = new Map(loaded.map((e) => [e.filePath!, cache.read(e.filePath!).project]));
 
-  await processPreclassify(loaded, cache);
+  await processPreclassify(
+    loaded.filter((e) => cache.read(e.filePath!).action !== CLASSIFY_ACTIONS.ERROR),
+    cache,
+  );
 
-  const remaining = loaded.filter((e) => cache.read(e.entry.filePath!).action === CLASSIFY_ACTIONS.REMAINING);
+  const remaining = loaded.filter((e) => cache.read(e.filePath!).action === CLASSIFY_ACTIONS.REMAINING);
   const uncached = (await Promise.all(
     remaining.map(async (e) => {
-      const _cachedProject = _cachedProjects.get(e.entry.filePath!);
+      const _cachedProject = _cachedProjects.get(e.filePath!);
       if (_cachedProject != null) {
-        await cache.write(e.entry.filePath!, { project: _cachedProject, action: CLASSIFY_ACTIONS.MOVEBYAI });
+        await cache.write(e.filePath!, { project: _cachedProject, action: CLASSIFY_ACTIONS.MOVEBYAI });
         return undefined;
       }
-      return e.entry;
+      return e;
     }),
   )).filter((file): file is ChatlogEntry => file !== undefined);
 
-  return { filePaths, entries, uncached };
+  return { entries, uncached };
 };

--- a/skills/classify-chatlogs/scripts/types/classify.types.ts
+++ b/skills/classify-chatlogs/scripts/types/classify.types.ts
@@ -105,21 +105,10 @@ export const CLASSIFY_ACTIONS = {
 /** `CLASSIFY_ACTIONS` の値の型。 */
 export type ClassifyAction = typeof CLASSIFY_ACTIONS[keyof typeof CLASSIFY_ACTIONS];
 
-/** ファイルエントリのみを運ぶ薄いバッファエントリ。 */
-export type ClassifyBufferEntry = {
-  /** 分類対象のファイルエントリ。 */
-  entry: ChatlogEntry;
-};
-
-/** `preClassify` および `processChunk` が返すバッファ。 */
-export type ClassifyBuffer = ClassifyBufferEntry[];
-
-/** `partitionClassifyEntries` が返す、分類候補ファイルエントリの分割結果。 */
+/** `partitionByPreclassify` が返す、分類候補ファイルエントリの分割結果。 */
 export type ClassifyPartition = {
-  /** 今回発見した全ファイルパス。 */
-  filePaths: string[];
-  /** ファイルパスから対応する `ChatlogEntry` へのマップ。 */
-  entries: Map<string, ChatlogEntry>;
+  /** 読み込み済み `ChatlogEntry` の配列（読み込み失敗分も含む）。 */
+  entries: ChatlogEntry[];
   /** AI 分類が必要な `ChatlogEntry` のみ。 */
   uncached: ChatlogEntry[];
 };
@@ -128,8 +117,8 @@ export type ClassifyPartition = {
 // findBufferEntries オプション型
 // ─────────────────────────────────────────────
 
-/** ファイルパスから `ClassifyBufferEntry` を読み込む関数。 */
-export type ClassifyBufferProvider = (path: string) => Promise<ClassifyBufferEntry>;
+/** ファイルパスから `ChatlogEntry` を読み込む関数。 */
+export type ClassifyBufferProvider = (path: string) => Promise<ChatlogEntry>;
 
 /** `findBufferEntries` のオプション。テスト時に glob / loadMeta を差し替えられる。 */
 export type FindBufferEntriesOptions = {


### PR DESCRIPTION
## Overview

**Summary**
Use `ChatlogEntry` directly across the classify-chatlogs pipeline instead of wrapper types.

**Background / Motivation**
The classify-chatlogs module passed data around as `ClassifyBufferEntry` / `ClassifyBuffer`
wrapper types plus separate `filePaths` collections, requiring conversion adapters between
file loading, partitioning, and classification steps. This refactor removes those wrapper
types and threads `ChatlogEntry` directly through discovery, partitioning, no-AI
classification, and file-move application, simplifying the data flow and removing
redundant conversion logic.

## Changes

### Core Changes

- `types/classify.types.ts`: remove `ClassifyBufferEntry`, `ClassifyBuffer`, and `filePaths`;
  change `ClassifyPartition.entries` from `Map` to `ChatlogEntry[]`
- `modules/find-buffer-entries.ts`: use `ChatlogEntry` directly, remove the conversion
  adapter, include errored entries in `loadClassifyEntries` results
- `modules/partition-classify-entries.ts`: use `ChatlogEntry` throughout; rename
  `partitionClassifyEntries` to `partitionByPreclassify`, which now partitions preloaded
  entries instead of loading files internally; skip errored entries during preclassification;
  remove `filePaths` from the returned partition
- `modules/classify-noai.ts`: use `ChatlogEntry` directly in `preClassify` and
  `processPreclassify`
- `modules/file-ops.ts`: `applyClassifications` takes `ChatlogEntry[]` instead of
  `filePaths` + a `Map`; read `filePath` from each entry for cache lookups and move dispatch
- `classify-chatlogs.ts`: replace `partitionClassifyEntries` with the new
  `findChatlogFilePaths` → `loadClassifyEntries` → `partitionByPreclassify` pipeline; reuse
  `_originalLogsDir` for directory lookup

### Test Updates

- Update unit/integration/functional specs for `find-buffer-entries`,
  `partition-classify-entries`, `classify-noai`, and `move-classified` to use `ChatlogEntry`
  fixtures and the new function signatures
- `partition-classify-entries.unit.spec.ts`: add coverage for errored entries staying in
  `entries` and excluded from `uncached`; remove obsolete file-loading stubs
- `find-buffer-entries.unit.spec.ts`: add coverage for errored entries being included in
  results
- `process-chunk.functional.spec.ts`: update return type comment from `ClassifyBuffer` to
  `ChatlogEntry[]`

### Removed

- `ClassifyBufferEntry`, `ClassifyBuffer` types
- `filePaths` field from `ClassifyPartition`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Internal refactor only — no change to external CLI behavior. Scope is limited to
`skills/classify-chatlogs/scripts/`. `ClassifyBufferEntry` and `ClassifyBuffer` were
internal types, not exported outside the module. `partitionClassifyEntries` was renamed
with its only caller updated in the same PR, so this is not a breaking change.
