### PR TITLE
refactor(file-io): unify chatlog entry loading via shared loader

### DIFF
--- a/skills/_scripts/libs/file-io/__tests__/unit/chatlog-entry-loader.unit.spec.ts
+++ b/skills/_scripts/libs/file-io/__tests__/unit/chatlog-entry-loader.unit.spec.ts
@@ -1,0 +1,161 @@
+// src: skills/_scripts/libs/file-io/__tests__/unit/chatlog-entry-loader.unit.spec.ts
+// @(#): loadChatlogEntry ユニットテスト
+//       対象: loadChatlogEntry
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertRejects } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { loadChatlogEntry } from '../../chatlog-entry-loader.ts';
+
+// ─── Helpers
+// classes
+import { ChatlogEntry } from '../../../../classes/ChatlogEntry.class.ts';
+import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
+
+// ─── Internal Helpers
+
+// constants
+/** 正しい frontmatter を持つエントリ本文。 */
+const _VALID_ENTRY = `---\ntitle: Test\ndate: 2026-01-01\n---\n\n### User\nHello\n`;
+
+/** YAML 構文が不正な frontmatter を持つエントリ本文。 */
+const _INVALID_YAML_ENTRY = `---\ntitle: [unclosed\n---\n\n### User\nHello\n`;
+
+/** frontmatter の閉じ `---` がない不正フォーマットのエントリ本文。 */
+const _INVALID_FORMAT_ENTRY = `---\ntitle: Test\n\n### User\nHello\n`;
+
+// functions
+/**
+ * テスト用の一時ファイルを指定された内容で作成する。
+ *
+ * @param content - 書き込むファイル内容
+ * @returns 作成した一時ファイルのパス
+ */
+const _makeTempFile = async (content: string): Promise<string> => {
+  const path = await Deno.makeTempFile({ suffix: '.md' });
+  await Deno.writeTextFile(path, content);
+  return path;
+};
+
+// ─── Tests
+
+/**
+ * `loadChatlogEntry` 関数のユニットテストスイート。
+ *
+ * ファイルパスからテキストを読み込み `ChatlogEntry` インスタンスを生成する。
+ * ファイル I/O エラー・frontmatter 解析エラーはいずれも catch せず呼び出し元に throw する。
+ *
+ * テスト ID 範囲: T-LIB-U-CEL-01 〜 T-LIB-U-CEL-07
+ *
+ * @see loadChatlogEntry
+ */
+describe('loadChatlogEntry', () => {
+  /** 各テストで作成した一時ファイルのパスを記録する。 */
+  let tempFiles: string[] = [];
+
+  beforeEach(() => {
+    tempFiles = [];
+  });
+
+  afterEach(async () => {
+    for (const f of tempFiles) {
+      await Deno.remove(f).catch(() => {});
+    }
+  });
+
+  /**
+   * 正常系のテスト。
+   *
+   * 存在する正しい frontmatter 付きファイルを読み込むと `ChatlogEntry` が返ることを検証する。
+   */
+  describe('When: 正常系', () => {
+    it('[Normal] T-LIB-U-CEL-01: 正しい frontmatter 付きファイルを読み込むと ChatlogEntry が返る', async () => {
+      const path = await _makeTempFile(_VALID_ENTRY);
+      tempFiles.push(path);
+
+      const result = await loadChatlogEntry(path);
+
+      assertEquals(result instanceof ChatlogEntry, true);
+    });
+
+    it('[Normal] T-LIB-U-CEL-02: 返された ChatlogEntry の options.filePath に渡した filePath が設定される', async () => {
+      const path = await _makeTempFile(_VALID_ENTRY);
+      tempFiles.push(path);
+
+      const result = await loadChatlogEntry(path);
+
+      assertEquals(result.options.filePath, path);
+    });
+  });
+
+  /**
+   * 異常系のテスト。
+   *
+   * ファイル未存在・不正 YAML・不正フォーマットのいずれも例外を呼び出し元に伝播することを検証する。
+   */
+  describe('When: 異常系', () => {
+    it('[Error] T-LIB-U-CEL-03: 存在しないファイルパス → ChatlogError(FileDirNotFound)', async () => {
+      const err = await assertRejects(
+        () => loadChatlogEntry('/nonexistent/path/to/file.md'),
+        ChatlogError,
+      );
+      assertEquals((err as ChatlogError).kind, 'FileDirNotFound');
+    });
+
+    it('[Error] T-LIB-U-CEL-04: frontmatter の YAML 構文が不正 → ChatlogError(InvalidYaml)', async () => {
+      const path = await _makeTempFile(_INVALID_YAML_ENTRY);
+      tempFiles.push(path);
+
+      const err = await assertRejects(
+        () => loadChatlogEntry(path),
+        ChatlogError,
+      );
+      assertEquals((err as ChatlogError).kind, 'InvalidYaml');
+    });
+
+    it('[Error] T-LIB-U-CEL-05: frontmatter が閉じられていない → ChatlogError(InvalidFormat)', async () => {
+      const path = await _makeTempFile(_INVALID_FORMAT_ENTRY);
+      tempFiles.push(path);
+
+      const err = await assertRejects(
+        () => loadChatlogEntry(path),
+        ChatlogError,
+      );
+      assertEquals((err as ChatlogError).kind, 'InvalidFormat');
+      assertEquals((err as ChatlogError).subindex, 'NotClosed');
+    });
+  });
+
+  /**
+   * エッジケースのテスト。
+   *
+   * `throwFileIoError: false` を指定した場合の挙動を検証する。
+   * ファイル I/O 起因のエラーは `null` を返し、ファイル I/O 起因ではない
+   * frontmatter 解析エラーは `throwFileIoError` の値に関わらず throw されることを確認する。
+   */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-LIB-U-CEL-06: 存在しないファイルパス + throwFileIoError=false → null が返る', async () => {
+      const result = await loadChatlogEntry('/nonexistent/path/to/file.md', false);
+
+      assertEquals(result, null);
+    });
+
+    it('[Edge] T-LIB-U-CEL-07: frontmatter の YAML 構文が不正 + throwFileIoError=false → ChatlogError(InvalidYaml)', async () => {
+      const path = await _makeTempFile(_INVALID_YAML_ENTRY);
+      tempFiles.push(path);
+
+      const err = await assertRejects(
+        () => loadChatlogEntry(path, false),
+        ChatlogError,
+      );
+      assertEquals((err as ChatlogError).kind, 'InvalidYaml');
+    });
+  });
+});

--- a/skills/_scripts/libs/file-io/chatlog-entry-loader.ts
+++ b/skills/_scripts/libs/file-io/chatlog-entry-loader.ts
@@ -1,0 +1,41 @@
+// src: skills/_scripts/libs/file-io/chatlog-entry-loader.ts
+// @(#): ChatlogEntry 読み込みユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// --- shared modules ---
+import { readTextFile } from './read-utils.ts';
+// classes
+import { ChatlogEntry } from '../../classes/ChatlogEntry.class.ts';
+
+// --- functions ---
+/**
+ * ファイルパスからテキストを読み込み、`ChatlogEntry` インスタンスを生成する。
+ * - ファイル I/O 起因のエラー（`ChatlogError('FileDirNotFound')` 等）は、通常は呼び出し元に throw する
+ *   （`throwFileIoError: false` を除く）。
+ * - `throwFileIoError: false` を指定すると、ファイル I/O 起因のエラーは throw せず `null` を返す。
+ * - frontmatter 解析エラー（`ChatlogError('InvalidFormat')` / `ChatlogError('InvalidYaml')` 等）は
+ *   ファイル I/O 起因ではないため、`throwFileIoError` の値に関わらず常に呼び出し元に throw する。
+ *
+ * @param filePath - 読み込む Chatlog エントリファイルの絶対パス
+ * @param throwFileIoError - ファイル I/O 起因のエラーを throw するか（デフォルト: `true`）
+ * @returns 読み込んだ内容から生成した `ChatlogEntry` インスタンス（`throwFileIoError: false` でファイル I/O エラー時は `null`）
+ */
+export function loadChatlogEntry(filePath: string, throwFileIoError?: true): Promise<ChatlogEntry>;
+export function loadChatlogEntry(filePath: string, throwFileIoError: false): Promise<ChatlogEntry | null>;
+export async function loadChatlogEntry(
+  filePath: string,
+  throwFileIoError = true,
+): Promise<ChatlogEntry | null> {
+  const textOrError = await readTextFile(filePath, { throwFileIoError: false });
+  if (textOrError instanceof Error) {
+    if (throwFileIoError) {
+      throw textOrError;
+    }
+    return null;
+  }
+  return new ChatlogEntry(textOrError, { filePath });
+}

--- a/skills/classify-chatlogs/scripts/modules/classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/modules/classify-noai.ts
@@ -10,12 +10,14 @@
 // cspell:words noai
 
 // ─── Shared scripts
-import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { loadChatlogEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
+import { isFileIoError } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Local
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 // types
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import type { ActionStatusEntry } from '../../../_scripts/types/action-status-entry.types.ts';
@@ -36,11 +38,13 @@ export const loadClassifyEntry = async (
   filePath: string,
   cache: ChatlogCache<ClassifyCache>,
 ): Promise<ActionStatusEntry> => {
-  const _text = await readTextFile(filePath);
   try {
-    const _entry = new ChatlogEntry(_text, { filePath });
+    const _entry = await loadChatlogEntry(filePath);
     return { entry: _entry, options: { filePath } };
   } catch (e) {
+    if (isFileIoError(e) || (e instanceof ChatlogError && e.kind === 'FileDirNotFound')) {
+      throw e;
+    }
     const _reason = e instanceof Error ? e.message : String(e);
     await cache.write(filePath, { action: CLASSIFY_ACTIONS.ERROR, reason: _reason });
     return {

--- a/skills/filter-chatlogs/scripts/libs/batch-prompt.ts
+++ b/skills/filter-chatlogs/scripts/libs/batch-prompt.ts
@@ -7,11 +7,9 @@
 // https://opensource.org/licenses/MIT
 
 // ─── shared ───
-// classes
-import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 // functions
 import { buildConversationEntries } from '../../../_scripts/libs/ai/prompt-utils.ts';
-import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { loadChatlogEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
 
 // ─── internal ───
 // constants
@@ -23,11 +21,6 @@ import { MAX_BODY_CHARS } from '../constants/common.constants.ts';
 
 export const buildBatchPrompt = async (files: string[]): Promise<string> => {
   if (files.length === 0) { return ''; }
-  const _entries = await Promise.all(
-    files.map(async (filePath) => {
-      const text = await readTextFile(filePath);
-      return new ChatlogEntry(text, { filePath });
-    }),
-  );
+  const _entries = await Promise.all(files.map((filePath) => loadChatlogEntry(filePath)));
   return buildConversationEntries(_entries, MAX_BODY_CHARS);
 };

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -18,7 +18,7 @@ import {
   isSingleUserTurn,
   parseConversation,
 } from '../../../_scripts/libs/chatlogs/conversation-utils.ts';
-import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { loadChatlogEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
 import { removeFile } from '../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -160,15 +160,8 @@ type _ReadEntryResult =
  */
 const _readEntry = async (filePath: string): Promise<_ReadEntryResult> => {
   const filename = getFilename(filePath);
-  const text = await readTextFile(filePath, { throwFileIoError: false });
-  if (text instanceof Error) {
-    return {
-      kind: 'error',
-      result: { filePath, filename, reason: text.message, decision: FILTER_DECISIONS.ERROR },
-    };
-  }
   try {
-    const entry = new ChatlogEntry(text, { filePath });
+    const entry = await loadChatlogEntry(filePath);
     return { kind: 'ok', entry };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/skills/normalize-chatlogs/scripts/modules/process-files.ts
+++ b/skills/normalize-chatlogs/scripts/modules/process-files.ts
@@ -149,7 +149,7 @@ export const processFiles = async (
     });
 
     for (const { filePath, content } of _inputs) {
-      const _entry = new ChatlogEntry(content);
+      const _entry = new ChatlogEntry(content, { filePath });
       const _projectVal = _entry.frontmatter.get('project');
       const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
       const outputDir = resolveOutputDir(_outputBase, filePath, _project);

--- a/skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm
 
 // ─── Shared scripts
-import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { loadChatlogEntry as _loadEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
 import { findFiles } from '../../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -46,9 +46,9 @@ export const loadAllEntries = async (
 };
 
 export const loadChatlogEntry = async (filePath: string): Promise<ChatlogEntry | null> => {
-  let text: string;
+  let entry: ChatlogEntry;
   try {
-    text = await readTextFile(filePath);
+    entry = await _loadEntry(filePath);
   } catch (e) {
     if (e instanceof ChatlogError && e.kind === 'FileDirNotFound') {
       return null;
@@ -56,9 +56,7 @@ export const loadChatlogEntry = async (filePath: string): Promise<ChatlogEntry |
     throw e;
   }
 
-  const entry = new ChatlogEntry(text, { filePath });
   const fullBody = entry.content;
-
   if (!/^#/m.test(fullBody)) { return null; }
   if (!fullBody.trim()) { return null; }
 


### PR DESCRIPTION
## Overview

**Summary**
Add a shared chatlog entry loader and migrate five skills to use it.

**Background / Motivation**
Several skills each duplicated the same pattern: read a file, then build a
`ChatlogEntry` from its contents. This refactor extracts that pattern into
one shared `loadChatlogEntry` function so the loading and error-handling
logic lives in a single place.

## Changes

### Core Changes

- `skills/_scripts/libs/file-io/chatlog-entry-loader.ts`: add `loadChatlogEntry(filePath, throwFileIoError?)`.
  Loads a `ChatlogEntry` from a file path. File I/O errors can be suppressed
  (returns `null`) via `throwFileIoError`, but frontmatter parsing errors are
  always thrown.
- `skills/classify-chatlogs/scripts/modules/classify-noai.ts`: use `loadChatlogEntry` instead of manual
  file read + `ChatlogEntry` construction.
- `skills/filter-chatlogs/scripts/libs/batch-prompt.ts`: use `loadChatlogEntry(filePath)`.
- `skills/filter-chatlogs/scripts/modules/prefilter.ts`: use `loadChatlogEntry(filePath)` in `_readEntry`.
- `skills/normalize-chatlogs/scripts/modules/process-files.ts`: pass `filePath` through to `ChatlogEntry`.
- `skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts`: use `loadChatlogEntry` instead of manual
  file read + `ChatlogEntry` construction.

### Test Updates

- `skills/_scripts/libs/file-io/__tests__/unit/chatlog-entry-loader.unit.spec.ts`: add unit tests for
  successful loading, `filePath` assignment, file I/O error handling (both with and without
  `throwFileIoError`), and frontmatter parsing errors.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to b85 (beads issue tracker; no GitHub issue)

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is a behavior-preserving refactor. All five call sites follow the same
migration pattern, so review can focus on the new loader's error-handling
behavior.
