### PR TITLE
refactor(filter): introduce shared filter process options type

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts
@@ -97,7 +97,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -122,7 +122,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, '---\ntitle: テスト\n---\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -147,7 +147,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, '---\ntitle: テスト\n---\n短い本文\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -173,7 +173,11 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(1200));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { minCharCount: 2428, stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), {
+            minCharCount: 2428,
+            dryRun: false,
+            concurrency: 2,
+          });
           errStub.restore();
 
           assertEquals(result.length, 0);
@@ -184,7 +188,11 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(1200));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { minCharCount: 2426, stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), {
+            minCharCount: 2426,
+            dryRun: false,
+            concurrency: 2,
+          });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -210,10 +218,10 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeValidContent('テスト', 'u'.repeat(1500), 'a'.repeat(400)));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], {
+          const result = await prefilterFiles([entry], _makeStats(), {
             minCharCount: 1000,
             minAssistantChars: 401,
-            stats: _makeStats(),
+            dryRun: false,
             concurrency: 2,
           });
           errStub.restore();
@@ -226,10 +234,10 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeValidContent('テスト', 'u'.repeat(1500), 'a'.repeat(400)));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], {
+          const result = await prefilterFiles([entry], _makeStats(), {
             minCharCount: 1000,
             minAssistantChars: 399,
-            stats: _makeStats(),
+            dryRun: false,
             concurrency: 2,
           });
           errStub.restore();
@@ -260,8 +268,8 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
 
           const _stats = _makeStats();
-          const result = await prefilterFiles([excludedEntry, shortEntry, validEntry], {
-            stats: _stats,
+          const result = await prefilterFiles([excludedEntry, shortEntry, validEntry], _stats, {
+            dryRun: false,
             concurrency: 2,
           });
           errStub.restore();
@@ -288,7 +296,7 @@ describe('prefilterFiles', () => {
           const entry2 = await _writeEntry(validPath2, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry1, entry2], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry1, entry2], _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 2);
@@ -312,7 +320,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -326,7 +334,10 @@ describe('prefilterFiles', () => {
           const shortEntry = await _writeEntry(shortPath, '---\ntitle: 短い\n---\n短い本文\n');
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([validEntry, shortEntry], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([validEntry, shortEntry], _makeStats(), {
+            dryRun: false,
+            concurrency: 2,
+          });
           errStub.restore();
 
           assertEquals(result.length, 1);
@@ -356,11 +367,7 @@ describe('prefilterFiles', () => {
           const validEntry = await _writeEntry(validPath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const loggerStub = makeLoggerStub();
 
-          await prefilterFiles([excludedEntry, shortEntry, validEntry], {
-            stats: _makeStats(),
-            dryRun: true,
-            concurrency: 2,
-          });
+          await prefilterFiles([excludedEntry, shortEntry, validEntry], _makeStats(), { dryRun: true, concurrency: 2 });
           loggerStub.restore();
 
           assertEquals(loggerStub.dryrunLogs.length, 2);
@@ -376,14 +383,13 @@ describe('prefilterFiles', () => {
           const loggerStub = makeLoggerStub();
 
           const statsDryRun = _makeStats();
-          const resultDryRun = await prefilterFiles([excludedEntry, shortEntry, validEntry], {
-            stats: statsDryRun,
+          const resultDryRun = await prefilterFiles([excludedEntry, shortEntry, validEntry], statsDryRun, {
             dryRun: true,
             concurrency: 2,
           });
           const statsNormal = _makeStats();
-          const resultNormal = await prefilterFiles([excludedEntry, shortEntry, validEntry], {
-            stats: statsNormal,
+          const resultNormal = await prefilterFiles([excludedEntry, shortEntry, validEntry], statsNormal, {
+            dryRun: false,
             concurrency: 2,
           });
           loggerStub.restore();
@@ -414,7 +420,7 @@ describe('prefilterFiles', () => {
           const entry = await _writeEntry(filePath, makeRepeatedContent(FILTER_MIN_CONTENT_LENGTH));
           const errStub = stub(console, 'error', () => {});
 
-          const result = await prefilterFiles([entry], { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles([entry], _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.map((e) => e.filePath).includes(filePath), true);
@@ -448,7 +454,7 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
 
           const entries = [validEntry3, excludedEntry, validEntry1, shortEntry, validEntry2];
-          const result = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
+          const result = await prefilterFiles(entries, _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(result.map((e) => e.filePath), [validPath3, validPath1, validPath2]);
@@ -463,8 +469,8 @@ describe('prefilterFiles', () => {
    * 実削除・dry-run 時のスキップ動作を検証する。
    */
   describe('Given: 除外パターンのファイル名を持つファイル', () => {
-    /** prefilterFiles([file], { stats }) を呼び出すとき。 */
-    describe('When: prefilterFiles([file], { stats }) を呼び出す', () => {
+    /** prefilterFiles([file], stats, { ... }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], stats, { ... }) を呼び出す', () => {
       /** ファイルが実削除される、または dry-run 時は削除されないことを検証する。 */
       describe('Then: T-FL-PFF-20 - ファイルが実削除される', () => {
         it('T-FL-PFF-20-01: 実削除され stats.remove が加算される', async () => {
@@ -473,7 +479,7 @@ describe('prefilterFiles', () => {
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
 
-          await prefilterFiles([entry], { stats, concurrency: 2 });
+          await prefilterFiles([entry], stats, { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(await Deno.stat(filePath).catch(() => null), null);
@@ -486,7 +492,7 @@ describe('prefilterFiles', () => {
           const loggerStub = makeLoggerStub();
           const stats = _makeStats();
 
-          await prefilterFiles([entry], { stats, dryRun: true, concurrency: 2 });
+          await prefilterFiles([entry], stats, { dryRun: true, concurrency: 2 });
           loggerStub.restore();
 
           assertEquals(await Deno.stat(filePath).then(() => true).catch(() => false), true);
@@ -502,8 +508,8 @@ describe('prefilterFiles', () => {
    * `removeFile` が `false` を返すケースで stats.error が加算されることを検証する。
    */
   describe('Given: 除外パターンのファイル名を持つファイルが実削除前に既に存在しない', () => {
-    /** prefilterFiles([file], { stats }) を呼び出すとき。 */
-    describe('When: prefilterFiles([file], { stats }) を呼び出す', () => {
+    /** prefilterFiles([file], stats, { ... }) を呼び出すとき。 */
+    describe('When: prefilterFiles([file], stats, { ... }) を呼び出す', () => {
       /** stats.error が増え、stats.remove は増えないことを検証する。 */
       describe('Then: T-FL-PFF-21 - stats.error が 1 になる', () => {
         it('T-FL-PFF-21-01: removeFile 失敗 → stats.error === 1, stats.remove === 0', async () => {
@@ -513,7 +519,7 @@ describe('prefilterFiles', () => {
 
           // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
           const entry = new ChatlogEntry('', { filePath });
-          await prefilterFiles([entry], { stats, concurrency: 2 });
+          await prefilterFiles([entry], stats, { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(stats.error, 1);
@@ -527,7 +533,7 @@ describe('prefilterFiles', () => {
 
           // ファイルを作成しないことで removeFile が NotFound → false を返す状態を再現する
           const entry = new ChatlogEntry('', { filePath });
-          const passed = await prefilterFiles([entry], { stats, concurrency: 2 });
+          const passed = await prefilterFiles([entry], stats, { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(passed.map((e) => e.filePath), [filePath]);

--- a/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts
@@ -78,7 +78,7 @@ describe('findMdFiles → prefilterFiles パイプライン', () => {
           const allFiles = await findFiles(tempDir);
           const { entries } = await loadFilterEntries(allFiles, cache, 2);
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
+          const passed = await prefilterFiles(entries, _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(passed.length, 2);
@@ -102,7 +102,7 @@ describe('prefilterFiles → buildBatchPrompt パイプライン', () => {
 
           const { entries } = await loadFilterEntries([file1, file2], cache, 2);
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
+          const passed = await prefilterFiles(entries, _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           const prompt = buildBatchPrompt(passed);
@@ -147,7 +147,7 @@ describe('loadFilterEntries → prefilterFiles パイプライン', () => {
           const { entries, errors } = await loadFilterEntries(allFiles, cache, 2);
 
           const errStub = stub(console, 'error', () => {});
-          const passed = await prefilterFiles(entries, { stats: _makeStats(), concurrency: 2 });
+          const passed = await prefilterFiles(entries, _makeStats(), { dryRun: false, concurrency: 2 });
           errStub.restore();
 
           assertEquals(errors.length, 1);

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -137,10 +137,9 @@ export const main = async (args?: string[]): Promise<void> => {
     );
   }
 
-  const targetEntries = await prefilterFiles(entries, {
+  const targetEntries = await prefilterFiles(entries, stats, {
     minCharCount: _config.minCharCount,
     minAssistantChars: _config.minAssistantChars,
-    stats,
     dryRun: _config.dryRun,
     concurrency: _config.concurrency,
   });

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts
@@ -53,7 +53,7 @@ const _writeEntry = async (filePath: string, content: string): Promise<ChatlogEn
 /**
  * `processNoiseFiles` 関数の機能テストスイート。
  *
- * `processNoiseFiles(entries, counts, { dryRun })` は `ChatlogEntry` 配列を受け取り、
+ * `processNoiseFiles(entries, counts, { dryRun, concurrency })` は `ChatlogEntry` 配列を受け取り、
  * 各エントリを分類してノイズを削除（または dry-run 出力）し、counts を更新する。
  *
  * テスト ID 範囲: T-PF-PNF-01 〜 T-PF-PNF-05
@@ -94,7 +94,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: false, concurrency: Infinity });
 
           assertEquals(await fileExists(filePath), false);
         });
@@ -104,7 +104,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: false, concurrency: Infinity });
 
           assertEquals(counts.remove, 1);
         });
@@ -129,7 +129,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: false, concurrency: Infinity });
 
           assertEquals(await fileExists(filePath), true);
         });
@@ -139,7 +139,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: false }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: false, concurrency: Infinity });
 
           assertEquals(counts.keep, 1);
         });
@@ -164,7 +164,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: true, concurrency: Infinity });
 
           assertEquals(await fileExists(filePath), true);
         });
@@ -174,7 +174,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: true, concurrency: Infinity });
 
           assertEquals(loggerStub.dryrunLogs.some((line) => line.includes(_NOISE_FILENAME)), true);
         });
@@ -184,7 +184,7 @@ describe('processNoiseFiles', () => {
           const entry = await _writeEntry(filePath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([entry], counts, { dryRun: true }, Infinity);
+          await processNoiseFiles([entry], counts, { dryRun: true, concurrency: Infinity });
 
           assertEquals(counts.skip, 1);
         });
@@ -211,7 +211,7 @@ describe('processNoiseFiles', () => {
           const keepEntry = await _writeEntry(keepPath, _makeValidContent());
           const counts = { keep: 0, skip: 0, remove: 0, error: 0 };
 
-          await processNoiseFiles([noiseEntry, keepEntry], counts, { dryRun: false }, Infinity);
+          await processNoiseFiles([noiseEntry, keepEntry], counts, { dryRun: false, concurrency: Infinity });
 
           assertEquals(counts.remove, 1);
           assertEquals(counts.keep, 1);

--- a/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
+++ b/skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts
@@ -17,6 +17,7 @@ import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts
 
 // ─── internal ───
 // types
+import type { FilterProcessOptions } from '../../types/filter.types.ts';
 import type { NoiseDiscardFile } from '../../types/noise-filter.types.ts';
 import type { NoiseFilterStats } from '../../types/stats.types.ts';
 // functions
@@ -137,14 +138,14 @@ export const _phase3DiscardOrSkip = async (
  * @param entries - 処理対象の `ChatlogEntry` 配列
  * @param stats - 加算対象の処理統計オブジェクト
  * @param options.dryRun - `true` のとき、ノイズ判定確定ファイルを実削除せず `stats.skip` に計上する
- * @param concurrency - 同時実行する削除処理の最大並列数。
+ * @param options.concurrency - 同時実行する削除処理の最大並列数。
  */
 export const processNoiseFiles = async (
   entries: ChatlogEntry[],
   stats: NoiseFilterStats,
-  options: { dryRun: boolean },
-  concurrency: number,
+  options: FilterProcessOptions,
 ): Promise<void> => {
+  const { dryRun, concurrency } = options;
   const { discardFiles: filenameDiscardFiles, passEntries } = _phase0ClassifyByFilename(entries);
   const { discardFiles: contentDiscardFiles, keepFiles } = _phase2ClassifyConversations(passEntries);
 
@@ -153,7 +154,7 @@ export const processNoiseFiles = async (
   await _phase3DiscardOrSkip(
     [...filenameDiscardFiles, ...contentDiscardFiles],
     stats,
-    options.dryRun,
+    dryRun,
     concurrency,
   );
 };

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -276,23 +276,23 @@ export const _discardFiles = async (
  * 読み込み済みエントリをファイル名パターンと本文内容で事前フィルタリングし、通過したエントリを返す。
  *
  * @param entries - フィルタリング対象の `ChatlogEntry` 配列（読み込み済み）
+ * @param stats - 処理統計オブジェクト。ファイル名パターン除外・内容除外の実削除数を `remove` に、
+ *   dry-run 時のスキップ数を `skip` に加算する。
  * @param options - `prefilterFiles` のオプション
  * @param options.minCharCount - 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）
  * @param options.minAssistantChars - User ターンが 1 件のとき、Assistant 応答の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）
- * @param options.stats - 処理統計オブジェクト。ファイル名パターン除外・内容除外の実削除数を `remove` に、
- *   dry-run 時のスキップ数を `skip` に加算する。
  * @param options.dryRun - `true` のとき、削除対象ファイルを実削除せず `stats.skip` に計上する（デフォルト: `false`）
  * @param options.concurrency - 同時実行する削除処理の最大並列数。
  * @returns フィルタリングを通過した `ChatlogEntry` 配列
  */
 export const prefilterFiles = async (
   entries: ChatlogEntry[],
+  stats: BaseStats,
   options: PrefilterFilesOptions,
 ): Promise<ChatlogEntry[]> => {
   const {
     minCharCount = DEFAULT_CONFIG_VALUES.minCharCount as number,
     minAssistantChars = DEFAULT_CONFIG_VALUES.minAssistantChars as number,
-    stats,
     dryRun = false,
     concurrency,
   } = options;

--- a/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts
@@ -93,15 +93,14 @@ export const main = async (args: string[] = Deno.args): Promise<void> => {
     );
   }
 
-  const targetEntries = await prefilterFiles(entries, {
+  const targetEntries = await prefilterFiles(entries, stats, {
     minCharCount,
     minAssistantChars,
-    stats,
     dryRun,
     concurrency,
   });
 
-  await processNoiseFiles(targetEntries, stats, { dryRun }, concurrency);
+  await processNoiseFiles(targetEntries, stats, { dryRun, concurrency });
 
   const suffix = dryRun ? ' (dry-run)' : '';
   logger.info(

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -8,7 +8,6 @@
 
 // types
 import type { FilterDecision } from './filter-decision.const.types.ts';
-import type { BaseStats } from './stats.types.ts';
 
 // ─────────────────────────────────────────────
 // 分類設定型
@@ -74,16 +73,18 @@ export interface DiscardFile {
   decision: FilterDecision;
 }
 
+/** ノイズフィルタ処理関数（prefilterFiles / processNoiseFiles）共通のオプション引数。 */
+export interface FilterProcessOptions {
+  /** `true` のとき、削除対象ファイルを実削除せず `stats.skip` に計上する。 */
+  dryRun: boolean;
+  /** 同時実行する削除処理の最大並列数。 */
+  concurrency: number;
+}
+
 /** `prefilterFiles` のオプション引数。 */
-export interface PrefilterFilesOptions {
+export interface PrefilterFilesOptions extends FilterProcessOptions {
   /** 本文の最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minCharCount`）。 */
   minCharCount?: number;
   /** User ターン 1 件時の Assistant 応答最小文字数（デフォルト: `DEFAULT_CONFIG_VALUES.minAssistantChars`）。 */
   minAssistantChars?: number;
-  /** 処理統計オブジェクト。事前段階での KEEP 確定数は `keep` に、読み込み失敗数は `error` に加算される。 */
-  stats: BaseStats;
-  /** `true` のとき、スキップ理由・サマリのログ出力を抑制する。 */
-  dryRun?: boolean;
-  /** 同時実行するファイル削除処理の最大並列数。 */
-  concurrency: number;
 }


### PR DESCRIPTION
## Overview

**Summary**
Unify shared options between `prefilterFiles` and `processNoiseFiles` into a single `FilterProcessOptions` type.

**Background / Motivation**
`PrefilterFilesOptions` and the noise-filter options duplicated `dryRun` and `concurrency` fields. This change extracts them into a shared type and moves `stats` out of the options object into its own parameter, clarifying the contract between the two filter stages. `dryRun` semantics were also tightened: it now skips deletion and counts the file toward `stats.skip`, instead of only suppressing log output.

## Changes

### Core Changes

- `skills/filter-chatlogs/scripts/types/filter.types.ts`: add `FilterProcessOptions` (`dryRun`, `concurrency`); `PrefilterFilesOptions` extends it and drops its own `stats`/`dryRun`/`concurrency` fields
- `skills/filter-chatlogs/scripts/modules/prefilter.ts`: `prefilterFiles` receives `stats` as its own parameter
- `skills/filter-chatlogs/scripts/modules/noise-filter/process-noise-files.ts`: `processNoiseFiles` options type changed to `FilterProcessOptions`
- `skills/filter-chatlogs/scripts/filter-chatlogs.ts`: pass `stats` as a separate argument to `prefilterFiles`
- `skills/filter-chatlogs/scripts/noise-filter-chatlogs.ts`: pass `stats` separately; move `concurrency` into `processNoiseFiles` options

### Test Updates

- `skills/filter-chatlogs/scripts/__tests__/functional/filter/prefilter.functional.spec.ts`: update calls to the new `(options, stats)` signature
- `skills/filter-chatlogs/scripts/__tests__/integration/filter/file-ops.integration.spec.ts`: update calls to split `stats` from `dryRun`/`concurrency`
- `skills/filter-chatlogs/scripts/modules/noise-filter/__tests__/functional/process-noise-files.functional.spec.ts`: update calls to pass `concurrency` via `options`

### Removed

- N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`dryRun` now skips deletion and counts toward `stats.skip`, instead of only suppressing logs. No public CLI or config surface changes.
