### PR TITLE
refactor: unify move-and-cache-cleanup state in write phase

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,28 +1,5 @@
-# src: .codegraph/.gitignore
-# @(#) : ignore codegraph db and logs
-#
-# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
-#
-# This software is released under the MIT License.
-# https://opensource.org/licenses/MIT
-
-
-# CodeGraph data files
-# These are local to each machine and should not be committed
-
-# Database
-*.db
-*.db-wal
-*.db-shm
-
-# Cache
-cache/
-
-# daemon
-daemon.*
-
-# Logs
-*.log
-
-# Hook markers
-.dirty
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -109,10 +109,9 @@ export const main = async (argv?: string[]): Promise<void> => {
   // Step 5: ファイル移動
   await applyClassifications(
     [..._partition.cached, ..._partition.uncached],
-    _cache,
     _originalLogsDir,
     _config.dryRun,
-    stats,
+    { cache: _cache, stats },
     _config,
   );
 

--- a/skills/classify-chatlogs/scripts/phases/__tests__/integration/apply-classifications.integration.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/integration/apply-classifications.integration.spec.ts
@@ -46,7 +46,7 @@ describe('applyClassifications', () => {
       );
     });
 
-    describe('When: applyClassifications(entries, cache, tempDir, false, stats) を呼び出す', () => {
+    describe('When: applyClassifications(entries, tempDir, false, state) を呼び出す', () => {
       describe('Then: T-CL-MC-10 - moveChatlogEntry の実失敗が stats.error に伝播する', () => {
         it('T-CL-MC-10-01: stats.error が 1 になる', async () => {
           const _cache = await _makeEmptyClassifyCache();
@@ -55,10 +55,9 @@ describe('applyClassifications', () => {
 
           await applyClassifications(
             [entry],
-            _cache,
             tempDir,
             false,
-            _stats,
+            { cache: _cache, stats: _stats },
             { concurrency: 4 },
           );
 
@@ -72,10 +71,9 @@ describe('applyClassifications', () => {
 
           await applyClassifications(
             [entry],
-            _cache,
             tempDir,
             false,
-            _stats,
+            { cache: _cache, stats: _stats },
             { concurrency: 4 },
           );
 
@@ -89,10 +87,9 @@ describe('applyClassifications', () => {
 
           await applyClassifications(
             [entry],
-            _cache,
             tempDir,
             false,
-            _stats,
+            { cache: _cache, stats: _stats },
             { concurrency: 4 },
           );
 
@@ -112,7 +109,7 @@ describe('applyClassifications', () => {
       entry = new ChatlogEntry(`---\ntitle: Test\n---\n本文`, { filePath: srcPath });
     });
 
-    describe('When: applyClassifications(entries, cache, destDir, false, stats) を呼び出す', () => {
+    describe('When: applyClassifications(entries, destDir, false, state) を呼び出す', () => {
       describe('Then: T-CL-MC-11 - ファイル移動成功後にキャッシュエントリが削除される', () => {
         it('T-CL-MC-11-01: stats.moved が 1 になる', async () => {
           const _cache = await _makeEmptyClassifyCache();
@@ -120,7 +117,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
           const destDir = `${tempDir}/out`;
 
-          await applyClassifications([entry], _cache, destDir, false, _stats, { concurrency: 4 });
+          await applyClassifications([entry], destDir, false, { cache: _cache, stats: _stats }, { concurrency: 4 });
 
           assertEquals(_stats.moved, 1);
         });
@@ -131,7 +128,7 @@ describe('applyClassifications', () => {
           const _stats = _makeStats();
           const destDir = `${tempDir}/out`;
 
-          await applyClassifications([entry], _cache, destDir, false, _stats, { concurrency: 4 });
+          await applyClassifications([entry], destDir, false, { cache: _cache, stats: _stats }, { concurrency: 4 });
 
           assertEquals(_cache.read(srcPath), {});
         });
@@ -140,7 +137,7 @@ describe('applyClassifications', () => {
   });
 
   describe('Given: キャッシュに ERROR（project なし）が登録済みのエントリと dryRun=false', () => {
-    describe('When: applyClassifications(entries, cache, destDir, false, stats) を呼び出す', () => {
+    describe('When: applyClassifications(entries, destDir, false, state) を呼び出す', () => {
       describe('Then: T-CL-MC-12 - project の有無で move/remaining が決まる', () => {
         it('T-CL-MC-12-02: action=error, project なし → remaining 扱いでキャッシュは削除されない', async () => {
           const _cache = await _makeEmptyClassifyCache();
@@ -150,10 +147,9 @@ describe('applyClassifications', () => {
 
           await applyClassifications(
             [errorEntry],
-            _cache,
             `${tempDir}/out`,
             false,
-            _stats,
+            { cache: _cache, stats: _stats },
             { concurrency: 4 },
           );
 

--- a/skills/classify-chatlogs/scripts/phases/__tests__/integration/move-chatlog-entry.integration.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/integration/move-chatlog-entry.integration.spec.ts
@@ -16,16 +16,58 @@ import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
 
 // ─── Helpers
 // classes
+import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // utils
 import { readTextFile } from '../../../../../_scripts/libs/file-io/read-utils.ts';
 import { dirExists, fileExists, fileOrDirExists } from '../../../../../_scripts/libs/file-ops/exists-utils.ts';
+// internal helpers
+import { _makeEmptyClassifyCache } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+// types
+import type { ClassifyCache } from '../../../types/classify.types.ts';
 
 // ─── Internal Helpers
 
 // constants
 const _FILE_CONTENT = `---\ntitle: Test Title\ncategory: development\n---\n本文`;
 const _SRC_FILENAME = 'a.md';
+
+// functions
+/**
+ * `removeFile` プロバイダが `NotFound` 以外のエラーを throw する `ChatlogCache<ClassifyCache>` を生成する。
+ *
+ * 他のプロバイダ（readTextFile/writeTextFile/mkdir/glob）は `_makeEmptyClassifyCache` と同様に
+ * インメモリバッファで実装する。`cache.delete` がこのエラーをそのまま re-throw することを
+ * 利用して、実ファイル移動が成功しても `moveChatlogEntry` が影響を受けないことを検証する。
+ *
+ * @returns 初期化済みの `ChatlogCache<ClassifyCache>`
+ */
+const _makeCacheWithFailingDelete = async (): Promise<ChatlogCache<ClassifyCache>> => {
+  const buf = new Map<string, string>();
+  const cache = new ChatlogCache<ClassifyCache>(
+    'classify-cache',
+    '/fake/cache',
+    undefined,
+    {
+      cache: {
+        readTextFile: (path) => {
+          const data = buf.get(path);
+          if (data === undefined) { return Promise.reject(new Error('not found')); }
+          return Promise.resolve(data);
+        },
+        writeTextFile: (path, data) => {
+          buf.set(path, data);
+          return Promise.resolve();
+        },
+        mkdir: () => Promise.resolve(),
+        glob: () => Promise.resolve([]),
+        removeFile: () => Promise.reject(new Error('permission denied')),
+      },
+    },
+  );
+  await cache.ready;
+  return cache;
+};
 
 // ─── Tests
 
@@ -52,43 +94,64 @@ describe('moveChatlogEntry', () => {
       entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
     });
 
-    describe('When: moveChatlogEntry(entry, "app1", tempDir, false) を呼び出す', () => {
+    describe('When: moveChatlogEntry(entry, "app1", tempDir, false, cache) を呼び出す', () => {
       describe('Then: T-CL-CF-02 - ファイルが app1/ サブディレクトリへ移動される', () => {
         it('T-CL-CF-02-04: action が MOVE になる', async () => {
-          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertEquals(_result.action, CLASSIFY_ACTIONS.MOVE);
         });
 
         it('T-CL-CF-02-06: dstDir（tempDir/app1）が存在する', async () => {
-          await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertEquals(await dirExists(`${tempDir}/app1`), true);
         });
 
         it('T-CL-CF-02-01: dstPath にファイルが存在する', async () => {
-          await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertEquals(await fileExists(`${tempDir}/app1/${_SRC_FILENAME}`), true);
         });
 
         it('T-CL-CF-02-02: srcPath が存在しない', async () => {
-          await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertEquals(await fileOrDirExists(srcPath), false, 'srcPath がまだ存在する');
         });
 
         it('T-CL-CF-02-03: dstPath のテキストに "project: app1" が含まれる', async () => {
-          await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           const _dstText = await readTextFile(`${tempDir}/app1/${_SRC_FILENAME}`);
           assertStringIncludes(_dstText, 'project: "app1"');
         });
 
         it('T-CL-CF-02-05: message に "moved:" が含まれる', async () => {
-          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertStringIncludes(_result.message, 'moved:');
+        });
+
+        it('T-CL-CF-02-07: 移動成功後、対応する cache エントリが削除される（read が空オブジェクトを返す）', async () => {
+          const cache = await _makeEmptyClassifyCache();
+          await cache.write(srcPath, { project: 'app1' });
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
+
+          assertEquals(cache.read(srcPath), {});
         });
       });
     });
@@ -106,28 +169,87 @@ describe('moveChatlogEntry', () => {
       );
     });
 
-    describe('When: moveChatlogEntry(entry, "app1", tempDir, false) を呼び出す（srcPath 不在）', () => {
+    describe('When: moveChatlogEntry(entry, "app1", tempDir, false, cache) を呼び出す（srcPath 不在）', () => {
       describe('Then: T-CL-CF-03 - 例外なしで action が ERROR になる', () => {
         it('T-CL-CF-03-01: 例外がスローされない', async () => {
-          await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
         });
 
         it('T-CL-CF-03-02: action が ERROR になる', async () => {
-          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertEquals(_result.action, CLASSIFY_ACTIONS.ERROR);
         });
 
         it('T-CL-CF-03-03: message に "move failed:" が含まれる', async () => {
-          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertStringIncludes(_result.message, 'move failed:');
         });
 
         it('T-CL-CF-03-04: action が MOVE でない', async () => {
-          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false);
+          const cache = await _makeEmptyClassifyCache();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
 
           assertEquals(_result.action !== CLASSIFY_ACTIONS.MOVE, true);
+        });
+
+        it('T-CL-CF-03-05: 移動失敗時、cache エントリは削除されない（read が書き込んだ値のまま）', async () => {
+          const cache = await _makeEmptyClassifyCache();
+          const srcPath = `${tempDir}/missing.md`;
+          await cache.write(srcPath, { project: 'app1' });
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
+
+          assertEquals(cache.read(srcPath), { project: 'app1' });
+        });
+      });
+    });
+  });
+
+  // ─── T-CL-CF-04: 移動成功だが cache.delete が失敗 ────────────────────────
+
+  describe('Given: 実在するファイル（実移動は成功する）だが cache.delete が non-NotFound エラーを throw する', () => {
+    let entry: ChatlogEntry;
+    let srcPath: string;
+
+    beforeEach(async () => {
+      srcPath = `${tempDir}/${_SRC_FILENAME}`;
+      await Deno.writeTextFile(srcPath, _FILE_CONTENT);
+      entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+    });
+
+    describe('When: moveChatlogEntry(entry, "app1", tempDir, false, cache) を呼び出す', () => {
+      describe('Then: T-CL-CF-04 - cache 削除失敗が move 失敗に化けない', () => {
+        it('T-CL-CF-04-01: action が MOVE になる', async () => {
+          const cache = await _makeCacheWithFailingDelete();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
+
+          assertEquals(_result.action, CLASSIFY_ACTIONS.MOVE);
+        });
+
+        it('T-CL-CF-04-02: message に "moved:" が含まれる', async () => {
+          const cache = await _makeCacheWithFailingDelete();
+
+          const _result = await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
+
+          assertStringIncludes(_result.message, 'moved:');
+        });
+
+        it('T-CL-CF-04-03: 実ファイルが tempDir/app1/ へ移動済みである', async () => {
+          const cache = await _makeCacheWithFailingDelete();
+
+          await moveChatlogEntry(entry, 'app1', tempDir, false, cache);
+
+          assertEquals(await fileExists(`${tempDir}/app1/${_SRC_FILENAME}`), true);
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-classifications.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-classifications.unit.spec.ts
@@ -58,7 +58,7 @@ describe('applyClassifications', () => {
       const _cache = await _makeEmptyClassifyCache();
       const _stats = _makeStats();
 
-      await applyClassifications([], _cache, '/tmp/output', false, _stats, { concurrency: 4 });
+      await applyClassifications([], '/tmp/output', false, { cache: _cache, stats: _stats }, { concurrency: 4 });
 
       assertEquals(_stats.moved, 0);
       assertEquals(_stats.movedByAI, 0);
@@ -74,10 +74,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         false,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -94,10 +93,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         false,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -115,10 +113,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -136,10 +133,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -157,10 +153,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         false,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -178,10 +173,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -205,10 +199,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -228,10 +221,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -250,10 +242,9 @@ describe('applyClassifications', () => {
 
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 
@@ -274,10 +265,9 @@ describe('applyClassifications', () => {
       // 実削除の検証は integration テストで実施する。
       await applyClassifications(
         [_entry],
-        _cache,
         '/tmp/output',
         true,
-        _stats,
+        { cache: _cache, stats: _stats },
         { concurrency: 4 },
       );
 

--- a/skills/classify-chatlogs/scripts/phases/__tests__/unit/move-chatlog-entry.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/unit/move-chatlog-entry.unit.spec.ts
@@ -17,48 +17,65 @@ import { FALLBACK_PROJECT } from '../../../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
 
 // ─── Internal Helpers
-import { _makeClassifyChatlogEntry } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+import {
+  _makeClassifyChatlogEntry,
+  _makeEmptyClassifyCache,
+} from '../../../__tests__/_helpers/classify-test-helpers.ts';
 
 // ─── Tests
 
 describe('moveChatlogEntry', () => {
   describe('Given: dryRun=true の呼び出し', () => {
-    describe('When: moveChatlogEntry(_entry, "app1", "/tmp/output", true) を呼び出す', () => {
+    describe('When: moveChatlogEntry(_entry, "app1", "/tmp/output", true, cache) を呼び出す', () => {
       describe('Then: T-CL-CF-01 - action=MOVE・message に "[dry-run]" と "→ app1/" が含まれる', () => {
         it('T-CL-CF-01-01: action が CLASSIFY_ACTIONS.MOVE になる', async () => {
           const _entry = _makeClassifyChatlogEntry('test.md');
+          const cache = await _makeEmptyClassifyCache();
 
-          const _result = await moveChatlogEntry(_entry, 'app1', '/tmp/output', true);
+          const _result = await moveChatlogEntry(_entry, 'app1', '/tmp/output', true, cache);
 
           assertEquals(_result.action, CLASSIFY_ACTIONS.MOVE);
         });
 
         it('T-CL-CF-01-02: message に "[dry-run]" が含まれる', async () => {
           const _entry = _makeClassifyChatlogEntry('test.md');
+          const cache = await _makeEmptyClassifyCache();
 
-          const _result = await moveChatlogEntry(_entry, 'app1', '/tmp/output', true);
+          const _result = await moveChatlogEntry(_entry, 'app1', '/tmp/output', true, cache);
 
           assertStringIncludes(_result.message, '[dry-run]');
         });
 
         it('T-CL-CF-01-03: message に "→ app1/" が含まれる', async () => {
           const _entry = _makeClassifyChatlogEntry('test.md');
+          const cache = await _makeEmptyClassifyCache();
 
-          const _result = await moveChatlogEntry(_entry, 'app1', '/tmp/output', true);
+          const _result = await moveChatlogEntry(_entry, 'app1', '/tmp/output', true, cache);
 
           assertStringIncludes(_result.message, '→ app1/');
+        });
+
+        it('T-CL-CF-01-04: cache エントリは削除されない（read が書き込んだ値のまま）', async () => {
+          const _entry = _makeClassifyChatlogEntry('test.md');
+          const cache = await _makeEmptyClassifyCache();
+          await cache.write(_entry.filePath!, { project: 'app1' });
+
+          await moveChatlogEntry(_entry, 'app1', '/tmp/output', true, cache);
+
+          assertEquals(cache.read(_entry.filePath!), { project: 'app1' });
         });
       });
     });
   });
 
   describe('Given: project=undefined の呼び出し', () => {
-    describe(`When: moveChatlogEntry(_entry, undefined, "/tmp/output", true) を呼び出す (dryRun=true)`, () => {
+    describe(`When: moveChatlogEntry(_entry, undefined, "/tmp/output", true, cache) を呼び出す (dryRun=true)`, () => {
       describe(`Then: T-CL-CF-03 - FALLBACK_PROJECT で dryRun 移動される・action=MOVE`, () => {
         it(`T-CL-CF-03-02: message に "→ ${FALLBACK_PROJECT}/" が含まれる`, async () => {
           const _entry = _makeClassifyChatlogEntry('test.md');
+          const cache = await _makeEmptyClassifyCache();
 
-          const _result = await moveChatlogEntry(_entry, undefined, '/tmp/output', true);
+          const _result = await moveChatlogEntry(_entry, undefined, '/tmp/output', true, cache);
 
           assertStringIncludes(_result.message, `→ ${FALLBACK_PROJECT}/`);
         });
@@ -67,12 +84,13 @@ describe('moveChatlogEntry', () => {
   });
 
   describe('Given: destDir に Windows バックスラッシュパスを渡す呼び出し', () => {
-    describe('When: moveChatlogEntry(_entry, "app1", "C:\\\\output", true) を呼び出す (dryRun=true)', () => {
+    describe('When: moveChatlogEntry(_entry, "app1", "C:\\\\output", true, cache) を呼び出す (dryRun=true)', () => {
       describe('Then: T-CL-CF-04 - normalizePath によりパスが正規化されて処理が壊れない', () => {
         it('T-CL-CF-04-01: destDir="C:\\\\output" + dryRun=true → action=MOVE・message に "→ app1/" が含まれる', async () => {
           const _entry = _makeClassifyChatlogEntry('test.md');
+          const cache = await _makeEmptyClassifyCache();
 
-          const _result = await moveChatlogEntry(_entry, 'app1', 'C:\\output', true);
+          const _result = await moveChatlogEntry(_entry, 'app1', 'C:\\output', true, cache);
 
           assertEquals(_result.action, CLASSIFY_ACTIONS.MOVE);
           assertStringIncludes(_result.message, '→ app1/');

--- a/skills/classify-chatlogs/scripts/phases/phase-write.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-write.ts
@@ -19,7 +19,7 @@ import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
 // ─── Local
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
-import type { ClassifyAction, ClassifyCache, ClassifyConfig, ClassifyStats } from '../types/classify.types.ts';
+import type { ClassifyAction, ClassifyCache, ClassifyConfig, ClassifyState } from '../types/classify.types.ts';
 // constants
 import { FALLBACK_PROJECT } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
@@ -33,12 +33,15 @@ export const resolveProject = (project: string | undefined): string => project ?
  * - `project` が `undefined` の場合は `FALLBACK_PROJECT` に補完して移動する。
  * - `dryRun` が `true` の場合は移動せず `{ action: MOVE, message }` を返す。
  * - 移動エラーは `{ action: ERROR, message }` を返す（スローしない）。
+ * - 移動成功時は対応する `cache` エントリも削除する。ただし cache 削除の失敗は
+ *   移動成功という結果に影響させず、`logger.warn` でログ出力するのみとする。
  */
 export const moveChatlogEntry = async (
   classifyEntry: ChatlogEntry,
   project: string | undefined,
   destDir: string,
   dryRun: boolean,
+  cache: ChatlogCache<ClassifyCache>,
 ): Promise<{ action: ClassifyAction; message: string }> => {
   const _project = resolveProject(project);
   const srcPath = classifyEntry.filePath!;
@@ -55,37 +58,39 @@ export const moveChatlogEntry = async (
     const _newContent = normalizeLine(classifyEntry.renderEntry());
     await Deno.writeTextFile(dstPath, _newContent);
     await Deno.remove(srcPath);
-
-    return { action: CLASSIFY_ACTIONS.MOVE, message: `moved: ${classifyEntry.filename!} → ${_project}/` };
   } catch (e) {
     return { action: CLASSIFY_ACTIONS.ERROR, message: `  move failed: ${classifyEntry.filename!}: ${e}` };
   }
+
+  try {
+    await cache.delete(srcPath);
+  } catch (e) {
+    logger.warn(`  cache delete failed: ${classifyEntry.filename!}: ${e}`);
+  }
+
+  return { action: CLASSIFY_ACTIONS.MOVE, message: `moved: ${classifyEntry.filename!} → ${_project}/` };
 };
 
 /**
- * `MOVE`/`MOVEBYAI` の分類結果を実際にファイル移動し、成功時に stats を更新してキャッシュを削除する。
+ * `MOVE`/`MOVEBYAI` の分類結果を実際にファイル移動し、成功時に stats を更新する。
+ * キャッシュ削除は `moveChatlogEntry` が移動成功時に行う。
  * 失敗時は `stats.error++` のみ（キャッシュは削除しない）。
  */
 const _applyMove = async (
-  filePath: string,
   entry: ChatlogEntry,
-  cached: Partial<ClassifyCache>,
   destDir: string,
   dryRun: boolean,
-  cache: ChatlogCache<ClassifyCache>,
-  stats: ClassifyStats,
-  movedCounter: 'moved' | 'movedByAI',
+  state: ClassifyState,
 ): Promise<void> => {
-  const _result = await moveChatlogEntry(entry, cached.project, destDir, dryRun);
+  const cached = state.cache.read(entry.filePath!);
+  const _result = await moveChatlogEntry(entry, cached.project, destDir, dryRun, state.cache);
   if (_result.action !== CLASSIFY_ACTIONS.MOVE) {
     logger.error(_result.message);
-    stats.error++;
-    return;
-  }
-  logger.info(_result.message);
-  stats[movedCounter]++;
-  if (!dryRun) {
-    await cache.delete(filePath);
+    state.stats.error++;
+  } else {
+    const movedCounter = cached.action === CLASSIFY_ACTIONS.MOVEBYAI ? 'movedByAI' : 'moved';
+    logger.info(_result.message);
+    state.stats[movedCounter]++;
   }
 };
 
@@ -114,33 +119,31 @@ const _applyMove = async (
  */
 export const applyClassifications = async (
   entries: ChatlogEntry[],
-  cache: ChatlogCache<ClassifyCache>,
   destDir: string,
   dryRun: boolean,
-  stats: ClassifyStats,
+  state: ClassifyState,
   config: Pick<ClassifyConfig, 'concurrency'>,
 ): Promise<void> => {
   await runConcurrent(entries, async (entry) => {
     const filePath = entry.filePath!;
-    const cached = cache.read(filePath);
+    const cached = state.cache.read(filePath);
 
     if (cached.action === CLASSIFY_ACTIONS.SKIP) {
-      stats.skip++;
+      state.stats.skip++;
       return;
     }
 
     if (!cached.project) {
-      stats.remaining++;
+      state.stats.remaining++;
       return;
     }
 
     if (dryRun) {
-      stats.skip++;
+      state.stats.skip++;
       logger.info(`<<dry-run>> move skipped: ${entry.filename!}`);
       return;
     }
 
-    const movedCounter = cached.action === CLASSIFY_ACTIONS.MOVEBYAI ? 'movedByAI' : 'moved';
-    await _applyMove(filePath, entry, cached, destDir, dryRun, cache, stats, movedCounter);
+    await _applyMove(entry, destDir, dryRun, state);
   }, config.concurrency);
 };

--- a/skills/classify-chatlogs/scripts/types/classify.types.ts
+++ b/skills/classify-chatlogs/scripts/types/classify.types.ts
@@ -10,6 +10,7 @@
 //
 // ─── Imports
 // types
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import type { DefaultArgFields, ParsedArgs } from '../../../_scripts/types/args-schema.types.ts';
 import type { GlobProvider } from '../../../_scripts/types/providers.types.ts';
@@ -56,6 +57,16 @@ export interface ClassifyStats {
   remaining: number;
   /** dry-run のため AI 呼び出しをスキップした件数。 */
   skip: number;
+}
+
+// ─────────────────────────────────────────────
+// 分類処理状態型
+// ─────────────────────────────────────────────
+
+/** 分類処理全体で共有される可変状態（キャッシュ・統計カウンター）。 */
+export interface ClassifyState {
+  cache: ChatlogCache<ClassifyCache>;
+  stats: ClassifyStats;
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Overview

**Summary**
Combine cache and stats into a single state object in the classify-chatlogs write phase.

**Background / Motivation**
The write phase passed `cache` and `stats` as separate arguments through
`applyClassifications` → `_applyMove` → `moveChatlogEntry`, and cache deletion happened
in the caller after the move result was checked. This change introduces a `ClassifyState`
type (`{ cache, stats }`) passed as one object, and moves cache-entry deletion into
`moveChatlogEntry` itself so cleanup happens right where the move succeeds.

## Changes

### Core Changes

- `skills/classify-chatlogs/scripts/types/classify.types.ts`: add `ClassifyState` type
- `skills/classify-chatlogs/scripts/phases/phase-write.ts`:
  - `moveChatlogEntry` now takes `cache` and deletes the cache entry on successful move
  - `applyClassifications` and `_applyMove` now take a single `state: ClassifyState`
    argument instead of separate `cache`/`stats` parameters
- `skills/classify-chatlogs/scripts/classify-chatlogs.ts`: update the call site to pass
  `{ cache: _cache, stats }`
- `.codegraph/.gitignore`: simplify local CodeGraph data ignore rules (unrelated
  housekeeping change carried on this branch)

### Test Updates

- `apply-classifications.unit.spec.ts` / `.integration.spec.ts`: update calls to pass the
  new `state` argument
- `move-chatlog-entry.unit.spec.ts` / `.integration.spec.ts`: add `cache` argument and
  cover cache behavior after successful move, failed move, and dry-run

### Removed

None.

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
