### PR TITLE
fix(export-chatlogs): make session project metadata optional

### DIFF
--- a/skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts
@@ -164,6 +164,44 @@ describe('renderMarkdown', () => {
     });
   });
 
+  /** meta.project が undefined の場合、frontmatter に project 行が出力されないケース。 */
+  describe('Given: meta.project が undefined', () => {
+    describe('When: renderMarkdown を呼び出す', () => {
+      describe('Then: T-EC-SW-10 - frontmatter に project 行が出力されない', () => {
+        it('T-EC-SW-10-01: 出力に "project:" が含まれない', () => {
+          const meta: SessionMeta = { ...BASE_META, project: undefined };
+          const markdown = renderMarkdown(meta, []);
+          assertEquals(markdown.includes('project:'), false);
+        });
+      });
+    });
+  });
+
+  /** meta.project が空文字列の場合、frontmatter に project 行が出力されないケース。 */
+  describe('Given: meta.project が空文字列', () => {
+    describe('When: renderMarkdown を呼び出す', () => {
+      describe('Then: T-EC-SW-11 - frontmatter に project 行が出力されない', () => {
+        it('T-EC-SW-11-01: 出力に "project:" が含まれない', () => {
+          const meta: SessionMeta = { ...BASE_META, project: '' };
+          const markdown = renderMarkdown(meta, []);
+          assertEquals(markdown.includes('project:'), false);
+        });
+      });
+    });
+  });
+
+  /** meta.project が非空文字列の場合、frontmatter に project 行が出力されるケース（claude/codex のデグレ防止）。 */
+  describe('Given: meta.project が非空文字列', () => {
+    describe('When: renderMarkdown を呼び出す', () => {
+      describe('Then: T-EC-SW-12 - frontmatter に project 行が出力される', () => {
+        it('T-EC-SW-12-01: 出力に "project: \'my-project\'" が含まれる', () => {
+          const markdown = renderMarkdown(BASE_META, []);
+          assertStringIncludes(markdown, `project: '${BASE_META.project}'`);
+        });
+      });
+    });
+  });
+
   /** turns が空配列の場合、会話ログセクションに何も出力されないケース。 */
   describe('Given: turns が空配列', () => {
     describe('When: renderMarkdown を呼び出す', () => {

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts
@@ -115,12 +115,12 @@ describe('parseChatGPTConversation', () => {
         assertEquals(result!.meta.sessionId, conv.conversation_id);
       });
 
-      // ─── T-EC-GP-01-03: meta.project === conv.title ──────────────────────
+      // ─── T-EC-GP-01-03: meta.project は未設定（classify-chatlogs が後付けする） ──
 
-      it('T-EC-GP-01-03: meta.project が conv.title と一致する', async () => {
+      it('T-EC-GP-01-03: meta.project が undefined になる', async () => {
         const conv = _makeNormalConv();
         const result = await parseChatGPTConversation(conv, ALL_PERIOD);
-        assertEquals(result!.meta.project, conv.title);
+        assertEquals(result!.meta.project, undefined);
       });
 
       // ─── T-EC-GP-01-04: turns.length が user+assistant の数 ──────────────

--- a/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
@@ -167,7 +167,6 @@ export const parseChatGPTConversation = async (
   const meta: SessionMeta = {
     sessionId: await resolveSessionId(conv.conversation_id),
     date: isoToDate(isoTimestamp),
-    project: conv.title,
     slug: '',
     firstUserText: firstUserTurn.content,
   };

--- a/skills/export-chatlogs/scripts/libs/session-writer.ts
+++ b/skills/export-chatlogs/scripts/libs/session-writer.ts
@@ -48,7 +48,7 @@ export const renderMarkdown = (meta: SessionMeta, turns: Turn[]): string => {
   _lines.push('---');
   _lines.push(`session_id: ${quoteString(meta.sessionId)}`);
   _lines.push(`date: ${quoteString(meta.date)}`);
-  _lines.push(`project: ${quoteString(meta.project)}`);
+  if (meta.project) { _lines.push(`project: ${quoteString(meta.project)}`); }
   if (meta.slug) { _lines.push(`slug: ${quoteString(meta.slug)}`); }
   _lines.push('---');
   _lines.push('');

--- a/skills/export-chatlogs/scripts/types/session.types.ts
+++ b/skills/export-chatlogs/scripts/types/session.types.ts
@@ -20,8 +20,11 @@ export interface SessionMeta {
   sessionId: string;
   /** セッション開始日（YYYY-MM-DD 形式）。出力パスの年/月ディレクトリに使用する */
   date: string; // YYYY-MM-DD
-  /** セッション開始時の作業ディレクトリ名（末尾セグメント）。フロントマターの project フィールドになる */
-  project: string;
+  /**
+   * セッション開始時の作業ディレクトリ名（末尾セグメント）。フロントマターの project フィールドになる。
+   * ChatGPT には対応する情報がなく、`/classify-chatlogs` スキルが後付けするため未設定でよい。
+   */
+  project?: string;
   /** セッションのスラッグ文字列。Claude の場合は JSONL から取得し、Codex の場合は空文字列 */
   slug: string;
   /** 最初の意味あるユーザーメッセージ。Markdown の H1 見出しおよびスラッグ生成に使用する */


### PR DESCRIPTION
## Overview

**Summary**
Make `project` an optional field in session metadata instead of forcing a fallback value.

**Background / Motivation**
ChatGPT conversations have no concept of a "project" (working directory). The exporter used to fill this
gap by falling back to `conv.title`, and the frontmatter writer always wrote a `project:` line even when
it was empty. This produced misleading or empty `project` values for ChatGPT exports. Now `project` is a
true optional field: no fallback title is assigned, and the `project:` line is omitted from frontmatter
when there is no value.

## Changes

### Core Changes

- `skills/export-chatlogs/scripts/types/session.types.ts`: changed `SessionMeta.project` to an optional
  property. Added a comment noting that ChatGPT has no source for this field and that the
  `/classify-chatlogs` skill assigns it later.
- `skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts`: removed the `project: conv.title`
  fallback when building `SessionMeta`.
- `skills/export-chatlogs/scripts/libs/session-writer.ts`: `renderMarkdown` now writes the `project:`
  frontmatter line only when `meta.project` is truthy, matching the existing `slug` handling.

### Test Updates

- `skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts`: added cases for
  `meta.project` being `undefined`, empty string, and a non-empty string, checking that `project:` is
  omitted or rendered as expected.
- `skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts`:
  updated the expected `meta.project` from `conv.title` to `undefined`.

### Removed

- The title-fallback assignment for `project` in the ChatGPT exporter.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
