### PR TITLE
refactor(concurrency): bound file I/O concurrency across skills

### DIFF
--- a/skills/_scripts/classes/ChatlogCache.class.ts
+++ b/skills/_scripts/classes/ChatlogCache.class.ts
@@ -13,6 +13,7 @@ import { parse as parseYaml } from '@std/yaml';
 // libs
 import { findFilesFlat } from '../libs/file-ops/find-files.ts';
 import { logger } from '../libs/io/logger.ts';
+import { runConcurrent } from '../libs/parallel/concurrency.ts';
 import { getBasename, isAbsolutePath, joinPath, normalizePath } from '../libs/path-utils/path-utils.ts';
 import { hasFrontmatter, hasFrontmatterFields, parseFrontmatterEntries } from '../libs/text/frontmatter-utils.ts';
 // classes
@@ -95,6 +96,8 @@ export interface ChatlogCacheInitializer {
   yaml?: string;
   /** 出力ディレクトリパス。`.md` ファイルを一覧して `hasFrontmatter` が true のファイルのみキャッシュに登録する。`yaml` が指定された場合は無視される。 */
   outputDir?: string;
+  /** ファイル読み込み・書き込みの並列実行数（省略時は `GlobalConfig` の `concurrency` を使用）。 */
+  concurrency?: number;
 }
 
 // ─────────────────────────────────────────────
@@ -171,9 +174,10 @@ export class ChatlogCache<T extends object> {
     if (initializer?.yaml != null) {
       this.loadFromYaml(initializer.yaml);
     } else {
-      await this.loadAll();
+      const _concurrency = initializer?.concurrency ?? Number(GlobalConfig.getInstance().get('concurrency'));
+      await this.loadAll(_concurrency);
       if (initializer?.outputDir != null) {
-        await this.initFromOutputDir(initializer.outputDir);
+        await this.initFromOutputDir(initializer.outputDir, undefined, _concurrency);
       }
     }
   }
@@ -301,10 +305,12 @@ export class ChatlogCache<T extends object> {
    *
    * @param outputDir - `.md` ファイルを探索するディレクトリパス
    * @param isComplete - テキストを受け取り完全書き込み対象か判定する述語（省略時は全5フィールド揃い判定）
+   * @param concurrency - ファイル読み込み・書き込みの並列実行数
    */
   async initFromOutputDir(
     outputDir: string,
     isComplete: (text: string) => boolean = _isComplete,
+    concurrency: number,
   ): Promise<void> {
     const _allFiles = await findFilesFlat(outputDir, { glob: this._glob });
 
@@ -315,26 +321,25 @@ export class ChatlogCache<T extends object> {
 
     // step 2: テキスト読み込み + 分類（並列）
     const _classified = (
-      await Promise.all(
-        _fresh.map(async ({ filePath, key }) => {
-          const _text = await this._readTextFile(filePath);
-          const _entry = _classifyEntry(_text, isComplete);
-          return _entry !== null ? { filePath, key, ..._entry } : null;
-        }),
-      )
+      await runConcurrent(_fresh, async ({ filePath, key }) => {
+        const _text = await this._readTextFile(filePath);
+        const _entry = _classifyEntry(_text, isComplete);
+        return _entry !== null ? { filePath, key, ..._entry } : null;
+      }, concurrency)
     ).filter((e): e is { filePath: string; key: string; status: _EntryStatus; meta: FrontmatterFields } => e !== null);
 
     // step 3: 書き込み対象（written / empty）と削除対象に分けて実行
     const _toWrite = _classified.filter(({ status }) => status !== 'delete');
     const _toDelete = _classified.filter(({ status }) => status === 'delete');
 
-    await Promise.all([
-      ..._toWrite.map(({ key, status, meta }) => {
+    const _ops = [
+      ..._toWrite.map(({ key, status, meta }) => () => {
         const _cacheStatus = status === 'written' ? CACHE_STATUSES.WRITTEN : CACHE_STATUSES.EMPTY;
         return this._writeFile(key, { ...meta, status: _cacheStatus } as unknown as Partial<T>);
       }),
-      ..._toDelete.map(({ filePath }) => this.delete(filePath)),
-    ]);
+      ..._toDelete.map(({ filePath }) => () => this.delete(filePath)),
+    ];
+    await runConcurrent(_ops, (op) => op(), concurrency);
   }
 
   /**
@@ -342,19 +347,19 @@ export class ChatlogCache<T extends object> {
    *
    * `findFilesFlat` で `.json` ファイル一覧を取得し、各ファイルを並列読み込みして格納する。
    * 読み込みに失敗したファイルはスキップされる。
+   *
+   * @param concurrency - ファイル読み込みの並列実行数
    */
-  async loadAll(): Promise<void> {
+  async loadAll(concurrency: number): Promise<void> {
     const _paths = await findFilesFlat(this._cacheDir, { ext: '.json', glob: this._glob });
     this._hash.clear();
-    await Promise.all(
-      _paths.map(async (path) => {
-        try {
-          const _text = await this._readTextFile(path);
-          this._hash.set(getBasename(path), JSON.parse(_text) as Partial<T>);
-        } catch (e) {
-          logger.warn(`[ChatlogCache] loadAll: skip ${path} — ${(e as Error).message}`);
-        }
-      }),
-    );
+    await runConcurrent(_paths, async (path) => {
+      try {
+        const _text = await this._readTextFile(path);
+        this._hash.set(getBasename(path), JSON.parse(_text) as Partial<T>);
+      } catch (e) {
+        logger.warn(`[ChatlogCache] loadAll: skip ${path} — ${(e as Error).message}`);
+      }
+    }, concurrency);
   }
 }

--- a/skills/_scripts/classes/__tests__/functional/ChatlogCache.functional.spec.ts
+++ b/skills/_scripts/classes/__tests__/functional/ChatlogCache.functional.spec.ts
@@ -102,7 +102,7 @@ describe('ChatlogCache', () => {
 
         const cache2 = new ChatlogCache<_CacheData>('clecache', tempDir);
         await cache2.ready;
-        await cache2.loadAll();
+        await cache2.loadAll(2);
         const result = cache2.read('foo');
 
         assertEquals(result, { value: 'bar' });
@@ -135,7 +135,7 @@ describe('ChatlogCache', () => {
         await cache.write('alpha', { n: 1 });
         await cache.write('beta', { n: 2 });
         await cache.write('gamma', { n: 3 });
-        await cache.loadAll();
+        await cache.loadAll(2);
 
         assertEquals(await cache.read('alpha'), { n: 1 });
         assertEquals(await cache.read('beta'), { n: 2 });

--- a/skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts
@@ -559,7 +559,7 @@ describe('ChatlogCache', () => {
               ]),
           },
         });
-        await _cache.loadAll();
+        await _cache.loadAll(2);
         assertEquals(await _cache.read('file-a'), { type: 'A' });
         assertEquals(await _cache.read('file-b'), { type: 'B' });
       });
@@ -595,7 +595,7 @@ describe('ChatlogCache', () => {
             glob: (_pattern: string) => Promise.resolve([]),
           },
         });
-        await _cache.loadAll();
+        await _cache.loadAll(2);
         assertEquals(await _cache.read('file-a'), {});
       });
 
@@ -608,7 +608,7 @@ describe('ChatlogCache', () => {
           },
         });
         _cache.loadFromYaml('old:\n  type: OLD\n');
-        await _cache.loadAll();
+        await _cache.loadAll(2);
         const _result = await _cache.read('old');
         assertEquals(_result, {});
       });
@@ -632,7 +632,7 @@ describe('ChatlogCache', () => {
               ]),
           },
         });
-        await _cache.loadAll();
+        await _cache.loadAll(2);
         assertEquals(await _cache.read('file-ok'), { type: 'OK' });
         assertEquals(await _cache.read('file-bad'), {});
       });
@@ -710,7 +710,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('a.md'), { title: 'A', type: 'tech', category: 'dev', status: '' });
         assertEquals(_cache.read('b.md'), { title: 'B', type: 'tech', category: 'dev', status: '' });
       });
@@ -731,7 +731,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('has-fm.md'), { title: 'Test', type: 'tech', category: 'dev', status: '' });
       });
 
@@ -761,7 +761,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('full.md'), {
           title: 'A',
           type: 'tech',
@@ -798,7 +798,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('hashtag.md'), {
           title: 'A',
           type: 'tech',
@@ -835,7 +835,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('no-hashtag.md'), {
           title: 'A',
           type: 'tech',
@@ -862,7 +862,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('base.md'), { title: 'B', type: 'tech', category: 'dev', status: '' });
       });
 
@@ -881,6 +881,7 @@ describe('ChatlogCache', () => {
         await _cache.initFromOutputDir(
           '/out',
           (text) => parseFrontmatter(text).meta['title'] !== undefined,
+          2,
         );
         assertEquals(_cache.read('with-title.md'), { title: 'Hello', status: 'written' });
         assertEquals(_cache.read('no-title.md'), {});
@@ -910,7 +911,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         // キャッシュ済みのため上書きされず { status: 'reviewed' } が保持される
         assertEquals(_cache.read('existing.md'), { status: 'reviewed' });
       });
@@ -928,7 +929,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         // a.md はフロントマターなし → isComplete false → 上書きされない
         assertEquals(_cache.read('a'), { status: 'kept' });
       });
@@ -952,7 +953,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('new.md'), { title: 'New', type: 'tech', category: 'dev', status: '' });
       });
 
@@ -967,7 +968,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('no-fm.md'), {});
       });
 
@@ -982,7 +983,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('empty-fm.md'), {});
       });
 
@@ -997,7 +998,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('bad-yaml.md'), {});
       });
 
@@ -1010,7 +1011,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('any'), {});
       });
 
@@ -1049,7 +1050,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         // フロントマターなし → スキップ（既存キャッシュ保持）
         assertEquals(_cache.read('fm-none.md'), { status: 'kept' });
         // 全5フィールド → status:written
@@ -1079,7 +1080,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         // *.md が空なので新規書き込みは発生しない
         assertEquals(_cache.read('any-new'), {});
       });
@@ -1098,7 +1099,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out'));
+        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
       });
 
       it('[Error] T-CLS-CC-50: writeTextFile 失敗 → initFromOutputDir が reject', async () => {
@@ -1114,7 +1115,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out'));
+        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
       });
 
       it('[Error] T-CLS-CC-56: readTextFile が reject → initFromOutputDir が reject', async () => {
@@ -1127,7 +1128,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out'));
+        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
       });
     });
   });
@@ -1159,7 +1160,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('complete.md'), { title: 'A', type: 'tech', category: 'dev', status: '' });
         assertEquals(_cache.read('missing-type.md'), {});
       });
@@ -1183,7 +1184,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('null-type.md'), {});
       });
 
@@ -1198,7 +1199,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out');
+        await _cache.initFromOutputDir('/out', undefined, 2);
         assertEquals(_cache.read('title-only.md'), {});
       });
     });

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -91,7 +91,7 @@ export const main = async (argv?: string[]): Promise<void> => {
 
   // Step 1: 分類候補エントリの読み込み。読み込み失敗（frontmatter パースエラー等）は errors に分離され、
   // 誤って処理を継続しないよう後続の事前分類・AI分類には渡らない
-  const { entries, errors } = await loadClassifyEntries(_filePaths, _cache);
+  const { entries, errors } = await loadClassifyEntries(_filePaths, _cache, _config);
   if (errors.length > 0) {
     stats.error += errors.length;
     errors.forEach(({ filePath, error }) => logger.warn(`  読み込み失敗 (${error.message}): ${getFilename(filePath)}`));

--- a/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-entries.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/libs/__tests__/unit/load-entries.unit.spec.ts
@@ -62,7 +62,7 @@ describe('loadClassifyEntries', () => {
         loadMeta: () => Promise.resolve(_makeEntry(_filePath, { project: 'proj-a' })),
       };
 
-      const _result = await loadClassifyEntries([_filePath], _cache, _opts);
+      const _result = await loadClassifyEntries([_filePath], _cache, { concurrency: 4 }, _opts);
 
       assertEquals(_result.entries.map((e) => e.filePath), [_filePath]);
       assertEquals(_result.errors.length, 0);
@@ -77,7 +77,7 @@ describe('loadClassifyEntries', () => {
         loadMeta: () => Promise.resolve(_makeEntry(_filePath, {})),
       };
 
-      const _result = await loadClassifyEntries([_filePath], _cache, _opts);
+      const _result = await loadClassifyEntries([_filePath], _cache, { concurrency: 4 }, _opts);
 
       assertEquals(_result.entries.map((e) => e.filePath), [_filePath]);
       assertEquals(_result.errors.length, 0);
@@ -103,6 +103,7 @@ describe('loadClassifyEntries', () => {
       const _result = await loadClassifyEntries(
         [_withProject, _errorPath, _noProject],
         _cache,
+        { concurrency: 4 },
         _opts,
       );
 
@@ -124,7 +125,7 @@ describe('loadClassifyEntries', () => {
         loadMeta: () => Promise.resolve(_makeErrorResult(_filePath)),
       };
 
-      const _result = await loadClassifyEntries([_filePath], _cache, _opts);
+      const _result = await loadClassifyEntries([_filePath], _cache, { concurrency: 4 }, _opts);
 
       assertEquals(_result.entries.length, 0);
       assertEquals(_result.errors.map((e) => e.filePath), [_filePath]);
@@ -138,7 +139,7 @@ describe('loadClassifyEntries', () => {
         const _filePath = `${_tempDir}/bad-yaml.md`;
         await Deno.writeTextFile(_filePath, '---\ntitle: [unclosed\n---\n本文');
 
-        const _result = await loadClassifyEntries([_filePath], _cache);
+        const _result = await loadClassifyEntries([_filePath], _cache, { concurrency: 4 });
 
         assertEquals(_result.entries.length, 0);
         assertEquals(_result.errors.map((e) => e.filePath), [_filePath]);

--- a/skills/classify-chatlogs/scripts/libs/load-entries.ts
+++ b/skills/classify-chatlogs/scripts/libs/load-entries.ts
@@ -7,12 +7,15 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// ─── Shared scripts
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
+
 // ─── Local
 import { loadClassifyEntry } from './load-classify-entry.ts';
 // types
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
-import type { ClassifyCache, FindBufferEntriesOptions } from '../types/classify.types.ts';
+import type { ClassifyCache, ClassifyConfig, FindBufferEntriesOptions } from '../types/classify.types.ts';
 import type { LoadClassifyEntryFailure } from '../types/load-classify-entry.types.ts';
 // constants
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
@@ -34,30 +37,35 @@ const _getExistingProject = (entry: ChatlogEntry): string | undefined => {
 export const loadClassifyEntries = async (
   filePaths: string[],
   cache: ChatlogCache<ClassifyCache>,
+  config: Pick<ClassifyConfig, 'concurrency'>,
   opts?: FindBufferEntriesOptions,
 ): Promise<{ entries: ChatlogEntry[]; errors: LoadClassifyEntryFailure[] }> => {
-  const _results = await Promise.all(
-    filePaths.map((filePath) => opts?.loadMeta ? opts.loadMeta(filePath) : loadClassifyEntry(filePath)),
+  const _results = await runConcurrent(
+    filePaths,
+    (filePath) => opts?.loadMeta ? opts.loadMeta(filePath) : loadClassifyEntry(filePath),
+    config.concurrency,
   );
 
   const entries = _results.filter((result): result is ChatlogEntry => result instanceof ChatlogEntry);
   const errors = _results.filter((result): result is LoadClassifyEntryFailure => !(result instanceof ChatlogEntry));
 
-  await Promise.all(
-    errors.map(({ filePath, error }) =>
-      cache.write(filePath, { action: CLASSIFY_ACTIONS.ERROR, reason: error.message })
-    ),
+  await runConcurrent(
+    errors,
+    ({ filePath, error }) => cache.write(filePath, { action: CLASSIFY_ACTIONS.ERROR, reason: error.message }),
+    config.concurrency,
   );
 
-  await Promise.all(
-    entries.map((entry) => {
+  await runConcurrent(
+    entries,
+    (entry) => {
       const _filePath = entry.filePath!;
       const _project = _getExistingProject(entry);
       return cache.update(_filePath, {
         ...(_project ? { project: _project } : {}),
         action: cache.read(_filePath).action ?? CLASSIFY_ACTIONS.EMPTY,
       });
-    }),
+    },
+    config.concurrency,
   );
 
   return { entries, errors };

--- a/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/build-config.functional.spec.ts
@@ -422,4 +422,50 @@ describe('buildConfig', () => {
       });
     });
   });
+
+  // ─── concurrency 優先順位 ────────────────────────────────────────────────────
+
+  /**
+   * GlobalConfig に concurrency が設定されている前提条件グループ。
+   *
+   * `globalConfig.concurrency` が `result.concurrency` に反映されることを検証する。
+   */
+  describe('Given: GlobalConfig に concurrency が設定されている', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `globalConfig.concurrency` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-21 - GlobalConfig の concurrency が使われる', () => {
+        beforeEach(async () => {
+          await _makeGlobalConfig('concurrency: 2');
+        });
+        it('T-EC-BC-21-01: globalConfig.concurrency=2 → result.concurrency === 2', () => {
+          const result = buildConfig([]);
+          assertEquals(result.concurrency, 2);
+        });
+      });
+    });
+  });
+
+  /**
+   * GlobalConfig に concurrency が設定されていない前提条件グループ。
+   *
+   * `DEFAULT_EXPORT_CONFIG.concurrency` にフォールバックされることを検証する。
+   */
+  describe('Given: GlobalConfig に concurrency が設定されていない', () => {
+    /** `buildConfig` を呼び出すとき。 */
+    describe('When: buildConfig を呼び出す', () => {
+      /** `DEFAULT_EXPORT_CONFIG.concurrency` が採用されることを検証する。 */
+      describe('Then: T-EC-BC-22 - DEFAULT_EXPORT_CONFIG.concurrency が使われる', () => {
+        beforeEach(async () => {
+          resetProjectRoot('/home/user/project');
+          GlobalConfig.resetInstance();
+          await GlobalConfig.getInstance({ schema: {} });
+        });
+        it('T-EC-BC-22-01: concurrency 未設定 → result.concurrency === DEFAULT_EXPORT_CONFIG.concurrency', () => {
+          const result = buildConfig([]);
+          assertEquals(result.concurrency, DEFAULT_EXPORT_CONFIG.concurrency);
+        });
+      });
+    });
+  });
 });

--- a/skills/export-chatlogs/scripts/constants/defaults.constants.ts
+++ b/skills/export-chatlogs/scripts/constants/defaults.constants.ts
@@ -8,7 +8,7 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // constants
-import { DEFAULT_AGENT } from '../../../_scripts/constants/defaults.constants.ts';
+import { DEFAULT_AGENT, DEFAULT_CONCURRENCY } from '../../../_scripts/constants/defaults.constants.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────
 // types
@@ -26,4 +26,5 @@ import type { ExportConfig } from '../types/export-config.types.ts';
  */
 export const DEFAULT_EXPORT_CONFIG: ExportConfig = {
   agent: DEFAULT_AGENT,
+  concurrency: DEFAULT_CONCURRENCY,
 };

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/export-chatgpt.functional.spec.ts
@@ -634,4 +634,77 @@ describe('exportChatGPT', () => {
       });
     });
   });
+
+  // ─── T-EC-GE-11: concurrency=1（直列相当）でも outputPaths の順序・件数が変わらない ─
+
+  /**
+   * concurrency 制限下での並列処理ケース。
+   * `config.concurrency=1` を指定して並列度を1に制限しても、
+   * outputPaths の内容・順序・件数が制限なし（Promise.all 相当）の場合と変わらないことを検証する。
+   */
+  describe('Given: id が "x"/"y"/"z" の会話を1件ずつ含む3ファイル、config.concurrency=1', () => {
+    /** `exportChatGPT` を呼び出したときの outputPaths の順序を検証する。 */
+    describe('When: exportChatGPT(config, providers) を呼び出す', () => {
+      it('T-EC-GE-11: outputPaths がファイル入力順 [x.md, y.md, z.md] で決定論的（concurrency=1）', async () => {
+        const convX: ChatGPTConversation = {
+          id: 'x',
+          conversation_id: 'conv-uuid-x',
+          create_time: 1742000000,
+          title: 'テスト X',
+          mapping: {},
+        };
+        const convY: ChatGPTConversation = {
+          id: 'y',
+          conversation_id: 'conv-uuid-y',
+          create_time: 1742000000,
+          title: 'テスト Y',
+          mapping: {},
+        };
+        const convZ: ChatGPTConversation = {
+          id: 'z',
+          conversation_id: 'conv-uuid-z',
+          create_time: 1742000000,
+          title: 'テスト Z',
+          mapping: {},
+        };
+        const fileX = `${tempDir}/conversations-010.json`;
+        const fileY = `${tempDir}/conversations-020.json`;
+        const fileZ = `${tempDir}/conversations-030.json`;
+        await Promise.all([
+          _writeConvFile(fileX, [convX]),
+          _writeConvFile(fileY, [convY]),
+          _writeConvFile(fileZ, [convZ]),
+        ]);
+
+        const config: ExportConfig = {
+          agent: 'chatgpt',
+          exportDir: outputDir,
+          inputDir: tempDir,
+          period: undefined,
+          concurrency: 1,
+        };
+
+        const validSession = _makeValidSession();
+
+        const result = await exportChatGPT(config, {
+          findFiles: (_baseDir: string): Promise<string[]> => Promise.resolve([fileX, fileY, fileZ]),
+          parseConversation: (conv: ChatGPTConversation, _range: PeriodRange): Promise<ExportedSession | null> =>
+            Promise.resolve({
+              ...validSession,
+              meta: { ...validSession.meta, sessionId: `session-${conv.id}` },
+            }),
+          writeSession: (_outputDir: string, _agent: string, session: ExportedSession): Promise<string> =>
+            Promise.resolve(`/fake/${session.meta.sessionId}.md`),
+        });
+
+        // concurrency=1（実質直列実行）でも outputPaths はファイル入力順で決定論的
+        assertEquals(result.outputPaths, [
+          '/fake/session-x.md',
+          '/fake/session-y.md',
+          '/fake/session-z.md',
+        ]);
+        assertEquals(result.exportedCount, 3);
+      });
+    });
+  });
 });

--- a/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
@@ -13,8 +13,10 @@
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 // libs
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { isoToDate } from '../../../_scripts/libs/text/date-utils.ts';
 // constants
+import { DEFAULT_CONCURRENCY } from '../../../_scripts/constants/defaults.constants.ts';
 import { ConversationRole } from '../../../_scripts/types/conversation-role.const.types.ts';
 
 // ─── Local modules ───────────────────────────────────────────────────────────
@@ -289,7 +291,7 @@ const _mergeResults = (results: FileResult[]): ExportResult => {
  * 1. `config.inputDir` が undefined → エラースロー
  * 2. `parsePeriod(config.period)` で PeriodRange 取得
  * 3. `findFiles()` でファイル一覧を収集
- * 4. 全ファイルを Promise.all で並列処理（各ファイルは独立して読み込み・パース・書き出し）
+ * 4. 全ファイルを `runConcurrent()` で `config.concurrency` 件ずつ並列処理（各ファイルは独立して読み込み・パース・書き出し）
  * 5. 各ファイルの結果をマージして返す
  *
  * `_providers` を省略した場合は実際のファイルシステム操作を行う。
@@ -324,9 +326,11 @@ export const exportChatGPT = async (
 
   const files = await _findFiles(inputDir);
 
-  const results = await Promise.all(
+  const results = await runConcurrent(
+    files,
     // buildConfig() が常に exportDir を string に解決するため non-null。
-    files.map((file) => _processFile(file, range, config.exportDir!, config.agent, _parseConversation, _writeSession)),
+    (file) => _processFile(file, range, config.exportDir!, config.agent, _parseConversation, _writeSession),
+    config.concurrency ?? DEFAULT_CONCURRENCY,
   );
 
   return _mergeResults(results);

--- a/skills/export-chatlogs/scripts/types/export-config.types.ts
+++ b/skills/export-chatlogs/scripts/types/export-config.types.ts
@@ -32,6 +32,8 @@ export type ExportConfig = DefaultArgFields & {
   exportDir?: string;
   /** GlobalConfig から解決されたチャットログディレクトリ。`exportDir` 未指定時のフォールバック元。 */
   chatlogsDir?: string;
+  /** ChatGPT エクスポート時のファイル処理並列数。 */
+  concurrency?: number;
 };
 
 /** `parseArgs()` に渡される引数の型定義。 */

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/discard-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/discard-files.functional.spec.ts
@@ -87,7 +87,7 @@ describe('_discardFiles', () => {
             { filePath, filename: 'discard-target.md', reason: 'trivial', decision: 'DISCARD' },
           ];
 
-          await _discardFiles(files, false, stats);
+          await _discardFiles(files, false, stats, 2);
           loggerStub.restore();
 
           assertEquals(await Deno.stat(filePath).catch(() => null), null);
@@ -103,7 +103,7 @@ describe('_discardFiles', () => {
             { filePath, filename: 'discard-target2.md', reason: 'trivial', decision: 'DISCARD' },
           ];
 
-          await _discardFiles(files, false, stats);
+          await _discardFiles(files, false, stats, 2);
           loggerStub.restore();
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('removed')), true);
@@ -131,7 +131,7 @@ describe('_discardFiles', () => {
             { filePath, filename: 'dryrun-target.md', reason: 'trivial', decision: 'DISCARD' },
           ];
 
-          await _discardFiles(files, true, stats);
+          await _discardFiles(files, true, stats, 2);
           loggerStub.restore();
 
           assertEquals(stats.skip, 1);
@@ -148,7 +148,7 @@ describe('_discardFiles', () => {
             { filePath, filename: 'dryrun-target2.md', reason: 'trivial', decision: 'DISCARD' },
           ];
 
-          await _discardFiles(files, true, stats);
+          await _discardFiles(files, true, stats, 2);
           loggerStub.restore();
 
           assertEquals(loggerStub.infoLogs.some((l) => l.includes('skipped')), true);
@@ -180,7 +180,7 @@ describe('_discardFiles', () => {
           ];
 
           // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
-          await _discardFiles(files, false, stats);
+          await _discardFiles(files, false, stats, 2);
           errStub.restore();
 
           assertEquals(stats.error, 1);
@@ -203,7 +203,7 @@ describe('_discardFiles', () => {
         it('T-FL-DF-04-01: 空配列を渡しても stats は全て 0 のまま', async () => {
           const stats = _makeStats();
 
-          await _discardFiles([], false, stats);
+          await _discardFiles([], false, stats, 2);
 
           assertEquals(stats, { keep: 0, skip: 0, remove: 0, error: 0 });
         });
@@ -242,7 +242,7 @@ describe('_discardFiles', () => {
             decision: FILTER_DECISIONS.DISCARD,
           };
 
-          const result = await _discardFiles([discardEntry, errorEntry], false, stats);
+          const result = await _discardFiles([discardEntry, errorEntry], false, stats, 2);
           loggerStub.restore();
 
           assertEquals(await Deno.stat(errorPath).then(() => true).catch(() => false), true);

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -97,7 +97,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats() });
+          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -122,7 +122,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, '---\ntitle: テスト\n---\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats() });
+          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -147,7 +147,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, '---\ntitle: テスト\n---\n短い本文\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats() });
+          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -173,7 +173,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(1200));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { minCharCount: 2428, stats: _makeStats() });
+          const result = await prefilterFiles([entry], { minCharCount: 2428, stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -184,7 +184,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(1200));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { minCharCount: 2426, stats: _makeStats() });
+          const result = await prefilterFiles([entry], { minCharCount: 2426, stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -214,6 +214,7 @@ describe('prefilterFiles', () => {
             minCharCount: 1000,
             minAssistantChars: 401,
             stats: _makeStats(),
+            concurrency: 2,
           });
           errStub.restore();
 
@@ -229,6 +230,7 @@ describe('prefilterFiles', () => {
             minCharCount: 1000,
             minAssistantChars: 399,
             stats: _makeStats(),
+            concurrency: 2,
           });
           errStub.restore();
 
@@ -258,7 +260,10 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
 
           const _stats = _makeStats();
-          const result = await prefilterFiles([excludedEntry, shortEntry, validEntry], { stats: _stats });
+          const result = await prefilterFiles([excludedEntry, shortEntry, validEntry], {
+            stats: _stats,
+            concurrency: 2,
+          });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -283,7 +288,7 @@ describe('prefilterFiles', () => {
           const entry2 = await _writeEntry(validPath2, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry1, entry2], { stats: _makeStats() });
+          const result = await prefilterFiles([entry1, entry2], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 2);
@@ -307,7 +312,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats() });
+          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -321,7 +326,7 @@ describe('prefilterFiles', () => {
           const shortEntry = await _writeEntry(shortPath, '---\ntitle: 短い\n---\n短い本文\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([validEntry, shortEntry], { stats: _makeStats() });
+          const result = await prefilterFiles([validEntry, shortEntry], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -351,7 +356,11 @@ describe('prefilterFiles', () => {
           const validEntry = await _writeEntry(validPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const loggerStub = makeLoggerStub();
 
-          await prefilterFiles([excludedEntry, shortEntry, validEntry], { stats: _makeStats(), dryRun: true });
+          await prefilterFiles([excludedEntry, shortEntry, validEntry], {
+            stats: _makeStats(),
+            dryRun: true,
+            concurrency: 2,
+          });
           loggerStub.restore();
 
           assertEquals(loggerStub.infoLogs.length, 2);
@@ -370,9 +379,13 @@ describe('prefilterFiles', () => {
           const resultDryRun = await prefilterFiles([excludedEntry, shortEntry, validEntry], {
             stats: statsDryRun,
             dryRun: true,
+            concurrency: 2,
           });
           const statsNormal = _makeStats();
-          const resultNormal = await prefilterFiles([excludedEntry, shortEntry, validEntry], { stats: statsNormal });
+          const resultNormal = await prefilterFiles([excludedEntry, shortEntry, validEntry], {
+            stats: statsNormal,
+            concurrency: 2,
+          });
           loggerStub.restore();
 
           assertEquals(resultDryRun.map((e) => e.filePath), [validPath]);
@@ -401,7 +414,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats() });
+          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.map((e) => e.filePath).includes(filePath), true);
@@ -435,7 +448,7 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
 
           const entries = [validEntry3, excludedEntry, validEntry1, shortEntry, validEntry2];
-          const result = await prefilterFiles(entries, { stats: _makeStats() });
+          const result = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.map((e) => e.filePath), [validPath3, validPath1, validPath2]);
@@ -460,7 +473,7 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await prefilterFiles([entry], { stats });
+          await prefilterFiles([entry], { stats, concurrency: 2 });
           errStub.restore();
 
           assertEquals(await Deno.stat(filePath).catch(() => null), null);
@@ -473,7 +486,7 @@ describe('prefilterFiles', () => {
           const loggerStub = makeLoggerStub();
           const stats = _makeStats();
 
-          await prefilterFiles([entry], { stats, dryRun: true });
+          await prefilterFiles([entry], { stats, dryRun: true, concurrency: 2 });
           loggerStub.restore();
 
           assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
@@ -500,7 +513,7 @@ describe('prefilterFiles', () => {
 
           // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
           const entry = new ChatlogEntry('', { filePath });
-          await prefilterFiles([entry], { stats });
+          await prefilterFiles([entry], { stats, concurrency: 2 });
           errStub.restore();
 
           assertEquals(stats.error, 1);
@@ -514,7 +527,7 @@ describe('prefilterFiles', () => {
 
           // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
           const entry = new ChatlogEntry('', { filePath });
-          const passed = await prefilterFiles([entry], { stats });
+          const passed = await prefilterFiles([entry], { stats, concurrency: 2 });
           errStub.restore();
 
           assertEquals(passed.map((e) => e.filePath), [filePath]);

--- a/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
@@ -78,7 +78,7 @@ describe('findMdFiles → prefilterFiles パイプライン', () => {
           const allFiles = await findFiles(tempDir);
           const { entries } = await loadFilterEntries(allFiles, cache, 2);
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(entries, { stats: _makeStats() });
+          const passed = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(passed.length, 2);
@@ -102,7 +102,7 @@ describe('prefilterFiles → buildBatchPrompt パイプライン', () => {
 
           const { entries } = await loadFilterEntries([file1, file2], cache, 2);
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(entries, { stats: _makeStats() });
+          const passed = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           const prompt = buildBatchPrompt(passed);
@@ -147,7 +147,7 @@ describe('loadFilterEntries → prefilterFiles パイプライン', () => {
           const { entries, errors } = await loadFilterEntries(allFiles, cache, 2);
 
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(entries, { stats: _makeStats() });
+          const passed = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
           errStub.restore();
 
           assertEquals(errors.length, 1);

--- a/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
@@ -76,7 +76,7 @@ describe('findMdFiles → prefilterFiles パイプライン', () => {
           );
 
           const allFiles = await findFiles(tempDir);
-          const { entries } = await loadFilterEntries(allFiles, cache);
+          const { entries } = await loadFilterEntries(allFiles, cache, 2);
           const errStub = stub(console, 'error', () => {});
           const passed = await prefilterFiles(entries, { stats: _makeStats() });
           errStub.restore();
@@ -100,7 +100,7 @@ describe('prefilterFiles → buildBatchPrompt パイプライン', () => {
           await Deno.writeTextFile(file1, _makeValidContent('Chat 1'));
           await Deno.writeTextFile(file2, _makeValidContent('Chat 2'));
 
-          const { entries } = await loadFilterEntries([file1, file2], cache);
+          const { entries } = await loadFilterEntries([file1, file2], cache, 2);
           const errStub = stub(console, 'error', () => {});
           const passed = await prefilterFiles(entries, { stats: _makeStats() });
           errStub.restore();
@@ -144,7 +144,7 @@ describe('loadFilterEntries → prefilterFiles パイプライン', () => {
           await Deno.writeTextFile(errorPath, _INVALID_YAML_ENTRY);
 
           const allFiles = await findFiles(tempDir);
-          const { entries, errors } = await loadFilterEntries(allFiles, cache);
+          const { entries, errors } = await loadFilterEntries(allFiles, cache, 2);
 
           const errStub = stub(console, 'error', () => {});
           const passed = await prefilterFiles(entries, { stats: _makeStats() });

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -34,6 +34,7 @@ export const DEFAULT_NOISE_FILTER_CONFIG: NoiseFilterConfig = {
   // config.yaml only
   minCharCount: DEFAULT_CONFIG_VALUES.minCharCount,
   minAssistantChars: DEFAULT_CONFIG_VALUES.minAssistantChars,
+  concurrency: DEFAULT_CONFIG_VALUES.concurrency,
 };
 
 /** filter-chatlogs の parseArgs で未指定のフィールドに適用するデフォルト設定。 */

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -139,6 +139,7 @@ export const main = async (args?: string[]): Promise<void> => {
     minAssistantChars: _config.minAssistantChars,
     stats,
     dryRun: _config.dryRun,
+    concurrency: _config.concurrency,
   });
 
   const total = targetEntries.length;

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -128,7 +128,7 @@ export const main = async (args?: string[]): Promise<void> => {
 
   // 候補ファイルを読み込む。読み込み失敗（frontmatter パースエラー等）は errors に分離され、
   // 誤って削除しないよう内容判定・claude CLI判定（prefilterFiles）には渡らない
-  const { entries, errors } = await loadFilterEntries(_targetEntries, _cache);
+  const { entries, errors } = await loadFilterEntries(_targetEntries, _cache, _config.concurrency);
   if (errors.length > 0) {
     stats.error += errors.length;
     errors.forEach(({ filePath, error }) => logger.warn(`  読み込み失敗 (${error.message}): ${getFilename(filePath)}`));

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -175,7 +175,7 @@ export const main = async (args?: string[]): Promise<void> => {
   }
 
   // DISCARD マーク済み（今回マーク分 + 前回削除されずに残ったゾンビファイル）をまとめて削除する
-  await sweepDiscards(allFiles, _cache, stats, _config.dryRun);
+  await sweepDiscards(allFiles, _cache, stats, _config.dryRun, _config.concurrency);
 
   // サマリー
   const drySuffix = _config.dryRun ? ' (dry-run)' : '';

--- a/skills/filter-chatlogs/scripts/libs/__tests__/unit/load-filter-entry.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/libs/__tests__/unit/load-filter-entry.unit.spec.ts
@@ -172,7 +172,7 @@ describe('loadFilterEntries', () => {
       tempFiles.push(path1, path2);
       const cache = await _makeEmptyFilterCache();
 
-      const results = await loadFilterEntries([path1, path2], cache);
+      const results = await loadFilterEntries([path1, path2], cache, 2);
 
       assertEquals(results.entries.length, 2);
       assertEquals(results.entries[0].filePath, path1);
@@ -183,7 +183,7 @@ describe('loadFilterEntries', () => {
     it('[Normal] T-FC-LFES-02: 空配列 → entries・errors ともに空配列が返る', async () => {
       const cache = await _makeEmptyFilterCache();
 
-      const results = await loadFilterEntries([], cache);
+      const results = await loadFilterEntries([], cache, 2);
 
       assertEquals(results.entries, []);
       assertEquals(results.errors, []);
@@ -198,7 +198,7 @@ describe('loadFilterEntries', () => {
       tempFiles.push(okPath, errorPath);
       const cache = await _makeEmptyFilterCache();
 
-      const results = await loadFilterEntries([okPath, errorPath], cache);
+      const results = await loadFilterEntries([okPath, errorPath], cache, 2);
 
       assertEquals(results.entries.length, 1);
       assertEquals(results.entries[0].filePath, okPath);
@@ -219,7 +219,7 @@ describe('loadFilterEntries', () => {
       const errorPath = await _makeTempFile(_INVALID_YAML_ENTRY);
       tempFiles.push(okPath, errorPath);
 
-      const results = await loadFilterEntries([okPath, errorPath]);
+      const results = await loadFilterEntries([okPath, errorPath], undefined, 2);
 
       assertEquals(results.entries.length, 1);
       assertEquals(results.entries[0].filePath, okPath);

--- a/skills/filter-chatlogs/scripts/libs/load-filter-entry.ts
+++ b/skills/filter-chatlogs/scripts/libs/load-filter-entry.ts
@@ -10,6 +10,7 @@
 // ─── Shared scripts
 import { loadChatlogEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
 import { isFileIoError } from '../../../_scripts/libs/file-io/read-utils.ts';
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 
 // ─── Local
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
@@ -45,21 +46,28 @@ export const loadFilterEntry = async (
  * ファイルパス一覧から `ChatlogEntry` を並列読み込みし、成功分と失敗分に振り分ける。
  * 失敗分（frontmatter 解析エラー等）はまとめて `cache` に `decision: ERROR` と `reason` を書き込む。
  * `cache` を省略した場合は ERROR 書き込みを行わない。
+ * `concurrency` で読み込み・cache 書き込みの並列度を制限する。
  */
 export const loadFilterEntries = async (
   filePaths: string[],
-  cache?: ChatlogCache<CLEResult>,
+  cache: ChatlogCache<CLEResult> | undefined,
+  concurrency: number,
 ): Promise<{ entries: ChatlogEntry[]; errors: { filePath: string; error: Error }[] }> => {
-  const results = await Promise.all(filePaths.map((filePath) => loadFilterEntry(filePath)));
+  const results = await runConcurrent(
+    filePaths,
+    (filePath) => loadFilterEntry(filePath),
+    concurrency,
+  );
 
   const entries = results.filter((result): result is ChatlogEntry => result instanceof ChatlogEntry);
   const errors = results.filter((result): result is LoadFilterEntryFailure => !(result instanceof ChatlogEntry));
 
   if (cache) {
-    await Promise.all(
-      errors.map(({ filePath, error }) =>
-        cache.write(filePath, { decision: FILTER_DECISIONS.ERROR, confidence: 0, reason: error.message })
-      ),
+    await runConcurrent(
+      errors,
+      ({ filePath, error }) =>
+        cache.write(filePath, { decision: FILTER_DECISIONS.ERROR, confidence: 0, reason: error.message }),
+      concurrency,
     );
   }
 

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/sweep-discards.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/sweep-discards.functional.spec.ts
@@ -133,7 +133,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const logStub = stub(console, 'log', () => {});
 
-          await sweepDiscards([filePath], cache, stats, false);
+          await sweepDiscards([filePath], cache, stats, false, Infinity);
           logStub.restore();
 
           assertEquals(await fileOrDirExists(filePath), false);
@@ -150,7 +150,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const logStub = stub(console, 'log', () => {});
 
-          await sweepDiscards([filePath], cache, stats, false);
+          await sweepDiscards([filePath], cache, stats, false, Infinity);
           logStub.restore();
 
           assertEquals(stats.remove, 1);
@@ -167,7 +167,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const logStub = stub(console, 'log', () => {});
 
-          await sweepDiscards([filePath], cache, stats, false);
+          await sweepDiscards([filePath], cache, stats, false, Infinity);
           logStub.restore();
 
           assertEquals(cache.read(filePath), {});
@@ -192,7 +192,7 @@ describe('sweepDiscards', () => {
           await cache.write(filePath, { decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' });
           const stats = _makeStats();
 
-          await sweepDiscards([filePath], cache, stats, false);
+          await sweepDiscards([filePath], cache, stats, false, Infinity);
 
           assertEquals(await fileOrDirExists(filePath), true);
           assertEquals(stats.remove, 0);
@@ -226,7 +226,7 @@ describe('sweepDiscards', () => {
           // fileExists では検出されるが、削除実行時に Deno.remove が NotFound を投げる TOCTOU を再現する
           const removeStub = stub(Deno, 'remove', () => Promise.reject(new Deno.errors.NotFound()));
 
-          await sweepDiscards([filePath], cache, stats, false);
+          await sweepDiscards([filePath], cache, stats, false, Infinity);
           removeStub.restore();
           warnStub.restore();
           logStub.restore();
@@ -248,7 +248,7 @@ describe('sweepDiscards', () => {
           const warnStub = stub(console, 'warn', () => {});
           const removeStub = stub(Deno, 'remove', () => Promise.reject(new Deno.errors.NotFound()));
 
-          await sweepDiscards([filePath], cache, stats, false);
+          await sweepDiscards([filePath], cache, stats, false, Infinity);
           removeStub.restore();
           warnStub.restore();
           logStub.restore();
@@ -284,7 +284,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const infoStub = stub(console, 'error', () => {});
 
-          await sweepDiscards([filePath], cache, stats, true);
+          await sweepDiscards([filePath], cache, stats, true, Infinity);
           infoStub.restore();
 
           assertEquals(await fileOrDirExists(filePath), true);
@@ -301,7 +301,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const infoStub = stub(console, 'error', () => {});
 
-          await sweepDiscards([filePath], cache, stats, true);
+          await sweepDiscards([filePath], cache, stats, true, Infinity);
           infoStub.restore();
 
           assertEquals(stats.skip, 1);
@@ -338,7 +338,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const infoStub = stub(console, 'error', () => {});
 
-          await sweepDiscards([filePath1, filePath2], cache, stats, true);
+          await sweepDiscards([filePath1, filePath2], cache, stats, true, Infinity);
           infoStub.restore();
 
           assertEquals(stats.skip, 2);
@@ -361,7 +361,7 @@ describe('sweepDiscards', () => {
           const stats = _makeStats();
           const infoStub = stub(console, 'error', () => {});
 
-          await sweepDiscards([filePath1, filePath2], cache, stats, true);
+          await sweepDiscards([filePath1, filePath2], cache, stats, true, Infinity);
           infoStub.restore();
 
           const messages = infoStub.calls.map((call) => call.args[0] as string);

--- a/skills/filter-chatlogs/scripts/modules/filter/sweep-discards.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/sweep-discards.ts
@@ -13,6 +13,7 @@ import type { ChatlogCache } from '../../../../_scripts/classes/ChatlogCache.cla
 import { fileExists } from '../../../../_scripts/libs/file-ops/exists-utils.ts';
 import { removeFile } from '../../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../../_scripts/libs/io/logger.ts';
+import { runConcurrent } from '../../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── internal ───
@@ -39,23 +40,25 @@ import type { FilterStats } from '../../types/stats.types.ts';
  * @param cache - 判定結果キャッシュ
  * @param stats - 削除件数・スキップ件数・エラー件数を加算する統計オブジェクト
  * @param dryRun - `true` の場合は削除を行わず、ファイルごとに `stats.skip` に計上する
+ * @param concurrency - 同時実行する存在確認・削除処理の最大並列数。
  */
 export const sweepDiscards = async (
   allFiles: string[],
   cache: ChatlogCache<CLEResult>,
   stats: FilterStats,
   dryRun: boolean,
+  concurrency: number,
 ): Promise<void> => {
   const _isMarkedDiscard = (filePath: string): boolean => cache.read(filePath).decision === FILTER_DECISIONS.DISCARD;
   const _isExistingFile = async (filePath: string): Promise<boolean> => await fileExists(filePath);
 
-  const targets = (await Promise.all(
-    allFiles
-      .filter(_isMarkedDiscard)
-      .map(async (filePath) => (await _isExistingFile(filePath)) ? filePath : null),
+  const targets = (await runConcurrent(
+    allFiles.filter(_isMarkedDiscard),
+    async (filePath) => (await _isExistingFile(filePath)) ? filePath : null,
+    concurrency,
   )).filter((filePath): filePath is string => filePath !== null);
 
-  await Promise.all(targets.map(async (filePath) => {
+  await runConcurrent(targets, async (filePath) => {
     if (dryRun) {
       stats.skip++;
       logger.info(`  skipped: ${getFilename(filePath)}`);
@@ -72,5 +75,5 @@ export const sweepDiscards = async (
       await cache.write(filePath, { ...cache.read(filePath), decision: FILTER_DECISIONS.ERROR });
       logger.warn(`  Error: cannot removed: ${getFilename(filePath)}`);
     }
-  }));
+  }, concurrency);
 };

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
@@ -64,7 +64,7 @@ describe('_phase3DiscardOrSkip', () => {
           ];
           const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await _phase3DiscardOrSkip(discardFiles, stats, false);
+          await _phase3DiscardOrSkip(discardFiles, stats, false, Infinity);
 
           assertEquals(await fileExists(filePath), false);
           assertEquals(stats.remove, 1);
@@ -88,7 +88,7 @@ describe('_phase3DiscardOrSkip', () => {
           ];
           const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await _phase3DiscardOrSkip(discardFiles, stats, true);
+          await _phase3DiscardOrSkip(discardFiles, stats, true, Infinity);
 
           assertEquals(await fileExists(filePath), true);
           assertEquals(stats.skip, 1);
@@ -114,7 +114,7 @@ describe('_phase3DiscardOrSkip', () => {
           ];
           const stats = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await _phase3DiscardOrSkip(discardFiles, stats, false);
+          await _phase3DiscardOrSkip(discardFiles, stats, false, Infinity);
 
           assertEquals(stats.error, 1);
           assertEquals(stats.remove, 0);

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -94,7 +94,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false });
+          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
 
           assertEquals(await fileExists(filePath), false);
         });
@@ -104,7 +104,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false });
+          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
 
           assertEquals(counts.remove, 1);
         });
@@ -129,7 +129,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false });
+          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
 
           assertEquals(await fileExists(filePath), true);
         });
@@ -139,7 +139,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false });
+          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
 
           assertEquals(counts.keep, 1);
         });
@@ -164,7 +164,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: true });
+          await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
 
           assertEquals(await fileExists(filePath), true);
         });
@@ -174,7 +174,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: true });
+          await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
 
           assertEquals(loggerStub.infoLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
         });
@@ -184,7 +184,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: true });
+          await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
 
           assertEquals(counts.skip, 1);
         });
@@ -211,7 +211,7 @@ describe('processNoiseFiles', () => {
           const keepEntry = await _writeEntry(keepPath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([noiseEntry, keepEntry], counts, { dryRun: false });
+          await processNoiseFiles([noiseEntry, keepEntry], counts, { dryRun: false }, Infinity);
 
           assertEquals(counts.remove, 1);
           assertEquals(counts.keep, 1);

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
@@ -11,6 +11,7 @@
 import { parseConversation } from '../../../../_scripts/libs/chatlogs/conversation-utils.ts';
 import { removeFile } from '../../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../../_scripts/libs/io/logger.ts';
+import { runConcurrent } from '../../../../_scripts/libs/parallel/concurrency.ts';
 // classes
 import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 
@@ -101,28 +102,28 @@ export const _phase2ClassifyConversations = (
  * @param discardFiles - ノイズ判定確定ファイル（`NoiseDiscardFile[]`）
  * @param stats - 加算対象の処理統計オブジェクト
  * @param dryRun - `true` のとき実削除を行わない
+ * @param concurrency - 同時実行する削除処理の最大並列数。
  */
 export const _phase3DiscardOrSkip = async (
   discardFiles: NoiseDiscardFile[],
   stats: NoiseFilterStats,
   dryRun: boolean,
+  concurrency: number,
 ): Promise<void> => {
-  await Promise.all(
-    discardFiles.map(async ({ filePath, reason }) => {
-      if (dryRun) {
-        logger.info(`<<dry-run>> skip: ${filePath} (${reason})`);
-        stats.skip++;
-        return;
-      }
-      if (await removeFile(filePath, { throwFileIoError: false })) {
-        logger.info(`deleted: ${filePath} (${reason})`);
-        stats.remove++;
-      } else {
-        // log output in removeFIle() already, so just count up stats.error
-        stats.error++;
-      }
-    }),
-  );
+  await runConcurrent(discardFiles, async ({ filePath, reason }) => {
+    if (dryRun) {
+      logger.info(`<<dry-run>> skip: ${filePath} (${reason})`);
+      stats.skip++;
+      return;
+    }
+    if (await removeFile(filePath, { throwFileIoError: false })) {
+      logger.info(`deleted: ${filePath} (${reason})`);
+      stats.remove++;
+    } else {
+      // log output in removeFIle() already, so just count up stats.error
+      stats.error++;
+    }
+  }, concurrency);
 };
 
 /**
@@ -136,16 +137,23 @@ export const _phase3DiscardOrSkip = async (
  * @param entries - 処理対象の `ChatlogEntry` 配列
  * @param stats - 加算対象の処理統計オブジェクト
  * @param options.dryRun - `true` のとき、ノイズ判定確定ファイルを実削除せず `stats.skip` に計上する
+ * @param concurrency - 同時実行する削除処理の最大並列数。
  */
 export const processNoiseFiles = async (
   entries: ChatlogEntry[],
   stats: NoiseFilterStats,
   options: { dryRun: boolean },
+  concurrency: number,
 ): Promise<void> => {
   const { discardFiles: filenameDiscardFiles, passEntries } = _phase0ClassifyByFilename(entries);
   const { discardFiles: contentDiscardFiles, keepFiles } = _phase2ClassifyConversations(passEntries);
 
   stats.keep += keepFiles.length;
 
-  await _phase3DiscardOrSkip([...filenameDiscardFiles, ...contentDiscardFiles], stats, options.dryRun);
+  await _phase3DiscardOrSkip(
+    [...filenameDiscardFiles, ...contentDiscardFiles],
+    stats,
+    options.dryRun,
+    concurrency,
+  );
 };

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../_scripts/libs/chatlogs/conversation-utils.ts';
 import { removeFile } from '../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 // constants
 import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
 
@@ -236,18 +237,21 @@ export const _phase3PartitionByContent = (
  * @param files - 削除対象の `DiscardFile` 配列
  * @param dryRun - `true` のとき実削除を行わない
  * @param stats - 加算対象の処理統計オブジェクト
+ * @param concurrency - 同時実行する削除処理の最大並列数。
  * @returns 削除できなかった（未実施 or 失敗）ファイル、および非 DISCARD エントリの `DiscardFile` 配列
  */
 export const _discardFiles = async (
   files: DiscardFile[],
   dryRun: boolean,
   stats: BaseStats,
+  concurrency: number,
 ): Promise<DiscardFile[]> => {
   const toDiscard = files.filter((entry) => entry.decision === FILTER_DECISIONS.DISCARD);
   const nonDiscard = files.filter((entry) => entry.decision !== FILTER_DECISIONS.DISCARD);
 
-  const results = await Promise.all(
-    toDiscard.map(async (entry): Promise<DiscardFile | null> => {
+  const results = await runConcurrent(
+    toDiscard,
+    async (entry): Promise<DiscardFile | null> => {
       const { filePath, filename, reason } = entry;
       if (dryRun) {
         logger.info(`  skipped (${reason}): ${filename}`);
@@ -261,7 +265,8 @@ export const _discardFiles = async (
       stats.remove++;
       logger.info(`  removed (${reason}): ${filename}`);
       return null;
-    }),
+    },
+    concurrency,
   );
   return [...results.filter((entry): entry is DiscardFile => entry !== null), ...nonDiscard];
 };
@@ -276,6 +281,7 @@ export const _discardFiles = async (
  * @param options.stats - 処理統計オブジェクト。ファイル名パターン除外・内容除外の実削除数を `remove` に、
  *   dry-run 時のスキップ数を `skip` に加算する。
  * @param options.dryRun - `true` のとき、削除対象ファイルを実削除せず `stats.skip` に計上する（デフォルト: `false`）
+ * @param options.concurrency - 同時実行する削除処理の最大並列数。
  * @returns フィルタリングを通過した `ChatlogEntry` 配列
  */
 export const prefilterFiles = async (
@@ -287,6 +293,7 @@ export const prefilterFiles = async (
     minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
     stats,
     dryRun = false,
+    concurrency,
   } = options;
 
   const { fileList, discardFiles } = _phase1PartitionByFilename(entries);
@@ -294,7 +301,7 @@ export const prefilterFiles = async (
 
   const toDelete = [...discardFiles, ...byContent.results];
 
-  const notDeleted = await _discardFiles(toDelete, dryRun, stats);
+  const notDeleted = await _discardFiles(toDelete, dryRun, stats, concurrency);
 
   const errorPaths = new Set(
     notDeleted.filter((entry) => entry.decision === FILTER_DECISIONS.ERROR).map((entry) => entry.filePath),

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -58,7 +58,9 @@ import { prefilterFiles } from './modules/prefilter.ts';
 // ─────────────────────────────────────────────
 
 export const main = async (args: string[] = Deno.args): Promise<void> => {
-  const { agent, period, chatlogsDir, inputDir, dryRun, minCharCount, minAssistantChars } = buildConfig(args);
+  const { agent, period, chatlogsDir, inputDir, dryRun, minCharCount, minAssistantChars, concurrency } = buildConfig(
+    args,
+  );
   const _searchDir = resolveChatlogsDir({
     chatlogsDir,
     agent,
@@ -81,7 +83,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
 
   // 候補ファイルを読み込む。読み込み失敗（ファイル I/O・frontmatter パースエラー等）は errors に分離され、
   // 誤って削除しないよう prefilterFiles/processNoiseFiles には渡らない
-  const { entries, errors } = await loadFilterEntries(files);
+  const { entries, errors } = await loadFilterEntries(files, undefined, concurrency);
   if (errors.length > 0) {
     stats.error += errors.length;
     errors.forEach(({ filePath, error }) => logger.error(`  読み込み失敗 (${error.message}): ${filePath}`));

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -94,6 +94,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
     minAssistantChars,
     stats,
     dryRun,
+    concurrency,
   });
 
   await processNoiseFiles(targetEntries, stats, { dryRun }, concurrency);

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -96,7 +96,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
     dryRun,
   });
 
-  await processNoiseFiles(targetEntries, stats, { dryRun });
+  await processNoiseFiles(targetEntries, stats, { dryRun }, concurrency);
 
   const suffix = dryRun ? ' (dry-run)' : '';
   logger.info(

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -84,4 +84,6 @@ export interface PrefilterFilesOptions {
   stats: BaseStats;
   /** `true` のとき、スキップ理由・サマリのログ出力を抑制する。 */
   dryRun?: boolean;
+  /** 同時実行するファイル削除処理の最大並列数。 */
+  concurrency: number;
 }

--- a/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/noise-filter.types.ts
@@ -22,6 +22,8 @@ export type NoiseFilterConfig = DefaultArgFields & {
   minCharCount: number;
   /** User ターンが 1 件のとき、Assistant 応答の最小文字数（GlobalConfig の minAssistantChars 由来）。 */
   minAssistantChars: number;
+  /** 同時実行する読み込み処理の最大並列数。 */
+  concurrency: number;
 };
 
 /** `noise-filter-chatlogs` の `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */

--- a/skills/set-frontmatter/scripts/modules/__tests__/functional/load-all-entries.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/functional/load-all-entries.functional.spec.ts
@@ -74,7 +74,7 @@ describe('loadAllEntries', () => {
       await _writeValidMd(tempDir, 'c.md');
       const stats = _makeStats();
 
-      const entries = await loadAllEntries(tempDir, stats);
+      const entries = await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(entries.length, 3);
     });
@@ -85,7 +85,7 @@ describe('loadAllEntries', () => {
       await _writeValidMd(tempDir, 'c.md');
       const stats = _makeStats();
 
-      await loadAllEntries(tempDir, stats);
+      await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(stats.total, 3);
     });
@@ -96,7 +96,7 @@ describe('loadAllEntries', () => {
       await _writeValidMd(tempDir, 'c.md');
       const stats = _makeStats();
 
-      await loadAllEntries(tempDir, stats);
+      await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(stats.skip, 0);
     });
@@ -114,7 +114,7 @@ describe('loadAllEntries', () => {
       await _writeSkipMd(tempDir, 'skip.md');
       const stats = _makeStats();
 
-      const entries = await loadAllEntries(tempDir, stats);
+      const entries = await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(entries.length, 2);
     });
@@ -125,7 +125,7 @@ describe('loadAllEntries', () => {
       await _writeSkipMd(tempDir, 'skip.md');
       const stats = _makeStats();
 
-      await loadAllEntries(tempDir, stats);
+      await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(stats.total, 3);
     });
@@ -136,7 +136,7 @@ describe('loadAllEntries', () => {
       await _writeSkipMd(tempDir, 'skip.md');
       const stats = _makeStats();
 
-      await loadAllEntries(tempDir, stats);
+      await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(stats.skip, 1);
     });
@@ -149,7 +149,7 @@ describe('loadAllEntries', () => {
     it('[Edge] T-SF-LAE-03-01: 空ディレクトリ → entries が空になる', async () => {
       const stats = _makeStats();
 
-      const entries = await loadAllEntries(tempDir, stats);
+      const entries = await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(entries.length, 0);
     });
@@ -157,7 +157,7 @@ describe('loadAllEntries', () => {
     it('[Edge] T-SF-LAE-03-02: 空ディレクトリ → stats.total が 0 になる', async () => {
       const stats = _makeStats();
 
-      await loadAllEntries(tempDir, stats);
+      await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(stats.total, 0);
     });
@@ -165,7 +165,7 @@ describe('loadAllEntries', () => {
     it('[Edge] T-SF-LAE-03-03: 空ディレクトリ → stats.skip が 0 になる', async () => {
       const stats = _makeStats();
 
-      await loadAllEntries(tempDir, stats);
+      await loadAllEntries(tempDir, stats, 2);
 
       assertEquals(stats.skip, 0);
     });

--- a/skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts
@@ -13,6 +13,7 @@
 import { loadChatlogEntry as _loadEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
 import { findFiles } from '../../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // classes
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
@@ -29,12 +30,13 @@ import type { Stats } from '../types/phase.types.ts';
 export const loadAllEntries = async (
   dir: string,
   stats: Stats,
+  concurrency: number,
 ): Promise<ChatlogEntry[]> => {
   const allFiles = await findFiles(dir);
   stats.total = allFiles.length;
   logger.info(`対象ファイル数: ${stats.total}`);
 
-  const _results = await Promise.all(allFiles.map(loadChatlogEntry));
+  const _results = await runConcurrent(allFiles, loadChatlogEntry, concurrency);
 
   allFiles
     .filter((_, i) => !_results[i])

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -71,8 +71,9 @@ export const phaseFrontmatter = async (
   const _alreadyFilled = _misses.filter((e) => e.frontmatter.hasRequiredFields());
   const _needsGenerate = _misses.filter((e) => !e.frontmatter.hasRequiredFields());
 
-  await Promise.all(
-    _alreadyFilled.map(async (entry) => {
+  await runConcurrent(
+    _alreadyFilled,
+    async (entry) => {
       const _fmSnapshot = extractEntryFrontmatter(entry);
       const _existing = cache.read(entry.filePath!);
       if (!dryRun) {
@@ -87,7 +88,8 @@ export const phaseFrontmatter = async (
       } else {
         logger.info(`  frontmatter (existing): ${getFilename(entry.filePath!)}`);
       }
-    }),
+    },
+    concurrency,
   );
 
   const _generate = generateProvider ?? generateFrontmatter;

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -123,7 +123,7 @@ export const main = async (args: string[]): Promise<void> => {
   const stats: Stats = { total: 0, success: 0, fail: 0, skip: 0, written: 0 };
 
   // Phase 1.1: メタ読み込み
-  const entries = await loadAllEntries(_inputDir, stats);
+  const entries = await loadAllEntries(_inputDir, stats, _config.concurrency);
   logger.info(`メタ読み込み: ${entries.length}件（スキップ: ${stats.skip}件）`);
   if (entries.length === 0) {
     logger.info('対象ファイルなし');


### PR DESCRIPTION
## Overview

**Summary**
Bound unbounded file I/O concurrency to a configurable limit across skills.

**Background / Motivation**
Several skills (`classify-chatlogs`, `filter-chatlogs`, `set-frontmatter`) and the shared
`ChatlogCache` class ran file I/O (reads, writes, deletions) with unbounded `Promise.all`,
spawning one concurrent operation per file regardless of collection size. For large chatlog
sets this risks exhausting file descriptors and memory. This PR replaces those unbounded
calls with `runConcurrent`, capping concurrent file operations via a `concurrency` option
threaded through each entry point (config → skill script → module/class).

## Changes

### Core Changes

- `skills/_scripts/classes/ChatlogCache.class.ts`: bound cache read/write concurrency in
  `loadAll` and `initFromOutputDir`.
- `skills/classify-chatlogs/scripts/libs/load-entries.ts`: `loadClassifyEntries` accepts and
  applies a `concurrency` option for entry loading and cache writes.
- `skills/filter-chatlogs/scripts/libs/load-filter-entry.ts`: `loadFilterEntries` reads and
  cache writes bounded via `runConcurrent`.
- `skills/filter-chatlogs/scripts/modules/filter/sweep-discards.ts`: existence checks and
  deletions bounded via `runConcurrent`.
- `skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts`: discard
  deletion in `_phase3DiscardOrSkip` bounded via `runConcurrent`.
- `skills/filter-chatlogs/scripts/modules/prefilter.ts`: prefilter discard deletion in
  `_discardFiles` bounded via `runConcurrent`.
- `skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts`: `loadAllEntries` bounded via
  `runConcurrent`.
- `skills/set-frontmatter/scripts/phases/phase-frontmatter.ts`: existing-frontmatter
  processing (`_alreadyFilled`) bounded via `runConcurrent`.
- `skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts`: ChatGPT export file
  processing bounded via `runConcurrent`, defaulting to `DEFAULT_CONCURRENCY` when
  `config.concurrency` is unset.
- Added `concurrency` to `PrefilterFilesOptions`, `NoiseFilterConfig`, and `ExportConfig`
  (all call sites updated accordingly).

### Test Updates

- Updated unit/functional/integration specs across `ChatlogCache`, `classify-chatlogs`,
  `filter-chatlogs`, `set-frontmatter`, and `export-chatlogs` to pass explicit `concurrency`
  values (or `Infinity`, where unbounded behavior is intentionally verified).
- Added functional coverage for deterministic ChatGPT export output ordering under bounded
  concurrency, and for `concurrency` fallback in `buildConfig`.

### Removed

- None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> Closes #335

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

No breaking changes. This branch consolidates a series of incremental
`bound <area> concurrency` refactors, one per file-I/O hotspot.
