### PR TITLE
refactor(normalize-chatlog): use internal cache for processing state

### DIFF
--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/aggregation.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/aggregation.e2e.spec.ts
@@ -28,6 +28,21 @@ import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.t
 // test target
 import { main } from '../../normalize-chatlogs.ts';
 
+// ─── Internal Helpers
+
+// functions
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを `cacheDir` 指定の YAML で生成する。
+ *
+ * `GlobalConfig.resetInstance()` 済みであることを前提に、`normalize-cache` を
+ * `tempDir` 配下に隔離し、他テストの残留キャッシュの影響を防ぐ。
+ *
+ * @param tempDir - キャッシュディレクトリの起点となる一時ディレクトリパス
+ */
+const _makeGlobalConfig = (tempDir: string): GlobalConfig =>
+  GlobalConfig.getInstance({ yaml: `cacheDir: '${tempDir}/cache'` });
+
 // ─── 集計テスト ────────────────────────────────────────────────────────────────
 
 /**
@@ -46,6 +61,8 @@ describe('main - aggregation', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       for (let i = 1; i <= 4; i++) {
         await Deno.writeTextFile(
@@ -101,6 +118,8 @@ describe('main - aggregation', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       for (let i = 1; i <= 3; i++) {
         await Deno.writeTextFile(
@@ -142,6 +161,8 @@ describe('main - aggregation', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       commandHandle = installCommandMock(makeSuccessMock(new Uint8Array()));
       loggerStub = makeLoggerStub();

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
@@ -29,6 +29,21 @@ import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/d
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import type { HashProvider } from '../../../../_scripts/types/providers.types.ts';
 
+// ─── Internal Helpers
+
+// functions
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを `cacheDir` 指定の YAML で生成する。
+ *
+ * `GlobalConfig.resetInstance()` 済みであることを前提に、`normalize-cache` を
+ * `tempDir` 配下に隔離し、他テストの残留キャッシュの影響を防ぐ。
+ *
+ * @param tempDir - キャッシュディレクトリの起点となる一時ディレクトリパス
+ */
+const _makeGlobalConfig = (tempDir: string): GlobalConfig =>
+  GlobalConfig.getInstance({ yaml: `cacheDir: '${tempDir}/cache'` });
+
 // ─── full E2E ─────────────────────────────────────────────────────────────────
 
 /**
@@ -46,6 +61,8 @@ describe('normalize-chatlogs - full E2E', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(
         `${inputDir}/chat-a.md`,
@@ -103,6 +120,8 @@ describe('normalize-chatlogs - full E2E', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(
         `${inputDir}/chat.md`,
@@ -153,6 +172,8 @@ describe('normalize-chatlogs - full E2E', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(`${inputDir}/chat.md`, inputContent);
 

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/io.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/io.e2e.spec.ts
@@ -31,6 +31,21 @@ import type { LogSilencer } from '../../../../_scripts/__tests__/helpers/e2e-set
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import type { HashProvider } from '../../../../_scripts/types/providers.types.ts';
 
+// ─── Internal Helpers
+
+// functions
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを `cacheDir` 指定の YAML で生成する。
+ *
+ * `GlobalConfig.resetInstance()` 済みであることを前提に、`normalize-cache` を
+ * `tempDir` 配下に隔離し、他テストの残留キャッシュの影響を防ぐ。
+ *
+ * @param tempDir - キャッシュディレクトリの起点となる一時ディレクトリパス
+ */
+const _makeGlobalConfig = (tempDir: string): GlobalConfig =>
+  GlobalConfig.getInstance({ yaml: `cacheDir: '${tempDir}/cache'` });
+
 // ─── I/O テスト ────────────────────────────────────────────────────────────────
 
 /**
@@ -49,6 +64,8 @@ describe('main - I/O', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       // 2 MD files with frontmatter
       await Deno.writeTextFile(
@@ -117,6 +134,8 @@ describe('main - I/O', () => {
 
     beforeEach(async () => {
       outputDir = await Deno.makeTempDir();
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       const samplePath = normalizePath(`${AGENT_DIR}/sample.md`);
       const segmentResponse = JSON.stringify([
@@ -173,6 +192,8 @@ describe('main - I/O', () => {
 
     beforeEach(async () => {
       outputBase = await Deno.makeTempDir();
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputBase);
 
       const chatPath = normalizePath(`${CHATLOG_INPUT_DIR}/chat.md`);
       const segmentResponse = JSON.stringify([
@@ -218,6 +239,8 @@ describe('main - I/O', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir: outputBase } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputBase);
 
       await Deno.writeTextFile(
         `${inputDir}/chat.md`,
@@ -267,6 +290,8 @@ describe('main - I/O', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir: outputBase } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputBase);
 
       await Deno.writeTextFile(
         `${inputDir}/chat.md`,
@@ -315,6 +340,8 @@ describe('main - I/O', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(
         `${inputDir}/single-topic.md`,

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
@@ -62,7 +62,11 @@ describe('main', () => {
               `${monthDir}/chat.md`,
               '---\nproject: my-project\n---\n### User\nHello\n\n### AI\nHi there.',
             );
-            await Deno.writeTextFile(configFile, `chatlogsDir: "${chatlogsDir}"\n`);
+            // normalize-cache を outputDir 配下に隔離し、他テストの残留キャッシュの影響を防ぐ
+            await Deno.writeTextFile(
+              configFile,
+              `chatlogsDir: "${chatlogsDir}"\ncacheDir: "${outputDir}/cache"\n`,
+            );
 
             const chatPath = normalizePath(`${monthDir}/chat.md`);
             const segmentResponse = JSON.stringify([

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/output-structure.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/output-structure.e2e.spec.ts
@@ -25,6 +25,21 @@ import { normalizePath } from '../../../../_scripts/libs/path-utils/path-utils.t
 import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
 import { main } from '../../normalize-chatlogs.ts';
 
+// ─── Internal Helpers
+
+// functions
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを `cacheDir` 指定の YAML で生成する。
+ *
+ * `GlobalConfig.resetInstance()` 済みであることを前提に、`normalize-cache` を
+ * `tempDir` 配下に隔離し、他テストの残留キャッシュの影響を防ぐ。
+ *
+ * @param tempDir - キャッシュディレクトリの起点となる一時ディレクトリパス
+ */
+const _makeGlobalConfig = (tempDir: string): GlobalConfig =>
+  GlobalConfig.getInstance({ yaml: `cacheDir: '${tempDir}/cache'` });
+
 // ─── 構造テスト ────────────────────────────────────────────────────────────────
 
 /**
@@ -44,6 +59,8 @@ describe('main - output structure', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(
         `${inputDir}/chat-a.md`,
@@ -96,6 +113,8 @@ describe('main - output structure', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(
         `${inputDir}/chat.md`,

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
@@ -36,6 +36,21 @@ import type { LogSilencer } from '../../../../_scripts/__tests__/helpers/e2e-set
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import type { HashProvider } from '../../../../_scripts/types/providers.types.ts';
 
+// ─── Internal Helpers
+
+// functions
+
+/**
+ * テスト用 `GlobalConfig` インスタンスを `cacheDir` 指定の YAML で生成する。
+ *
+ * `GlobalConfig.resetInstance()` 済みであることを前提に、`normalize-cache` を
+ * `tempDir` 配下に隔離し、他テストの残留キャッシュの影響を防ぐ。
+ *
+ * @param tempDir - キャッシュディレクトリの起点となる一時ディレクトリパス
+ */
+const _makeGlobalConfig = (tempDir: string): GlobalConfig =>
+  GlobalConfig.getInstance({ yaml: `cacheDir: '${tempDir}/cache'` });
+
 // ─── 再現性テスト ──────────────────────────────────────────────────────────────
 
 /**
@@ -55,6 +70,8 @@ describe('main - reproducibility', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(
         `${inputDir}/chat.md`,
@@ -111,6 +128,8 @@ describe('main - reproducibility', () => {
 
     beforeEach(async () => {
       ({ inputDir, outputDir } = await makeTempDirs());
+      GlobalConfig.resetInstance();
+      _makeGlobalConfig(outputDir);
 
       await Deno.writeTextFile(`${inputDir}/input.md`, inputContent);
 

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
@@ -18,7 +18,9 @@ import type { Stub } from '@std/testing/mock';
 // ─── Test target
 import { processFiles } from '../../process-files.ts';
 // classes
+import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../../_scripts/classes/GlobalConfig.class.ts';
 
 // ─── Helpers
 import { assertDirExist } from '../../../../../_scripts/__tests__/helpers/assert.ts';
@@ -32,6 +34,7 @@ import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helper
 import { logger } from '../../../../../_scripts/libs/io/logger.ts';
 import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 // types
+import type { NormalizeCache } from '../../../types/cache.types.ts';
 import type { NormalizeConfig, Stats } from '../../../types/normalize.types.ts';
 // constants
 import { BATCH_SIZE } from '../../../constants/normalize.constants.ts';
@@ -43,6 +46,12 @@ const _CONFIG: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
   dryRun: true,
   concurrency: 2,
 };
+
+// functions
+
+/** テスト用 `GlobalConfig` インスタンスを `cacheDir` 指定の YAML で生成する。他テストの残留キャッシュの影響を防ぐ。 */
+const _makeGlobalConfig = (tempDir: string): GlobalConfig =>
+  GlobalConfig.getInstance({ yaml: `cacheDir: '${tempDir}/cache'` });
 
 // ─── Tests
 
@@ -58,18 +67,24 @@ const _CONFIG: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
 describe('processFiles', () => {
   let tmpDir: string;
   let outputDir: string;
+  let cacheDir: string;
   let mockHandle: CommandMockHandle | undefined;
 
   beforeEach(async () => {
     tmpDir = await Deno.makeTempDir({ prefix: 'process-files-test-' });
     outputDir = await Deno.makeTempDir({ prefix: 'process-files-out-' });
+    cacheDir = await Deno.makeTempDir({ prefix: 'process-files-cache-' });
+    GlobalConfig.resetInstance();
+    _makeGlobalConfig(cacheDir);
   });
 
   afterEach(async () => {
     mockHandle?.restore();
     mockHandle = undefined;
+    GlobalConfig.resetInstance();
     await Deno.remove(tmpDir, { recursive: true });
     await Deno.remove(outputDir, { recursive: true });
+    await Deno.remove(cacheDir, { recursive: true });
   });
 
   /** 正常系: ファイルなし・dryRun のケース。 */
@@ -358,38 +373,11 @@ describe('processFiles', () => {
   });
 
   /**
-   * スキップ処理: 出力済みファイルが存在する場合に processFiles がスキップするケース。
+   * スキップ処理: cache に status:'done' が未登録の場合に processFiles がスキップしないケース。
    *
-   * `_isAlreadyNormalized` は内部関数のため processFiles() 経由で検証する。
    * project frontmatter なし → project=undefined → outputDir は `${outputBase}/misc`。
    */
   describe('When: スキップ処理', () => {
-    it('[Normal] T-PF-SKIP-01: outputDir に baseName-*.md が存在するとき stats.skip が 1増加する', async () => {
-      // arrange
-      const filePath = normalizePath(`${tmpDir}/dummy.md`);
-      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      await Deno.writeTextFile(filePath, '# Test\n\nContent');
-
-      // project frontmatter なし → misc フォールバック → outputDir = ${outputDir}/misc
-      const miscDir = normalizePath(`${outputDir}/misc`);
-      await Deno.mkdir(miscDir, { recursive: true });
-      // baseName = 'dummy'（hash suffix なし）。パターン dummy-*.md にマッチするファイルを配置する
-      await Deno.writeTextFile(`${miscDir}/dummy-01-abc1234.md`, 'already normalized');
-
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
-
-      // act
-      await processFiles(tmpDir, outputDir, _CONFIG, stats);
-
-      // assert
-      assertEquals(stats.skip, 1);
-      assertEquals(stats.success, 0);
-      assertEquals(stats.fail, 0);
-    });
-
     it('[Normal] T-PF-SKIP-02: outputDir に baseName-*.md が存在しないとき stats.skip は増加しない', async () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
@@ -449,78 +437,6 @@ describe('processFiles', () => {
       assertEquals(stats.skip, 0);
       assertEquals(stats.fail, 0);
     });
-
-    it('[Normal] T-PF-SKIP-05: 出力済みファイルがある場合 stats.skip が 1増加し stats.success は増加しない', async () => {
-      // arrange — T-PF-SKIP-01 と同等（T-02 統合テスト）
-      const filePath = normalizePath(`${tmpDir}/dummy.md`);
-      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      await Deno.writeTextFile(filePath, '# Test\n\nContent');
-
-      const miscDir = normalizePath(`${outputDir}/misc`);
-      await Deno.mkdir(miscDir, { recursive: true });
-      await Deno.writeTextFile(`${miscDir}/dummy-01-abc1234.md`, 'already normalized');
-
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
-
-      // act
-      await processFiles(tmpDir, outputDir, _CONFIG, stats);
-
-      // assert
-      assertEquals(stats.skip, 1);
-      assertEquals(stats.success, 0);
-      assertEquals(stats.fail, 0);
-    });
-
-    it('[Normal] T-PF-SKIP-08: 出力済みファイルがあるとき AI コマンドは呼び出されない', async () => {
-      // arrange — すでに正規化済みのファイルに対して AI が呼ばれないことを検証する
-      const filePath = normalizePath(`${tmpDir}/dummy.md`);
-      await Deno.writeTextFile(filePath, '# Test\n\nContent');
-
-      const miscDir = normalizePath(`${outputDir}/misc`);
-      await Deno.mkdir(miscDir, { recursive: true });
-      await Deno.writeTextFile(`${miscDir}/dummy-01-abc1234.md`, 'already normalized');
-
-      const counter = { calls: 0 };
-      // makeCountingMock: コンストラクタ呼び出しごとに counter.calls をインクリメントする
-      mockHandle = installCommandMock(makeCountingMock('[]', counter));
-
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
-
-      // act
-      await processFiles(tmpDir, outputDir, _CONFIG, stats);
-
-      // assert — スキップされたので AI コマンドは 0 回呼ばれる
-      assertEquals(stats.skip, 1);
-      assertEquals(counter.calls, 0);
-    });
-
-    it('[Edge] T-PF-SKIP-07: outputBase の深いサブディレクトリに baseName-*.md があるとき stats.skip が 1増加する', async () => {
-      // arrange — ** glob パターンでサブディレクトリ内のファイルを検出できることを確認する
-      const filePath = normalizePath(`${tmpDir}/dummy.md`);
-      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      await Deno.writeTextFile(filePath, '# Test\n\nContent');
-
-      // 深いサブディレクトリ（chatlogs/claude/2026/2026-06/misc 相当）に出力済みファイルを配置
-      const deepDir = normalizePath(`${outputDir}/chatlogs/claude/2026/2026-06/misc`);
-      await Deno.mkdir(deepDir, { recursive: true });
-      await Deno.writeTextFile(`${deepDir}/dummy-01-abc1234.md`, 'already normalized');
-
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
-
-      // act
-      await processFiles(tmpDir, outputDir, _CONFIG, stats);
-
-      // assert — ** glob がサブディレクトリを再帰検索してスキップを検出する
-      assertEquals(stats.skip, 1);
-      assertEquals(stats.success, 0);
-      assertEquals(stats.fail, 0);
-    });
   });
 
   /** --single-file モード: 1ファイルずつ個別に AI 呼び出しを行うケース。 */
@@ -568,6 +484,182 @@ describe('processFiles', () => {
       // assert — AI 失敗 → fallback で 1セグメント処理される
       assertEquals(stats.fallback, 1);
       assertEquals(stats.fail, 0);
+      assertEquals(stats.success, 1);
+    });
+  });
+
+  /** キャッシュ連携: ChatlogCache による処理済み判定・リジューム動作。 */
+  describe('When: キャッシュ連携', () => {
+    it('[Normal] T-PF-CACHE-01: 1回目に成功したファイルは2回目の呼び出しでキャッシュ経由でスキップされ AI は呼ばれない', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
+      const stats1: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act — 1回目: 実際に処理を成功させる
+      await processFiles(tmpDir, outputDir, config, stats1);
+      assertEquals(stats1.success, 1);
+
+      // 2回目: 同じ cache インスタンスを渡し、AI が呼ばれないことを確認する
+      mockHandle.restore();
+      const counter = { calls: 0 };
+      mockHandle = installCommandMock(makeCountingMock('[]', counter));
+      const stats2: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      await processFiles(tmpDir, outputDir, config, stats2);
+
+      // assert
+      assertEquals(stats2.skip, 1);
+      assertEquals(counter.calls, 0);
+    });
+
+    it('[Edge] T-PF-CACHE-02: dryRun=true のときキャッシュに書き込まれず後続の dryRun=false 呼び出しはスキップされない', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const stats1: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act — 1回目: dryRun=true で処理（キャッシュに書き込まれないはず）
+      await processFiles(tmpDir, outputDir, _CONFIG, stats1);
+      assertEquals(stats1.skip, 0);
+
+      // 2回目: dryRun=false で同じファイルを処理 → キャッシュ未登録なのでスキップされず処理される
+      const stats2: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
+
+      await processFiles(tmpDir, outputDir, config, stats2);
+
+      // assert — dryRun の1回目はキャッシュに残らないため2回目はスキップされない
+      assertEquals(stats2.skip, 0);
+      assertEquals(stats2.success, 1);
+    });
+
+    it('[Edge] T-PF-CACHE-03: segments が null（AI 失敗）のときキャッシュに書き込まれず後続呼び出しでスキップされない', async () => {
+      // arrange
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const stats1: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act — 1回目: AI 失敗 → stats.fail が増加し、キャッシュに書き込まれない
+      await processFiles(tmpDir, outputDir, _CONFIG, stats1);
+      assertEquals(stats1.fail, 1);
+
+      // 2回目: 同じファイルを処理 → キャッシュ未登録なのでスキップされない
+      mockHandle.restore();
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      const stats2: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      await processFiles(tmpDir, outputDir, _CONFIG, stats2);
+
+      // assert
+      assertEquals(stats2.skip, 0);
+    });
+
+    it('[Normal] T-PF-CACHE-08: outputBase 配下に無関係な.mdファイルが存在してもキャッシュ未登録の入力ファイルはスキップされずAIが呼ばれる', async () => {
+      // arrange — report.md を正規化対象とし、outputBase 配下に無関係な notes/report.md を配置する。
+      // report.md 自身の正規化はまだ一度も成功していない（cache未登録）ため、
+      // outputBase 側にファイルが存在するだけではスキップされてはならない。
+      const filePath = normalizePath(`${tmpDir}/report.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const capturedArgs: { value: string[] } = { value: [] };
+      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
+
+      await Deno.writeTextFile(filePath, '# Report\n\nContent');
+
+      // outputBase 配下の無関係なファイル（正規化セグメント出力ではない）
+      const notesDir = normalizePath(`${outputDir}/notes`);
+      await Deno.mkdir(notesDir, { recursive: true });
+      await Deno.writeTextFile(`${notesDir}/report.md`, 'unrelated note, not a normalize output');
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert — 無関係な出力ファイルの存在によってスキップされず、AI が実際に呼ばれている
+      assertEquals(stats.skip, 0);
+      assertEquals(stats.fail, 0);
+      assert(capturedArgs.value.length > 0);
+    });
+
+    it('[Normal] T-PF-CACHE-05: AI 成功後 cache に segments（startLine/endLine 付き）が書き込まれる', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 2 }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, config, stats);
+
+      // assert — cache に segments の境界情報が保存される
+      const cache = new ChatlogCache<NormalizeCache>('normalize-cache');
+      await cache.ready;
+      const cached = cache.read('dummy');
+      assertEquals(cached.segments, [{ title: 'Topic', startLine: 1, endLine: 2 }]);
+    });
+
+    it('[Normal] T-PF-CACHE-06: dryRun=true でも AI 成功後 cache に segments が書き込まれる（status は書き込まれない）', async () => {
+      // arrange
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 2 }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      await Deno.writeTextFile(filePath, '# Test\n\nContent');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act — dryRun=true
+      await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+      // assert — dryRun でも segments は書き込まれるが、status:'done' は付与しない
+      // （T-PF-CACHE-02 互換: dryRun 後の非dryRun呼び出しがスキップされてはならないため）
+      const cache = new ChatlogCache<NormalizeCache>('normalize-cache');
+      await cache.ready;
+      const cached = cache.read('dummy');
+      assertEquals(cached.segments, [{ title: 'Topic', startLine: 1, endLine: 2 }]);
+      assertEquals(cached.status, undefined);
+    });
+
+    it('[Normal] T-PF-CACHE-07: cache に segments のみ登録（status未登録・出力ファイル未生成）のとき AI を呼ばずキャッシュから書き出す', async () => {
+      // arrange — 事前に cache へ segments のみを直接登録（中断・再開シナリオ）
+      const filePath = normalizePath(`${tmpDir}/dummy.md`);
+      await Deno.writeTextFile(filePath, '# Test\n\nline2\nline3');
+      const cache = new ChatlogCache<NormalizeCache>('normalize-cache');
+      await cache.ready;
+      await cache.write('dummy', {
+        segments: [{ title: 'Cached Topic', startLine: 1, endLine: 2 }],
+      });
+
+      const counter = { calls: 0 };
+      mockHandle = installCommandMock(makeCountingMock('[]', counter));
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+
+      // act
+      await processFiles(tmpDir, outputDir, config, stats);
+
+      // assert — AI は呼ばれず、キャッシュ済みセグメントから書き出される
+      assertEquals(counter.calls, 0);
+      assertEquals(stats.skip, 0);
       assertEquals(stats.success, 1);
     });
   });

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
@@ -404,8 +404,8 @@ describe('segmentChatlogs', () => {
 
       // assert
       assertEquals(result.get('test.md'), [
-        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1' },
-        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2' },
+        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1', startLine: 1, endLine: 1 },
+        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2', startLine: 2, endLine: 2 },
       ]);
     });
 
@@ -426,8 +426,8 @@ describe('segmentChatlogs', () => {
       const result = await segmentChatlogs(inputs);
 
       // assert
-      assertEquals(result.get('a.md'), [{ title: 'T1', summary: 'S1', content: 'C1' }]);
-      assertEquals(result.get('b.md'), [{ title: 'T2', summary: 'S2', content: 'C2' }]);
+      assertEquals(result.get('a.md'), [{ title: 'T1', summary: 'S1', content: 'C1', startLine: 1, endLine: 1 }]);
+      assertEquals(result.get('b.md'), [{ title: 'T2', summary: 'S2', content: 'C2', startLine: 1, endLine: 1 }]);
     });
 
     it('[Normal] T-SCB-01-02: 1ファイルでAIが12セグメントを返すとき先頭5件に制限される（MAX_SEGMENTS上限）', async () => {
@@ -579,7 +579,7 @@ describe('segmentChatlogs', () => {
       const result = await segmentChatlogs(inputs);
 
       // assert
-      assertEquals(result.get('solo.md'), [{ title: 'T', summary: 'S', content: 'C' }]);
+      assertEquals(result.get('solo.md'), [{ title: 'T', summary: 'S', content: 'C', startLine: 1, endLine: 1 }]);
     });
 
     it('[Edge] T-SCB-04-01: AIが返す filePath が inputs にない場合無視され、inputs にある filePath は null になる', async () => {
@@ -774,7 +774,7 @@ describe('segmentChatlogs', () => {
       const result = await segmentChatlogs(inputs);
 
       // assert
-      assertEquals(result.get('a.md'), [{ title: 'T', summary: 'S', content: 'C' }]);
+      assertEquals(result.get('a.md'), [{ title: 'T', summary: 'S', content: 'C', startLine: 1, endLine: 1 }]);
     });
   });
 

--- a/skills/normalize-chatlogs/scripts/modules/process-files.ts
+++ b/skills/normalize-chatlogs/scripts/modules/process-files.ts
@@ -7,9 +7,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// --- std
-import { expandGlob } from '@std/fs';
-
 // --- shared
 // constants
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
@@ -24,14 +21,16 @@ import { getBasename, normalizePath } from '../../../_scripts/libs/path-utils/pa
 
 // types
 import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
-import type { NormalizeConfig, Stats } from '../types/normalize.types.ts';
+import type { NormalizeCache } from '../types/cache.types.ts';
+import type { NormalizeConfig, Segment, Stats } from '../types/normalize.types.ts';
 
 // classes
+import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 
 // --- internal modules
-import { extractSegmentBaseName, segmentChatlogs, writeSegmentToFile } from './segment-io.ts';
+import { extractLines, extractSegmentBaseName, segmentChatlogs, writeSegmentToFile } from './segment-io.ts';
 
 // constants
 import { BATCH_SIZE } from '../constants/normalize.constants.ts';
@@ -52,34 +51,209 @@ export const resolveOutputDir = (outputBase: string, filePath: string, project?:
     : `${outputBase}/${effectiveProject}`;
 };
 
+/** Derives a cache key from a source chatlog file path (same normalization as {@link extractSegmentBaseName}). */
+const _toCacheKey = (filePath: string): string => extractSegmentBaseName(filePath);
+
+/** Result of the "prepare files" phase: files still needing processing, and files already normalized. */
+type _PreparedFiles = {
+  pendingFiles: string[];
+  skipFiles: string[];
+};
+
 /**
- * Returns true if an output file for `filePath` already exists anywhere under `outputBase`.
+ * Phase 1: Validates inputDir/outputBase, discovers files, and partitions `findFiles(inputDir)`
+ * results into already-normalized (skip) and pending files based on the cache.
  *
- * Searches recursively using the glob pattern outputBase/{@code **}/baseName-*.md,
- * so any project subdirectory structure is covered. Returns false when no match is found.
- *
- * @param filePath   - Source chatlog file path
- * @param outputBase - Base output directory
- * @returns Promise resolving to true if already normalized, false otherwise
+ * @param inputDir   - Source directory (already normalized)
+ * @param outputBase - Base output directory (already normalized)
+ * @param cache      - Cache used to detect already-normalized files across runs
+ * @returns Pending file paths and the number of files skipped as already-normalized
  */
-const _isAlreadyNormalized = async (
-  filePath: string,
+const _prepareFiles = async (
+  inputDir: string,
   outputBase: string,
-): Promise<boolean> => {
-  const _baseName = extractSegmentBaseName(filePath);
-  const _pattern = `${outputBase}/**/${_baseName}-*.md`;
-  for await (const _entry of expandGlob(_pattern)) {
-    if (_entry.isFile) { return true; }
+  cache: ChatlogCache<NormalizeCache>,
+): Promise<_PreparedFiles> => {
+  // inputDir 存在確認
+  if (!await dirExists(inputDir)) {
+    throw new ChatlogError('InputNotFound', 'InputDir', `inputDir not found or not a directory: ${inputDir}`);
   }
-  return false;
+
+  // outputBase 作成・存在確認
+  await Deno.mkdir(outputBase, { recursive: true });
+  if (!await dirExists(outputBase)) {
+    throw new ChatlogError('FileDirNotFound', 'OutputBase', `outputBase could not be created: ${outputBase}`);
+  }
+
+  // containment チェック（outputBase が inputDir 配下でないこと）
+  if (outputBase.startsWith(inputDir + '/') || outputBase === inputDir) {
+    throw new ChatlogError(
+      'ForbiddenOutput',
+      'OutputInsideInput',
+      `outputBase must not be inside inputDir: ${outputBase}`,
+    );
+  }
+
+  const mdFiles = await findFiles(inputDir);
+
+  // cache に status:'done' が記録済みのファイル（正規化済み）を pending から除外
+  const skipFiles = mdFiles.filter((f) => cache.read(_toCacheKey(f)).status === 'done');
+  const pendingFiles = mdFiles.filter((f) => cache.read(_toCacheKey(f)).status !== 'done');
+
+  return { pendingFiles, skipFiles };
+};
+
+/** A single chatlog file's path and raw content, prepared as input for segment planning. */
+type _ChatlogInput = { filePath: string; content: string };
+
+/** Phase 2: Reads the Markdown content for each file in `filePaths`. */
+const _readInputs = (filePaths: string[]): Promise<_ChatlogInput[]> =>
+  Promise.all(
+    filePaths.map(async (filePath) => ({ filePath, content: await readTextFile(filePath) })),
+  );
+
+/**
+ * Phase 3: Determines segment split plans for `inputs`, preferring cached `segments`
+ * (resume support) over a fresh AI call, and persists newly-decided segments to the cache.
+ *
+ * For inputs with cached `segments`, ranges are re-sliced from the current file content via
+ * {@link extractLines} (no AI call). For the remainder, `segmentChatlogs` is invoked; on
+ * success, segment boundaries (`title`/`startLine`/`endLine`) are written to the cache —
+ * even when `dryRun` is true, so a subsequent run does not re-invoke the AI. The cache
+ * write in `dryRun` omits `status: 'done'` so the file is still writable in the following run.
+ *
+ * @param inputs  - Files with their Markdown content
+ * @param config  - Model/timeout options forwarded to `segmentChatlogs`
+ * @param cache   - Cache read for resume, written with decided segment boundaries
+ * @returns Map from filePath to its planned `Segment[]`, or `null` when planning failed
+ */
+const _planSegments = async (
+  inputs: _ChatlogInput[],
+  config: Pick<NormalizeConfig, 'model' | 'timeoutMs' | 'dryRun'>,
+  cache: ChatlogCache<NormalizeCache>,
+): Promise<Map<string, Segment[] | null>> => {
+  const _cachedInputs = inputs.filter((i) => cache.read(_toCacheKey(i.filePath)).segments !== undefined);
+  const _uncachedInputs = inputs.filter((i) => cache.read(_toCacheKey(i.filePath)).segments === undefined);
+
+  const _resultMap = new Map<string, Segment[] | null>(
+    _cachedInputs.map(({ filePath, content }) => {
+      const _lines = content.split('\n');
+      const _cachedSegments = cache.read(_toCacheKey(filePath)).segments!;
+      return [
+        filePath,
+        _cachedSegments.map((s) => ({
+          title: s.title,
+          summary: '',
+          content: extractLines(_lines, s.startLine, s.endLine),
+          startLine: s.startLine,
+          endLine: s.endLine,
+        })),
+      ];
+    }),
+  );
+
+  if (_uncachedInputs.length === 0) {
+    return _resultMap;
+  }
+
+  const _aiResultMap = await segmentChatlogs(_uncachedInputs, {
+    model: config.model,
+    ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+  });
+
+  await Promise.all(
+    _uncachedInputs.map(async ({ filePath }) => {
+      const segments = _aiResultMap.get(filePath);
+      _resultMap.set(filePath, segments ?? null);
+      if (!segments || segments.some((s) => s.startLine === undefined || s.endLine === undefined)) {
+        return;
+      }
+      const _cacheEntry: Partial<NormalizeCache> = {
+        segments: segments.map((s) => ({ title: s.title, startLine: s.startLine!, endLine: s.endLine! })),
+      };
+      // write() (overwrite, not merge) is safe here: files reaching _planSegments always have
+      // status === undefined (status:'done' files are filtered into skipFiles by _prepareFiles).
+      await cache.write(_toCacheKey(filePath), _cacheEntry);
+    }),
+  );
+
+  return _resultMap;
+};
+
+/**
+ * Phase 4: Writes planned segments to output files, applying the `--single-file` fallback
+ * and `failFast` behavior, and marks the file `status: 'done'` in the cache once written
+ * (skipped when `dryRun`).
+ *
+ * @param inputs      - Files with their Markdown content (fallback needs the raw content)
+ * @param segmentsMap - Planned segments per filePath, from {@link _planSegments}
+ * @param outputBase  - Base output directory
+ * @param config      - Processing config (dryRun, failFast, singleFile)
+ * @param stats       - Mutable counters updated in place
+ * @param cache       - Cache marked `status: 'done'` on successful, non-dryRun writes
+ * @param hashFn      - Optional hash generator for output file names (injectable for testing)
+ */
+const _writeSegments = async (
+  inputs: _ChatlogInput[],
+  segmentsMap: Map<string, Segment[] | null>,
+  outputBase: string,
+  config: Pick<NormalizeConfig, 'dryRun' | 'failFast' | 'singleFile'>,
+  stats: Stats,
+  cache: ChatlogCache<NormalizeCache>,
+  hashFn?: HashProvider,
+): Promise<void> => {
+  for (const { filePath, content } of inputs) {
+    const _entry = new ChatlogEntry(content, { filePath });
+    const _projectVal = _entry.frontmatter.get('project');
+    const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
+    const outputDir = resolveOutputDir(outputBase, filePath, _project);
+    await Deno.mkdir(outputDir, { recursive: true });
+
+    let segments = segmentsMap.get(filePath) ?? null;
+
+    if (segments === null && config.singleFile) {
+      // fallback: content 全体を1セグメントとして使う
+      segments = [{
+        title: getBasename(filePath).replace(/-[0-9a-f]{7}$/, ''),
+        summary: '(auto-generated: AI segmentation failed)',
+        content: content,
+      }];
+      logger.info(`${LOGGER_TEXT.INDENT}fallback (1-segment): ${getBasename(filePath)}`);
+      stats.fallback++;
+    } else if (segments === null) {
+      logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
+      stats.fail++;
+      if (config.failFast) {
+        throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
+      }
+      continue;
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      await writeSegmentToFile(
+        outputDir,
+        filePath,
+        i,
+        segments[i],
+        _entry.frontmatter,
+        config.dryRun,
+        stats,
+        hashFn,
+      );
+    }
+
+    if (!config.dryRun) {
+      await cache.update(_toCacheKey(filePath), { status: 'done' });
+    }
+  }
 };
 
 /**
  * Processes markdown files under `inputDir` by segmenting each via AI and writing output.
  *
- * Discovers files via `findFiles(inputDir)`, then for each file: reads content,
- * extracts frontmatter, calls `segmentChatlogs`, and for each segment generates
- * an output file and writes it (respecting dryRun).
+ * Flow: {@link _prepareFiles} (discover + skip already-normalized) → chunked
+ * {@link _readInputs} → {@link _planSegments} (AI call, or cached segments on resume) →
+ * {@link _writeSegments} (write output, update cache).
  * Updates `stats` in place: `fail` increments on AI error, `success` on each write.
  *
  * @param inputDir   - Source directory (files are discovered here via findFiles)
@@ -95,41 +269,18 @@ export const processFiles = async (
   stats: Stats,
   hashFn?: HashProvider,
 ): Promise<void> => {
-  // 0. パス正規化
   const _inputDir = normalizePath(inputDir);
   const _outputBase = normalizePath(outputBase);
 
-  // 1. inputDir 存在確認
-  if (!await dirExists(_inputDir)) {
-    throw new ChatlogError('InputNotFound', 'InputDir', `inputDir not found or not a directory: ${_inputDir}`);
-  }
+  const cache = new ChatlogCache<NormalizeCache>('normalize-cache');
+  await cache.ready;
 
-  // 2. outputBase 作成・存在確認
-  await Deno.mkdir(_outputBase, { recursive: true });
-  if (!await dirExists(_outputBase)) {
-    throw new ChatlogError('FileDirNotFound', 'OutputBase', `outputBase could not be created: ${_outputBase}`);
-  }
-
-  // 3. containment チェック（outputBase が inputDir 配下でないこと）
-  if (_outputBase.startsWith(_inputDir + '/') || _outputBase === _inputDir) {
-    throw new ChatlogError(
-      'ForbiddenOutput',
-      'OutputInsideInput',
-      `outputBase must not be inside inputDir: ${_outputBase}`,
-    );
-  }
-
-  const mdFiles = await findFiles(_inputDir);
-
-  // 正規化済みファイルを事前にフィルタ
-  const _normalized = await Promise.all(mdFiles.map((f) => _isAlreadyNormalized(f, _outputBase)));
-  const _skipFiles = mdFiles.filter((_, i) => _normalized[i]);
-  const _pendingFiles = mdFiles.filter((_, i) => !_normalized[i]);
+  const { pendingFiles: _pendingFiles, skipFiles: _skipFiles } = await _prepareFiles(_inputDir, _outputBase, cache);
 
   for (const filePath of _skipFiles) {
     logger.info(`${LOGGER_TEXT.INDENT}skipped (already normalized): ${getBasename(filePath)}`);
-    stats.skip++;
   }
+  stats.skip += _skipFiles.length;
 
   const _chunkSize = config.singleFile ? 1 : BATCH_SIZE;
   const _chunks = Array.from(
@@ -138,57 +289,8 @@ export const processFiles = async (
   );
 
   await runConcurrent(_chunks, async (chunk) => {
-    const _inputs = await Promise.all(
-      chunk.map(async (filePath) => {
-        const content = await readTextFile(filePath);
-        return { filePath, content };
-      }),
-    );
-
-    const _resultMap = await segmentChatlogs(_inputs, {
-      model: config.model,
-      ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
-    });
-
-    for (const { filePath, content } of _inputs) {
-      const _entry = new ChatlogEntry(content, { filePath });
-      const _projectVal = _entry.frontmatter.get('project');
-      const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
-      const outputDir = resolveOutputDir(_outputBase, filePath, _project);
-      await Deno.mkdir(outputDir, { recursive: true });
-
-      let segments = _resultMap.get(filePath) ?? null;
-
-      if (segments === null && config.singleFile) {
-        // fallback: content 全体を1セグメントとして使う
-        segments = [{
-          title: getBasename(filePath).replace(/-[0-9a-f]{7}$/, ''),
-          summary: '(auto-generated: AI segmentation failed)',
-          content: content,
-        }];
-        logger.info(`${LOGGER_TEXT.INDENT}fallback (1-segment): ${getBasename(filePath)}`);
-        stats.fallback++;
-      } else if (segments === null) {
-        logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
-        stats.fail++;
-        if (config.failFast) {
-          throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
-        }
-        continue;
-      }
-
-      for (let i = 0; i < segments.length; i++) {
-        await writeSegmentToFile(
-          outputDir,
-          filePath,
-          i,
-          segments[i],
-          _entry.frontmatter,
-          config.dryRun,
-          stats,
-          hashFn,
-        );
-      }
-    }
+    const _inputs = await _readInputs(chunk);
+    const _segmentsMap = await _planSegments(_inputs, config, cache);
+    await _writeSegments(_inputs, _segmentsMap, _outputBase, config, stats, cache, hashFn);
   }, config.concurrency);
 };

--- a/skills/normalize-chatlogs/scripts/modules/segment-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/segment-io.ts
@@ -156,7 +156,13 @@ const _addLineNumbers = (content: string): string => {
   return content.split('\n').map((line, i) => `${i + 1}: ${line}`).join('\n');
 };
 
-const _extractLines = (lines: string[], startLine: number, endLine: number): string => {
+/**
+ * Extracts the inclusive line range `[startLine, endLine]` (1-based) from `lines`, clamped to bounds.
+ *
+ * Used both for the initial AI response (segmentChatlogs) and for re-slicing content from
+ * cached `{startLine, endLine}` ranges on resume (process-files phase 4).
+ */
+export const extractLines = (lines: string[], startLine: number, endLine: number): string => {
   const total = lines.length;
   if (total === 0) { return ''; }
   const start = Math.max(1, Math.min(startLine, total));
@@ -257,7 +263,9 @@ export const segmentChatlogs = async (
       _segments.slice(0, MAX_SEGMENTS).map((r) => ({
         title: r.title,
         summary: r.summary,
-        content: _extractLines(_lines, r.startLine, r.endLine),
+        content: extractLines(_lines, r.startLine, r.endLine),
+        startLine: r.startLine,
+        endLine: r.endLine,
       })),
     );
   }

--- a/skills/normalize-chatlogs/scripts/types/cache.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/cache.types.ts
@@ -1,0 +1,20 @@
+// src: scripts/types/cache.types.ts
+// @(#): normalize-chatlogs キャッシュデータ型定義
+//       対象: NormalizeCache
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/** ChatlogCache が保存する正規化済み判定結果。 */
+export interface NormalizeCache {
+  /** 正規化処理が完了済みであることを示す。 */
+  status: 'done';
+  /** AI が決定したセグメント分割設定（再分割に使用）。summary は含まない（再分割時は空文字で出力する）。 */
+  segments?: Array<{
+    title: string;
+    startLine: number;
+    endLine: number;
+  }>;
+}

--- a/skills/normalize-chatlogs/scripts/types/normalize.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/normalize.types.ts
@@ -21,6 +21,10 @@ export type Segment = {
   summary: string;
   /** セグメントの会話本文（元テキストをそのままコピー）。 */
   content: string;
+  /** AI が返した開始行番号（1-based、キャッシュ保存用）。 */
+  startLine?: number;
+  /** AI が返した終了行番号（1-based、キャッシュ保存用）。 */
+  endLine?: number;
 };
 
 /**


### PR DESCRIPTION
## Overview

**Summary**
Replace output-file discovery with an explicit cache to track normalize-chatlogs processing state.

**Background / Motivation**
`normalize-chatlogs` used to infer what was already processed by checking for existing output files.
This PR introduces a `ChatlogCache` (backed by a new `NormalizeCache` type) that explicitly tracks
per-file status and segment line ranges, making skip/reuse logic more reliable.

## Changes

### Core Changes

- `normalize-chatlogs.ts`: move cache setup out of `main` into `processFiles`
- `process-files.ts`: replace output-file discovery with `ChatlogCache`; seed cache entries, reuse
  cached segments, split skipped/pending files, and update cache status after segment output
- `segment-io.ts`: export `extractLines`, add `startLine`/`endLine` to segment output
- `cache.types.ts` (new): add `NormalizeCache` interface with `status` and `segments`
- `normalize.types.ts`: add optional `startLine`/`endLine` fields to `Segment`

### Test Updates

- `process-files.unit.spec.ts`: configure `cacheDir` through `GlobalConfig`; add coverage for cache
  reuse, skipped files, dry-run, AI failures, hashed filenames, segment persistence, and cache-based
  output
- `segment-io.unit.spec.ts`: update expected segment data to include line ranges
- e2e specs (`aggregation`, `full`, `io`, `original-logs-dir`, `output-structure`, `reproducibility`):
  add a test-local `cacheDir` via `GlobalConfig` in `beforeEach`

### Removed

- `processFiles` no longer takes a cache argument from `main`

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

None.
