### PR TITLE
refactor(classes/chatlog-cache): pass init options object

### DIFF
--- a/skills/_scripts/classes/ChatlogCache.class.ts
+++ b/skills/_scripts/classes/ChatlogCache.class.ts
@@ -90,6 +90,12 @@ export interface ChatlogCacheProviders {
   env?: EnvProvider;
 }
 
+/** `initFromOutputDir` の追加オプション。 */
+export interface InitFromOutputDirOptions {
+  /** テキストを受け取り完全書き込み対象か判定する述語（省略時は全5フィールド揃い判定）。 */
+  isComplete?: (text: string) => boolean;
+}
+
 /** `ChatlogCache` コンストラクタに渡すキャッシュ初期化オプション。 */
 export interface ChatlogCacheInitializer {
   /** YAML 文字列でキャッシュを初期化する場合に指定する。省略時はディレクトリから自動読み込み。 */
@@ -177,7 +183,7 @@ export class ChatlogCache<T extends object> {
       const _concurrency = initializer?.concurrency ?? Number(GlobalConfig.getInstance().get('concurrency'));
       await this.loadAll(_concurrency);
       if (initializer?.outputDir != null) {
-        await this.initFromOutputDir(initializer.outputDir, undefined, _concurrency);
+        await this.initFromOutputDir(initializer.outputDir, _concurrency);
       }
     }
   }
@@ -308,14 +314,15 @@ export class ChatlogCache<T extends object> {
    * 両方の完了を待った上で、いずれかが reject していればそのエラーを伝播する。
    *
    * @param outputDir - `.md` ファイルを探索するディレクトリパス
-   * @param isComplete - テキストを受け取り完全書き込み対象か判定する述語（省略時は全5フィールド揃い判定）
    * @param concurrency - ファイル読み込み・書き込みの並列実行数
+   * @param options - 追加オプション（`isComplete` 述語など。省略時は全5フィールド揃い判定）
    */
   async initFromOutputDir(
     outputDir: string,
-    isComplete: (text: string) => boolean = _isComplete,
     concurrency: number,
+    options: InitFromOutputDirOptions = {},
   ): Promise<void> {
+    const { isComplete = _isComplete } = options;
     const _allFiles = await findFilesFlat(outputDir, { glob: this._glob });
 
     // step 1: 未キャッシュのファイルのみに絞る（同期 filter）

--- a/skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts
+++ b/skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts
@@ -710,7 +710,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('a.md'), { title: 'A', type: 'tech', category: 'dev', status: '' });
         assertEquals(_cache.read('b.md'), { title: 'B', type: 'tech', category: 'dev', status: '' });
       });
@@ -731,7 +731,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('has-fm.md'), { title: 'Test', type: 'tech', category: 'dev', status: '' });
       });
 
@@ -761,7 +761,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('full.md'), {
           title: 'A',
           type: 'tech',
@@ -798,7 +798,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('hashtag.md'), {
           title: 'A',
           type: 'tech',
@@ -835,7 +835,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('no-hashtag.md'), {
           title: 'A',
           type: 'tech',
@@ -862,7 +862,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('base.md'), { title: 'B', type: 'tech', category: 'dev', status: '' });
       });
 
@@ -878,11 +878,9 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir(
-          '/out',
-          (text) => parseFrontmatter(text).meta['title'] !== undefined,
-          2,
-        );
+        await _cache.initFromOutputDir('/out', 2, {
+          isComplete: (text) => parseFrontmatter(text).meta['title'] !== undefined,
+        });
         assertEquals(_cache.read('with-title.md'), { title: 'Hello', status: 'written' });
         assertEquals(_cache.read('no-title.md'), {});
       });
@@ -911,7 +909,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         // キャッシュ済みのため上書きされず { status: 'reviewed' } が保持される
         assertEquals(_cache.read('existing.md'), { status: 'reviewed' });
       });
@@ -929,7 +927,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         // a.md はフロントマターなし → isComplete false → 上書きされない
         assertEquals(_cache.read('a'), { status: 'kept' });
       });
@@ -953,7 +951,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('new.md'), { title: 'New', type: 'tech', category: 'dev', status: '' });
       });
 
@@ -968,7 +966,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('no-fm.md'), {});
       });
 
@@ -983,7 +981,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('empty-fm.md'), {});
       });
 
@@ -998,7 +996,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('bad-yaml.md'), {});
       });
 
@@ -1011,7 +1009,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('any'), {});
       });
 
@@ -1050,7 +1048,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         // フロントマターなし → スキップ（既存キャッシュ保持）
         assertEquals(_cache.read('fm-none.md'), { status: 'kept' });
         // 全5フィールド → status:written
@@ -1080,7 +1078,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         // *.md が空なので新規書き込みは発生しない
         assertEquals(_cache.read('any-new'), {});
       });
@@ -1099,7 +1097,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
+        await assertRejects(() => _cache.initFromOutputDir('/out', 2));
       });
 
       it('[Error] T-CLS-CC-50: writeTextFile 失敗 → initFromOutputDir が reject', async () => {
@@ -1115,7 +1113,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
+        await assertRejects(() => _cache.initFromOutputDir('/out', 2));
       });
 
       it('[Error] T-CLS-CC-56: readTextFile が reject → initFromOutputDir が reject', async () => {
@@ -1128,7 +1126,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 2));
+        await assertRejects(() => _cache.initFromOutputDir('/out', 2));
       });
 
       it('[Error] T-CLS-CC-84: write失敗（concurrency:1）でも delete 対象の removeFile は実行が試みられ、initFromOutputDir が reject する', async () => {
@@ -1153,7 +1151,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 1));
+        await assertRejects(() => _cache.initFromOutputDir('/out', 1));
         assertEquals(_removeFileCalled, true);
       });
 
@@ -1180,7 +1178,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await assertRejects(() => _cache.initFromOutputDir('/out', undefined, 1));
+        await assertRejects(() => _cache.initFromOutputDir('/out', 1));
         assertEquals(_writeTextFileCalled, true);
       });
     });
@@ -1213,7 +1211,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('complete.md'), { title: 'A', type: 'tech', category: 'dev', status: '' });
         assertEquals(_cache.read('missing-type.md'), {});
       });
@@ -1237,7 +1235,7 @@ describe('ChatlogCache', () => {
           },
         );
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('null-type.md'), {});
       });
 
@@ -1252,7 +1250,7 @@ describe('ChatlogCache', () => {
           },
         });
         await _cache.ready;
-        await _cache.initFromOutputDir('/out', undefined, 2);
+        await _cache.initFromOutputDir('/out', 2);
         assertEquals(_cache.read('title-only.md'), {});
       });
     });


### PR DESCRIPTION
## Overview

**Summary**
Replace the `isComplete` positional parameter with an options object in `ChatlogCache.initFromOutputDir`.

**Background / Motivation**
`initFromOutputDir` took `isComplete` as a positional parameter between `outputDir` and `concurrency`. This forced callers to pass `undefined` explicitly when they only wanted to set `concurrency`. Using an options object removes that awkward `undefined` and makes `concurrency` the natural second argument.

## Changes

### Core Changes

- `skills/_scripts/classes/ChatlogCache.class.ts`
  - Add `InitFromOutputDirOptions` interface with an optional `isComplete` predicate.
  - Change `initFromOutputDir` signature from `(outputDir, isComplete, concurrency)` to `(outputDir, concurrency, options)`.
  - Read `_isComplete` default from the destructured `options` instead of a positional argument.

### Test Updates

- `skills/_scripts/classes/__tests__/unit/ChatlogCache.unit.spec.ts`
  - Update `initFromOutputDir` call sites to match the new signature: drop the `undefined` second argument, move `concurrency` to the second position, and pass `isComplete` via `options.isComplete`.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
