### PR TITLE
feat: use deterministic session hash in output paths

### DIFF
--- a/skills/_scripts/libs/io/__tests__/unit/hash.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/hash.unit.spec.ts
@@ -14,7 +14,7 @@ import { describe, it } from '@std/testing/bdd';
 import { DEFAULT_HASH_LENGTH } from '../../../../constants/defaults.constants.ts';
 
 // test target
-import { generateHash } from '../../hash.ts';
+import { generateHash, sessionHash } from '../../hash.ts';
 
 // -- types --
 import type { GenerateHashOptions } from '../../../../types/common.types.ts';
@@ -129,6 +129,71 @@ describe('generateHash', () => {
         it('T-LIB-H-04-01: "project-a" と "project-b" の結果が異なる', async () => {
           const ra = await generateHash('project-a');
           const rb = await generateHash('project-b');
+          assertNotEquals(ra, rb);
+        });
+      });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// sessionHash
+// ─────────────────────────────────────────────
+
+/**
+ * `sessionHash` のユニットテストスイート。
+ *
+ * 入力文字列から決定的な SHA-256 16進数文字列を生成する関数の
+ * 決定性・デフォルト長・長さ指定・入力差分反映の各ケースをカバーする。
+ *
+ * @see sessionHash
+ */
+describe('sessionHash', () => {
+  describe('Given: 同じ input "same-input" で2回呼び出す', () => {
+    describe('When: sessionHash を連続で2回呼び出す', () => {
+      describe('Then: T-LIB-SH-01 - 毎回同じ値を返す（決定性の確認）', () => {
+        it('T-LIB-SH-01-01: 1回目と2回目の結果が一致する', async () => {
+          const r1 = await sessionHash('same-input');
+          const r2 = await sessionHash('same-input');
+          assertEquals(r1, r2);
+        });
+      });
+    });
+  });
+
+  describe('Given: filenameBase="base", options を省略', () => {
+    describe('When: sessionHash("base") を呼び出す', () => {
+      describe('Then: T-LIB-SH-02 - デフォルト長 12 の16進数文字列を返す', () => {
+        it('T-LIB-SH-02-01: 結果の長さが 12 である', async () => {
+          const result = await sessionHash('base');
+          assertEquals(result.length, 12);
+        });
+
+        it('T-LIB-SH-02-02: 結果が /^[0-9a-f]+$/ にマッチする', async () => {
+          const result = await sessionHash('base');
+          assertMatch(result, /^[0-9a-f]+$/);
+        });
+      });
+    });
+  });
+
+  describe('Given: input="base", length=16', () => {
+    describe('When: sessionHash("base", 16) を呼び出す', () => {
+      describe('Then: T-LIB-SH-03 - 指定長の16進数文字列を返す', () => {
+        it('T-LIB-SH-03-01: 結果の長さが 16 である', async () => {
+          const result = await sessionHash('base', 16);
+          assertEquals(result.length, 16);
+        });
+      });
+    });
+  });
+
+  describe('Given: 異なる input "input-a" と "input-b"', () => {
+    describe('When: それぞれ sessionHash を呼び出す', () => {
+      describe('Then: T-LIB-SH-04 - 異なる input は異なる結果を返す', () => {
+        it('T-LIB-SH-04-01: "input-a" と "input-b" の結果が異なる', async () => {
+          const ra = await sessionHash('input-a');
+          const rb = await sessionHash('input-b');
           assertNotEquals(ra, rb);
         });
       });

--- a/skills/_scripts/libs/io/hash.ts
+++ b/skills/_scripts/libs/io/hash.ts
@@ -140,3 +140,16 @@ export const generateHash = async (
   const hex = await _sha256Hex(seed);
   return hex.slice(0, length);
 };
+
+/**
+ * 入力文字列から決定的な SHA-256 ハッシュを生成する。
+ * `generateHash` と異なりタイムスタンプ・乱数を混ぜないため、同じ input なら常に同じ値を返す。
+ *
+ * @param input ハッシュ計算の入力文字列（例: sessionId）
+ * @param length 返す16進数文字列の長さ（デフォルト: 12）
+ * @returns 先頭 `length` 文字の16進数ハッシュ文字列
+ */
+export const sessionHash = async (input: string, length = 12): Promise<string> => {
+  const hex = await _sha256Hex(input);
+  return hex.slice(0, length);
+};

--- a/skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts
@@ -246,20 +246,19 @@ describe('writeSession', () => {
 
   /**
    * sessionId ハッシュのファイル名への埋め込みを確認するシナリオ。
-   * ハイフンを除去した先頭 8 文字が含まれることで、
+   * sessionId 全体を入力とした決定的な SHA-256 ハッシュ（先頭12文字）が含まれることで、
    * 同一日付の別セッションとのファイル名衝突を防ぐ設計の確認。
-   * ハイフンを除去した先頭 8 文字が含まれることで、同一日付の別セッションとの衝突を防ぐ設計の確認。
    */
   describe('Given: sessionId="sess-abcdef12-3456-7890-abcd-ef1234567890"', () => {
     /** writeSession を呼び出す */
     describe('When: writeSession を呼び出す', () => {
-      /** T-EC-WS-06: ファイル名に sessionId 先頭8文字（ハイフン除去）が含まれる */
-      describe('Then: T-EC-WS-06 - ファイル名に sessionId 先頭8文字（ハイフン除去）が含まれる', () => {
-        it('T-EC-WS-06-01: パスに "sessabcd" が含まれる', async () => {
+      /** T-EC-WS-06: ファイル名に sessionId 全体の SHA-256 ハッシュ先頭12文字が含まれる */
+      describe('Then: T-EC-WS-06 - ファイル名に sessionId 全体の決定的ハッシュ（先頭12文字）が含まれる', () => {
+        it('T-EC-WS-06-01: パスに "aa9da8ccb6de" が含まれる', async () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
-          // "sess-abcdef12-..." → ハイフン除去 → "sessabcdef12..." → 先頭8文字 → "sessabcd"
-          assertStringIncludes(outPath, 'sessabcd');
+          // sessionHash('sess-abcdef12-3456-7890-abcd-ef1234567890', 12) の先頭12文字
+          assertStringIncludes(outPath, 'aa9da8ccb6de');
         });
       });
     });

--- a/skills/export-chatlogs/scripts/__tests__/unit/output-path.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/output-path.unit.spec.ts
@@ -7,7 +7,7 @@
 // This software is released under the MIT License.
 
 // ─── BDD modules
-import { assertStringIncludes } from '@std/assert';
+import { assertNotEquals, assertStringIncludes } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -57,11 +57,11 @@ describe('buildOutputPath', () => {
     describe('When: buildOutputPath(...) を呼び出す', () => {
       /** T-EC-OP-01: 正しいパス構造を生成する */
       describe('Then: T-EC-OP-01 - 正しいパス構造を生成する', () => {
-        it('T-EC-OP-01-03: sessionId のハイフンを除去した先頭8文字が含まれる', () => {
+        it('T-EC-OP-01-03: sessionId 全体の決定的な SHA-256 ハッシュ（先頭12文字）が含まれる', async () => {
           const meta = _makeMeta({ sessionId: 'abc-def-12345678' });
-          const result = buildOutputPath('/out', 'claude', meta, 'test-slug');
-          // abcdef12 (ハイフン除去 → 'abcdef12345678' の先頭8文字)
-          assertStringIncludes(result, 'abcdef12');
+          const result = await buildOutputPath('/out', 'claude', meta, 'test-slug');
+          // sessionHash('abc-def-12345678', 12) の先頭12文字
+          assertStringIncludes(result, '996c4ad8c274');
         });
       });
     });
@@ -73,10 +73,40 @@ describe('buildOutputPath', () => {
    * パスに埋め込まれることを確認する。Obsidian の月別フォルダ整理に直結する仕様。
    */
   describe('Given: date="2026-03-15"', () => {
-    it('T-EC-OP-01-05: YYYY="2026", YYYY-MM="2026-03" が正しく埋め込まれる', () => {
+    it('T-EC-OP-01-05: YYYY="2026", YYYY-MM="2026-03" が正しく埋め込まれる', async () => {
       const meta = _makeMeta({ date: '2026-03-15' });
-      const result = buildOutputPath('/out', 'claude', meta, 'test');
+      const result = await buildOutputPath('/out', 'claude', meta, 'test');
       assertStringIncludes(result, '2026/2026-03/');
+    });
+  });
+
+  /**
+   * sessionId 衝突回避シナリオ。
+   *
+   * UUIDv7 はタイムスタンプ由来の先頭ビットを持つため、近接した時刻に生成された
+   * 複数の sessionId はハイフン除去後の先頭8文字が一致しうる（実際の障害事例）。
+   * sessionId 全体を入力とした決定的ハッシュにより、そのようなケースでも
+   * 異なるファイル名が生成されることを確認する。
+   */
+  describe('Given: ハイフン除去後の先頭8文字が一致する2つの UUIDv7 sessionId（実際の障害事例）', () => {
+    describe('When: それぞれ buildOutputPath を呼び出す', () => {
+      describe('Then: T-EC-OP-02 - 異なるファイル名が生成される（衝突回避）', () => {
+        it('T-EC-OP-02-01: 019eff4a-393e-... と 019eff4a-6eb8-... は異なる出力パスになる', async () => {
+          const metaA = _makeMeta({ sessionId: '019eff4a-393e-7980-8ced-d185bd4d9e76', date: '2026-06-25' });
+          const metaB = _makeMeta({ sessionId: '019eff4a-6eb8-7af2-9735-23025984e328', date: '2026-06-25' });
+          const resultA = await buildOutputPath('/out', 'codex', metaA, 'print-hello');
+          const resultB = await buildOutputPath('/out', 'codex', metaB, 'print-hello');
+          assertNotEquals(resultA, resultB);
+        });
+
+        it('T-EC-OP-02-02: 019eff4a-393e-... と 019eff4a-89f9-... は異なる出力パスになる', async () => {
+          const metaA = _makeMeta({ sessionId: '019eff4a-393e-7980-8ced-d185bd4d9e76', date: '2026-06-25' });
+          const metaC = _makeMeta({ sessionId: '019eff4a-89f9-7582-8978-455f490bf729', date: '2026-06-25' });
+          const resultA = await buildOutputPath('/out', 'codex', metaA, 'print-hello');
+          const resultC = await buildOutputPath('/out', 'codex', metaC, 'print-hello');
+          assertNotEquals(resultA, resultC);
+        });
+      });
     });
   });
 });

--- a/skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts
@@ -52,22 +52,24 @@ describe('buildOutputPath', () => {
   describe('Given: 通常の SessionMeta', () => {
     describe('When: buildOutputPath を呼び出す', () => {
       describe('Then: T-EC-SW-01 - 期待するパス文字列を返す', () => {
-        it('T-EC-SW-01-01: outputBase/agent/year/yearMonth/date-slug-hash.md の形式になる', () => {
-          const path = buildOutputPath('out', 'claude', BASE_META, 'test-question');
-          assertEquals(path, 'out/claude/2026/2026-03/2026-03-15-test-question-sessabcd.md');
+        it('T-EC-SW-01-01: outputBase/agent/year/yearMonth/date-slug-hash.md の形式になる', async () => {
+          const path = await buildOutputPath('out', 'claude', BASE_META, 'test-question');
+          // sessionHash(BASE_META.sessionId, 12) の先頭12文字
+          assertEquals(path, 'out/claude/2026/2026-03/2026-03-15-test-question-aa9da8ccb6de.md');
         });
       });
     });
   });
 
-  /** ハイフン除去後の文字列が8文字未満になる境界ケース。 */
+  /** 短い sessionId（ハイフン除去後8文字未満）でも固定長ハッシュが使われる境界ケース。 */
   describe('Given: sessionId のハイフン除去後の長さが8文字未満', () => {
     describe('When: buildOutputPath を呼び出す', () => {
-      describe('Then: T-EC-SW-02 - 短い文字列がそのままファイル名に使われる', () => {
-        it('T-EC-SW-02-01: sessionId="ab-cd" → ハッシュ部分が "abcd"（4文字）になる', () => {
+      describe('Then: T-EC-SW-02 - 短い sessionId でも固定長（12文字）のハッシュが使われる', () => {
+        it('T-EC-SW-02-01: sessionId="ab-cd" → ハッシュ部分が12文字の16進数になる', async () => {
           const meta: SessionMeta = { ...BASE_META, sessionId: 'ab-cd' };
-          const path = buildOutputPath('out', 'claude', meta, 'test-question');
-          assertStringIncludes(path, '2026-03-15-test-question-abcd.md');
+          const path = await buildOutputPath('out', 'claude', meta, 'test-question');
+          // sessionHash('ab-cd', 12) の先頭12文字
+          assertStringIncludes(path, '2026-03-15-test-question-5db3d84c79b4.md');
         });
       });
     });
@@ -76,11 +78,12 @@ describe('buildOutputPath', () => {
   /** sessionId に複数のハイフンが含まれる UUID 形式のケース。 */
   describe('Given: sessionId に複数のハイフンが含まれる（UUID 形式）', () => {
     describe('When: buildOutputPath を呼び出す', () => {
-      describe('Then: T-EC-SW-03 - すべてのハイフンが除去された先頭8文字が使われる', () => {
-        it('T-EC-SW-03-01: sessionId="a1-b2-c3-d4-e5" → ハッシュ部分が "a1b2c3d4"（先頭8文字）になる', () => {
+      describe('Then: T-EC-SW-03 - sessionId 全体を入力とした決定的ハッシュ（先頭12文字）が使われる', () => {
+        it('T-EC-SW-03-01: sessionId="a1-b2-c3-d4-e5" → sessionHash の先頭12文字が使われる', async () => {
           const meta: SessionMeta = { ...BASE_META, sessionId: 'a1-b2-c3-d4-e5' };
-          const path = buildOutputPath('out', 'claude', meta, 'test-question');
-          assertStringIncludes(path, '2026-03-15-test-question-a1b2c3d4.md');
+          const path = await buildOutputPath('out', 'claude', meta, 'test-question');
+          // sessionHash('a1-b2-c3-d4-e5', 12) の先頭12文字
+          assertStringIncludes(path, '2026-03-15-test-question-80c69dec6e3a.md');
         });
       });
     });

--- a/skills/export-chatlogs/scripts/libs/session-writer.ts
+++ b/skills/export-chatlogs/scripts/libs/session-writer.ts
@@ -8,7 +8,7 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
-import { generateHash } from '../../../_scripts/libs/io/hash.ts';
+import { generateHash, sessionHash } from '../../../_scripts/libs/io/hash.ts';
 import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 import { textToSlug } from '../../../_scripts/libs/text/slug-utils.ts';
@@ -29,16 +29,16 @@ export const resolveSessionId = async (sessionId: string | undefined): Promise<s
   sessionId ? sessionId : await generateHash(SESSION_ID_FALLBACK);
 
 /** セッションの Markdown ファイル出力パスを生成する。 */
-export const buildOutputPath = (
+export const buildOutputPath = async (
   outputBase: string,
   agent: string,
   meta: SessionMeta,
   slug: string,
-): string => {
+): Promise<string> => {
   const yearMonth = meta.date.slice(0, 7);
   const year = meta.date.slice(0, 4);
-  const sessionId8 = meta.sessionId.replace(/-/g, '').slice(0, 8);
-  const filename = `${meta.date}-${slug}-${sessionId8}.md`;
+  const sessionIdHash = await sessionHash(meta.sessionId);
+  const filename = `${meta.date}-${slug}-${sessionIdHash}.md`;
   return `${outputBase}/${agent}/${year}/${yearMonth}/${filename}`;
 };
 
@@ -73,7 +73,7 @@ export const writeSession = async (
   session: ExportedSession,
 ): Promise<string> => {
   const slug = textToSlug(session.meta.firstUserText, session.meta.slug || 'session');
-  const outPath = buildOutputPath(outputBase, agent, session.meta, slug);
+  const outPath = await buildOutputPath(outputBase, agent, session.meta, slug);
   const content = renderMarkdown(session.meta, session.turns);
 
   const dir = getDirectory(outPath);


### PR DESCRIPTION
## Overview

**Summary**
Fix output filename collisions by hashing the full session ID instead of a timestamp-correlated prefix.

**Background / Motivation**
UUIDv7 session IDs encode a timestamp in their leading bits, so sessions created close together in time can share the same first 8 characters once hyphens are stripped. This caused a real collision: two distinct sessions produced the same output filename, and one export silently overwrote the other.

## Changes

### Core Changes

- `skills/_scripts/libs/io/hash.ts`: add `sessionHash(input, length = 12)`, a deterministic SHA-256-based hash (no timestamp/random seed).
- `skills/export-chatlogs/scripts/libs/session-writer.ts`: `buildOutputPath` is now `async` and uses `sessionHash(meta.sessionId)` on the full session ID instead of the hyphen-stripped first 8 characters; `writeSession` awaits the new async call.

### Test Updates

- `skills/_scripts/libs/io/__tests__/unit/hash.unit.spec.ts`: add coverage for `sessionHash` determinism, default length (12), custom length (16), and differing output for differing input.
- `skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts`: update expectations for the new async `buildOutputPath` and hashed filename.
- `skills/export-chatlogs/scripts/__tests__/unit/output-path.unit.spec.ts`: update filename expectations, and add a regression test reproducing the real incident — two UUIDv7 session IDs with identical first 8 characters now resolve to different output paths.
- `skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts`: update the end-to-end filename expectation to the new hash segment.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

**Breaking changes:**

- Output filenames now use `sessionHash(sessionId)` instead of the hyphen-stripped first 8 characters. Re-running an export for a previously-exported session produces a different filename, so old files are not overwritten and may need manual cleanup.
- `buildOutputPath` changed from sync to async (`string` → `Promise<string>`). The only in-repo caller (`writeSession`) has been updated; any external caller will need to `await` it.
