### PR TITLE
fix(parallel): abort on task rejection and wrap parallel errors

### DIFF
--- a/skills/_scripts/classes/ChatlogCache.class.ts
+++ b/skills/_scripts/classes/ChatlogCache.class.ts
@@ -302,6 +302,7 @@ export class ChatlogCache<T extends object> {
    * フロントマターあり + `isComplete` false + 基本3フィールド不足 → `this.delete(filePath)` で削除してスキップ。
    *
    * 並列実行するため、glob の reject や writeFile / readTextFile の reject はそのまま伝播する。
+   * いずれかの操作が reject すると以降の未着手操作は中断される（`withConcurrency` の abort-on-reject 挙動）。
    *
    * @param outputDir - `.md` ファイルを探索するディレクトリパス
    * @param isComplete - テキストを受け取り完全書き込み対象か判定する述語（省略時は全5フィールド揃い判定）

--- a/skills/_scripts/classes/ChatlogCache.class.ts
+++ b/skills/_scripts/classes/ChatlogCache.class.ts
@@ -302,7 +302,10 @@ export class ChatlogCache<T extends object> {
    * フロントマターあり + `isComplete` false + 基本3フィールド不足 → `this.delete(filePath)` で削除してスキップ。
    *
    * 並列実行するため、glob の reject や writeFile / readTextFile の reject はそのまま伝播する。
-   * いずれかの操作が reject すると以降の未着手操作は中断される（`withConcurrency` の abort-on-reject 挙動）。
+   * 書き込み対象と削除対象は独立した `runConcurrent` 呼び出しで並行実行するため、
+   * 一方が reject しても他方の未着手タスクは中断されず最後まで実行が試みられる
+   * （`withConcurrency` の abort-on-reject 挙動は各 `runConcurrent` 呼び出し内で閉じている）。
+   * 両方の完了を待った上で、いずれかが reject していればそのエラーを伝播する。
    *
    * @param outputDir - `.md` ファイルを探索するディレクトリパス
    * @param isComplete - テキストを受け取り完全書き込み対象か判定する述語（省略時は全5フィールド揃い判定）
@@ -329,18 +332,19 @@ export class ChatlogCache<T extends object> {
       }, concurrency)
     ).filter((e): e is { filePath: string; key: string; status: _EntryStatus; meta: FrontmatterFields } => e !== null);
 
-    // step 3: 書き込み対象（written / empty）と削除対象に分けて実行
+    // step 3: 書き込み対象（written / empty）と削除対象を独立した並列実行で処理する
     const _toWrite = _classified.filter(({ status }) => status !== 'delete');
     const _toDelete = _classified.filter(({ status }) => status === 'delete');
 
-    const _ops = [
-      ..._toWrite.map(({ key, status, meta }) => () => {
+    const [_writeResult, _deleteResult] = await Promise.allSettled([
+      runConcurrent(_toWrite, ({ key, status, meta }) => {
         const _cacheStatus = status === 'written' ? CACHE_STATUSES.WRITTEN : CACHE_STATUSES.EMPTY;
         return this._writeFile(key, { ...meta, status: _cacheStatus } as unknown as Partial<T>);
-      }),
-      ..._toDelete.map(({ filePath }) => () => this.delete(filePath)),
-    ];
-    await runConcurrent(_ops, (op) => op(), concurrency);
+      }, concurrency),
+      runConcurrent(_toDelete, ({ filePath }) => this.delete(filePath), concurrency),
+    ]);
+    if (_writeResult.status === 'rejected') { throw _writeResult.reason; }
+    if (_deleteResult.status === 'rejected') { throw _deleteResult.reason; }
   }
 
   /**

--- a/skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts
@@ -1130,6 +1130,59 @@ describe('ChatlogCache', () => {
         await _cache.ready;
         await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
       });
+
+      it('[Error] T-CLS-CC-84: write失敗（concurrency:1）でも delete 対象の removeFile は実行が試みられ、initFromOutputDir が reject する', async () => {
+        const _buf = new Map<string, string>([
+          // write 対象（基本3フィールドあり → status:'' で書き込み）
+          ['/out/write-target.md', '---\ntitle: A\ntype: tech\ncategory: dev\n---\n'],
+          // delete 対象（フロントマターはあるが基本3フィールド不足）
+          ['/out/delete-target.md', '---\ntitle: B\n---\n'],
+        ]);
+        const _writeErr = new Error('disk full');
+        let _removeFileCalled = false;
+        const _cache = new ChatlogCache<{ status: string }>('sub', '/cache', undefined, {
+          cache: {
+            ..._makeBufferProviders(_buf),
+            glob: _makePatternGlob(['/out/write-target.md', '/out/delete-target.md']),
+            writeTextFile: (_path: string, _data: string): Promise<void> => Promise.reject(_writeErr),
+            removeFile: (path: string): Promise<void> => {
+              _removeFileCalled = true;
+              _buf.delete(path);
+              return Promise.resolve();
+            },
+          },
+        });
+        await _cache.ready;
+        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 1));
+        assertEquals(_removeFileCalled, true);
+      });
+
+      it('[Error] T-CLS-CC-85: delete失敗（concurrency:1）でも write 対象の writeTextFile は実行が試みられ、initFromOutputDir が reject する', async () => {
+        const _buf = new Map<string, string>([
+          // write 対象（基本3フィールドあり → status:'' で書き込み）
+          ['/out/write-target.md', '---\ntitle: A\ntype: tech\ncategory: dev\n---\n'],
+          // delete 対象（フロントマターはあるが基本3フィールド不足）
+          ['/out/delete-target.md', '---\ntitle: B\n---\n'],
+        ]);
+        // NotFound 以外のエラーで reject（delete() は NotFound のみ握りつぶすため）
+        const _removeErr = new Error('remove failed');
+        let _writeTextFileCalled = false;
+        const _cache = new ChatlogCache<{ status: string }>('sub', '/cache', undefined, {
+          cache: {
+            ..._makeBufferProviders(_buf),
+            glob: _makePatternGlob(['/out/write-target.md', '/out/delete-target.md']),
+            writeTextFile: (path: string, data: string): Promise<void> => {
+              _writeTextFileCalled = true;
+              _buf.set(path, data);
+              return Promise.resolve();
+            },
+            removeFile: (_path: string): Promise<void> => Promise.reject(_removeErr),
+          },
+        });
+        await _cache.ready;
+        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 1));
+        assertEquals(_writeTextFileCalled, true);
+      });
     });
   });
 

--- a/skills/_scripts/constants/chatlog-error.constants.ts
+++ b/skills/_scripts/constants/chatlog-error.constants.ts
@@ -16,4 +16,5 @@ export const ERROR_KIND_LABELS = {
   EnvVarNotAllowed: 'Env Var Not Allowed',
   EnvVarNotSet: 'Env Var Not Set',
   InvalidPath: 'Invalid Path',
+  ParallelExecutionError: 'Parallel Execution Error',
 } as const;

--- a/skills/_scripts/constants/chatlog-error.constants.ts
+++ b/skills/_scripts/constants/chatlog-error.constants.ts
@@ -17,4 +17,5 @@ export const ERROR_KIND_LABELS = {
   EnvVarNotSet: 'Env Var Not Set',
   InvalidPath: 'Invalid Path',
   ParallelExecutionError: 'Parallel Execution Error',
+  Aborted: 'Aborted',
 } as const;

--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -42,6 +42,24 @@ const _makeCommandStub = (output: Deno.CommandOutput) => {
   };
 };
 
+/**
+ * `Deno.Command` の代替クラスを返すファクトリ。
+ * spawn().output() が常に reject するフェイクを生成する（外部 signal abort 時の挙動を再現）。
+ *
+ * @returns `Deno.Command` と互換の偽クラス
+ */
+const _makeRejectingCommandStub = () => {
+  return class {
+    constructor(_cmd: string, _opts: unknown) {}
+    spawn() {
+      return {
+        stdin: { getWriter: () => ({ write: () => Promise.resolve(), close: () => Promise.resolve() }) },
+        output: () => Promise.reject(new Error('aborted')),
+      };
+    }
+  };
+};
+
 // constants
 /** レートリミット検出のテーブル駆動ケース (RA-13, RA-14, RA-15)。 */
 const _rateLimitCases = [
@@ -252,6 +270,48 @@ describe('runAI', () => {
         try {
           const _result = await runAI('sys', 'user', { model: 'sonnet' });
           assertEquals(_result, 'hello');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+    });
+  });
+
+  /**
+   * 外部から渡された `AbortSignal` による中断の検証。
+   *
+   * `options.signal` が abort された状態でサブプロセスが失敗した場合、
+   * タイムアウトとは区別された ChatlogError('Aborted', 'ExternalAbort') がスローされることを確認する。
+   */
+  describe('external signal abort', () => {
+    /** 外部 signal が原因で中断されるケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-LIB-AI-RA-16: runAI — options.signal が abort 済み → ChatlogError(Aborted) subindex=ExternalAbort', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeRejectingCommandStub() as unknown as typeof Deno.Command;
+        const _externalController = new AbortController();
+        _externalController.abort();
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet', signal: _externalController.signal }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'Aborted');
+          assertEquals(_err.subindex, 'ExternalAbort');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-17: runAI — signal 未指定でサブプロセス失敗 → ChatlogError(AiError) がそのまま伝播する（回帰確認）', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeRejectingCommandStub() as unknown as typeof Deno.Command;
+        try {
+          await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            Error,
+            'aborted',
+          );
         } finally {
           Deno.Command = _origCommand;
         }

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -24,6 +24,7 @@ import { AI_BACKEND_COMMAND_MAP } from '../../types/ai.const.types.ts';
 export type RunAIOptions = {
   model?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 type _CommandSpec = { command: AiBackendCommand; args: string[]; hasSystemPromptWithArgs: boolean };
@@ -134,12 +135,13 @@ export const runAI = async (
   const _timer = _options.timeoutMs !== 0
     ? setTimeout(() => _controller.abort(), _options.timeoutMs)
     : undefined;
+  const _signals = _options.signal ? [_controller.signal, _options.signal] : [_controller.signal];
   const _cmd = new Deno.Command(_spec.command, {
     args: _spec.args,
     stdin: 'piped',
     stdout: 'piped',
     stderr: 'piped',
-    signal: _controller.signal,
+    signal: AbortSignal.any(_signals),
   });
   try {
     const _process = _cmd.spawn();
@@ -159,6 +161,9 @@ export const runAI = async (
     }
     return new TextDecoder().decode(_output.stdout).trim();
   } catch (e) {
+    if (_options.signal?.aborted) {
+      throw new ChatlogError('Aborted', 'ExternalAbort', `${_spec.command} was aborted by an external signal`);
+    }
     if (_controller.signal.aborted) {
       throw new ChatlogError('TimedOut', 'Timeout', `${_spec.command} timed out after ${_options.timeoutMs}ms`);
     }

--- a/skills/_scripts/libs/io/__tests__/unit/hash.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/hash.unit.spec.ts
@@ -14,7 +14,7 @@ import { describe, it } from '@std/testing/bdd';
 import { DEFAULT_HASH_LENGTH } from '../../../../constants/defaults.constants.ts';
 
 // test target
-import { generateHash } from '../../hash.ts';
+import { generateHash, sessionHash } from '../../hash.ts';
 
 // -- types --
 import type { GenerateHashOptions } from '../../../../types/common.types.ts';
@@ -129,6 +129,71 @@ describe('generateHash', () => {
         it('T-LIB-H-04-01: "project-a" と "project-b" の結果が異なる', async () => {
           const ra = await generateHash('project-a');
           const rb = await generateHash('project-b');
+          assertNotEquals(ra, rb);
+        });
+      });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// sessionHash
+// ─────────────────────────────────────────────
+
+/**
+ * `sessionHash` のユニットテストスイート。
+ *
+ * 入力文字列から決定的な SHA-256 16進数文字列を生成する関数の
+ * 決定性・デフォルト長・長さ指定・入力差分反映の各ケースをカバーする。
+ *
+ * @see sessionHash
+ */
+describe('sessionHash', () => {
+  describe('Given: 同じ input "same-input" で2回呼び出す', () => {
+    describe('When: sessionHash を連続で2回呼び出す', () => {
+      describe('Then: T-LIB-SH-01 - 毎回同じ値を返す（決定性の確認）', () => {
+        it('T-LIB-SH-01-01: 1回目と2回目の結果が一致する', async () => {
+          const r1 = await sessionHash('same-input');
+          const r2 = await sessionHash('same-input');
+          assertEquals(r1, r2);
+        });
+      });
+    });
+  });
+
+  describe('Given: filenameBase="base", options を省略', () => {
+    describe('When: sessionHash("base") を呼び出す', () => {
+      describe('Then: T-LIB-SH-02 - デフォルト長 12 の16進数文字列を返す', () => {
+        it('T-LIB-SH-02-01: 結果の長さが 12 である', async () => {
+          const result = await sessionHash('base');
+          assertEquals(result.length, 12);
+        });
+
+        it('T-LIB-SH-02-02: 結果が /^[0-9a-f]+$/ にマッチする', async () => {
+          const result = await sessionHash('base');
+          assertMatch(result, /^[0-9a-f]+$/);
+        });
+      });
+    });
+  });
+
+  describe('Given: input="base", length=16', () => {
+    describe('When: sessionHash("base", 16) を呼び出す', () => {
+      describe('Then: T-LIB-SH-03 - 指定長の16進数文字列を返す', () => {
+        it('T-LIB-SH-03-01: 結果の長さが 16 である', async () => {
+          const result = await sessionHash('base', 16);
+          assertEquals(result.length, 16);
+        });
+      });
+    });
+  });
+
+  describe('Given: 異なる input "input-a" と "input-b"', () => {
+    describe('When: それぞれ sessionHash を呼び出す', () => {
+      describe('Then: T-LIB-SH-04 - 異なる input は異なる結果を返す', () => {
+        it('T-LIB-SH-04-01: "input-a" と "input-b" の結果が異なる', async () => {
+          const ra = await sessionHash('input-a');
+          const rb = await sessionHash('input-b');
           assertNotEquals(ra, rb);
         });
       });

--- a/skills/_scripts/libs/io/hash.ts
+++ b/skills/_scripts/libs/io/hash.ts
@@ -140,3 +140,16 @@ export const generateHash = async (
   const hex = await _sha256Hex(seed);
   return hex.slice(0, length);
 };
+
+/**
+ * 入力文字列から決定的な SHA-256 ハッシュを生成する。
+ * `generateHash` と異なりタイムスタンプ・乱数を混ぜないため、同じ input なら常に同じ値を返す。
+ *
+ * @param input ハッシュ計算の入力文字列（例: sessionId）
+ * @param length 返す16進数文字列の長さ（デフォルト: 12）
+ * @returns 先頭 `length` 文字の16進数ハッシュ文字列
+ */
+export const sessionHash = async (input: string, length = 12): Promise<string> => {
+  const hex = await _sha256Hex(input);
+  return hex.slice(0, length);
+};

--- a/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
+++ b/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
@@ -225,6 +225,54 @@ describe('withConcurrency', () => {
     });
   });
 
+  describe('Given: limit=2 で先頭タスクが速く reject し、他ワーカーがまだ実行中', () => {
+    describe('When: withConcurrency(tasks, 2) を実行する', () => {
+      describe('Then: T-LIB-C-25 - reject 返却前に実行中の他ワーカーの完了を待つ', () => {
+        it('T-LIB-C-25-01: reject が呼び出し元に返る時点で実行中タスクは完了している', async () => {
+          let _task1Done = false;
+          const _tasks = [
+            async () => {
+              await new Promise((r) => setTimeout(r, 5));
+              throw new Error('task0 failed');
+            },
+            async () => {
+              await new Promise((r) => setTimeout(r, 30));
+              _task1Done = true;
+              return 1;
+            },
+          ];
+          await assertRejects(
+            () => withConcurrency(_tasks, 2),
+            Error,
+            'task0 failed',
+          );
+          assertEquals(_task1Done, true);
+        });
+      });
+    });
+  });
+
+  describe('Given: limit=2 で先頭タスクが即時 reject し、他ワーカーが後から reject する', () => {
+    describe('When: withConcurrency(tasks, 2) を実行する', () => {
+      describe('Then: T-LIB-C-26 - 全ワーカー完了を待った上でも最初に発生したエラーが伝播する', () => {
+        it('T-LIB-C-26-01: 先頭タスクの reject が後発タスクの reject より優先して伝播する', async () => {
+          const _tasks = [
+            () => Promise.reject(new Error('first')),
+            async () => {
+              await new Promise((r) => setTimeout(r, 20));
+              throw new Error('second');
+            },
+          ];
+          await assertRejects(
+            () => withConcurrency(_tasks, 2),
+            Error,
+            'first',
+          );
+        });
+      });
+    });
+  });
+
   describe('Given: limit=1（順序実行）', () => {
     describe('When: withConcurrency を実行する', () => {
       describe('Then: T-LIB-C-16 - タスクが順序通りに実行され結果が入力順で返る', () => {
@@ -336,6 +384,50 @@ describe('withConcurrency', () => {
           const results = await withConcurrency(tasks, 2);
 
           assertEquals(results, ['a', 'b', 'c']);
+        });
+      });
+    });
+  });
+
+  describe('Given: limit=2 でタスク0が即時 reject し、タスク1が ctl.signal の abort を購読する', () => {
+    describe('When: withConcurrency(tasks, 2) を実行する', () => {
+      describe('Then: T-LIB-C-27 - 実行中タスクが abort シグナルを尊重して速やかに完了する', () => {
+        it('T-LIB-C-27-01: reject が伝播し、タスク1は abort 経由で完了しタスク2は未着手のまま', async () => {
+          let _task1ResolvedVia: 'abort' | 'timeout' | undefined;
+          const _calls: number[] = [];
+          const _tasks = [
+            () => {
+              _calls.push(0);
+              return Promise.reject(new Error('boom'));
+            },
+            (ctl: AbortController) => {
+              _calls.push(1);
+              return new Promise<number>((resolve) => {
+                const _timer = setTimeout(() => {
+                  _task1ResolvedVia = 'timeout';
+                  resolve(1);
+                }, 50);
+                ctl.signal.addEventListener('abort', () => {
+                  clearTimeout(_timer);
+                  _task1ResolvedVia = 'abort';
+                  resolve(1);
+                });
+              });
+            },
+            () => {
+              _calls.push(2);
+              return Promise.resolve(2);
+            },
+          ];
+
+          await assertRejects(
+            () => withConcurrency(_tasks, 2),
+            Error,
+            'boom',
+          );
+
+          assertEquals(_task1ResolvedVia, 'abort');
+          assertEquals(_calls.includes(2), false);
         });
       });
     });

--- a/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
+++ b/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
@@ -145,6 +145,83 @@ describe('withConcurrency', () => {
     });
   });
 
+  describe('Given: limit=1 で先頭タスクが reject する', () => {
+    describe('When: withConcurrency(tasks, 1) を実行する', () => {
+      describe('Then: T-LIB-C-19 - reject 検知で自動 abort され後続タスクは呼ばれない', () => {
+        it('T-LIB-C-19-01: 先頭タスクの reject で後続タスクは呼ばれず calls が [0] になる', async () => {
+          const _calls: number[] = [];
+          const _tasks = [0, 1, 2].map((n) => () => {
+            _calls.push(n);
+            return n === 0 ? Promise.reject(new Error('task0 failed')) : Promise.resolve(n * 10);
+          });
+          await assertRejects(
+            () => withConcurrency(_tasks, 1),
+            Error,
+            'task0 failed',
+          );
+          assertEquals(_calls, [0]);
+        });
+
+        it('T-LIB-C-19-02: 先頭タスクの reject で ctl.signal.aborted が true になる', async () => {
+          let _capturedCtl: AbortController | undefined;
+          const _tasks = [
+            (ctl: AbortController) => {
+              _capturedCtl = ctl;
+              return Promise.reject(new Error('task0 failed'));
+            },
+          ];
+          await assertRejects(
+            () => withConcurrency(_tasks, 1),
+            Error,
+            'task0 failed',
+          );
+          assertEquals(_capturedCtl?.signal.aborted, true);
+        });
+      });
+    });
+  });
+
+  describe('Given: limit=2 でタスクが reject し他ワーカーが実行中', () => {
+    describe('When: withConcurrency(tasks, 2) を実行する', () => {
+      describe('Then: T-LIB-C-20 - reject 後に未着手タスクへ着手しない', () => {
+        it('T-LIB-C-20-01: reject 発生後、他ワーカーは以降のタスクを取得しない', async () => {
+          const _calls: number[] = [];
+          const _tasks = [
+            async () => {
+              _calls.push(0);
+              await new Promise((r) => setTimeout(r, 5));
+              throw new Error('task0 failed');
+            },
+            async () => {
+              _calls.push(1);
+              await new Promise((r) => setTimeout(r, 20));
+              _calls.push(-1);
+              return 1;
+            },
+            () => {
+              _calls.push(2);
+              return Promise.resolve(2);
+            },
+            () => {
+              _calls.push(3);
+              return Promise.resolve(3);
+            },
+          ];
+          await assertRejects(
+            () => withConcurrency(_tasks, 2),
+            Error,
+            'task0 failed',
+          );
+          // worker1 は task1 の完了(20ms)を待つ間に worker0 が5msでrejectしabortされるため、
+          // task2/task3（未着手）には着手しないはず。worker1 の継続を待ってから検証する。
+          await new Promise((r) => setTimeout(r, 30));
+          assertEquals(_calls.includes(2), false);
+          assertEquals(_calls.includes(3), false);
+        });
+      });
+    });
+  });
+
   describe('Given: limit=1（順序実行）', () => {
     describe('When: withConcurrency を実行する', () => {
       describe('Then: T-LIB-C-16 - タスクが順序通りに実行され結果が入力順で返る', () => {

--- a/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
+++ b/skills/_scripts/libs/parallel/__tests__/unit/concurrency.unit.spec.ts
@@ -7,11 +7,14 @@
 // https://opensource.org/licenses/MIT
 
 // -- BDD modules --
-import { assertEquals, assertRejects } from '@std/assert';
+import { assertEquals, assertInstanceOf, assertRejects } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // -- test target --
 import { createTasks, runChunked, runConcurrent, withConcurrency } from '../../concurrency.ts';
+
+// -- helpers --
+import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
 
 // ─────────────────────────────────────────────
 // withConcurrency
@@ -431,6 +434,43 @@ describe('runConcurrent', () => {
       });
     });
   });
+
+  describe('Given: fn が ChatlogError で reject する', () => {
+    describe('When: runConcurrent を実行する', () => {
+      describe('Then: T-LIB-C-21 - ChatlogError はラップされず元の kind のまま伝播する', () => {
+        it('T-LIB-C-21-01: throw された ChatlogError がそのまま（kind=FileDirNotFound）伝播する', async () => {
+          const _error = await assertRejects(
+            () =>
+              runConcurrent(
+                [1],
+                () => Promise.reject(new ChatlogError('FileDirNotFound', 'somewhere', 'not found')),
+                2,
+              ),
+            ChatlogError,
+          );
+          assertEquals(_error.kind, 'FileDirNotFound');
+          assertEquals(_error.subindex, 'somewhere');
+        });
+      });
+    });
+  });
+
+  describe('Given: fn が素の Error で reject する', () => {
+    describe('When: runConcurrent を実行する', () => {
+      describe('Then: T-LIB-C-22 - 素の Error が ParallelExecutionError でラップされる', () => {
+        it('T-LIB-C-22-01: throw された Error が kind=ParallelExecutionError, subindex=Error でラップされる', async () => {
+          const _error = await assertRejects(
+            () => runConcurrent([1], () => Promise.reject(new Error('boom')), 2),
+            ChatlogError,
+          );
+          assertInstanceOf(_error, ChatlogError);
+          assertEquals(_error.kind, 'ParallelExecutionError');
+          assertEquals(_error.subindex, 'Error');
+          assertEquals(_error.message.includes('boom'), true);
+        });
+      });
+    });
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -496,6 +536,43 @@ describe('runChunked', () => {
           const _results = await runChunked([10, 20, 30], 1, _fn, 2);
           assertEquals(_received, [[10], [20], [30]]);
           assertEquals(_results, [10, 20, 30]);
+        });
+      });
+    });
+  });
+
+  describe('Given: chunk 内の fn が ChatlogError で reject する', () => {
+    describe('When: runChunked を実行する', () => {
+      describe('Then: T-LIB-C-23 - ChatlogError はラップされず元の kind のまま伝播する', () => {
+        it('T-LIB-C-23-01: throw された ChatlogError がそのまま（kind=FileDirNotFound）伝播する', async () => {
+          const _error = await assertRejects(
+            () =>
+              runChunked(
+                [1, 2],
+                2,
+                () => Promise.reject(new ChatlogError('FileDirNotFound', 'somewhere', 'not found')),
+                2,
+              ),
+            ChatlogError,
+          );
+          assertEquals(_error.kind, 'FileDirNotFound');
+          assertEquals(_error.subindex, 'somewhere');
+        });
+      });
+    });
+  });
+
+  describe('Given: chunk 内の fn が素の Error で reject する', () => {
+    describe('When: runChunked を実行する', () => {
+      describe('Then: T-LIB-C-24 - 素の Error が ParallelExecutionError でラップされる', () => {
+        it('T-LIB-C-24-01: throw された Error が kind=ParallelExecutionError, subindex=Error でラップされる', async () => {
+          const _error = await assertRejects(
+            () => runChunked([1, 2], 2, () => Promise.reject(new Error('boom')), 2),
+            ChatlogError,
+          );
+          assertEquals(_error.kind, 'ParallelExecutionError');
+          assertEquals(_error.subindex, 'Error');
+          assertEquals(_error.message.includes('boom'), true);
         });
       });
     });

--- a/skills/_scripts/libs/parallel/concurrency.ts
+++ b/skills/_scripts/libs/parallel/concurrency.ts
@@ -20,7 +20,9 @@ export type { Task } from '../../types/common.types.ts';
  *
  * `ctl.abort()` が呼ばれた後は未着手タスクを実行せず、結果配列の該当インデックスは
  * 穴（未代入）のまま残る。いずれかのタスクが reject した場合は直ちに `ctl.abort()` を呼び、
- * 全ワーカーの未着手タスク着手を止めたうえで、最初に発生したエラーを呼び出し元に伝播する。
+ * 全ワーカーの未着手タスク着手を止める。ただし、実行中の他ワーカーが副作用を伴う処理を
+ * 継続している可能性があるため、呼び出し元へエラーを返す前に全ワーカーの終了を待ち、
+ * その後で最初に発生したエラーを呼び出し元に伝播する。
  */
 export const withConcurrency = async <T>(
   tasks: Task<T>[],
@@ -29,18 +31,26 @@ export const withConcurrency = async <T>(
   const results: T[] = new Array(tasks.length);
   const ctl = new AbortController();
   let idx = 0;
+  let _errored = false;
+  let _firstError: unknown;
   const _worker = async (): Promise<void> => {
     while (idx < tasks.length && !ctl.signal.aborted) {
       const i = idx++;
       try {
         results[i] = await tasks[i](ctl);
       } catch (e) {
+        if (!_errored) {
+          _errored = true;
+          _firstError = e;
+        }
         ctl.abort();
-        throw e;
       }
     }
   };
-  await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, _worker));
+  await Promise.allSettled(Array.from({ length: Math.min(limit, tasks.length) }, _worker));
+  if (_errored) {
+    throw _firstError;
+  }
   return results;
 };
 

--- a/skills/_scripts/libs/parallel/concurrency.ts
+++ b/skills/_scripts/libs/parallel/concurrency.ts
@@ -6,6 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 import type { Task } from '../../types/common.types.ts';
 
 export type { Task } from '../../types/common.types.ts';
@@ -76,24 +77,48 @@ export const createChunkedTasks = <T, R>(
 // ─────────────────────────────────────────────
 
 /**
+ * `withConcurrency` で発生した例外を `ChatlogError('ParallelExecutionError', ...)` にラップする。
+ *
+ * 元の例外が既に `ChatlogError` の場合は、呼び出し元の既存 `kind` 分岐を壊さないよう
+ * ラップせずそのまま返す。それ以外の場合は `Error.name`（不明な場合は `'UnknownError'`）を
+ * `subindex` として `ChatlogError('ParallelExecutionError', ...)` にラップする。
+ */
+const _wrapParallelError = (e: unknown): Error => {
+  if (e instanceof ChatlogError) {
+    return e;
+  }
+  const _subindex = e instanceof Error ? e.name : 'UnknownError';
+  const _detail = e instanceof Error ? e.message : String(e);
+  return new ChatlogError('ParallelExecutionError', _subindex, _detail);
+};
+
+/**
  * `items` の各要素に `fn` を並列度 `limit` で適用し、入力順の結果配列を返す。
  */
-export const runConcurrent = <T, R>(
+export const runConcurrent = async <T, R>(
   items: T[],
   fn: (item: T, ctl: AbortController) => Promise<R>,
   limit: number,
 ): Promise<R[]> => {
-  return withConcurrency(createTasks(items, fn), limit);
+  try {
+    return await withConcurrency(createTasks(items, fn), limit);
+  } catch (e) {
+    throw _wrapParallelError(e);
+  }
 };
 
 /**
  * `items` を `chunkSize` 単位に分割し、各 chunk に `fn` を並列度 `limit` で適用する。
  */
-export const runChunked = <T, R>(
+export const runChunked = async <T, R>(
   items: T[],
   chunkSize: number,
   fn: (chunk: T[], ctl: AbortController) => Promise<R>,
   limit: number,
 ): Promise<R[]> => {
-  return withConcurrency(createChunkedTasks(items, chunkSize, fn), limit);
+  try {
+    return await withConcurrency(createChunkedTasks(items, chunkSize, fn), limit);
+  } catch (e) {
+    throw _wrapParallelError(e);
+  }
 };

--- a/skills/_scripts/libs/parallel/concurrency.ts
+++ b/skills/_scripts/libs/parallel/concurrency.ts
@@ -18,7 +18,8 @@ export type { Task } from '../../types/common.types.ts';
  * 非同期タスク配列を並列度 `limit` で実行し、入力順の結果配列を返す。
  *
  * `ctl.abort()` が呼ばれた後は未着手タスクを実行せず、結果配列の該当インデックスは
- * 穴（未代入）のまま残る。
+ * 穴（未代入）のまま残る。いずれかのタスクが reject した場合は直ちに `ctl.abort()` を呼び、
+ * 全ワーカーの未着手タスク着手を止めたうえで、最初に発生したエラーを呼び出し元に伝播する。
  */
 export const withConcurrency = async <T>(
   tasks: Task<T>[],
@@ -30,7 +31,12 @@ export const withConcurrency = async <T>(
   const _worker = async (): Promise<void> => {
     while (idx < tasks.length && !ctl.signal.aborted) {
       const i = idx++;
-      results[i] = await tasks[i](ctl);
+      try {
+        results[i] = await tasks[i](ctl);
+      } catch (e) {
+        ctl.abort();
+        throw e;
+      }
     }
   };
   await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, _worker));

--- a/skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/functional/write-session.functional.spec.ts
@@ -246,20 +246,19 @@ describe('writeSession', () => {
 
   /**
    * sessionId ハッシュのファイル名への埋め込みを確認するシナリオ。
-   * ハイフンを除去した先頭 8 文字が含まれることで、
+   * sessionId 全体を入力とした決定的な SHA-256 ハッシュ（先頭12文字）が含まれることで、
    * 同一日付の別セッションとのファイル名衝突を防ぐ設計の確認。
-   * ハイフンを除去した先頭 8 文字が含まれることで、同一日付の別セッションとの衝突を防ぐ設計の確認。
    */
   describe('Given: sessionId="sess-abcdef12-3456-7890-abcd-ef1234567890"', () => {
     /** writeSession を呼び出す */
     describe('When: writeSession を呼び出す', () => {
-      /** T-EC-WS-06: ファイル名に sessionId 先頭8文字（ハイフン除去）が含まれる */
-      describe('Then: T-EC-WS-06 - ファイル名に sessionId 先頭8文字（ハイフン除去）が含まれる', () => {
-        it('T-EC-WS-06-01: パスに "sessabcd" が含まれる', async () => {
+      /** T-EC-WS-06: ファイル名に sessionId 全体の SHA-256 ハッシュ先頭12文字が含まれる */
+      describe('Then: T-EC-WS-06 - ファイル名に sessionId 全体の決定的ハッシュ（先頭12文字）が含まれる', () => {
+        it('T-EC-WS-06-01: パスに "aa9da8ccb6de" が含まれる', async () => {
           const session = _makeSession();
           const outPath = await writeSession(tempDir, 'claude', session);
-          // "sess-abcdef12-..." → ハイフン除去 → "sessabcdef12..." → 先頭8文字 → "sessabcd"
-          assertStringIncludes(outPath, 'sessabcd');
+          // sessionHash('sess-abcdef12-3456-7890-abcd-ef1234567890', 12) の先頭12文字
+          assertStringIncludes(outPath, 'aa9da8ccb6de');
         });
       });
     });

--- a/skills/export-chatlogs/scripts/__tests__/unit/output-path.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/output-path.unit.spec.ts
@@ -7,7 +7,7 @@
 // This software is released under the MIT License.
 
 // ─── BDD modules
-import { assertStringIncludes } from '@std/assert';
+import { assertNotEquals, assertStringIncludes } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -57,11 +57,11 @@ describe('buildOutputPath', () => {
     describe('When: buildOutputPath(...) を呼び出す', () => {
       /** T-EC-OP-01: 正しいパス構造を生成する */
       describe('Then: T-EC-OP-01 - 正しいパス構造を生成する', () => {
-        it('T-EC-OP-01-03: sessionId のハイフンを除去した先頭8文字が含まれる', () => {
+        it('T-EC-OP-01-03: sessionId 全体の決定的な SHA-256 ハッシュ（先頭12文字）が含まれる', async () => {
           const meta = _makeMeta({ sessionId: 'abc-def-12345678' });
-          const result = buildOutputPath('/out', 'claude', meta, 'test-slug');
-          // abcdef12 (ハイフン除去 → 'abcdef12345678' の先頭8文字)
-          assertStringIncludes(result, 'abcdef12');
+          const result = await buildOutputPath('/out', 'claude', meta, 'test-slug');
+          // sessionHash('abc-def-12345678', 12) の先頭12文字
+          assertStringIncludes(result, '996c4ad8c274');
         });
       });
     });
@@ -73,10 +73,40 @@ describe('buildOutputPath', () => {
    * パスに埋め込まれることを確認する。Obsidian の月別フォルダ整理に直結する仕様。
    */
   describe('Given: date="2026-03-15"', () => {
-    it('T-EC-OP-01-05: YYYY="2026", YYYY-MM="2026-03" が正しく埋め込まれる', () => {
+    it('T-EC-OP-01-05: YYYY="2026", YYYY-MM="2026-03" が正しく埋め込まれる', async () => {
       const meta = _makeMeta({ date: '2026-03-15' });
-      const result = buildOutputPath('/out', 'claude', meta, 'test');
+      const result = await buildOutputPath('/out', 'claude', meta, 'test');
       assertStringIncludes(result, '2026/2026-03/');
+    });
+  });
+
+  /**
+   * sessionId 衝突回避シナリオ。
+   *
+   * UUIDv7 はタイムスタンプ由来の先頭ビットを持つため、近接した時刻に生成された
+   * 複数の sessionId はハイフン除去後の先頭8文字が一致しうる（実際の障害事例）。
+   * sessionId 全体を入力とした決定的ハッシュにより、そのようなケースでも
+   * 異なるファイル名が生成されることを確認する。
+   */
+  describe('Given: ハイフン除去後の先頭8文字が一致する2つの UUIDv7 sessionId（実際の障害事例）', () => {
+    describe('When: それぞれ buildOutputPath を呼び出す', () => {
+      describe('Then: T-EC-OP-02 - 異なるファイル名が生成される（衝突回避）', () => {
+        it('T-EC-OP-02-01: 019eff4a-393e-... と 019eff4a-6eb8-... は異なる出力パスになる', async () => {
+          const metaA = _makeMeta({ sessionId: '019eff4a-393e-7980-8ced-d185bd4d9e76', date: '2026-06-25' });
+          const metaB = _makeMeta({ sessionId: '019eff4a-6eb8-7af2-9735-23025984e328', date: '2026-06-25' });
+          const resultA = await buildOutputPath('/out', 'codex', metaA, 'print-hello');
+          const resultB = await buildOutputPath('/out', 'codex', metaB, 'print-hello');
+          assertNotEquals(resultA, resultB);
+        });
+
+        it('T-EC-OP-02-02: 019eff4a-393e-... と 019eff4a-89f9-... は異なる出力パスになる', async () => {
+          const metaA = _makeMeta({ sessionId: '019eff4a-393e-7980-8ced-d185bd4d9e76', date: '2026-06-25' });
+          const metaC = _makeMeta({ sessionId: '019eff4a-89f9-7582-8978-455f490bf729', date: '2026-06-25' });
+          const resultA = await buildOutputPath('/out', 'codex', metaA, 'print-hello');
+          const resultC = await buildOutputPath('/out', 'codex', metaC, 'print-hello');
+          assertNotEquals(resultA, resultC);
+        });
+      });
     });
   });
 });

--- a/skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts
+++ b/skills/export-chatlogs/scripts/__tests__/unit/session-writer.unit.spec.ts
@@ -52,22 +52,24 @@ describe('buildOutputPath', () => {
   describe('Given: 通常の SessionMeta', () => {
     describe('When: buildOutputPath を呼び出す', () => {
       describe('Then: T-EC-SW-01 - 期待するパス文字列を返す', () => {
-        it('T-EC-SW-01-01: outputBase/agent/year/yearMonth/date-slug-hash.md の形式になる', () => {
-          const path = buildOutputPath('out', 'claude', BASE_META, 'test-question');
-          assertEquals(path, 'out/claude/2026/2026-03/2026-03-15-test-question-sessabcd.md');
+        it('T-EC-SW-01-01: outputBase/agent/year/yearMonth/date-slug-hash.md の形式になる', async () => {
+          const path = await buildOutputPath('out', 'claude', BASE_META, 'test-question');
+          // sessionHash(BASE_META.sessionId, 12) の先頭12文字
+          assertEquals(path, 'out/claude/2026/2026-03/2026-03-15-test-question-aa9da8ccb6de.md');
         });
       });
     });
   });
 
-  /** ハイフン除去後の文字列が8文字未満になる境界ケース。 */
+  /** 短い sessionId（ハイフン除去後8文字未満）でも固定長ハッシュが使われる境界ケース。 */
   describe('Given: sessionId のハイフン除去後の長さが8文字未満', () => {
     describe('When: buildOutputPath を呼び出す', () => {
-      describe('Then: T-EC-SW-02 - 短い文字列がそのままファイル名に使われる', () => {
-        it('T-EC-SW-02-01: sessionId="ab-cd" → ハッシュ部分が "abcd"（4文字）になる', () => {
+      describe('Then: T-EC-SW-02 - 短い sessionId でも固定長（12文字）のハッシュが使われる', () => {
+        it('T-EC-SW-02-01: sessionId="ab-cd" → ハッシュ部分が12文字の16進数になる', async () => {
           const meta: SessionMeta = { ...BASE_META, sessionId: 'ab-cd' };
-          const path = buildOutputPath('out', 'claude', meta, 'test-question');
-          assertStringIncludes(path, '2026-03-15-test-question-abcd.md');
+          const path = await buildOutputPath('out', 'claude', meta, 'test-question');
+          // sessionHash('ab-cd', 12) の先頭12文字
+          assertStringIncludes(path, '2026-03-15-test-question-5db3d84c79b4.md');
         });
       });
     });
@@ -76,11 +78,12 @@ describe('buildOutputPath', () => {
   /** sessionId に複数のハイフンが含まれる UUID 形式のケース。 */
   describe('Given: sessionId に複数のハイフンが含まれる（UUID 形式）', () => {
     describe('When: buildOutputPath を呼び出す', () => {
-      describe('Then: T-EC-SW-03 - すべてのハイフンが除去された先頭8文字が使われる', () => {
-        it('T-EC-SW-03-01: sessionId="a1-b2-c3-d4-e5" → ハッシュ部分が "a1b2c3d4"（先頭8文字）になる', () => {
+      describe('Then: T-EC-SW-03 - sessionId 全体を入力とした決定的ハッシュ（先頭12文字）が使われる', () => {
+        it('T-EC-SW-03-01: sessionId="a1-b2-c3-d4-e5" → sessionHash の先頭12文字が使われる', async () => {
           const meta: SessionMeta = { ...BASE_META, sessionId: 'a1-b2-c3-d4-e5' };
-          const path = buildOutputPath('out', 'claude', meta, 'test-question');
-          assertStringIncludes(path, '2026-03-15-test-question-a1b2c3d4.md');
+          const path = await buildOutputPath('out', 'claude', meta, 'test-question');
+          // sessionHash('a1-b2-c3-d4-e5', 12) の先頭12文字
+          assertStringIncludes(path, '2026-03-15-test-question-80c69dec6e3a.md');
         });
       });
     });
@@ -159,6 +162,44 @@ describe('renderMarkdown', () => {
         it('T-EC-SW-08-01: 出力に "slug: \'test-question\'" が含まれる', () => {
           const markdown = renderMarkdown(BASE_META, []);
           assertStringIncludes(markdown, `slug: '${BASE_META.slug}'`);
+        });
+      });
+    });
+  });
+
+  /** meta.project が undefined の場合、frontmatter に project 行が出力されないケース。 */
+  describe('Given: meta.project が undefined', () => {
+    describe('When: renderMarkdown を呼び出す', () => {
+      describe('Then: T-EC-SW-10 - frontmatter に project 行が出力されない', () => {
+        it('T-EC-SW-10-01: 出力に "project:" が含まれない', () => {
+          const meta: SessionMeta = { ...BASE_META, project: undefined };
+          const markdown = renderMarkdown(meta, []);
+          assertEquals(markdown.includes('project:'), false);
+        });
+      });
+    });
+  });
+
+  /** meta.project が空文字列の場合、frontmatter に project 行が出力されないケース。 */
+  describe('Given: meta.project が空文字列', () => {
+    describe('When: renderMarkdown を呼び出す', () => {
+      describe('Then: T-EC-SW-11 - frontmatter に project 行が出力されない', () => {
+        it('T-EC-SW-11-01: 出力に "project:" が含まれない', () => {
+          const meta: SessionMeta = { ...BASE_META, project: '' };
+          const markdown = renderMarkdown(meta, []);
+          assertEquals(markdown.includes('project:'), false);
+        });
+      });
+    });
+  });
+
+  /** meta.project が非空文字列の場合、frontmatter に project 行が出力されるケース（claude/codex のデグレ防止）。 */
+  describe('Given: meta.project が非空文字列', () => {
+    describe('When: renderMarkdown を呼び出す', () => {
+      describe('Then: T-EC-SW-12 - frontmatter に project 行が出力される', () => {
+        it('T-EC-SW-12-01: 出力に "project: \'my-project\'" が含まれる', () => {
+          const markdown = renderMarkdown(BASE_META, []);
+          assertStringIncludes(markdown, `project: '${BASE_META.project}'`);
         });
       });
     });

--- a/skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts
+++ b/skills/export-chatlogs/scripts/exporter/__tests__/functional/parse-chatgpt-conversation.functional.spec.ts
@@ -115,12 +115,12 @@ describe('parseChatGPTConversation', () => {
         assertEquals(result!.meta.sessionId, conv.conversation_id);
       });
 
-      // ─── T-EC-GP-01-03: meta.project === conv.title ──────────────────────
+      // ─── T-EC-GP-01-03: meta.project は未設定（classify-chatlogs が後付けする） ──
 
-      it('T-EC-GP-01-03: meta.project が conv.title と一致する', async () => {
+      it('T-EC-GP-01-03: meta.project が undefined になる', async () => {
         const conv = _makeNormalConv();
         const result = await parseChatGPTConversation(conv, ALL_PERIOD);
-        assertEquals(result!.meta.project, conv.title);
+        assertEquals(result!.meta.project, undefined);
       });
 
       // ─── T-EC-GP-01-04: turns.length が user+assistant の数 ──────────────

--- a/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
+++ b/skills/export-chatlogs/scripts/exporter/chatgpt-exporter.ts
@@ -167,7 +167,6 @@ export const parseChatGPTConversation = async (
   const meta: SessionMeta = {
     sessionId: await resolveSessionId(conv.conversation_id),
     date: isoToDate(isoTimestamp),
-    project: conv.title,
     slug: '',
     firstUserText: firstUserTurn.content,
   };

--- a/skills/export-chatlogs/scripts/libs/session-writer.ts
+++ b/skills/export-chatlogs/scripts/libs/session-writer.ts
@@ -8,7 +8,7 @@
 
 // ─── Shared modules ─────────────────────────────────────────────────────────
 // libs
-import { generateHash } from '../../../_scripts/libs/io/hash.ts';
+import { generateHash, sessionHash } from '../../../_scripts/libs/io/hash.ts';
 import { getDirectory } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 import { textToSlug } from '../../../_scripts/libs/text/slug-utils.ts';
@@ -29,16 +29,16 @@ export const resolveSessionId = async (sessionId: string | undefined): Promise<s
   sessionId ? sessionId : await generateHash(SESSION_ID_FALLBACK);
 
 /** セッションの Markdown ファイル出力パスを生成する。 */
-export const buildOutputPath = (
+export const buildOutputPath = async (
   outputBase: string,
   agent: string,
   meta: SessionMeta,
   slug: string,
-): string => {
+): Promise<string> => {
   const yearMonth = meta.date.slice(0, 7);
   const year = meta.date.slice(0, 4);
-  const sessionId8 = meta.sessionId.replace(/-/g, '').slice(0, 8);
-  const filename = `${meta.date}-${slug}-${sessionId8}.md`;
+  const sessionIdHash = await sessionHash(meta.sessionId);
+  const filename = `${meta.date}-${slug}-${sessionIdHash}.md`;
   return `${outputBase}/${agent}/${year}/${yearMonth}/${filename}`;
 };
 
@@ -48,7 +48,7 @@ export const renderMarkdown = (meta: SessionMeta, turns: Turn[]): string => {
   _lines.push('---');
   _lines.push(`session_id: ${quoteString(meta.sessionId)}`);
   _lines.push(`date: ${quoteString(meta.date)}`);
-  _lines.push(`project: ${quoteString(meta.project)}`);
+  if (meta.project) { _lines.push(`project: ${quoteString(meta.project)}`); }
   if (meta.slug) { _lines.push(`slug: ${quoteString(meta.slug)}`); }
   _lines.push('---');
   _lines.push('');
@@ -73,7 +73,7 @@ export const writeSession = async (
   session: ExportedSession,
 ): Promise<string> => {
   const slug = textToSlug(session.meta.firstUserText, session.meta.slug || 'session');
-  const outPath = buildOutputPath(outputBase, agent, session.meta, slug);
+  const outPath = await buildOutputPath(outputBase, agent, session.meta, slug);
   const content = renderMarkdown(session.meta, session.turns);
 
   const dir = getDirectory(outPath);

--- a/skills/export-chatlogs/scripts/types/session.types.ts
+++ b/skills/export-chatlogs/scripts/types/session.types.ts
@@ -20,8 +20,11 @@ export interface SessionMeta {
   sessionId: string;
   /** セッション開始日（YYYY-MM-DD 形式）。出力パスの年/月ディレクトリに使用する */
   date: string; // YYYY-MM-DD
-  /** セッション開始時の作業ディレクトリ名（末尾セグメント）。フロントマターの project フィールドになる */
-  project: string;
+  /**
+   * セッション開始時の作業ディレクトリ名（末尾セグメント）。フロントマターの project フィールドになる。
+   * ChatGPT には対応する情報がなく、`/classify-chatlogs` スキルが後付けするため未設定でよい。
+   */
+  project?: string;
   /** セッションのスラッグ文字列。Claude の場合は JSONL から取得し、Codex の場合は空文字列 */
   slug: string;
   /** 最初の意味あるユーザーメッセージ。Markdown の H1 見出しおよびスラッグ生成に使用する */

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -584,10 +584,13 @@ describe('main - Claude CLI NotFound', () => {
           });
 
           it('T-FL-E2E-07-01: NotFound エラーで main が reject される', async () => {
-            await assertRejects(
+            const _error = await assertRejects(
               () => main(['claude', '2026-03', '--input-dir', chatlogsDir]),
-              Deno.errors.NotFound,
+              ChatlogError,
             );
+
+            assertEquals(_error.kind, 'ParallelExecutionError');
+            assertEquals(_error.subindex, 'NotFound');
           });
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/integration/filter/with-concurrency.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/filter/with-concurrency.integration.spec.ts
@@ -87,4 +87,35 @@ describe('withConcurrency', () => {
       });
     });
   });
+
+  // ─── T-FL-WC-04: reject 返却前に実行中の他タスクの完了を待つ ───────────────
+
+  describe('Given: 一部のタスクが reject し、他タスクがまだ実行中の場合', () => {
+    describe('When: withConcurrency(tasks, limit) を呼び出す', () => {
+      describe('Then: T-FL-WC-04 - reject 返却前に実行中タスクの完了を待つ', () => {
+        it('T-FL-WC-04-01: reject が呼び出し元に返る時点で実行中タスクは完了している', async () => {
+          let otherTaskDone = false;
+          const tasks = [
+            async () => {
+              await new Promise((resolve) => setTimeout(resolve, 5));
+              throw new Error('タスク失敗');
+            },
+            async () => {
+              await new Promise((resolve) => setTimeout(resolve, 30));
+              otherTaskDone = true;
+              return 1;
+            },
+          ];
+
+          await assertRejects(
+            () => withConcurrency(tasks, 2),
+            Error,
+            'タスク失敗',
+          );
+
+          assertEquals(otherTaskDone, true);
+        });
+      });
+    });
+  });
 });

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -503,6 +503,87 @@ describe('processChunk', () => {
   });
 
   /**
+   * `ctl` が事前に abort 済みの状態で processChunk を呼び出す前提条件グループ。
+   *
+   * `withConcurrency` が他タスクの reject を検知して `ctl.abort()` を呼んだ後、
+   * 実行中の他チャンクが `processChunk` に入ってきた場合を模倣する。
+   * `runAI` に `ctl.signal` が渡されていれば `ChatlogError('Aborted', 'ExternalAbort', ...)` を
+   * throw するため、NotFound エラーではなく Aborted エラーとして扱われることを検証する。
+   */
+  describe('Given: ctl が事前に abort 済みの状態', () => {
+    /** processChunk([entry1, entry2], stats, threshold, cache, ctl) を呼び出すとき。 */
+    describe('When: processChunk([entry1, entry2], stats, threshold, cache, ctl) を呼び出す', () => {
+      /** stats.error が入力ファイル数分加算され、ChatlogError(Aborted) が返ることを検証する。 */
+      describe('Then: T-FL-PCK-11 - stats.error が加算され ChatlogError(Aborted) を返す', () => {
+        it('T-FL-PCK-11-01: stats.error が 2 になり ChatlogError(kind=Aborted, subindex=ExternalAbort) を返す', async () => {
+          const file1 = await _createTempFile('k1.md');
+          const entry1 = new ChatlogEntry(_TEMP_CONTENT, { filePath: file1 });
+          const file2 = await _createTempFile('k2.md');
+          const entry2 = new ChatlogEntry(_TEMP_CONTENT, { filePath: file2 });
+          commandHandle = installCommandMock(makeNotFoundMock());
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+          ctl.abort();
+
+          const result = await processChunk(
+            [entry1, entry2],
+            stats,
+            DEFAULT_CONFIG_VALUES.discardThreshold as number,
+            cache,
+            ctl,
+          );
+          errStub.restore();
+
+          assertEquals(stats.error, 2);
+          assertEquals(result instanceof ChatlogError, true);
+          assertEquals((result as ChatlogError).kind, 'Aborted');
+          assertEquals((result as ChatlogError).subindex, 'ExternalAbort');
+        });
+
+        it('T-FL-PCK-11-02: error 扱いになった各ファイル名がログに出力される', async () => {
+          const file1 = await _createTempFile('k3.md');
+          const entry1 = new ChatlogEntry(_TEMP_CONTENT, { filePath: file1 });
+          const file2 = await _createTempFile('k4.md');
+          const entry2 = new ChatlogEntry(_TEMP_CONTENT, { filePath: file2 });
+          commandHandle = installCommandMock(makeNotFoundMock());
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+          ctl.abort();
+
+          await processChunk([entry1, entry2], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
+          errStub.restore();
+
+          const logged = errStub.calls.map((c) => c.args.join(' ')).join('\n');
+          assertEquals(logged.includes('k3.md'), true);
+          assertEquals(logged.includes('k4.md'), true);
+        });
+
+        it('T-FL-PCK-11-03: Aborted エラーでは ctl.abort() が再度呼ばれない', async () => {
+          const file1 = await _createTempFile('k5.md');
+          const entry1 = new ChatlogEntry(_TEMP_CONTENT, { filePath: file1 });
+          commandHandle = installCommandMock(makeNotFoundMock());
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+          ctl.abort();
+          const abortStub = stub(ctl, 'abort');
+
+          await processChunk([entry1], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
+          errStub.restore();
+          abortStub.restore();
+
+          assertEquals(abortStub.calls.length, 0);
+        });
+      });
+    });
+  });
+
+  /**
    * Claude が JSON でないテキストを返すモックの前提条件グループ。
    *
    * JSON パース失敗時はチャンク内ファイルをすべて `stats.error` に計上し、

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -52,7 +52,7 @@ export const processChunk = async (
 
   let rawResult: string;
   try {
-    rawResult = await runAI(_SYSTEM_PROMPT, batchPrompt);
+    rawResult = await runAI(_SYSTEM_PROMPT, batchPrompt, { signal: ctl.signal });
   } catch (e) {
     if (!(e instanceof ChatlogError)) { throw e; }
     logger.warn(`  claude CLI 実行失敗。チャンク内ファイルをすべて error 扱い`);


### PR DESCRIPTION
## Overview

**Summary**
Abort unstarted parallel tasks on rejection and wrap raw errors for consistent handling.

**Background / Motivation**
Parallel execution kept starting new tasks even after one had already rejected, and raw
errors from `withConcurrency` were not distinguished from `ChatlogError`. This made failure
handling inconsistent and wasted work on tasks that no longer mattered. This PR stops
dispatching new tasks after a rejection, waits for in-flight workers before throwing, and
wraps non-`ChatlogError` failures as `ParallelExecutionError`. It also makes `ChatlogCache`
write/delete scans independent, and lets `run-ai` accept an external `AbortSignal` so
`process-chunk` can propagate cancellation.

## Changes

### Core Changes

- `skills/_scripts/libs/parallel/concurrency.ts`: abort on task rejection so unstarted tasks
  are skipped; wait for all workers before rethrowing the first error; wrap non-`ChatlogError`
  exceptions as `ParallelExecutionError`
- `skills/_scripts/classes/ChatlogCache.class.ts`: run write and delete scans independently so
  one side's rejection no longer blocks the other
- `skills/_scripts/libs/ai/run-ai.ts`: add optional `signal?: AbortSignal` to `RunAIOptions`;
  combine it with the internal timeout signal; throw `ChatlogError('Aborted', 'ExternalAbort')`
  if already aborted
- `skills/_scripts/constants/chatlog-error.constants.ts`: add error labels for
  `ParallelExecutionError` and `Aborted`
- `skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts`: pass the abort signal to
  `runAI` so external abort propagates into the AI subprocess

### Test Updates

- `concurrency.unit.spec.ts`: cover abort-on-reject, waiting for in-flight tasks, first-error
  propagation, and error wrapping
- `ChatlogCache.unit.spec.ts`: cover independent write/delete scan attempts
- `run-ai.unit.spec.ts`: cover `ExternalAbort` handling
- `process-chunk.functional.spec.ts`: cover a pre-aborted controller
- `with-concurrency.integration.spec.ts`: verify waiting for in-flight tasks before rejecting
- `main.e2e.spec.ts`: expect a wrapped `ParallelExecutionError` instead of a raw
  `Deno.errors.NotFound`

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

The `signal` option on `run-ai` is optional and backward compatible. Error wrapping changes
the concrete error type from parallel execution: raw errors are now wrapped as
`ChatlogError('ParallelExecutionError', ...)`. Callers catching raw `Error`/`Deno.errors.*`
types directly should be aware of this.
