### PR TITLE
refactor(classify-chatlogs): organize classify actions

### DIFF
--- a/skills/classify-chatlogs/scripts/__tests__/unit/main.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/unit/main.unit.spec.ts
@@ -140,7 +140,7 @@ describe('main', () => {
       }
     });
 
-    it('[Normal] T-CL-MAIN-06: --dry-run 指定 → claude CLI は呼び出されず、完了ログに skip=1 が含まれる', async () => {
+    it('[Normal] T-CL-MAIN-06: --dry-run 指定 → claude CLI は呼び出されず、完了ログに remaining=1 が含まれる', async () => {
       const { inputDir, configsDir, configFile, monthDir } = await _makeTestDirs();
       await Deno.writeTextFile(
         `${monthDir}/chat.md`,
@@ -156,7 +156,7 @@ describe('main', () => {
         await main(['claude', '2026-03', '--dry-run', '--input-dir', monthDir, '--config', configFile]);
 
         assertEquals(counter.calls, 0);
-        assertEquals(loggerStub.infoLogs.some((l) => l.includes('skip=1')), true);
+        assertEquals(loggerStub.infoLogs.some((l) => l.includes('remaining=1')), true);
       } finally {
         commandHandle.restore();
         loggerStub.restore();

--- a/skills/classify-chatlogs/scripts/phases/__tests__/fixtures/fixtures-data/pre-classify/edge/empty-project/expected.yaml
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/fixtures/fixtures-data/pre-classify/edge/empty-project/expected.yaml
@@ -1,1 +1,1 @@
-action: remaining
+{}

--- a/skills/classify-chatlogs/scripts/phases/__tests__/fixtures/fixtures-data/pre-classify/normal/remaining/expected.yaml
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/fixtures/fixtures-data/pre-classify/normal/remaining/expected.yaml
@@ -1,1 +1,1 @@
-action: remaining
+{}

--- a/skills/classify-chatlogs/scripts/phases/__tests__/fixtures/pre-classify.fixtures.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/fixtures/pre-classify.fixtures.spec.ts
@@ -46,7 +46,7 @@ interface _FixtureInput {
 }
 
 interface _FixtureExpected {
-  action: ClassifyAction;
+  action?: ClassifyAction;
   project?: string;
 }
 
@@ -108,7 +108,7 @@ describe('classifyByNoAI', () => {
     for (const { relPath: _relPath, input, expected } of _fixtures) {
       const _testId = _relPath.replace(/\//g, '-');
       it(
-        `[Fixture] SF-CL-PRE-${_testId}: action=${expected.action}${
+        `[Fixture] SF-CL-PRE-${_testId}: action=${expected.action ?? '(none)'}${
           expected.project ? `, project=${expected.project}` : ''
         }`,
         async () => {

--- a/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
@@ -136,7 +136,7 @@ describe('classifyByAI', () => {
   });
 
   /**
-   * 正常系: dryRun=true の場合、AI 呼び出しをスキップし cache に action=SKIP を書き込むケース。
+   * 正常系: dryRun=true の場合、AI 呼び出しをスキップし cache には何も書き込まないケース。
    */
   describe('When: dry-run', () => {
     let mockHandle: CommandMockHandle;
@@ -156,7 +156,7 @@ describe('classifyByAI', () => {
       loggerStub.restore();
     });
 
-    it('[Normal] T-CL-CBA-06-01: dryRun=true・対象2件 → claude CLI は呼び出されず、両方の cache に action=SKIP が書き込まれる', async () => {
+    it('[Normal] T-CL-CBA-06-01: dryRun=true・対象2件 → claude CLI は呼び出されず、cache には何も書き込まれない', async () => {
       const targets: ChatlogEntry[] = [
         _makeClassifyChatlogEntry('a.md'),
         _makeClassifyChatlogEntry('b.md'),
@@ -165,9 +165,9 @@ describe('classifyByAI', () => {
       await classifyByAI(targets, _PROJECTS, _makeConfig(), cache, true);
 
       assertEquals(counter.calls, 0);
-      assertEquals(cache.read('/tmp/input/a.md').action, CLASSIFY_ACTIONS.SKIP);
+      assertEquals(cache.read('/tmp/input/a.md').action, undefined);
       assertEquals(cache.read('/tmp/input/a.md').project, undefined);
-      assertEquals(cache.read('/tmp/input/b.md').action, CLASSIFY_ACTIONS.SKIP);
+      assertEquals(cache.read('/tmp/input/b.md').action, undefined);
       assertEquals(cache.read('/tmp/input/b.md').project, undefined);
     });
 

--- a/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-classifications.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/unit/apply-classifications.unit.spec.ts
@@ -66,10 +66,10 @@ describe('applyClassifications', () => {
       assertEquals(_stats.remaining, 0);
     });
 
-    it('[Normal] T-CL-MC-05: action=remaining → stats.remaining++ のみ', async () => {
+    it('[Normal] T-CL-MC-05: project なし（action 未設定） → stats.remaining++ のみ', async () => {
       const _cache = await _makeEmptyClassifyCache();
       const _entry = _makeEntry('/tmp/input/test.md');
-      await _cache.write('/tmp/input/test.md', { action: CLASSIFY_ACTIONS.REMAINING });
+      await _cache.write('/tmp/input/test.md', {});
       const _stats = _makeStats();
 
       await applyClassifications(
@@ -160,27 +160,6 @@ describe('applyClassifications', () => {
       );
 
       assertEquals(_stats.remaining, 1);
-      assertEquals(_stats.moved, 0);
-      assertEquals(_stats.movedByAI, 0);
-      assertEquals(_stats.error, 0);
-    });
-
-    it('[Normal] T-CL-MC-16: action=skip, project なし → stats.skip++ のみ、remaining は増えず移動もしない', async () => {
-      const _cache = await _makeEmptyClassifyCache();
-      const _entry = _makeEntry('/tmp/input/test.md');
-      await _cache.write('/tmp/input/test.md', { action: CLASSIFY_ACTIONS.SKIP });
-      const _stats = _makeStats();
-
-      await applyClassifications(
-        [_entry],
-        '/tmp/output',
-        true,
-        { cache: _cache, stats: _stats },
-        { concurrency: 4 },
-      );
-
-      assertEquals(_stats.skip, 1);
-      assertEquals(_stats.remaining, 0);
       assertEquals(_stats.moved, 0);
       assertEquals(_stats.movedByAI, 0);
       assertEquals(_stats.error, 0);

--- a/skills/classify-chatlogs/scripts/phases/__tests__/unit/phase-classify-noai.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/unit/phase-classify-noai.unit.spec.ts
@@ -65,7 +65,7 @@ describe('classifyByNoAI', () => {
       assertEquals(cache.read(_filePath).project, FALLBACK_PROJECT);
     });
 
-    it('[Normal] T-CL-PRE-04: project フィールドなし + hasMeta=true → cache: action=remaining（AI 処理対象）', async () => {
+    it('[Normal] T-CL-PRE-04: project フィールドなし + hasMeta=true → cache: action/project とも未設定（AI 処理対象）', async () => {
       const _filePath = '/tmp/chatlogs/test.md';
       const _entry = _makeEntry(
         _filePath,
@@ -76,10 +76,11 @@ describe('classifyByNoAI', () => {
 
       await classifyByNoAI(_entry, cache);
 
-      assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.REMAINING);
+      assertEquals(cache.read(_filePath).action, undefined);
+      assertEquals(cache.read(_filePath).project, undefined);
     });
 
-    it('[Normal] T-CL-PRE-05: project フィールドなし + hasMeta=false + 長い → cache: action=remaining', async () => {
+    it('[Normal] T-CL-PRE-05: project フィールドなし + hasMeta=false + 長い → cache: action/project とも未設定', async () => {
       const _filePath = '/tmp/chatlogs/test.md';
       const _longContent = 'a'.repeat(100);
       const _entry = _makeEntry(_filePath, {}, _longContent);
@@ -87,7 +88,8 @@ describe('classifyByNoAI', () => {
 
       await classifyByNoAI(_entry, cache);
 
-      assertEquals(cache.read(_filePath).action, CLASSIFY_ACTIONS.REMAINING);
+      assertEquals(cache.read(_filePath).action, undefined);
+      assertEquals(cache.read(_filePath).project, undefined);
     });
   });
 });
@@ -96,7 +98,7 @@ describe('classifyByNoAI', () => {
  * `processClassifyNoAI` のユニットテストスイート。
  *
  * `ChatlogEntry[]` と `cache` を渡し、各エントリに `classifyByNoAI` を適用した上で、
- * 判定結果（cache の `action`）に基づき `move`（AI 不要で project 確定済み）と
+ * 判定結果（cache の `project` の有無）に基づき `move`（AI 不要で project 確定済み）と
  * `remaining`（AI 分類が必要）に分割することを検証する。
  *
  * テスト ID 範囲: T-CL-PCL-01 〜 T-CL-PCL-03
@@ -128,7 +130,8 @@ describe('processClassifyNoAI', () => {
       assertEquals(cache.read(_pathWithProject).project, 'app1');
       assertEquals(cache.read(_pathShort).action, CLASSIFY_ACTIONS.MOVE);
       assertEquals(cache.read(_pathShort).project, FALLBACK_PROJECT);
-      assertEquals(cache.read(_pathLong).action, CLASSIFY_ACTIONS.REMAINING);
+      assertEquals(cache.read(_pathLong).action, undefined);
+      assertEquals(cache.read(_pathLong).project, undefined);
     });
   });
 

--- a/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
@@ -12,7 +12,7 @@
 // ─── Shared scripts
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
-import { runChunked, runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
+import { runChunked } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
 
 // ─── Local
@@ -150,7 +150,7 @@ export const processChunk = async (
 /**
  * 分類対象のファイルエントリを AI で分類し、判定結果を `cache` に書き込む。
  * - `targets` が 0 件の場合は即座に return する。
- * - `dryRun === true` の場合は AI 呼び出しを行わず、`targets` 全件に `action: SKIP` を書き込んで return する
+ * - `dryRun === true` の場合は AI 呼び出しを行わず、何も書き込まず return する
  *   （`project` は未設定のまま。次回実行時は uncached として再度 AI 分類対象になる）。
  * - `dryRun === false` の場合は `runChunked` で並列 AI 分類する。
  * - ファイル移動・stats更新は行わない。判定結果はすべて `processChunk` 経由で `cache` に記録する。
@@ -165,11 +165,6 @@ export const classifyByAI = async (
   if (targets.length === 0) { return; }
 
   if (dryRun) {
-    await runConcurrent(
-      targets,
-      (f) => cache.write(f.filePath!, { action: CLASSIFY_ACTIONS.SKIP }),
-      config.concurrency,
-    );
     logger.dryrun(`AI 分類をスキップします（project は設定されません）: ${targets.length}件`);
     return;
   }

--- a/skills/classify-chatlogs/scripts/phases/phase-classify-noai.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-classify-noai.ts
@@ -27,7 +27,7 @@ import { CLASSIFY_ACTIONS } from '../types/classify.types.ts';
  * バッファエントリに対して AI 不要なケースの事前分類を行い、判定結果を `cache` に書き込む。
  * - frontmatter に `project` フィールドがある場合: `move`
  * - `project` フィールドがなく `hasMeta=false` かつ本文が短い場合: `FALLBACK_PROJECT` に `move`
- * - それ以外: `remaining`（AI 処理対象）
+ * - それ以外: 何もしない（`action`/`project` 未設定のまま、AI 処理対象）
  *
  * 戻り値は常に入力の `entry` をそのまま返す（cache への書き込みが主目的）。
  */
@@ -63,13 +63,13 @@ export const classifyByNoAI = async (
     return entry;
   }
 
-  await cache.write(f.filePath!, { action: CLASSIFY_ACTIONS.REMAINING });
   return entry;
 };
 
 /**
  * バッファエントリ配列に対して `classifyByNoAI` を適用し、各判定結果を `cache` に書き込んだ上で、
- * AI 分類が不要な確定済みエントリ（`move`）と AI 分類が必要なエントリ（`remaining`）に分割する。
+ * `cached.project` の有無に基づき AI 分類が不要な確定済みエントリ（`move`）と
+ * AI 分類が必要なエントリ（`remaining`）に分割する。
  */
 export const processClassifyNoAI = async (
   buffer: ChatlogEntry[],
@@ -77,7 +77,7 @@ export const processClassifyNoAI = async (
   config: Pick<ClassifyConfig, 'concurrency'>,
 ): Promise<{ move: ChatlogEntry[]; remaining: ChatlogEntry[] }> => {
   await runConcurrent(buffer, (entry) => classifyByNoAI(entry, cache), config.concurrency);
-  const move = buffer.filter((entry) => cache.read(entry.filePath!).action !== CLASSIFY_ACTIONS.REMAINING);
-  const remaining = buffer.filter((entry) => cache.read(entry.filePath!).action === CLASSIFY_ACTIONS.REMAINING);
+  const move = buffer.filter((entry) => cache.read(entry.filePath!).project);
+  const remaining = buffer.filter((entry) => !cache.read(entry.filePath!).project);
   return { move, remaining };
 };

--- a/skills/classify-chatlogs/scripts/phases/phase-write.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-write.ts
@@ -102,21 +102,17 @@ const _applyMove = async (
 /**
  * 分類結果キャッシュに基づき、各ファイルへ実際の処理（ファイル移動または保留）を適用する。
  *
- * `entries` は未分類（今回処理対象）のファイル集合であるため、判定は基本的に `cached.project` の
- * 有無による二値判定とする（`action` の値は move/remaining の判定には使わない）。
- * 例外として `action === CLASSIFY_ACTIONS.SKIP`（dry-run で AI 呼び出しをスキップしたエントリ）
- * のみ `action` を見て `stats.skip` に個別カウントする。
+ * `entries` は未分類（今回処理対象）のファイル集合であるため、判定は `cached.project` の
+ * 有無のみによる二値判定とする（`action` の値は move/remaining の判定には使わない）。
  *
- * `dryRun === true` の場合は `cached.project` の有無や `action` の種類に関わらず、
+ * `dryRun === true` の場合は `cached.project` の有無に関わらず、
  * `moveChatlogEntry`（ファイル移動処理）を一切呼び出さない。project が確定済みのケースも
  * `stats.skip++` として扱い、専用ログ `<<dry-run>> move skipped: <filename>` を出力する。
  *
  * - `dryRun === true`:
- *   - `cached.action === CLASSIFY_ACTIONS.SKIP` → `stats.skip++`（ログなし）
  *   - `cached.project` が falsy → `stats.remaining++`（ログなし）
  *   - それ以外（project 確定済み）→ `stats.skip++` し `<<dry-run>> move skipped: <filename>` をログ出力（move は呼ばない）
  * - `dryRun === false`:
- *   - `cached.action === CLASSIFY_ACTIONS.SKIP` → `stats.skip++`（ログなし、キャッシュ削除もしない）
  *   - `cached.project` が truthy → `moveChatlogEntry` を呼び出してファイルを移動する（移動先: `destDir/{project}/`）
  *     - 移動成功時はキャッシュエントリを削除する
  *     - `action === 'move-by-ai'` のときのみ `stats.movedByAI` を、それ以外は `stats.moved` をインクリメントする
@@ -132,11 +128,6 @@ export const applyClassifications = async (
   await runConcurrent(entries, async (entry) => {
     const filePath = entry.filePath!;
     const cached = state.cache.read(filePath);
-
-    if (cached.action === CLASSIFY_ACTIONS.SKIP) {
-      state.stats.skip++;
-      return;
-    }
 
     if (!cached.project) {
       state.stats.remaining++;

--- a/skills/classify-chatlogs/scripts/types/classify.types.ts
+++ b/skills/classify-chatlogs/scripts/types/classify.types.ts
@@ -108,8 +108,6 @@ type _ClassifyConfigCheck = _Assert<ClassifyConfig>;
 export const CLASSIFY_ACTIONS = {
   MOVE: 'move',
   MOVEBYAI: 'move-by-ai',
-  REMAINING: 'remaining',
-  SKIP: 'skip',
   ERROR: 'error',
   EMPTY: '',
 } as const;


### PR DESCRIPTION
## Overview

**Summary**
Simplify classify action handling by dropping the redundant `REMAINING`/`SKIP` action values.

**Background / Motivation**
`CLASSIFY_ACTIONS.REMAINING` and `CLASSIFY_ACTIONS.SKIP` only re-expressed a binary move/remaining decision that `cached.project` already encodes. This duplication added extra cache writes and branching without adding information, so the move/remaining decision is now based solely on whether `cached.project` is set.

## Changes

### Core Changes

- `phase-classify-noai.ts`: stop writing `action: remaining` to cache; split move/remaining by `cached.project` presence
- `phase-classify-ai.ts`: on dry-run, skip AI calls without writing `action: SKIP` to cache
- `phase-write.ts`: remove the `action === SKIP` branch from `applyClassifications`; decide purely by `cached.project` presence
- `classify.types.ts`: remove `REMAINING` and `SKIP` from `CLASSIFY_ACTIONS`

### Test Updates

- Update unit/functional specs and fixtures to reflect the new cache expectations (no `action` written when remaining; `action`/`project` left `undefined` instead of `remaining`/`skip`)

### Removed

- `CLASSIFY_ACTIONS.REMAINING`
- `CLASSIFY_ACTIONS.SKIP`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

All tests pass: 310 passed / 5484 steps / 0 failed / 3 ignored (`deno task test`).
