### PR TITLE
refactor(logger): adopt logger prefix/text constants across all skills

### DIFF
--- a/skills/_scripts/__tests__/helpers/logger-stub.ts
+++ b/skills/_scripts/__tests__/helpers/logger-stub.ts
@@ -16,15 +16,17 @@ export type LoggerStub = {
   infoLogs: string[];
   warnLogs: string[];
   errorLogs: string[];
+  dryrunLogs: string[];
   logStub: Stub;
   infoStub: Stub;
   warnStub: Stub;
   errorStub: Stub;
+  dryrunStub: Stub;
   restore(): void;
 };
 
 /**
- * logger.info / logger.warn / logger.error をキャプチャするスタブを設置し、ハンドルを返す。
+ * logger.info / logger.warn / logger.error / logger.dryrun をキャプチャするスタブを設置し、ハンドルを返す。
  * afterEach で loggerStub.restore() を呼ぶこと。
  */
 export function makeLoggerStub(): LoggerStub {
@@ -32,6 +34,7 @@ export function makeLoggerStub(): LoggerStub {
   const infoLogs: string[] = [];
   const warnLogs: string[] = [];
   const errorLogs: string[] = [];
+  const dryrunLogs: string[] = [];
   const logStub = stub(logger, 'log', (msg: string) => {
     logLogs.push(msg);
   });
@@ -44,20 +47,26 @@ export function makeLoggerStub(): LoggerStub {
   const errorStub = stub(logger, 'error', (msg: string) => {
     errorLogs.push(msg);
   });
+  const dryrunStub = stub(logger, 'dryrun', (msg: string) => {
+    dryrunLogs.push(msg);
+  });
   return {
     logLogs,
     infoLogs,
     warnLogs,
     errorLogs,
+    dryrunLogs,
     logStub,
     infoStub,
     warnStub,
     errorStub,
+    dryrunStub,
     restore() {
       logStub.restore();
       infoStub.restore();
       warnStub.restore();
       errorStub.restore();
+      dryrunStub.restore();
     },
   };
 }

--- a/skills/_scripts/constants/logger.constants.ts
+++ b/skills/_scripts/constants/logger.constants.ts
@@ -1,0 +1,15 @@
+// src: _scripts/constants/logger.constants.ts
+// @(#): ロガー出力用共通定数定義
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/** ロガー出力で使うテキスト定数（インデント等）。 */
+export const LOGGER_TEXT = {
+  /** ログ出力でネストした状態を表す際に使うインデント（半角スペース2つ）。 */
+  INDENT: '  ',
+} as const;
+
+export type LoggerTextKey = keyof typeof LOGGER_TEXT;

--- a/skills/_scripts/constants/logger.constants.ts
+++ b/skills/_scripts/constants/logger.constants.ts
@@ -13,3 +13,13 @@ export const LOGGER_TEXT = {
 } as const;
 
 export type LoggerTextKey = keyof typeof LOGGER_TEXT;
+
+/** ロガー出力で使う prefix 定数（スペースなし）。呼び出し側で `${PREFIX} ${msg}` の形にスペースを挿入する。 */
+export const LOGGER_PREFIX = {
+  INFO: '::info::',
+  WARN: '::warn::',
+  ERROR: '::error::',
+  DRYRUN: '<<dry-run>>',
+} as const;
+
+export type LoggerPrefixKey = keyof typeof LOGGER_PREFIX;

--- a/skills/_scripts/libs/file-ops/remove-utils.ts
+++ b/skills/_scripts/libs/file-ops/remove-utils.ts
@@ -10,6 +10,8 @@
 // shared modules
 // ─────────────────────────────────────────────
 
+// constants
+import { LOGGER_TEXT } from '../../constants/logger.constants.ts';
 // functions
 import { isFileIoError } from '../file-io/read-utils.ts';
 import { logger } from '../io/logger.ts';
@@ -64,7 +66,7 @@ export async function removeFile(
     if (throwFileIoError) {
       throw e;
     }
-    logger.warn(`  削除失敗 (${(e as Error).message}): ${filePath}`);
+    logger.warn(`${LOGGER_TEXT.INDENT}削除失敗 (${(e as Error).message}): ${filePath}`);
     return false;
   }
 }

--- a/skills/_scripts/libs/io/__tests__/unit/logger.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/logger.unit.spec.ts
@@ -142,4 +142,30 @@ describe('logger', () => {
       });
     });
   });
+
+  // ─── グループ05: logger.dryrun ───────────────────────────────────────────────
+
+  describe('Given: msg="dry message"', () => {
+    describe('When: logger.dryrun("dry message") を呼び出す', () => {
+      describe('Then: T-LIB-LOG-05 - "::info:: <<dry-run>>" prefix を付けて stderr へ出力する', () => {
+        it('T-LIB-LOG-05-01: console.error が 1 回呼ばれる', () => {
+          logger.dryrun('dry message');
+          assertSpyCalls(errorSpy, 1);
+        });
+
+        it('T-LIB-LOG-05-02: console.error の引数が "::info:: <<dry-run>> dry message" である', () => {
+          logger.dryrun('dry message');
+          const [arg] = errorSpy.calls[0].args as [string];
+          if (arg !== '::info:: <<dry-run>> dry message') {
+            throw new Error(`Expected "::info:: <<dry-run>> dry message", got "${arg}"`);
+          }
+        });
+
+        it('T-LIB-LOG-05-03: console.log は呼ばれない', () => {
+          logger.dryrun('dry message');
+          assertSpyCalls(logSpy, 0);
+        });
+      });
+    });
+  });
 });

--- a/skills/_scripts/libs/io/logger.ts
+++ b/skills/_scripts/libs/io/logger.ts
@@ -2,19 +2,23 @@
 // @(#): ログ出力ユーティリティ
 //       logger.log → stdout (prefix なし)
 //       logger.info/warn/error → stderr (::info:: / ::warn:: / ::error:: prefix 付き)
+//       logger.dryrun → stderr (::info:: <<dry-run>> prefix 付き、logger.info に委譲)
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { LOGGER_PREFIX } from '../../constants/logger.constants.ts';
+
 /**
  * logger — ログレベルごとに prefix を付けて出力するユーティリティ。
  *
- * - `log`  : prefix なし、stdout へ出力（結果・ファイルパス等）
- * - `info` : `::info::` prefix を付けて stderr へ出力（進捗情報）
- * - `warn` : `::warn::` prefix を付けて stderr へ出力（警告）
- * - `error`: `::error::` prefix を付けて stderr へ出力（エラー）
+ * - `log`   : prefix なし、stdout へ出力（結果・ファイルパス等）
+ * - `info`  : `::info::` prefix を付けて stderr へ出力（進捗情報）
+ * - `warn`  : `::warn::` prefix を付けて stderr へ出力（警告）
+ * - `error` : `::error::` prefix を付けて stderr へ出力（エラー）
+ * - `dryrun`: `::info:: <<dry-run>>` prefix を付けて stderr へ出力（dry-run 時の予定操作）
  *
  * `const logger = {...}` 形式で export することで、`@std/testing/mock` の `stub()` による
  * テスト時のメソッド差し替えが可能。
@@ -24,12 +28,15 @@ export const logger = {
     console.log(msg);
   },
   info(msg: string): void {
-    console.error(`::info:: ${msg}`);
+    console.error(`${LOGGER_PREFIX.INFO} ${msg}`);
   },
   warn(msg: string): void {
-    console.error(`::warn:: ${msg}`);
+    console.error(`${LOGGER_PREFIX.WARN} ${msg}`);
   },
   error(msg: string): void {
-    console.error(`::error:: ${msg}`);
+    console.error(`${LOGGER_PREFIX.ERROR} ${msg}`);
+  },
+  dryrun(msg: string): void {
+    this.info(`${LOGGER_PREFIX.DRYRUN} ${msg}`);
   },
 };

--- a/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -119,10 +119,10 @@ describe('main - dry-run モード', () => {
           assertEquals(await fileExists(`${monthDir}/chat.md`), true);
         });
 
-        it('T-CL-E2E-01-02: "[dry-run]" がログに出力される', async () => {
+        it('T-CL-E2E-01-02: dryrun ログが出力される', async () => {
           await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
-          assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]')), true);
+          assertEquals(loggerStub.dryrunLogs.length > 0, true);
         });
       });
     });
@@ -621,11 +621,11 @@ describe('main - 期間フィルタ', () => {
           assertEquals(allInfoLogs.includes('out-of-scope.md'), false);
         });
 
-        it('T-CL-E2E-07-02: 期間内ファイルのみが対象となり、[dry-run] AI 分類スキップログに 1件と出力される', async () => {
+        it('T-CL-E2E-07-02: 期間内ファイルのみが対象となり、dryrun AI 分類スキップログに 1件と出力される', async () => {
           await main(['claude', '2026-03', '--dry-run', '--config', configFile]);
 
           assertEquals(
-            loggerStub.infoLogs.some((l) => l.includes('[dry-run]') && l.includes('1件')),
+            loggerStub.dryrunLogs.some((l) => l.includes('1件')),
             true,
           );
         });
@@ -743,9 +743,9 @@ describe('main - --input-dir フルパス直接指定', () => {
           assertEquals(await fileExists(`${monthDir}/chat.md`), true);
         });
 
-        it('T-CL-E2E-10-02: "[dry-run]" がログに出力される', async () => {
+        it('T-CL-E2E-10-02: dryrun ログが出力される', async () => {
           await main(['--input-dir', monthDir, '--dry-run', '--config', configFile]);
-          assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]')), true);
+          assertEquals(loggerStub.dryrunLogs.length > 0, true);
         });
       });
     });

--- a/skills/classify-chatlogs/scripts/__tests__/unit/main.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/unit/main.unit.spec.ts
@@ -114,7 +114,7 @@ describe('main', () => {
       }
     });
 
-    it('[Normal] T-CL-MAIN-05: --dry-run 指定 → "dry-run モード" ログと完了ログの "(dry-run)" サフィックスが出力される', async () => {
+    it('[Normal] T-CL-MAIN-05: --dry-run 指定 → dryrun ログと完了ログの "(dry-run)" サフィックスが出力される', async () => {
       const { inputDir, configsDir, configFile, monthDir } = await _makeTestDirs();
       await Deno.writeTextFile(
         `${monthDir}/chat.md`,
@@ -131,7 +131,7 @@ describe('main', () => {
       try {
         await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
-        assertEquals(loggerStub.infoLogs.some((l) => l.includes('dry-run モード')), true);
+        assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('ファイルは移動しません')), true);
         assertEquals(loggerStub.infoLogs.some((l) => l.includes('完了 (dry-run):')), true);
       } finally {
         commandHandle.restore();

--- a/skills/classify-chatlogs/scripts/classify-chatlogs.ts
+++ b/skills/classify-chatlogs/scripts/classify-chatlogs.ts
@@ -25,6 +25,7 @@ import { logger } from '../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../_scripts/libs/path-utils/path-utils.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
+import { LOGGER_TEXT } from '../../_scripts/constants/logger.constants.ts';
 
 // ─── Local
 import { findChatlogFilePaths } from './libs/find-files-flat.ts';
@@ -36,9 +37,106 @@ import { processClassifyNoAI } from './phases/phase-classify-noai.ts';
 import { partitionEntries } from './phases/phase-partition.ts';
 import { applyClassifications } from './phases/phase-write.ts';
 // types
-import type { ClassifyCache, ClassifyStats } from './types/classify.types.ts';
+import type {
+  ClassifyCache,
+  ClassifyConfig,
+  ClassifyPartition,
+  ClassifyStats,
+  ProjectDicEntry,
+} from './types/classify.types.ts';
 // constants
 import { FALLBACK_PROJECT } from './constants/classify.constants.ts';
+
+// ─────────────────────────────────────────────
+// 内部関数
+// ─────────────────────────────────────────────
+
+/**
+ * 入力ディレクトリを解決し、存在確認する。
+ * 存在しない場合は `ChatlogError('InputNotFound', 'NotFound', ...)` を throw する。
+ */
+const _resolveInputDir = async (config: ClassifyConfig): Promise<string> => {
+  const originalLogsDir = resolveChatlogsDir({
+    chatlogsDir: config.chatlogsDir,
+    agent: config.agent,
+    period: config.period,
+    addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
+    override: config.inputDir,
+  });
+  if (!await dirExists(originalLogsDir)) {
+    throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${originalLogsDir}`);
+  }
+  return originalLogsDir;
+};
+
+/**
+ * プロジェクト辞書を読み込み、設定内容をログ出力する。
+ */
+const _loadProjects = async (config: ClassifyConfig): Promise<ProjectDicEntry> => {
+  const projects = await loadProjectDic(config.projectsDic);
+  const projectNames = Object.keys(projects);
+  if (projectNames.every((name) => name === FALLBACK_PROJECT)) {
+    logger.warn('projects.dic にプロジェクトが定義されていません。すべて misc に分類されます。');
+  }
+
+  logger.info(`対象 agent: ${config.agent}`);
+  if (config.period) { logger.info(`対象期間: ${config.period}`); }
+  if (config.dryRun) { logger.dryrun('ファイルは移動しません'); }
+  logger.info(`プロジェクト候補: ${projectNames.join(', ')}`);
+
+  return projects;
+};
+
+/**
+ * 対象ファイル一覧を収集し、判定結果キャッシュを準備する。
+ * 対象ファイルが0件の場合は完了ログを出力し `null` を返す。
+ */
+const _collectFilesAndCache = async (
+  originalLogsDir: string,
+): Promise<{ filePaths: string[]; cache: ChatlogCache<ClassifyCache> } | null> => {
+  const filePaths = await findChatlogFilePaths(originalLogsDir);
+  if (filePaths.length === 0) {
+    logger.info('対象ファイルなし');
+    logger.info('完了: moved=0 movedByAI=0 error=0 remaining=0 skip=0');
+    return null;
+  }
+  const cache = new ChatlogCache<ClassifyCache>('classify-cache');
+  await cache.ready;
+  return { filePaths, cache };
+};
+
+/**
+ * エントリ読み込み・キャッシュ分類・AI なし分類・AI 分類までを実行する。
+ * ファイル移動（`applyClassifications`）はこの関数には含まない。
+ */
+const _classify = async (
+  filePaths: string[],
+  cache: ChatlogCache<ClassifyCache>,
+  config: ClassifyConfig,
+  projects: ProjectDicEntry,
+  stats: ClassifyStats,
+): Promise<ClassifyPartition> => {
+  // Step 1: 分類候補エントリの読み込み。読み込み失敗（frontmatter パースエラー等）は errors に分離され、
+  // 誤って処理を継続しないよう後続の事前分類・AI分類には渡らない
+  const { entries, errors } = await loadClassifyEntries(filePaths, cache, config);
+  if (errors.length > 0) {
+    stats.error += errors.length;
+    errors.forEach(({ filePath, error }) =>
+      logger.warn(`${LOGGER_TEXT.INDENT}読み込み失敗 (${error.message}): ${getFilename(filePath)}`)
+    );
+  }
+
+  // Step 2: キャッシュ済み/未キャッシュ分類
+  const partition = partitionEntries(entries, cache);
+
+  // Step 3: 分類 (AI なし)
+  const { remaining } = await processClassifyNoAI(partition.uncached, cache, config);
+
+  // Step 4: 分類（AI あり）
+  await classifyByAI(remaining, projects, config, cache, config.dryRun);
+
+  return partition;
+};
 
 // ─────────────────────────────────────────────
 // メイン
@@ -52,59 +150,16 @@ import { FALLBACK_PROJECT } from './constants/classify.constants.ts';
 export const main = async (argv?: string[]): Promise<void> => {
   const _config = buildConfig(argv ?? Deno.args);
 
-  // 入力ディレクトリ確認
-  const _originalLogsDir = resolveChatlogsDir({
-    chatlogsDir: _config.chatlogsDir,
-    agent: _config.agent,
-    period: _config.period,
-    addOnDir: DEFAULT_ORIGINAL_LOGS_DIR,
-    override: _config.inputDir,
-  });
-  if (!await dirExists(_originalLogsDir)) {
-    throw new ChatlogError('InputNotFound', 'NotFound', `入力ディレクトリが見つかりません: ${_originalLogsDir}`);
-  }
-
-  // プロジェクト辞書読み込み
-  const projects = await loadProjectDic(_config.projectsDic);
-  const _projectNames = Object.keys(projects);
-  if (_projectNames.every((name) => name === FALLBACK_PROJECT)) {
-    logger.warn('projects.dic にプロジェクトが定義されていません。すべて misc に分類されます。');
-  }
-
-  logger.info(`対象 agent: ${_config.agent}`);
-  if (_config.period) { logger.info(`対象期間: ${_config.period}`); }
-  if (_config.dryRun) { logger.info('dry-run モード: ファイルは移動しません'); }
-  logger.info(`プロジェクト候補: ${_projectNames.join(', ')}`);
+  const _originalLogsDir = await _resolveInputDir(_config);
+  const projects = await _loadProjects(_config);
 
   const stats: ClassifyStats = { moved: 0, movedByAI: 0, error: 0, remaining: 0, skip: 0 };
 
-  // Step 0: ファイルリスト、キャッシュ取得
-  const _filePaths = await findChatlogFilePaths(_originalLogsDir);
-  if (_filePaths.length === 0) {
-    logger.info('対象ファイルなし');
-    logger.info('完了: moved=0 movedByAI=0 error=0 remaining=0 skip=0');
-    return;
-  }
-  // 判定結果キャッシュ
-  const _cache = new ChatlogCache<ClassifyCache>('classify-cache');
-  await _cache.ready;
+  const _collected = await _collectFilesAndCache(_originalLogsDir);
+  if (_collected === null) { return; }
+  const { filePaths: _filePaths, cache: _cache } = _collected;
 
-  // Step 1: 分類候補エントリの読み込み。読み込み失敗（frontmatter パースエラー等）は errors に分離され、
-  // 誤って処理を継続しないよう後続の事前分類・AI分類には渡らない
-  const { entries, errors } = await loadClassifyEntries(_filePaths, _cache, _config);
-  if (errors.length > 0) {
-    stats.error += errors.length;
-    errors.forEach(({ filePath, error }) => logger.warn(`  読み込み失敗 (${error.message}): ${getFilename(filePath)}`));
-  }
-
-  // Step 2: キャッシュ済み/未キャッシュ分類
-  const _partition = partitionEntries(entries, _cache);
-
-  // Step 3: 分類 (AI なし)
-  const { remaining } = await processClassifyNoAI(_partition.uncached, _cache, _config);
-
-  // Step 4: 分類（AI あり）
-  await classifyByAI(remaining, projects, _config, _cache, _config.dryRun);
+  const _partition = await _classify(_filePaths, _cache, _config, projects, stats);
 
   // Step 5: ファイル移動
   await applyClassifications(

--- a/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
@@ -171,19 +171,19 @@ describe('classifyByAI', () => {
       assertEquals(cache.read('/tmp/input/b.md').project, undefined);
     });
 
-    it('[Normal] T-CL-CBA-06-02: dryRun=true・対象1件 → logger.info が呼び出される', async () => {
+    it('[Normal] T-CL-CBA-06-02: dryRun=true・対象1件 → logger.dryrun が呼び出される', async () => {
       const targets: ChatlogEntry[] = [_makeClassifyChatlogEntry('a.md')];
 
       await classifyByAI(targets, _PROJECTS, _makeConfig(), cache, true);
 
-      assertEquals(loggerStub.infoLogs.length > 0, true);
+      assertEquals(loggerStub.dryrunLogs.length > 0, true);
     });
 
-    it('[Edge] T-CL-CBA-06-03: dryRun=true・targets が空配列 → cache 書き込みも logger.info も呼ばれない', async () => {
+    it('[Edge] T-CL-CBA-06-03: dryRun=true・targets が空配列 → cache 書き込みも logger.dryrun も呼ばれない', async () => {
       await classifyByAI([], _PROJECTS, _makeConfig(), cache, true);
 
       assertEquals(counter.calls, 0);
-      assertEquals(loggerStub.infoLogs.length, 0);
+      assertEquals(loggerStub.dryrunLogs.length, 0);
     });
 
     it('[Edge] T-CL-CBA-06-04: dryRun=true・concurrency=2・targets=5件 → cache.write の同時実行数のピークが concurrency を超えない', async () => {

--- a/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-classifications.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-classifications.unit.spec.ts
@@ -210,7 +210,7 @@ describe('applyClassifications', () => {
       assertEquals(_stats.moved, 0);
       assertEquals(_stats.movedByAI, 0);
       assertEquals(_stats.remaining, 0);
-      assertEquals(loggerStub.infoLogs.some((l) => l.includes('<<dry-run>> move skipped: test.md')), true);
+      assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('move skipped: test.md')), true);
     });
 
     it('[Normal] T-CL-MC-03: action=MOVEBYAI, dryRun=true → stats.skip++（moveChatlogEntry は呼ばれない）', async () => {
@@ -231,7 +231,7 @@ describe('applyClassifications', () => {
       assertEquals(_stats.moved, 0);
       assertEquals(_stats.movedByAI, 0);
       assertEquals(_stats.remaining, 0);
-      assertEquals(loggerStub.infoLogs.some((l) => l.includes('<<dry-run>> move skipped: test.md')), true);
+      assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('move skipped: test.md')), true);
     });
 
     it('[Normal] T-CL-MC-08: action=move, project=undefined, dryRun=true → project 未確定のため stats.remaining++', async () => {

--- a/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-move.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-move.unit.spec.ts
@@ -1,0 +1,162 @@
+// src: scripts/phases/__tests__/unit/apply-move.unit.spec.ts
+// @(#): _applyMove の単体テスト
+//       対象: _applyMove
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// cspell:words MoveByAI
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { _applyMove } from '../../phase-write.ts';
+
+// ─── Helpers
+import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+// types
+import type { LoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+// constants
+import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
+
+// ─── Internal Helpers
+import { _makeEmptyClassifyCache, _makeStats } from '../../../__tests__/_helpers/classify-test-helpers.ts';
+
+// constants
+const _FILE_CONTENT = `---\ntitle: Test Title\n---\n本文`;
+
+// ─── Tests
+
+/**
+ * `_applyMove` のユニットテストスイート。
+ *
+ * `cached.action` による moved/movedByAI の振り分け、実移動失敗時の
+ * stats/cache 非変化を検証する。
+ *
+ * テスト ID 範囲: T-CL-AM-01 〜 T-CL-AM-07
+ *
+ * @see _applyMove
+ */
+describe('_applyMove', () => {
+  let loggerStub: LoggerStub;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    loggerStub = makeLoggerStub();
+    tempDir = await Deno.makeTempDir();
+  });
+
+  afterEach(async () => {
+    loggerStub.restore();
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  /**
+   * 正常系: 実ファイル移動が成功するケースでの stats/cache/ログの検証。
+   */
+  describe('When: 正常系', () => {
+    it('[Normal] T-CL-AM-01: cached.action=move, project あり → stats.moved++（movedByAI は増えない）', async () => {
+      const srcPath = `${tempDir}/test.md`;
+      await Deno.writeTextFile(srcPath, _FILE_CONTENT);
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1', action: CLASSIFY_ACTIONS.MOVE });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(_stats.moved, 1);
+      assertEquals(_stats.movedByAI, 0);
+    });
+
+    it('[Normal] T-CL-AM-02: cached.action=move で移動成功後、キャッシュエントリが削除される', async () => {
+      const srcPath = `${tempDir}/test.md`;
+      await Deno.writeTextFile(srcPath, _FILE_CONTENT);
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1', action: CLASSIFY_ACTIONS.MOVE });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(_cache.read(srcPath), {});
+    });
+
+    it('[Normal] T-CL-AM-03: cached.action=move-by-ai, project あり → stats.movedByAI++（moved は増えない）', async () => {
+      const srcPath = `${tempDir}/test.md`;
+      await Deno.writeTextFile(srcPath, _FILE_CONTENT);
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1', action: CLASSIFY_ACTIONS.MOVEBYAI });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(_stats.movedByAI, 1);
+      assertEquals(_stats.moved, 0);
+    });
+
+    it('[Normal] T-CL-AM-04: 移動成功時 logger.info が呼ばれる', async () => {
+      const srcPath = `${tempDir}/test.md`;
+      await Deno.writeTextFile(srcPath, _FILE_CONTENT);
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1', action: CLASSIFY_ACTIONS.MOVE });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(loggerStub.infoLogs.length > 0, true);
+    });
+  });
+
+  /**
+   * 異常系: 実ファイル移動が失敗する（srcPath が存在しない）ケースでの stats/cache/ログの検証。
+   */
+  describe('When: 異常系', () => {
+    it('[Error] T-CL-AM-05: srcPath 不在 → stats.error++ のみ（moved/movedByAI/remaining/skip は不変）', async () => {
+      const srcPath = `${tempDir}/missing.md`;
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1' });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(_stats.error, 1);
+      assertEquals(_stats.moved, 0);
+      assertEquals(_stats.movedByAI, 0);
+      assertEquals(_stats.remaining, 0);
+      assertEquals(_stats.skip, 0);
+    });
+
+    it('[Error] T-CL-AM-06: srcPath 不在 → キャッシュエントリは削除されない', async () => {
+      const srcPath = `${tempDir}/missing.md`;
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1' });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(_cache.read(srcPath), { project: 'app1' });
+    });
+
+    it('[Error] T-CL-AM-07: srcPath 不在 → logger.error が呼ばれる', async () => {
+      const srcPath = `${tempDir}/missing.md`;
+      const _entry = new ChatlogEntry(_FILE_CONTENT, { filePath: srcPath });
+      const _cache = await _makeEmptyClassifyCache();
+      await _cache.write(srcPath, { project: 'app1' });
+      const _stats = _makeStats();
+
+      await _applyMove(_entry, tempDir, false, { cache: _cache, stats: _stats });
+
+      assertEquals(loggerStub.errorLogs.length > 0, true);
+    });
+  });
+});

--- a/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
@@ -25,6 +25,7 @@ import type {
   ProjectDicEntry,
 } from '../types/classify.types.ts';
 // constants
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { FALLBACK_PROJECT } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
 
@@ -120,21 +121,21 @@ export const processChunk = async (
     rawResult = await runAI(_systemPrompt, _batchPrompt, { model });
   } catch (e) {
     const _reason = `claude CLI 実行失敗: ${e}`;
-    logger.warn(`  ${_reason}`);
+    logger.warn(`${LOGGER_TEXT.INDENT}${_reason}`);
     return _writeChunkError(chunkMetas, cache, _reason);
   }
 
   const parsed = parseAiJsonArray<ClassifyCache>(rawResult);
   if (!parsed) {
     const _reason = `JSON パース失敗: ${rawResult.slice(0, 200)}`;
-    logger.warn(`  ${_reason}`);
+    logger.warn(`${LOGGER_TEXT.INDENT}${_reason}`);
     return _writeChunkError(chunkMetas, cache, _reason);
   }
 
   await Promise.all(chunkMetas.map((fileMeta) => {
     const result = parsed.find((r) => r.file === fileMeta.filename);
     const project = result?.project ?? FALLBACK_PROJECT;
-    logger.info(`  classify: ${fileMeta.filename} → ${project} (conf=${result?.confidence ?? 0})`);
+    logger.info(`${LOGGER_TEXT.INDENT}classify: ${fileMeta.filename} → ${project} (conf=${result?.confidence ?? 0})`);
     return cache.write(fileMeta.filePath!, {
       project,
       confidence: result?.confidence ?? 0,
@@ -169,7 +170,7 @@ export const classifyByAI = async (
       (f) => cache.write(f.filePath!, { action: CLASSIFY_ACTIONS.SKIP }),
       config.concurrency,
     );
-    logger.info(`[dry-run] AI 分類をスキップします（project は設定されません）: ${targets.length}件`);
+    logger.dryrun(`AI 分類をスキップします（project は設定されません）: ${targets.length}件`);
     return;
   }
 

--- a/skills/classify-chatlogs/scripts/phases/phase-classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-classify-noai.ts
@@ -19,6 +19,7 @@ import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.
 import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import type { ClassifyCache, ClassifyConfig } from '../types/classify.types.ts';
 // constants
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { FALLBACK_PROJECT, MIN_CLASSIFIABLE_LENGTH } from '../constants/classify.constants.ts';
 import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
 
@@ -57,7 +58,7 @@ export const classifyByNoAI = async (
   // メタ情報がなく内容も短い → fallback プロジェクトに移動
   if (!_hasMeta && _fullLength < MIN_CLASSIFIABLE_LENGTH) {
     logger.warn(`[skip-ai: too-short] ${f.filename} (content is too short)`);
-    logger.info(`  classify: ${f.filename} → fallback:${FALLBACK_PROJECT}`);
+    logger.info(`${LOGGER_TEXT.INDENT}classify: ${f.filename} → fallback:${FALLBACK_PROJECT}`);
     await cache.write(f.filePath!, { project: FALLBACK_PROJECT, action: CLASSIFY_ACTIONS.MOVE });
     return entry;
   }

--- a/skills/classify-chatlogs/scripts/phases/phase-write.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-write.ts
@@ -15,6 +15,8 @@ import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { normalizeLine } from '../../../_scripts/libs/text/line-utils.ts';
+// constants
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 
 // ─── Local
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
@@ -59,13 +61,16 @@ export const moveChatlogEntry = async (
     await Deno.writeTextFile(dstPath, _newContent);
     await Deno.remove(srcPath);
   } catch (e) {
-    return { action: CLASSIFY_ACTIONS.ERROR, message: `  move failed: ${classifyEntry.filename!}: ${e}` };
+    return {
+      action: CLASSIFY_ACTIONS.ERROR,
+      message: `${LOGGER_TEXT.INDENT}move failed: ${classifyEntry.filename!}: ${e}`,
+    };
   }
 
   try {
     await cache.delete(srcPath);
   } catch (e) {
-    logger.warn(`  cache delete failed: ${classifyEntry.filename!}: ${e}`);
+    logger.warn(`${LOGGER_TEXT.INDENT}cache delete failed: ${classifyEntry.filename!}: ${e}`);
   }
 
   return { action: CLASSIFY_ACTIONS.MOVE, message: `moved: ${classifyEntry.filename!} → ${_project}/` };
@@ -140,7 +145,7 @@ export const applyClassifications = async (
 
     if (dryRun) {
       state.stats.skip++;
-      logger.info(`<<dry-run>> move skipped: ${entry.filename!}`);
+      logger.dryrun(`move skipped: ${entry.filename!}`);
       return;
     }
 

--- a/skills/classify-chatlogs/scripts/phases/phase-write.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-write.ts
@@ -147,3 +147,6 @@ export const applyClassifications = async (
     await _applyMove(entry, destDir, dryRun, state);
   }, config.concurrency);
 };
+
+// テスト用 export（内部関数だが unit テストから直接検証するため公開する）
+export { _applyMove };

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -1539,7 +1539,7 @@ describe('main - 判定集計ログ（dry-run）', () => {
           it('T-FL-E2E-20-01: 判定済み数（judged=0）がログに出力される', async () => {
             await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
-            assertEquals(loggerStub.infoLogs.some((l) => l.includes('judged=0')), true);
+            assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('judged=0')), true);
           });
         });
       });

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/noise-filter.main.e2e.spec.ts
@@ -96,8 +96,8 @@ describe('main (noise-filter) - dry-run モード', () => {
   describe('Given: ノイズファイル名の .md ファイルと --dry-run フラグ', () => {
     /** `main(["claude", "--dry-run", "--input-dir", chatlogsDir])` を呼び出すとき。 */
     describe('When: main(["claude", "--dry-run", "--input-dir", chatlogsDir]) を呼び出す', () => {
-      /** ファイルが削除されず、info ログにノイズファイルのパスが出力されること。 */
-      describe('Then: T-PF-E2E-01 - ファイルが削除されずパスが info ログに出力される', () => {
+      /** ファイルが削除されず、dryrun ログにノイズファイルのパスが出力されること。 */
+      describe('Then: T-PF-E2E-01 - ファイルが削除されずパスが dryrun ログに出力される', () => {
         let tempDir: string;
         let chatlogsDir: string;
         let loggerStub: LoggerStub;
@@ -113,14 +113,14 @@ describe('main (noise-filter) - dry-run モード', () => {
           await Deno.remove(tempDir, { recursive: true });
         });
 
-        it('T-PF-E2E-01-01: ファイルが削除されずに残り、info ログにパスが出力される', async () => {
+        it('T-PF-E2E-01-01: ファイルが削除されずに残り、dryrun ログにパスが出力される', async () => {
           const filePath = `${chatlogsDir}/say-ok-and-nothing-else.md`;
           await Deno.writeTextFile(filePath, _makeValidContent());
 
           await main(['claude', '2026-03', '--dry-run', '--input-dir', chatlogsDir]);
 
           assertEquals(await fileExists(filePath), true);
-          assertEquals(loggerStub.infoLogs.some((line) => line.includes('say-ok-and-nothing-else.md')), true);
+          assertEquals(loggerStub.dryrunLogs.some((line) => line.includes('say-ok-and-nothing-else.md')), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/discard-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/discard-files.functional.spec.ts
@@ -136,7 +136,7 @@ describe('_discardFiles', () => {
 
           assertEquals(stats.skip, 1);
           assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
-          assertEquals(loggerStub.infoLogs.length, 1);
+          assertEquals(loggerStub.dryrunLogs.length, 1);
         });
 
         it('T-FL-DF-02-02: ログに "skipped" という文言が出力される', async () => {
@@ -151,7 +151,7 @@ describe('_discardFiles', () => {
           await _discardFiles(files, true, stats, 2);
           loggerStub.restore();
 
-          assertEquals(loggerStub.infoLogs.some((l) => l.includes('skipped')), true);
+          assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('skipped')), true);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -347,7 +347,7 @@ describe('prefilterFiles', () => {
     describe('When: dryRun: true を渡して prefilterFiles を呼び出す', () => {
       /** dryRun でも削除予定ファイルはログ出力・stats.skip に計上され、DISCARD 確定分は passed から除外されることを検証する。 */
       describe('Then: T-FL-PFF-09 - 削除予定がログ出力され、DISCARD 確定分は passed から除外される', () => {
-        it('T-FL-PFF-09-01: [Normal] dryRun: true のとき削除予定ファイルの logger.info が呼ばれる', async () => {
+        it('T-FL-PFF-09-01: [Normal] dryRun: true のとき削除予定ファイルの logger.dryrun が呼ばれる', async () => {
           const excludedPath = `${periodDir1}/say-ok-and-nothing-else.md`;
           const shortPath = `${periodDir1}/short-body.md`;
           const validPath = `${periodDir1}/valid.md`;
@@ -363,7 +363,7 @@ describe('prefilterFiles', () => {
           });
           loggerStub.restore();
 
-          assertEquals(loggerStub.infoLogs.length, 2);
+          assertEquals(loggerStub.dryrunLogs.length, 2);
         });
 
         it('T-FL-PFF-09-02: [Normal] dryRun: true でも DISCARD 確定分は passed から除外され、stats.skip に計上される', async () => {

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -32,6 +32,7 @@ import { getFilename } from '../../_scripts/libs/path-utils/path-utils.ts';
 // constants
 import { DEFAULT_ORIGINAL_LOGS_DIR } from '../../_scripts/constants/defaults.constants.ts';
 import { LOGGER_HEADER } from '../../_scripts/constants/logger-header.constants.ts';
+import { LOGGER_TEXT } from '../../_scripts/constants/logger.constants.ts';
 // types
 import type { ArgSchema } from '../../_scripts/types/args-schema.types.ts';
 
@@ -131,7 +132,9 @@ export const main = async (args?: string[]): Promise<void> => {
   const { entries, errors } = await loadFilterEntries(_targetEntries, _cache, _config.concurrency);
   if (errors.length > 0) {
     stats.error += errors.length;
-    errors.forEach(({ filePath, error }) => logger.warn(`  読み込み失敗 (${error.message}): ${getFilename(filePath)}`));
+    errors.forEach(({ filePath, error }) =>
+      logger.warn(`${LOGGER_TEXT.INDENT}読み込み失敗 (${error.message}): ${getFilename(filePath)}`)
+    );
   }
 
   const targetEntries = await prefilterFiles(entries, {
@@ -149,10 +152,10 @@ export const main = async (args?: string[]): Promise<void> => {
     logger.info(`判定対象ファイル数: ${total}`);
 
     if (_config.dryRun) {
-      logger.info('dry-run モード: claude CLI を呼び出さず対象ファイルを一覧表示します');
+      logger.dryrun('claude CLI を呼び出さず対象ファイルを一覧表示します');
       targetEntries.forEach((entry) => logger.info(`対象: ${entry.filePath}`));
       stats.skip += targetEntries.length;
-      logger.info('判定済み: judged=0（dry-run）');
+      logger.dryrun('判定済み: judged=0');
     } else {
       // チャンク分割して並列処理（判定結果はキャッシュに書き込むのみ。削除は後続のスイープで行う）
       const chunkResults = await runChunked(

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -14,6 +14,8 @@ import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts
 import { runAI } from '../../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../../_scripts/libs/io/logger.ts';
 import { parseAiJsonArray } from '../../../../_scripts/libs/text/json-utils.ts';
+// constants
+import { LOGGER_TEXT } from '../../../../_scripts/constants/logger.constants.ts';
 // types
 import type { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 
@@ -55,9 +57,9 @@ export const processChunk = async (
     rawResult = await runAI(_SYSTEM_PROMPT, batchPrompt, { signal: ctl.signal });
   } catch (e) {
     if (!(e instanceof ChatlogError)) { throw e; }
-    logger.warn(`  claude CLI 実行失敗。チャンク内ファイルをすべて error 扱い`);
-    logger.warn(`  error: ${e.message}`);
-    chunkEntries.forEach((entry) => logger.warn(`  error扱い: ${entry.filename}`));
+    logger.warn(`${LOGGER_TEXT.INDENT}claude CLI 実行失敗。チャンク内ファイルをすべて error 扱い`);
+    logger.warn(`${LOGGER_TEXT.INDENT}error: ${e.message}`);
+    chunkEntries.forEach((entry) => logger.warn(`${LOGGER_TEXT.INDENT}error扱い: ${entry.filename}`));
     stats.error += chunkEntries.length;
     if (e.subindex === 'RateLimit') { ctl.abort(); }
     return e;
@@ -65,9 +67,9 @@ export const processChunk = async (
 
   const parsed = parseAiJsonArray<ClaudeResult>(rawResult);
   if (!parsed) {
-    logger.warn(`  JSON パース失敗。チャンク内ファイルをすべて error 扱い`);
-    logger.warn(`  raw output: ${rawResult.slice(0, 200)}`);
-    chunkEntries.forEach((entry) => logger.warn(`  error扱い: ${entry.filename}`));
+    logger.warn(`${LOGGER_TEXT.INDENT}JSON パース失敗。チャンク内ファイルをすべて error 扱い`);
+    logger.warn(`${LOGGER_TEXT.INDENT}raw output: ${rawResult.slice(0, 200)}`);
+    chunkEntries.forEach((entry) => logger.warn(`${LOGGER_TEXT.INDENT}error扱い: ${entry.filename}`));
     stats.error += chunkEntries.length;
     return new ChatlogError('InvalidFormat', 'JsonParse', `raw output: ${rawResult.slice(0, 200)}`);
   }
@@ -77,7 +79,7 @@ export const processChunk = async (
     const result = parsed.find((r) => r.file === filename);
 
     if (!result) {
-      logger.info(`  判定不能: ${filename} - skipped`);
+      logger.info(`${LOGGER_TEXT.INDENT}判定不能: ${filename} - skipped`);
       stats.skip++;
       continue;
     }
@@ -88,15 +90,15 @@ export const processChunk = async (
 
     if (isConfirmedDiscard) {
       await cache.write(entry.filePath as string, { decision: FILTER_DECISIONS.DISCARD, confidence, reason });
-      logger.info(`  discard confirmed (conf=${confidence}): ${filename}`);
-      logger.info(`  reason: ${reason}`);
+      logger.info(`${LOGGER_TEXT.INDENT}discard confirmed (conf=${confidence}): ${filename}`);
+      logger.info(`${LOGGER_TEXT.INDENT}reason: ${reason}`);
     } else if (isGreyZoneDiscard) {
       await cache.write(entry.filePath as string, { decision: FILTER_DECISIONS.EMPTY, confidence, reason });
-      logger.info(`  閾値未満 (decision=${decision}, conf=${confidence}): ${filename} - skipped`);
+      logger.info(`${LOGGER_TEXT.INDENT}閾値未満 (decision=${decision}, conf=${confidence}): ${filename} - skipped`);
       stats.skip++;
     } else {
       await cache.write(entry.filePath as string, { decision: FILTER_DECISIONS.KEEP, confidence, reason });
-      logger.info(`  kept (decision=${decision}, conf=${confidence}): ${filename}`);
+      logger.info(`${LOGGER_TEXT.INDENT}kept (decision=${decision}, conf=${confidence}): ${filename}`);
       stats.keep++;
     }
   }

--- a/skills/filter-chatlogs/scripts/modules/filter/sweep-discards.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/sweep-discards.ts
@@ -15,6 +15,8 @@ import { removeFile } from '../../../../_scripts/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../../_scripts/libs/path-utils/path-utils.ts';
+// constants
+import { LOGGER_TEXT } from '../../../../_scripts/constants/logger.constants.ts';
 
 // ─── internal ───
 // functions
@@ -61,7 +63,7 @@ export const sweepDiscards = async (
   await runConcurrent(targets, async (filePath) => {
     if (dryRun) {
       stats.skip++;
-      logger.info(`  skipped: ${getFilename(filePath)}`);
+      logger.dryrun(`${LOGGER_TEXT.INDENT}skipped: ${getFilename(filePath)}`);
       return;
     }
 
@@ -69,11 +71,11 @@ export const sweepDiscards = async (
     if (await removeFile(filePath, { throwFileIoError: false })) {
       stats.remove++;
       await cache.delete(filePath);
-      logger.info(`  removed: ${getFilename(filePath)}`);
+      logger.info(`${LOGGER_TEXT.INDENT}removed: ${getFilename(filePath)}`);
     } else {
       stats.error++;
       await cache.write(filePath, { ...cache.read(filePath), decision: FILTER_DECISIONS.ERROR });
-      logger.warn(`  Error: cannot removed: ${getFilename(filePath)}`);
+      logger.warn(`${LOGGER_TEXT.INDENT}Error: cannot removed: ${getFilename(filePath)}`);
     }
   }, concurrency);
 };

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/phase3-discard-or-skip.functional.spec.ts
@@ -80,7 +80,7 @@ describe('_phase3DiscardOrSkip', () => {
   describe('Given: ノイズ確定ファイル 1 件と dryRun=true', () => {
     describe('When: _phase3DiscardOrSkip(discardFiles, stats, true) を呼び出す', () => {
       describe('Then: T-PF-P3-02 - ファイルが削除されず stats.skip が 1 になる', () => {
-        it('T-PF-P3-02-01: ファイルが削除されずに残り stats.skip=1、logger.log には出力されず logger.info にファイルパスと reason が出力される', async () => {
+        it('T-PF-P3-02-01: ファイルが削除されずに残り stats.skip=1、logger.log には出力されず logger.dryrun にファイルパスと reason が出力される', async () => {
           const filePath = `${tempDir}/noise.md`;
           await Deno.writeTextFile(filePath, 'dummy');
           const discardFiles = [
@@ -94,7 +94,7 @@ describe('_phase3DiscardOrSkip', () => {
           assertEquals(stats.skip, 1);
           assertEquals(loggerStub.logLogs, []);
           assertEquals(
-            loggerStub.infoLogs.some((line) => line.includes(filePath) && line.includes('テスト理由')),
+            loggerStub.dryrunLogs.some((line) => line.includes(filePath) && line.includes('テスト理由')),
             true,
           );
         });

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -152,13 +152,13 @@ describe('processNoiseFiles', () => {
   /**
    * ノイズファイルが dry-run モードで処理される前提グループ。
    *
-   * ファイルが削除されず、パスが info ログに出力されることを検証する。
+   * ファイルが削除されず、パスが dryrun ログに出力されることを検証する。
    */
   describe('Given: ノイズファイル 1 件と dryRun=true', () => {
     /** `processNoiseFiles(files, counts, { dryRun: true })` を呼び出すとき。 */
     describe('When: processNoiseFiles を dry-run モードで呼び出す', () => {
-      /** ファイルが削除されず、info ログにファイルパスが含まれること。 */
-      describe('Then: T-PF-PNF-03 - ファイルが削除されずパスが info ログに出力される', () => {
+      /** ファイルが削除されず、dryrun ログにファイルパスが含まれること。 */
+      describe('Then: T-PF-PNF-03 - ファイルが削除されずパスが dryrun ログに出力される', () => {
         it('T-PF-PNF-03-01: ファイルが削除されずに残る', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           const entry = await _writeEntry(filePath, _makeValidContent());
@@ -169,14 +169,14 @@ describe('processNoiseFiles', () => {
           assertEquals(await fileExists(filePath), true);
         });
 
-        it('T-PF-PNF-03-02: infoLogs にファイルパスが含まれる', async () => {
+        it('T-PF-PNF-03-02: dryrunLogs にファイルパスが含まれる', async () => {
           const filePath = `${tempDir}/${_NOISE_FILENAME}`;
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
           await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
 
-          assertEquals(loggerStub.infoLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
+          assertEquals(loggerStub.dryrunLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
         });
 
         it('T-PF-PNF-03-03: counts.skip が 1 になる', async () => {

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
@@ -112,7 +112,7 @@ export const _phase3DiscardOrSkip = async (
 ): Promise<void> => {
   await runConcurrent(discardFiles, async ({ filePath, reason }) => {
     if (dryRun) {
-      logger.info(`<<dry-run>> skip: ${filePath} (${reason})`);
+      logger.dryrun(`skip: ${filePath} (${reason})`);
       stats.skip++;
       return;
     }

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -23,6 +23,7 @@ import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 // constants
 import { DEFAULT_CONFIG_VALUES } from '../../../_scripts/constants/config-schema.constants.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 
 // ─── internal ───
 // classes
@@ -254,7 +255,7 @@ export const _discardFiles = async (
     async (entry): Promise<DiscardFile | null> => {
       const { filePath, filename, reason } = entry;
       if (dryRun) {
-        logger.info(`  skipped (${reason}): ${filename}`);
+        logger.dryrun(`${LOGGER_TEXT.INDENT}skipped (${reason}): ${filename}`);
         stats.skip++;
         return entry;
       }
@@ -263,7 +264,7 @@ export const _discardFiles = async (
         return { ...entry, decision: FILTER_DECISIONS.ERROR };
       }
       stats.remove++;
-      logger.info(`  removed (${reason}): ${filename}`);
+      logger.info(`${LOGGER_TEXT.INDENT}removed (${reason}): ${filename}`);
       return null;
     },
     concurrency,

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -41,6 +41,8 @@ import { findFiles } from '../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
 // classes
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
+// constants
+import { LOGGER_TEXT } from '../../_scripts/constants/logger.constants.ts';
 
 // ─── internal ───
 // constants
@@ -76,7 +78,7 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
   const files = await findFiles(_searchDir);
   logger.info(`対象ファイル数: ${files.length}`);
   if (dryRun) {
-    logger.info('dry-run モード: ファイルは削除しません');
+    logger.dryrun('ファイルは削除しません');
   }
 
   const stats: NoiseFilterStats = { keep: 0, skip: 0, remove: 0, error: 0 };
@@ -86,7 +88,9 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
   const { entries, errors } = await loadFilterEntries(files, undefined, concurrency);
   if (errors.length > 0) {
     stats.error += errors.length;
-    errors.forEach(({ filePath, error }) => logger.error(`  読み込み失敗 (${error.message}): ${filePath}`));
+    errors.forEach(({ filePath, error }) =>
+      logger.error(`${LOGGER_TEXT.INDENT}読み込み失敗 (${error.message}): ${filePath}`)
+    );
   }
 
   const targetEntries = await prefilterFiles(entries, {

--- a/skills/normalize-chatlogs/scripts/modules/file-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/file-io.ts
@@ -48,7 +48,7 @@ export const writeOutput = async (
   glob?: GlobProvider,
 ): Promise<boolean> => {
   if (dryRun) {
-    logger.info(`[dry-run] would write: ${outputPath}`);
+    logger.dryrun(`would write: ${outputPath}`);
     return false;
   }
 

--- a/skills/normalize-chatlogs/scripts/modules/process-files.ts
+++ b/skills/normalize-chatlogs/scripts/modules/process-files.ts
@@ -11,6 +11,8 @@
 import { expandGlob } from '@std/fs';
 
 // --- shared
+// constants
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 // functions
 import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
 import { extractChatlogPath } from '../../../_scripts/libs/file-io/resolve-directory.ts';
@@ -125,7 +127,7 @@ export const processFiles = async (
   const _pendingFiles = mdFiles.filter((_, i) => !_normalized[i]);
 
   for (const filePath of _skipFiles) {
-    logger.info(`  skipped (already normalized): ${getBasename(filePath)}`);
+    logger.info(`${LOGGER_TEXT.INDENT}skipped (already normalized): ${getBasename(filePath)}`);
     stats.skip++;
   }
 
@@ -164,10 +166,10 @@ export const processFiles = async (
           summary: '(auto-generated: AI segmentation failed)',
           content: content,
         }];
-        logger.info(`  fallback (1-segment): ${getBasename(filePath)}`);
+        logger.info(`${LOGGER_TEXT.INDENT}fallback (1-segment): ${getBasename(filePath)}`);
         stats.fallback++;
       } else if (segments === null) {
-        logger.warn(`  failed (no segments returned): ${getBasename(filePath)}`);
+        logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
         stats.fail++;
         if (config.failFast) {
           throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);

--- a/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -141,7 +141,7 @@ describe('main - dry-run モード', () => {
           assertEquals(updatedContent, originalContent);
         });
 
-        it('T-SF-E2E-01-02: "[dry-run]" がログに出力される', async () => {
+        it('T-SF-E2E-01-02: dryrun ログが出力される', async () => {
           await main([
             '--input-dir',
             inputDir,
@@ -153,10 +153,10 @@ describe('main - dry-run モード', () => {
             dicsDir,
           ]);
 
-          assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]')), true);
+          assertEquals(loggerStub.dryrunLogs.length > 0, true);
         });
 
-        it('T-SF-E2E-01-03: dry-run 時は type/category エントリログに [dry-run] が付く', async () => {
+        it('T-SF-E2E-01-03: dry-run 時は type/category エントリの dryrun ログが出力される', async () => {
           await main([
             '--input-dir',
             inputDir,
@@ -168,7 +168,7 @@ describe('main - dry-run モード', () => {
             dicsDir,
           ]);
 
-          assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]') && l.includes('type/category')), true);
+          assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('type/category')), true);
         });
       });
     });
@@ -664,7 +664,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('T-SF-DR-04-01: [dry-run] ログに target.md のファイル名が含まれる', async () => {
+        it('T-SF-DR-04-01: dryrun ログに target.md のファイル名が含まれる', async () => {
           await main([
             '--input-dir',
             inputDir,
@@ -678,10 +678,10 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
             dicsDir,
           ]);
 
-          assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run]') && l.includes('target.md')), true);
+          assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('target.md')), true);
         });
 
-        it('T-SF-DR-04-02: [dry-run] ログに written.md のファイル名が含まれない', async () => {
+        it('T-SF-DR-04-02: dryrun ログに written.md のファイル名が含まれない', async () => {
           await main([
             '--input-dir',
             inputDir,
@@ -695,7 +695,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
             dicsDir,
           ]);
 
-          assertEquals(loggerStub.infoLogs.every((l) => !(l.includes('[dry-run]') && l.includes('written.md'))), true);
+          assertEquals(loggerStub.dryrunLogs.every((l) => !l.includes('written.md')), true);
         });
       });
     });
@@ -730,7 +730,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('T-SF-DR-05-01: [dry-run] を含むログが0件', async () => {
+        it('T-SF-DR-05-01: dryrun ログが0件', async () => {
           await main([
             '--input-dir',
             inputDir,
@@ -744,7 +744,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
             dicsDir,
           ]);
 
-          assertEquals(loggerStub.infoLogs.every((l) => !l.includes('[dry-run]')), true);
+          assertEquals(loggerStub.dryrunLogs.length, 0);
         });
       });
     });

--- a/skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-entry-loader.ts
@@ -10,6 +10,7 @@
 // cspell:words setfm
 
 // ─── Shared scripts
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { loadChatlogEntry as _loadEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
 import { findFiles } from '../../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
@@ -40,7 +41,7 @@ export const loadAllEntries = async (
 
   allFiles
     .filter((_, i) => !_results[i])
-    .forEach((filePath) => logger.warn(`  skip: ${getFilename(filePath)}`));
+    .forEach((filePath) => logger.warn(`${LOGGER_TEXT.INDENT}skip: ${getFilename(filePath)}`));
 
   const _entries = _results.filter((e): e is ChatlogEntry => e !== null);
   stats.skip = allFiles.length - _entries.length;

--- a/skills/set-frontmatter/scripts/modules/setfm-write.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-write.ts
@@ -19,6 +19,7 @@ import { getDirectory, getFilename } from '../../../_scripts/libs/path-utils/pat
 
 // ─── Local
 import { DEFAULT_ORDERED_FIELDS } from '../../../_scripts/constants/common.constants.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types.ts';
 import type { FrontmatterFields } from '../../../_scripts/types/frontmatter.types.ts';
 import type { SetfmCache } from '../types/cache.types.ts';
@@ -107,7 +108,7 @@ export const writeFrontmatter = async (
 ): Promise<boolean> => {
   const _inputPath = entry.filePath!;
   if (!entry.frontmatter.hasRequiredFields()) {
-    logger.error(`  FAIL (yaml空): ${getFilename(_inputPath)}`);
+    logger.error(`${LOGGER_TEXT.INDENT}FAIL (yaml空): ${getFilename(_inputPath)}`);
     return false;
   }
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-status.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-status.unit.spec.ts
@@ -205,17 +205,17 @@ describe('phaseStatus', () => {
         loggerStub.restore();
       });
 
-      it('[Edge] T-SF-PS-08: dryRun=true, written 以外のエントリ → "[dry-run] status:" がファイル名を含んでログ出力される', async () => {
+      it('[Edge] T-SF-PS-08: dryRun=true, written 以外のエントリ → "status:" がファイル名を含んでログ出力される', async () => {
         const buf = new Map<string, string>();
         const cache = await _makeCache(buf);
         const entry = _makeFullEntry('/path/to/full.md');
 
         await phaseStatus([entry], cache, true);
 
-        assertEquals(loggerStub.infoLogs.some((l) => l.includes('[dry-run] status:') && l.includes('full.md')), true);
+        assertEquals(loggerStub.dryrunLogs.some((l) => l.includes('status:') && l.includes('full.md')), true);
       });
 
-      it('[Edge] T-SF-PS-09: dryRun=true, cache.status === "written" のエントリ → "[dry-run] status:" ログなし', async () => {
+      it('[Edge] T-SF-PS-09: dryRun=true, cache.status === "written" のエントリ → "status:" ログなし', async () => {
         const buf = new Map<string, string>();
         const cache = await _makeCache(buf, 'written:\n  status: written');
         const entry = _makeFullEntry('/path/to/written.md');
@@ -223,7 +223,7 @@ describe('phaseStatus', () => {
         await phaseStatus([entry], cache, true);
 
         assertEquals(
-          loggerStub.infoLogs.every((l) => !(l.includes('[dry-run] status:') && l.includes('written.md'))),
+          loggerStub.dryrunLogs.every((l) => !(l.includes('status:') && l.includes('written.md'))),
           true,
         );
       });

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-write.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-write.unit.spec.ts
@@ -342,7 +342,7 @@ describe('phaseWrite', () => {
     assertEquals(stats.fail, 0);
   });
 
-  /** dryRun=true: [dry-run] ログに type/category/ファイル名が含まれる。 */
+  /** dryRun=true: dryrun ログに type/category/ファイル名が含まれる。 */
   describe('When: dryRun ログ出力', () => {
     let loggerStub: LoggerStub;
 
@@ -354,7 +354,7 @@ describe('phaseWrite', () => {
       loggerStub.restore();
     });
 
-    it('[Normal] T-SF-PW-06-04: dryRun=true → logger.info に type/category/filename が含まれる', async () => {
+    it('[Normal] T-SF-PW-06-04: dryRun=true → logger.dryrun に type/category/filename が含まれる', async () => {
       const filePath = '/path/to/a.md';
       const cache = await _makeCacheWithEntry(filePath);
       const { stub: writeStub } = _makeWriteStub();
@@ -368,7 +368,7 @@ describe('phaseWrite', () => {
         writeStub,
       );
 
-      const dryRunLine = loggerStub.infoLogs.find((msg) => msg.includes('[dry-run]'));
+      const dryRunLine = loggerStub.dryrunLogs[0];
       assertStringIncludes(dryRunLine ?? '', 'tech');
       assertStringIncludes(dryRunLine ?? '', 'backend');
       assertStringIncludes(dryRunLine ?? '', 'a.md');

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -12,6 +12,7 @@
 // ─── Shared scripts
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -62,9 +63,9 @@ export const phaseFrontmatter = async (
       await cache.write(e.filePath!, { ..._cached, status: CACHE_STATUSES.NEED_REVIEW });
     }
     if (dryRun) {
-      logger.info(`  [dry-run] frontmatter (cached): ${getFilename(e.filePath!)}`);
+      logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter (cached): ${getFilename(e.filePath!)}`);
     } else {
-      logger.info(`  generated (cached): ${getFilename(e.filePath!)}`);
+      logger.info(`${LOGGER_TEXT.INDENT}generated (cached): ${getFilename(e.filePath!)}`);
     }
   }
 
@@ -84,9 +85,9 @@ export const phaseFrontmatter = async (
         });
       }
       if (dryRun) {
-        logger.info(`  [dry-run] frontmatter (existing): ${getFilename(entry.filePath!)}`);
+        logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter (existing): ${getFilename(entry.filePath!)}`);
       } else {
-        logger.info(`  frontmatter (existing): ${getFilename(entry.filePath!)}`);
+        logger.info(`${LOGGER_TEXT.INDENT}frontmatter (existing): ${getFilename(entry.filePath!)}`);
       }
     },
     concurrency,
@@ -97,13 +98,13 @@ export const phaseFrontmatter = async (
     _needsGenerate,
     async (entry) => {
       if (dryRun) {
-        logger.info(`  [dry-run] frontmatter: ${getFilename(entry.filePath!)}`);
+        logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter: ${getFilename(entry.filePath!)}`);
       } else {
         let _ok: boolean;
         try {
           _ok = await _generate(entry, maxContentLength, dics, prompts, maxRetry);
         } catch (e) {
-          logger.warn(`  FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
+          logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
         }
         if (_ok) {
@@ -111,9 +112,9 @@ export const phaseFrontmatter = async (
           const _existing = cache.read(entry.filePath!);
           const _statusUpdate = entry.frontmatter.hasRequiredFields() ? { status: CACHE_STATUSES.NEED_REVIEW } : {};
           await cache.write(entry.filePath!, { ..._existing, frontmatter: _fmSnapshot, ..._statusUpdate });
-          logger.info(`  generated: ${getFilename(entry.filePath!)}`);
+          logger.info(`${LOGGER_TEXT.INDENT}generated: ${getFilename(entry.filePath!)}`);
         } else {
-          logger.warn(`  FAIL (生成失敗): ${getFilename(entry.filePath!)}`);
+          logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)}`);
         }
       }
     },

--- a/skills/set-frontmatter/scripts/phases/phase-review.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-review.ts
@@ -12,6 +12,7 @@
 // ─── Shared scripts
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -45,7 +46,7 @@ export const phaseReview = async (
   const _misses = entries.filter((e) => cache.read(e.filePath!).status !== CACHE_STATUSES.REVIEWED);
 
   _hits.forEach((e) => {
-    logger.info(`  review (cached): ${getFilename(e.filePath!)}`);
+    logger.info(`${LOGGER_TEXT.INDENT}review (cached): ${getFilename(e.filePath!)}`);
   });
 
   const _review = reviewProvider ?? reviewFrontmatter;
@@ -53,17 +54,17 @@ export const phaseReview = async (
     _misses,
     async (entry) => {
       if (dryRun) {
-        logger.info(`  [dry-run] review: ${getFilename(entry.filePath!)}`);
+        logger.dryrun(`${LOGGER_TEXT.INDENT}review: ${getFilename(entry.filePath!)}`);
       } else {
         let r: ReviewResult;
         try {
           r = await _review(entry, dics, prompts, maxRetry);
         } catch (e) {
-          logger.warn(`  FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
+          logger.warn(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
         }
         if (r.validity === 'pass') {
-          logger.info(`  review OK: ${getFilename(entry.filePath!)}`);
+          logger.info(`${LOGGER_TEXT.INDENT}review OK: ${getFilename(entry.filePath!)}`);
           const _existing = cache.read(entry.filePath!);
           const _fmSnapshot = { ...(_existing.frontmatter ?? {}), ...extractEntryFrontmatter(entry) };
           const _correctedType = (entry.frontmatter.get('type') as string | undefined) ?? _existing.type;
@@ -76,7 +77,7 @@ export const phaseReview = async (
             status: CACHE_STATUSES.REVIEWED,
           });
         } else if (r.validity === 'corrected') {
-          logger.info(`  review corrected: ${getFilename(entry.filePath!)}`);
+          logger.info(`${LOGGER_TEXT.INDENT}review corrected: ${getFilename(entry.filePath!)}`);
           const _existing = cache.read(entry.filePath!);
           const _filtered = filterFrontmatterFields(r.corrected ?? {});
           const _fmSnapshot = { ...(_existing.frontmatter ?? {}), ..._filtered };
@@ -91,7 +92,7 @@ export const phaseReview = async (
           });
         } else {
           // r.validity === 'error'
-          logger.warn(`  review error: ${getFilename(entry.filePath!)} — ${r.errors.join('; ')}`);
+          logger.warn(`${LOGGER_TEXT.INDENT}review error: ${getFilename(entry.filePath!)} — ${r.errors.join('; ')}`);
           const _existing = cache.read(entry.filePath!);
           await cache.write(entry.filePath!, {
             ..._existing,

--- a/skills/set-frontmatter/scripts/phases/phase-status.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-status.ts
@@ -12,6 +12,7 @@
 // ─── Shared scripts
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types.ts';
@@ -42,14 +43,14 @@ export const phaseStatus = async (
         return;
       }
       if (dryRun) {
-        logger.info(`  [dry-run] status: ${getFilename(entry.filePath!)} - skipped`);
+        logger.dryrun(`${LOGGER_TEXT.INDENT}status: ${getFilename(entry.filePath!)} - skipped`);
         return;
       }
       const _status = entry.frontmatter.hasRequiredFields()
         ? CACHE_STATUSES.NEED_REVIEW
         : CACHE_STATUSES.EMPTY;
       await cache.write(entry.filePath!, { ..._existing, status: _status });
-      logger.info(`  status: ${getFilename(entry.filePath!)} - status: ${_status || '(empty)'}`);
+      logger.info(`${LOGGER_TEXT.INDENT}status: ${getFilename(entry.filePath!)} - status: ${_status || '(empty)'}`);
     }),
   );
 };

--- a/skills/set-frontmatter/scripts/phases/phase-type-category.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-type-category.ts
@@ -12,6 +12,7 @@
 // ─── Shared scripts
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -55,7 +56,7 @@ export const phaseTypeAndCategory = async (
     const _cached = cache.read(e.filePath!);
     e.frontmatter.set('type', _cached.type!);
     e.frontmatter.set('category', _cached.category!);
-    logger.info(`  type+category (cached): ${getFilename(e.filePath!)}`);
+    logger.info(`${LOGGER_TEXT.INDENT}type+category (cached): ${getFilename(e.filePath!)}`);
   });
 
   const _judge = judgeProvider ?? judgeTypeAndCategory;
@@ -63,7 +64,7 @@ export const phaseTypeAndCategory = async (
     _misses,
     async (entry) => {
       if (dryRun) {
-        logger.info(`  [dry-run] type/category: ${getFilename(entry.filePath!)}`);
+        logger.dryrun(`${LOGGER_TEXT.INDENT}type/category: ${getFilename(entry.filePath!)}`);
       } else {
         await _judge(entry, maxContentLength, dics, prompts);
         const _type = entry.frontmatter.get('type') as string;
@@ -74,9 +75,9 @@ export const phaseTypeAndCategory = async (
           await cache.delete(entry.filePath!);
         }
         logger.info(
-          `  type [${entry.frontmatter.get('type')}] category [${entry.frontmatter.get('category')}]: ${
-            getFilename(entry.filePath!)
-          }`,
+          `${LOGGER_TEXT.INDENT}type [${entry.frontmatter.get('type')}] category [${
+            entry.frontmatter.get('category')
+          }]: ${getFilename(entry.filePath!)}`,
         );
       }
     },

--- a/skills/set-frontmatter/scripts/phases/phase-write.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-write.ts
@@ -12,6 +12,7 @@
 // ─── Shared scripts
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types.ts';
@@ -68,12 +69,12 @@ export const phaseWrite = async (
     if (config.dryRun) {
       const _type = (entry.frontmatter.get('type') as string) ?? '';
       const _category = (entry.frontmatter.get('category') as string) ?? '';
-      logger.info(`  [dry-run] [${_type}/${_category}]: ${getFilename(entry.filePath!)} -- skipped`);
+      logger.dryrun(`${LOGGER_TEXT.INDENT}[${_type}/${_category}]: ${getFilename(entry.filePath!)} -- skipped`);
       stats.skip++;
     } else {
       const _ok = await _write(entry, cache, config.outputDir, config.inputDir);
       if (_ok) {
-        logger.info(`  OK: ${getFilename(entry.filePath!)}`);
+        logger.info(`${LOGGER_TEXT.INDENT}OK: ${getFilename(entry.filePath!)}`);
         stats.success++;
       } else {
         stats.fail++;

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -28,6 +28,7 @@
 // ─── Shared scripts
 import { ChatlogError } from '../../_scripts/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_scripts/classes/GlobalConfig.class.ts';
+import { LOGGER_TEXT } from '../../_scripts/constants/logger.constants.ts';
 import { resolveChatlogsDir } from '../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_scripts/libs/file-ops/exists-utils.ts';
 import { logger } from '../../_scripts/libs/io/logger.ts';
@@ -194,7 +195,7 @@ export const main = async (args: string[]): Promise<void> => {
   if (!_config.dryRun) {
     const _failEntries = _candidateEntries.filter((e) => !filterWriteEntry(e.filePath!, _cache, _config.review));
     _failEntries.forEach((e) => {
-      logger.error(`  FAIL (yaml空): ${getFilename(e.filePath!)}`);
+      logger.error(`${LOGGER_TEXT.INDENT}FAIL (yaml空): ${getFilename(e.filePath!)}`);
       stats.fail++;
     });
   }


### PR DESCRIPTION
## Overview

**Summary**
Replace hand-written logger prefix/indent strings with shared constants across all skills.

**Background / Motivation**
Dry-run log formatting was duplicated and inconsistent across skills — some used a manual
`[dry-run]` prefix or manual indentation, others didn't. Centralizing this in `LOGGER_PREFIX` /
`LOGGER_TEXT` constants and a new `logger.dryrun()` method removes the duplication and makes the
dry-run output format a single source of truth. Along the way, the `classify-chatlogs` pipeline
was simplified and `_applyMove` gained direct unit test coverage.

## Changes

### Core Changes

- Add `LOGGER_PREFIX` (`INFO`/`WARN`/`ERROR`/`DRYRUN`) and `LOGGER_TEXT.INDENT` constants in
  `skills/_scripts/constants/logger.constants.ts`.
- Add `logger.dryrun()` in `skills/_scripts/libs/io/logger.ts`, emitting `<<dry-run>>`-prefixed
  messages via `console.error`.
- Adopt `logger.dryrun` / `LOGGER_TEXT.INDENT` across `classify-chatlogs`, `filter-chatlogs`,
  `normalize-chatlogs`, and `set-frontmatter` skills.
- Simplify `classify-chatlogs.ts` by extracting pipeline setup/execution helper functions.
- Export `_applyMove` from `phase-write.ts` for direct unit testing.

### Test Updates

- Add unit tests for `logger.dryrun` and `_applyMove` (move / move-by-ai / missing-source error
  paths).
- Add `dryrunLogs` capture support to `LoggerStub`.
- Add cache-deletion coverage for successful, failed, and dry-run moves.
- Update dry-run log assertions across e2e/unit/functional specs to match the new output format.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`logger.dryrun` is additive; no public API signatures changed. Dry-run output now goes through
`console.error` with a `<<dry-run>>` prefix instead of `console.log`/`info` at the affected call
sites — this changes the log text/stream for dry-run messages but not any public interface.
