### PR TITLE
refactor(normalize-chatlogs): split process-files into phase pipeline

### DIFF
--- a/skills/normalize-chatlogs/SKILL.md
+++ b/skills/normalize-chatlogs/SKILL.md
@@ -4,7 +4,7 @@ description: >
   チャットログMarkdownをAI（Claude CLI）でトピック別セグメントに分割し、
   フロントマター付きMarkdownとして出力する。
   /normalize-chatlogs で呼び出す。
-  入力ファイルのフロントマターを引き継ぎつつ、title/log_id/summaryをAIが生成する。
+  入力ファイルのフロントマターを引き継ぎつつ、title/log_idをAIが生成する。summaryは本文の`## Summary`セクションに使われる。
 argument-hint: "<agent> <YYYY-MM> | <path> [--output <dir>] [--concurrency <n>] [--model <model>] [--dry-run]"
 allowed-tools: Bash, Glob
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/edge-01-minimal-frontmatter/output-1.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/edge-01-minimal-frontmatter/output-1.md
@@ -2,5 +2,4 @@
 session_id: e3e28738-a584-8aa2-f5c1-214f94b2dd35
 title: 最小フロントマターテスト
 log_id: input-01-abc1234
-summary: ユーザーがテストと入力し、Assistantが了解した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/edge-02-no-frontmatter/output-1.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/edge-02-no-frontmatter/output-1.md
@@ -1,5 +1,4 @@
 ---
 title: フロントマターなし会話
 log_id: input-01-def5678
-summary: ユーザーがテストと入力し、Assistantが了解した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/edge-03-empty-title/output-1.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/edge-03-empty-title/output-1.md
@@ -4,5 +4,4 @@ date: 2026-04-01
 project: test-project
 slug: empty-title-test
 log_id: input-01-abc1234
-summary: ユーザーがテストと入力し、Assistantが了解した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-01-one-segment/output-1.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-01-one-segment/output-1.md
@@ -5,5 +5,4 @@ project: aplys
 slug: sharded-questing-starfish
 title: API設計レビュー
 log_id: input-01-0a1b2c3
-summary: ユーザーがaplysコマンドのCLI設計を評価し、path traversal対策としてdomain/targetのバリデーション仕様追加を提案し、Assistantが承認・対応した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-02-two-segments/output-1.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-02-two-segments/output-1.md
@@ -5,5 +5,4 @@ project: test-project
 slug: sample-two-topic
 title: テストフレームワーク
 log_id: input-01-a1b2c3d
-summary: ユーザーがDenoのテストフレームワークについて質問し、AssistantがBDDスタイルのAPIを紹介した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-02-two-segments/output-2.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-02-two-segments/output-2.md
@@ -5,5 +5,4 @@ project: test-project
 slug: sample-two-topic
 title: TypeScript型推論
 log_id: input-02-e4f5a6b
-summary: ユーザーがTypeScriptの型推論について質問し、Assistantがコンテキストベースの自動型決定を説明した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-03-three-segments/output-1.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-03-three-segments/output-1.md
@@ -5,5 +5,4 @@ project: aplys
 slug: sharded-questing-starfish
 title: API設計
 log_id: input-01-ef90605
-summary: ユーザーがaplysコマンドのAPI設計（ドメイン・バリデーション、exit code、APLYS_ARGS、git ls-files、extension mapping、APLYS_LIBS、dispatcher仕様、XDGディレクトリ、セキュリティ仕様、shellcheck、acceptance criteria、tasks構造）についてレビューし、改善点を列挙した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-03-three-segments/output-2.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-03-three-segments/output-2.md
@@ -5,5 +5,4 @@ project: aplys
 slug: sharded-questing-starfish
 title: Assistantの調査と確認
 log_id: input-02-a1f5a39
-summary: Assistantはプロジェクト構造・GitHub issueを確認し、issueが存在しないことを特定した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-03-three-segments/output-3.md
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-data/runai-frontmatter/normal-03-three-segments/output-3.md
@@ -5,5 +5,4 @@ project: aplys
 slug: sharded-questing-starfish
 title: Issue下書きの更新方針
 log_id: input-03-913ce11
-summary: ユーザーがtemp配下のissue下書きをコアとして更新し、詳細仕様はdocs/specsに分離する方針を指示した。
 ---

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-frontmatter.spec.ts
@@ -25,17 +25,14 @@ import { collectOutputFiles } from './helpers/fixture-helpers.ts';
 // test target
 import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { parseFrontmatterEntries as parseFrontmatter } from '../../../../_scripts/libs/text/frontmatter-utils.ts';
-import {
-  attachFrontmatter,
-  generateSegmentFile,
-  segmentChatlogs,
-} from '../../modules/segment-io.ts';
+import { segmentChatlogs } from '../../modules/segment-ai.ts';
+import { attachFrontmatter, generateSegmentFile } from '../../modules/segment-io.ts';
 import type { Segment } from '../../types/normalize.types.ts';
 
 // ─── フロントマター検証対象フィールド ────────────────────────────────────────
 
 // log_id はランダムハッシュを含むためここでは検証しない（file-gen.unit.spec.ts で検証）
-const FRONTMATTER_KEYS = ['title', 'summary'] as const;
+const FRONTMATTER_KEYS = ['title'] as const;
 
 // ─── fixtures ルートパス ──────────────────────────────────────────────────────
 
@@ -76,7 +73,6 @@ function _buildOutput(
   return attachFrontmatter(segmentContent, entry.frontmatter, {
     title: segment.title,
     log_id: 'dummy',
-    summary: segment.summary,
   });
 }
 
@@ -122,8 +118,8 @@ describe('attachFrontmatter — runai-frontmatter', () => {
 
               try {
                 const _inputContent = await readTextFile(_inputPath);
-                const _entry = new ChatlogEntry(_inputContent);
-                const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+                const _entry = new ChatlogEntry(_inputContent, { filePath: _inputPath });
+                const _map = await segmentChatlogs([_entry]);
                 const _segments = _map.get(_inputPath) ?? [];
 
                 const _actual = _buildOutput(_segments[_idx], _entry);

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-segments.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-segments.spec.ts
@@ -35,7 +35,9 @@ import { findFixtureDirs } from '../../../../_scripts/__tests__/helpers/find-fix
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 
 // test target
-import { segmentChatlogs } from '../../modules/segment-io.ts';
+import { segmentChatlogs } from '../../modules/segment-ai.ts';
+// classes
+import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 
 // ─── fixtures ルートパス ──────────────────────────────────────────────────────
 
@@ -108,7 +110,7 @@ describe('segmentChatlogs — runai-segments', () => {
           const _mockHandle = installCommandMock(_buildMock(_output, _inputPath));
           try {
             const _inputContent = await readTextFile(_inputPath);
-            const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+            const _map = await segmentChatlogs([new ChatlogEntry(_inputContent, { filePath: _inputPath })]);
             const _segments = _map.get(_inputPath) ?? [];
             assertEquals(_segments.length, _output.count);
           } finally {
@@ -120,7 +122,7 @@ describe('segmentChatlogs — runai-segments', () => {
           const _mockHandle = installCommandMock(_buildMock(_output, _inputPath));
           try {
             const _inputContent = await readTextFile(_inputPath);
-            const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+            const _map = await segmentChatlogs([new ChatlogEntry(_inputContent, { filePath: _inputPath })]);
             const _segments = _map.get(_inputPath) ?? [];
             for (const seg of _segments) {
               assertExists(seg.title);
@@ -145,7 +147,7 @@ describe('segmentChatlogs — runai-segments', () => {
           const _mockHandle = installCommandMock(_buildMock(_output, _inputPath));
           try {
             const _inputContent = await readTextFile(_inputPath);
-            const _map = await segmentChatlogs([{ filePath: _inputPath, content: _inputContent }]);
+            const _map = await segmentChatlogs([new ChatlogEntry(_inputContent, { filePath: _inputPath })]);
             assertNull(_map.get(_inputPath));
           } finally {
             _mockHandle.restore();

--- a/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
@@ -22,9 +22,16 @@ import {
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
 // test target
-import { segmentChatlogs } from '../../modules/segment-io.ts';
+import { segmentChatlogs } from '../../modules/segment-ai.ts';
+// classes
+import { ChatlogEntry } from '../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
 import type { Segment } from '../../types/normalize.types.ts';
+
+// ─── Internal Helpers
+
+// functions
+const _makeEntry = (filePath: string, content: string): ChatlogEntry => new ChatlogEntry(content, { filePath });
 
 // ─── segmentChatlogs tests ─────────────────────────────────────────────────────
 
@@ -61,7 +68,7 @@ describe('segmentChatlogs', () => {
           ];
           mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(aiSegments))));
 
-          const resultMap = await segmentChatlogs([{ filePath, content: 'Body A\nBody B' }]);
+          const resultMap = await segmentChatlogs([_makeEntry(filePath, 'Body A\nBody B')]);
           const result = resultMap.get(filePath);
 
           assertEquals(Array.isArray(result), true);
@@ -84,7 +91,7 @@ describe('segmentChatlogs', () => {
           ];
           mockHandle = installCommandMock(makeCountingMock(JSON.stringify(aiSegments), counter));
 
-          await segmentChatlogs([{ filePath, content: 'some chat content' }]);
+          await segmentChatlogs([_makeEntry(filePath, 'some chat content')]);
 
           assertEquals(counter.calls, 1);
         });
@@ -110,7 +117,7 @@ describe('segmentChatlogs', () => {
           const filePath = 'path/to/file.md';
           mockHandle = installCommandMock(makeFailMock(1));
 
-          const resultMap = await segmentChatlogs([{ filePath, content: 'some chat content' }]);
+          const resultMap = await segmentChatlogs([_makeEntry(filePath, 'some chat content')]);
 
           assertNull(resultMap.get(filePath));
         });
@@ -119,7 +126,7 @@ describe('segmentChatlogs', () => {
           const filePath = 'path/to/file.md';
           mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('not json')));
 
-          const resultMap = await segmentChatlogs([{ filePath, content: 'some chat content' }]);
+          const resultMap = await segmentChatlogs([_makeEntry(filePath, 'some chat content')]);
 
           assertNull(resultMap.get(filePath));
         });
@@ -157,7 +164,7 @@ describe('segmentChatlogs', () => {
           ];
           mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(aiSegments))));
 
-          const resultMap = await segmentChatlogs([{ filePath, content }]);
+          const resultMap = await segmentChatlogs([_makeEntry(filePath, content)]);
           const result = resultMap.get(filePath);
 
           assertEquals((result as Segment[]).length, 5);

--- a/skills/normalize-chatlogs/scripts/libs/__tests__/unit/load-entries.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/libs/__tests__/unit/load-entries.unit.spec.ts
@@ -1,0 +1,72 @@
+// src: skills/normalize-chatlogs/scripts/libs/__tests__/unit/load-entries.unit.spec.ts
+// @(#): loadEntries のユニットテスト
+//       対象: loadEntries
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { loadEntries } from '../../load-entries.ts';
+
+// ─── Helpers
+// classes
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+
+// ─── Tests
+
+/**
+ * `loadEntries` のユニットテストスイート。
+ *
+ * ファイルパス一覧から `ChatlogEntry` を並列読み込みし、成功分（`entries`）と
+ * 失敗分（`errors`）に分離するロジックを検証する。
+ *
+ * @see loadEntries
+ */
+describe('loadEntries', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await Deno.makeTempDir();
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  /** 正常系: 全ファイルが有効な場合の分離結果検証。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-NE-LEs-01: 全ファイルが有効なとき entries に全件含まれ errors は空になる', async () => {
+      const filePath1 = `${tempDir}/a.md`;
+      const filePath2 = `${tempDir}/b.md`;
+      await Deno.writeTextFile(filePath1, '---\ntitle: A\n---\n本文A');
+      await Deno.writeTextFile(filePath2, '---\ntitle: B\n---\n本文B');
+
+      const _result = await loadEntries([filePath1, filePath2], 2);
+
+      assertEquals(_result.entries.length, 2);
+      assertEquals(_result.entries.every((e) => e instanceof ChatlogEntry), true);
+      assertEquals(_result.errors.length, 0);
+    });
+  });
+
+  /** エッジケース: 正常/異常混在時の分離順序検証。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-NE-LEs-02: 正常/異常混在のとき正常分は entries に、異常分は errors に分離される', async () => {
+      const validPath = `${tempDir}/valid.md`;
+      const badPath = `${tempDir}/bad-yaml.md`;
+      await Deno.writeTextFile(validPath, '---\ntitle: OK\n---\n本文');
+      await Deno.writeTextFile(badPath, '---\ntitle: [unclosed\n---\n本文');
+
+      const _result = await loadEntries([validPath, badPath], 2);
+
+      assertEquals(_result.entries.map((e) => e.filePath), [validPath]);
+      assertEquals(_result.errors.map((e) => e.filePath), [badPath]);
+    });
+  });
+});

--- a/skills/normalize-chatlogs/scripts/libs/__tests__/unit/load-entry.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/libs/__tests__/unit/load-entry.unit.spec.ts
@@ -1,0 +1,86 @@
+// src: skills/normalize-chatlogs/scripts/libs/__tests__/unit/load-entry.unit.spec.ts
+// @(#): loadEntry のユニットテスト
+//       対象: loadEntry
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals, assertInstanceOf, assertRejects } from '@std/assert';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { loadEntry } from '../../load-entry.ts';
+
+// ─── Helpers
+// errors
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+// classes
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+
+// ─── Tests
+
+/**
+ * `loadEntry` のユニットテストスイート。
+ *
+ * ファイル読み込みと `ChatlogEntry | LoadEntryFailure` 返却のロジックを検証する。
+ * 正常系では戻り値が `ChatlogEntry` インスタンス、エラー系では `{ filePath, error }` の失敗結果を検証する。
+ *
+ * @see loadEntry
+ */
+describe('loadEntry', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await Deno.makeTempDir();
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  /** 正常系: 有効な .md ファイルを読み込んだときの戻り値検証。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-NE-LE-01: 戻り値が ChatlogEntry のインスタンスである', async () => {
+      const filePath = `${tempDir}/valid.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: テスト\n---\n本文');
+
+      const _result = await loadEntry(filePath);
+
+      assertInstanceOf(_result, ChatlogEntry);
+    });
+  });
+
+  /** 異常系: ファイル不在とフロントマターエラーのケース。 */
+  describe('When: 異常系', () => {
+    it('[Error] T-NE-LE-02: 存在しないパスで ChatlogError がスローされる', async () => {
+      await assertRejects(
+        () => loadEntry('/nonexistent/path/file.md'),
+        ChatlogError,
+      );
+    });
+
+    it('[Error] T-NE-LE-03: エラー時の戻り値が { filePath, error } 形式である', async () => {
+      const filePath = `${tempDir}/bad-yaml.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
+
+      const _result = await loadEntry(filePath);
+
+      assertEquals(_result instanceof ChatlogEntry, false);
+      assertEquals((_result as { filePath: string }).filePath, filePath);
+    });
+
+    it('[Error] T-NE-LE-04: エラー時の error が空でないメッセージを持つ', async () => {
+      const filePath = `${tempDir}/bad-yaml.md`;
+      await Deno.writeTextFile(filePath, '---\ntitle: [unclosed\n---\n本文');
+
+      const _result = await loadEntry(filePath);
+
+      const _error = (_result as { error: Error }).error;
+      assertInstanceOf(_error, Error);
+      assertEquals(_error.message.length > 0, true);
+    });
+  });
+});

--- a/skills/normalize-chatlogs/scripts/libs/load-entries.ts
+++ b/skills/normalize-chatlogs/scripts/libs/load-entries.ts
@@ -1,0 +1,39 @@
+// src: skills/normalize-chatlogs/scripts/libs/load-entries.ts
+// @(#): normalize-chatlogs バッチエントリ読み込みユーティリティ
+//       対象: loadEntries
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared scripts
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
+
+// ─── Local
+import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import { loadEntry } from './load-entry.ts';
+// types
+import type { LoadEntryFailure } from '../types/load-entry.types.ts';
+
+/**
+ * ファイルパス一覧から `ChatlogEntry` を並列読み込みし、成功分（`entries`）と
+ * 失敗分（`errors`）に分離して返す。
+ * - ファイルシステムエラーは `loadEntry` からそのままスローされる（このレベルでは捕捉しない）。
+ * - フロントマター解析エラー等は `errors` に集約され、`entries` には含まれない。
+ */
+export const loadEntries = async (
+  filePaths: string[],
+  concurrency: number,
+): Promise<{ entries: ChatlogEntry[]; errors: LoadEntryFailure[] }> => {
+  const _results = await runConcurrent(
+    filePaths,
+    (filePath) => loadEntry(filePath),
+    concurrency,
+  );
+
+  const entries = _results.filter((result): result is ChatlogEntry => result instanceof ChatlogEntry);
+  const errors = _results.filter((result): result is LoadEntryFailure => !(result instanceof ChatlogEntry));
+
+  return { entries, errors };
+};

--- a/skills/normalize-chatlogs/scripts/libs/load-entry.ts
+++ b/skills/normalize-chatlogs/scripts/libs/load-entry.ts
@@ -1,0 +1,39 @@
+// src: skills/normalize-chatlogs/scripts/libs/load-entry.ts
+// @(#): normalize-chatlogs エントリ読み込みユーティリティ
+//       対象: loadEntry
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared scripts
+import { loadChatlogEntry } from '../../../_scripts/libs/file-io/chatlog-entry-loader.ts';
+import { isFileIoError } from '../../../_scripts/libs/file-io/read-utils.ts';
+
+// ─── Local
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+// types
+import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import type { LoadEntryFailure } from '../types/load-entry.types.ts';
+
+/**
+ * ファイルパスから `ChatlogEntry` を読み込む。
+ * - ファイルシステムエラー（`NotFound`, `PermissionDenied` 等）はそのままスロー（致命的エラー）。
+ * - フロントマターの解析エラー（`InvalidFormat`, `InvalidYaml`）は `{ filePath, error }`
+ *   （`LoadEntryFailure`）を返す。
+ * - 正常時は読み込んだ `ChatlogEntry` をそのまま返す。
+ */
+export const loadEntry = async (
+  filePath: string,
+): Promise<ChatlogEntry | LoadEntryFailure> => {
+  try {
+    return await loadChatlogEntry(filePath);
+  } catch (e) {
+    if (isFileIoError(e) || (e instanceof ChatlogError && e.kind === 'FileDirNotFound')) {
+      throw e;
+    }
+    const _error = e instanceof Error ? e : new Error(String(e));
+    return { filePath, error: _error };
+  }
+};

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
@@ -341,6 +341,74 @@ describe('processFiles', () => {
     });
   });
 
+  /** 読み込みエラー: frontmatter パースエラー等、loadEntries が返す errors の扱い。 */
+  describe('When: 読み込みエラー', () => {
+    it('[Error] T-PF-LE-01: フロントマターが不正なファイルは stats.fail が増加し logger.warn が呼ばれ、書き出し対象から除外される', async () => {
+      // arrange
+      const badFilePath = normalizePath(`${tmpDir}/bad-yaml.md`);
+      await Deno.writeTextFile(badFilePath, '---\ntitle: [unclosed\n---\n本文');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await processFiles(tmpDir, outputDir, _CONFIG, stats);
+
+        // assert — 読み込みエラーで fail が増加し、warn が呼ばれる
+        assertEquals(stats.fail, 1);
+        assert(warnStub.calls.length > 0);
+      } finally {
+        warnStub?.restore();
+      }
+    });
+
+    it('[Error] T-PF-LE-02: failFast=true のとき読み込みエラーで ChatlogError(FailFast) をスローする', async () => {
+      // arrange
+      const badFilePath = normalizePath(`${tmpDir}/bad-yaml.md`);
+      await Deno.writeTextFile(badFilePath, '---\ntitle: [unclosed\n---\n本文');
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
+        dryRun: true,
+        concurrency: 1,
+        failFast: true,
+      };
+
+      // act & assert
+      const err = await assertRejects(
+        () => processFiles(tmpDir, outputDir, config, stats),
+        ChatlogError,
+      );
+      assertEquals((err as ChatlogError).kind, 'FailFast');
+    });
+
+    it('[Normal] T-PF-LE-03: failFast=false のとき読み込みエラーがあっても残りの正常ファイルは処理される', async () => {
+      // arrange
+      const badFilePath = normalizePath(`${tmpDir}/bad-yaml.md`);
+      const goodFilePath = normalizePath(`${tmpDir}/good.md`);
+      await Deno.writeTextFile(badFilePath, '---\ntitle: [unclosed\n---\n本文');
+      await Deno.writeTextFile(goodFilePath, '# Test\n\nContent');
+
+      const segments = [{ title: 'Topic', summary: 'Summary', content: 'Body' }];
+      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath: goodFilePath, segments }]));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
+        dryRun: true,
+        concurrency: 2,
+        failFast: false,
+      };
+
+      // act
+      await processFiles(tmpDir, outputDir, config, stats);
+
+      // assert — 読み込みエラーで fail が1増え、正常ファイルはエラーにならず処理される
+      assertEquals(stats.fail, 1);
+    });
+  });
+
   /** BATCH_SIZE 境界: ファイル数が BATCH_SIZE を超えるとき 2 チャンクに分割して処理するケース。 */
   describe('When: BATCH_SIZE 境界', () => {
     it('[Edge] T-PF-BATCH-01: ファイル数が BATCH_SIZE+1 のとき全ファイルが処理されて stats.fail === 0', async () => {

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/resolve-output-dir.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/resolve-output-dir.unit.spec.ts
@@ -12,7 +12,7 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { resolveOutputDir } from '../../process-files.ts';
+import { resolveOutputDir } from '../../../phases/phase-write.ts';
 
 // ─── Tests
 

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-ai.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-ai.unit.spec.ts
@@ -1,0 +1,596 @@
+// src: skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-ai.unit.spec.ts
+// @(#): segment-ai モジュールのユニットテスト
+//       対象: segmentChatlogs
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assert, assertEquals, assertFalse, assertNotEquals } from '@std/assert';
+import { afterEach, describe, it } from '@std/testing/bdd';
+// stub
+import { stub } from '@std/testing/mock';
+import type { DenoCommandLike } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+// types
+import type { Stub } from '@std/testing/mock';
+
+// ─── Test target
+import { segmentChatlogs } from '../../segment-ai.ts';
+
+// ─── Helpers
+import { assertNull } from '../../../../../_scripts/__tests__/helpers/assert.ts';
+// functions
+import { logger } from '../../../../../_scripts/libs/io/logger.ts';
+// mock helpers
+import {
+  BaseMockCommand,
+  installCommandMock,
+  makeDelayedSuccessMock,
+  makeFailMock,
+  makeSuccessMock,
+} from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+// classes
+import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+// constants
+import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
+
+// ─── Internal Helpers
+
+// functions
+
+/** テスト用の `ChatlogEntry` を `filePath` と本文 `content` から生成する（frontmatterなし）。 */
+const _makeEntry = (filePath: string, content: string): ChatlogEntry => new ChatlogEntry(content, { filePath });
+
+// classes
+
+/**
+ * stdin に書き込まれた内容をキャプチャするモック。
+ *
+ * `runAI` が `getWriter().write()` で送る userPrompt を検証するために使用する。
+ * `capturedStdin` にデコードされた文字列が蓄積される。
+ */
+class _StdinCaptureMock extends BaseMockCommand {
+  private readonly stdout: Uint8Array;
+  readonly capturedStdin: string[] = [];
+
+  constructor(_cmd: string, _opts: unknown, stdout: Uint8Array) {
+    super();
+    this.stdout = stdout;
+  }
+
+  override spawn() {
+    const captured = this.capturedStdin;
+    return {
+      stdin: {
+        getWriter() {
+          return {
+            write(data: Uint8Array): Promise<void> {
+              captured.push(new TextDecoder().decode(data));
+              return Promise.resolve();
+            },
+            close(): Promise<void> {
+              return Promise.resolve();
+            },
+          };
+        },
+      },
+      output: () => this.makeOutput(),
+    };
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
+  }
+}
+
+// functions
+
+/**
+ * `_StdinCaptureMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param stdout - AI が返す stdout バイト列
+ * @param captured - stdin のキャプチャ先（インスタンスを後から参照するための出口）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeStdinCaptureMock = (
+  stdout: Uint8Array,
+  captured: { instance: _StdinCaptureMock | null },
+): DenoCommandLike => {
+  return class extends _StdinCaptureMock {
+    constructor(cmd: string, opts: unknown) {
+      super(cmd, opts, stdout);
+      captured.instance = this;
+    }
+  } as unknown as DenoCommandLike;
+};
+
+// ─── Tests
+
+// ─── segmentChatlogs tests ────────────────────────────────────────────────────
+
+/**
+ * `segmentChatlogs` のユニットテストスイート。
+ *
+ * 複数ファイルをまとめて1回のAI呼び出しでセグメント分割する関数の
+ * 正常系・異常系・エッジケースを検証する。
+ *
+ * テスト ID 範囲: T-SC-01-01, T-SC-05-01, T-SC-05-02, T-SCB-01-01 〜 T-SCB-05-02, T-SIO-LR-14, T-SIO-LR-19 〜 T-SIO-LR-25, T-SIO-LOG-01 〜 T-SIO-LOG-02
+ *
+ * @see segmentChatlogs
+ */
+describe('segmentChatlogs', () => {
+  let mockHandle: CommandMockHandle;
+
+  afterEach(() => {
+    mockHandle?.restore();
+  });
+
+  describe('When: 正常系', () => {
+    it('[Normal] T-SC-01-01: 1要素入力でAIが有効なJSON(envelope形式)を返すとき Segment[]をMapで返す', async () => {
+      // arrange
+      const aiResult = [
+        {
+          filePath: 'test.md',
+          segments: [
+            { title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 },
+            { title: 'Topic 2', summary: 'Summary 2', startLine: 2, endLine: 2 },
+          ],
+        },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs([_makeEntry('test.md', 'Body 1\nBody 2')]);
+
+      // assert
+      assertEquals(result.get('test.md'), [
+        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1', startLine: 1, endLine: 1 },
+        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2', startLine: 2, endLine: 2 },
+      ]);
+    });
+
+    it('[Normal] T-SCB-01-01: 2ファイル入力でAIが有効なJSONを返すとき各ファイルのSegment[]をMapで返す', async () => {
+      // arrange
+      const inputs = [
+        _makeEntry('a.md', 'C1'),
+        _makeEntry('b.md', 'C2'),
+      ];
+      const aiResult = [
+        { filePath: 'a.md', segments: [{ title: 'T1', summary: 'S1', startLine: 1, endLine: 1 }] },
+        { filePath: 'b.md', segments: [{ title: 'T2', summary: 'S2', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md'), [{ title: 'T1', summary: 'S1', content: 'C1', startLine: 1, endLine: 1 }]);
+      assertEquals(result.get('b.md'), [{ title: 'T2', summary: 'S2', content: 'C2', startLine: 1, endLine: 1 }]);
+    });
+
+    it('[Normal] T-SCB-01-02: 1ファイルでAIが12セグメントを返すとき先頭5件に制限される（MAX_SEGMENTS上限）', async () => {
+      // arrange
+      const content = Array.from({ length: 12 }, (_, i) => `l${i + 1}`).join('\n');
+      const inputs = [_makeEntry('big.md', content)];
+      const manySegments = Array.from({ length: 12 }, (_, i) => ({
+        title: `Topic ${i + 1}`,
+        summary: `Summary ${i + 1}`,
+        startLine: i + 1,
+        endLine: i + 1,
+      }));
+      const aiResult = [{ filePath: 'big.md', segments: manySegments }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('big.md')?.length, 5);
+      assertEquals(result.get('big.md')?.[0].title, 'Topic 1');
+      assertEquals(result.get('big.md')?.[4].title, 'Topic 5');
+    });
+  });
+
+  /** model オプションを指定・省略したときの Deno.Command args 検証ケース。 */
+  describe('When: 正常系 — model 指定', () => {
+    it('[Normal] T-SC-05-01: model を明示指定したとき Deno.Command args に --model <指定モデル> が含まれる', async () => {
+      // arrange
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const capturedArgs: { value: string[] } = { value: [] };
+      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
+
+      // act
+      await segmentChatlogs([_makeEntry('test.md', 'content')], { model: 'claude-sonnet-4-6' });
+
+      // assert
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertNotEquals(modelIndex, -1);
+      assertEquals(capturedArgs.value[modelIndex + 1], 'claude-sonnet-4-6');
+    });
+
+    it('[Normal] T-SC-05-02: model を省略したとき Deno.Command args に --model DEFAULT_AI_MODEL が含まれる', async () => {
+      // arrange
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const capturedArgs: { value: string[] } = { value: [] };
+      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
+
+      // act
+      await segmentChatlogs([_makeEntry('test.md', 'content')]);
+
+      // assert
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertNotEquals(modelIndex, -1);
+      assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
+    });
+  });
+
+  describe('When: 異常系', () => {
+    it('[Error] T-SCB-02-01: AIが非ゼロ exit のとき全ファイルが null の Map を返す', async () => {
+      // arrange
+      const inputs = [
+        _makeEntry('a.md', 'content a'),
+        _makeEntry('b.md', 'content b'),
+      ];
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('a.md'));
+      assertNull(result.get('b.md'));
+    });
+
+    it('[Error] T-SCB-02-02: AIが不正JSONを返すとき全ファイルが null の Map を返す', async () => {
+      // arrange
+      const inputs = [_makeEntry('a.md', 'content a')];
+      const stdout = new TextEncoder().encode('not valid json');
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('a.md'));
+    });
+
+    it('[Error] T-SCB-WL-01: AI が非ゼロ exit のとき logger.warn が呼ばれる', async () => {
+      // arrange
+      const inputs = [_makeEntry('file-a.md', 'content a')];
+      mockHandle = installCommandMock(makeFailMock(1));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert — warn が 1 回呼ばれ、ファイル名（拡張子なし）がメッセージに含まれる
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('file-a'));
+      } finally {
+        warnStub?.restore();
+      }
+    });
+
+    it('[Error] T-SCB-WL-02: AI が不正 JSON を返すとき logger.warn が呼ばれる', async () => {
+      // arrange
+      const inputs = [_makeEntry('file-b.md', 'content b')];
+      const stdout = new TextEncoder().encode('not valid json');
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert — warn が 1 回呼ばれ、ファイル名（拡張子なし）がメッセージに含まれる
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('file-b'));
+      } finally {
+        warnStub?.restore();
+      }
+    });
+  });
+
+  describe('When: エッジケース', () => {
+    it('[Edge] T-SCB-03-01: 1ファイル入力でも正常動作する', async () => {
+      // arrange
+      const inputs = [_makeEntry('solo.md', 'C')];
+      const aiResult = [
+        { filePath: 'solo.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('solo.md'), [{ title: 'T', summary: 'S', content: 'C', startLine: 1, endLine: 1 }]);
+    });
+
+    it('[Edge] T-SCB-04-01: AIが返す filePath が inputs にない場合無視され、inputs にある filePath は null になる', async () => {
+      // arrange
+      const inputs = [_makeEntry('known.md', 'content')];
+      const aiResult = [
+        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('known.md'));
+      assertFalse(result.has('unknown.md'));
+    });
+  });
+
+  /** userPrompt に行番号付きコンテンツが含まれることを検証するケース。 */
+  describe('When: userPrompt 行番号付きコンテンツ', () => {
+    it('[Normal] T-SIO-LR-14: userPrompt に行番号付きコンテンツが含まれる', async () => {
+      // arrange
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 2 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const captured: { instance: _StdinCaptureMock | null } = { instance: null };
+      mockHandle = installCommandMock(_makeStdinCaptureMock(stdout, captured));
+      const content = 'line A\nline B';
+
+      // act
+      await segmentChatlogs([_makeEntry('test.md', content)]);
+
+      // assert — stdin には "1: line A\n2: line B" が含まれる
+      assert(captured.instance !== null, 'mock was not instantiated');
+      const written = captured.instance.capturedStdin.join('');
+      assert(written.includes('1: line A\n2: line B'), `expected line-numbered content in stdin, got: ${written}`);
+    });
+  });
+
+  /** 行番号範囲方式（_AiSegmentRange）: startLine/endLine でバッチ処理するケース。 */
+  describe('When: 行番号範囲方式（_AiSegmentRange）', () => {
+    it('[Normal] T-SIO-LR-19: 2ファイル入力でAIが {startLine,endLine} 返すとき各ファイルの Segment[] を Map で返す', async () => {
+      // arrange
+      const inputs = [
+        _makeEntry('a.md', 'a1\na2\na3'),
+        _makeEntry('b.md', 'b1\nb2'),
+      ];
+      const aiResult = [
+        { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 2 }] },
+        { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 1, endLine: 2 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md')?.[0].content, 'a1\na2');
+      assertEquals(result.get('b.md')?.[0].content, 'b1\nb2');
+    });
+
+    it('[Normal] T-SIO-LR-20: 各ファイルの行番号は独立（ファイルごとにリセット）', async () => {
+      // arrange
+      const inputs = [
+        _makeEntry('a.md', 'lineA1\nlineA2'),
+        _makeEntry('b.md', 'lineB1\nlineB2\nlineB3'),
+      ];
+      const aiResult = [
+        { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 1 }] },
+        { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 2, endLine: 3 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md')?.[0].content, 'lineA1');
+      assertEquals(result.get('b.md')?.[0].content, 'lineB2\nlineB3');
+    });
+
+    it('[Error] T-SIO-LR-21: AIが非ゼロ exit のとき全ファイルが null の Map を返す', async () => {
+      // arrange
+      const inputs = [
+        _makeEntry('a.md', 'content a'),
+        _makeEntry('b.md', 'content b'),
+      ];
+      mockHandle = installCommandMock(makeFailMock(1));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('a.md'));
+      assertNull(result.get('b.md'));
+    });
+
+    it('[Error] T-SIO-LR-22: AIが不正 JSON を返すとき全ファイルが null の Map を返す', async () => {
+      // arrange
+      const inputs = [_makeEntry('a.md', 'content a')];
+      const stdout = new TextEncoder().encode('not valid json');
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('a.md'));
+    });
+
+    it('[Edge] T-SIO-LR-23: AIが返す filePath が inputs にない場合無視され inputs 側は null になる', async () => {
+      // arrange
+      const inputs = [_makeEntry('known.md', 'c')];
+      const aiResult = [
+        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertNull(result.get('known.md'));
+      assertFalse(result.has('unknown.md'));
+    });
+
+    it('[Edge] T-SIO-LR-24: 1ファイルで6件のセグメントを返すとき先頭5件に制限される（MAX_SEGMENTS=5）', async () => {
+      // arrange
+      const inputs = [_makeEntry('big.md', 'l1\nl2\nl3\nl4\nl5\nl6')];
+      const aiSegments = Array.from({ length: 6 }, (_, i) => ({
+        title: `Topic ${i + 1}`,
+        summary: `Sum ${i + 1}`,
+        startLine: i + 1,
+        endLine: i + 1,
+      }));
+      const aiResult = [{ filePath: 'big.md', segments: aiSegments }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+
+      // act
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('big.md')?.length, 5);
+    });
+
+    it('[Edge] T-SIO-LR-25: timeoutMs:1 を渡すとタイムアウトして全ファイルが null の Map を返す', async () => {
+      // arrange — AI が 50ms 後に応答するモック
+      const inputs = [_makeEntry('a.md', 'content a')];
+      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
+
+      // act — 1ms タイムアウト: 50ms の遅延より先に abort される
+      const result = await segmentChatlogs(inputs, { timeoutMs: 1 });
+
+      // assert
+      assertNull(result.get('a.md'));
+    });
+  });
+
+  /** timeoutMs オプション転送: 指定・省略時の動作を検証するケース。 */
+  describe('When: timeoutMs オプション', () => {
+    it('[Normal] T-SCB-05-01: timeoutMs: 1 を渡すとタイムアウトして全ファイルが null の Map を返す', async () => {
+      // arrange — AI が 50ms 後に応答するモック
+      const inputs = [_makeEntry('a.md', 'content a')];
+      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
+
+      // act — 1ms タイムアウト: 50ms の遅延より先に abort される
+      const result = await segmentChatlogs(inputs, { timeoutMs: 1 });
+
+      // assert
+      assertNull(result.get('a.md'));
+    });
+
+    it('[Normal] T-SCB-05-02: timeoutMs を省略するとデフォルト(120s)が使われ正常にセグメントを返す', async () => {
+      // arrange — AI が 50ms 後に応答するモック
+      const inputs = [_makeEntry('a.md', 'C')];
+      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
+
+      // act — timeoutMs 省略: デフォルト 120s >> 50ms 遅延
+      const result = await segmentChatlogs(inputs);
+
+      // assert
+      assertEquals(result.get('a.md'), [{ title: 'T', summary: 'S', content: 'C', startLine: 1, endLine: 1 }]);
+    });
+  });
+
+  /** systemPrompt の内容検証: 「必ず 1 件以上返す」指示が含まれることを確認するケース。 */
+  describe('When: systemPrompt 内容検証', () => {
+    it('[Normal] T-SCB-SP-01: systemPrompt に "at least 1 segment" が含まれる', async () => {
+      // arrange
+      const aiResult = [
+        { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const capturedArgs: { value: string[] } = { value: [] };
+      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
+
+      // act
+      await segmentChatlogs([_makeEntry('test.md', 'single line')]);
+
+      // assert — args must have been captured
+      assert(capturedArgs.value.length > 0, 'no args captured — mock did not fire');
+      const argsText = capturedArgs.value.join(' ');
+      assert(argsText.includes('at least 1 segment'), `expected "at least 1 segment" in args, got: ${argsText}`);
+    });
+  });
+
+  /** AI がエントリを返さなかった・空セグメントを返したときの warn ログ検証ケース。 */
+  describe('When: エッジケース — ログ出力', () => {
+    it('[Edge] T-SIO-LOG-01: AI が当該ファイルのエントリを返さなかったとき "no entry returned for" を含む warn が出る', async () => {
+      // arrange — input は known.md だが AI は unknown.md のエントリのみ返す
+      const inputs = [_makeEntry('known.md', 'content')];
+      const aiResult = [
+        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('no entry returned for'));
+      } finally {
+        warnStub?.restore();
+      }
+    });
+
+    it('[Edge] T-SIO-LOG-02: AI が segments:[] を返したとき "empty segments returned for" を含む warn が出る', async () => {
+      // arrange — AI は known.md のエントリを返すが segments は空配列
+      const inputs = [_makeEntry('known.md', 'content')];
+      const aiResult = [
+        { filePath: 'known.md', segments: [] },
+      ];
+      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      let warnStub: Stub | undefined;
+
+      try {
+        warnStub = stub(logger, 'warn');
+
+        // act
+        await segmentChatlogs(inputs);
+
+        // assert
+        assertEquals(warnStub.calls.length, 1);
+        assert(warnStub.calls[0].args[0].includes('empty segments returned for'));
+      } finally {
+        warnStub?.restore();
+      }
+    });
+  });
+});

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
 // @(#): segment-io モジュールのユニットテスト
-//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, segmentChatlogs, writeSegmentToFile
+//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, writeSegmentToFile
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -12,11 +12,6 @@
 // ─── BDD modules
 import { assert, assertEquals, assertFalse, assertNotEquals, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
-// stub
-import { stub } from '@std/testing/mock';
-import type { DenoCommandLike } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-// types
-import type { Stub } from '@std/testing/mock';
 
 // ─── Test target
 import {
@@ -24,97 +19,18 @@ import {
   extractSegmentBaseName,
   generateOutputFileName,
   generateSegmentFile,
-  segmentChatlogs,
   START_BODY_HEADING,
   writeSegmentToFile,
 } from '../../segment-io.ts';
 
 // ─── Helpers
-import { assertFileExist, assertNull } from '../../../../../_scripts/__tests__/helpers/assert.ts';
-// functions
-import { logger } from '../../../../../_scripts/libs/io/logger.ts';
-// mock helpers
-import {
-  BaseMockCommand,
-  installCommandMock,
-  makeDelayedSuccessMock,
-  makeFailMock,
-  makeSuccessMock,
-} from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { assertFileExist } from '../../../../../_scripts/__tests__/helpers/assert.ts';
 // classes
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 import { ChatlogFrontmatter } from '../../../../../_scripts/classes/ChatlogFrontmatter.class.ts';
-// constants
-import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { Stats } from '../../../types/normalize.types.ts';
-
-// ─── Internal Helpers
-
-// classes
-
-/**
- * stdin に書き込まれた内容をキャプチャするモック。
- *
- * `runAI` が `getWriter().write()` で送る userPrompt を検証するために使用する。
- * `capturedStdin` にデコードされた文字列が蓄積される。
- */
-class _StdinCaptureMock extends BaseMockCommand {
-  private readonly stdout: Uint8Array;
-  readonly capturedStdin: string[] = [];
-
-  constructor(_cmd: string, _opts: unknown, stdout: Uint8Array) {
-    super();
-    this.stdout = stdout;
-  }
-
-  override spawn() {
-    const captured = this.capturedStdin;
-    return {
-      stdin: {
-        getWriter() {
-          return {
-            write(data: Uint8Array): Promise<void> {
-              captured.push(new TextDecoder().decode(data));
-              return Promise.resolve();
-            },
-            close(): Promise<void> {
-              return Promise.resolve();
-            },
-          };
-        },
-      },
-      output: () => this.makeOutput(),
-    };
-  }
-
-  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
-    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
-  }
-}
-
-// functions
-
-/**
- * `_StdinCaptureMock` を `DenoCommandLike` として返すファクトリヘルパー。
- *
- * @param stdout - AI が返す stdout バイト列
- * @param captured - stdin のキャプチャ先（インスタンスを後から参照するための出口）
- * @returns `DenoCommandLike` クラス
- */
-const _makeStdinCaptureMock = (
-  stdout: Uint8Array,
-  captured: { instance: _StdinCaptureMock | null },
-): DenoCommandLike => {
-  return class extends _StdinCaptureMock {
-    constructor(cmd: string, opts: unknown) {
-      super(cmd, opts, stdout);
-      captured.instance = this;
-    }
-  } as unknown as DenoCommandLike;
-};
 
 // ─── Tests
 
@@ -301,7 +217,7 @@ describe('attachFrontmatter', () => {
     it('[Normal] T-12-01-01: 出力フロントマターに project: "ci-platform" が含まれる', () => {
       fm.set('project', 'ci-platform');
       fm.set('date', '2026-03-01');
-      const segmentMeta = { title: 'Fix CI', log_id: 'abc1234', summary: 'CI fix' };
+      const segmentMeta = { title: 'Fix CI', log_id: 'abc1234' };
       const content = '## Summary\nFix CI';
 
       const result = attachFrontmatter(content, fm, segmentMeta);
@@ -309,21 +225,21 @@ describe('attachFrontmatter', () => {
       assert(result.includes('project: "ci-platform"'));
     });
 
-    it('[Normal] T-12-01-02: 出力フロントマターに title・log_id・summary が含まれる', () => {
+    it('[Normal] T-12-01-02: 出力フロントマターに title・log_id が含まれ summary は含まれない', () => {
       fm.set('project', 'ci-platform');
-      const segmentMeta = { title: 'Fix CI', log_id: 'abc1234', summary: 'CI fix' };
+      const segmentMeta = { title: 'Fix CI', log_id: 'abc1234' };
       const content = '## Summary\nFix CI';
 
       const result = attachFrontmatter(content, fm, segmentMeta);
 
       assert(result.includes('title: "Fix CI"'));
       assert(result.includes('log_id: "abc1234"'));
-      assert(result.includes('summary: "CI fix"'));
+      assertFalse(result.includes('summary:'));
     });
 
     it('[Normal] T-12-03-01: 出力が `---\\n` で始まりフロントマターブロックが `\\n---\\n` で終わる', () => {
       fm.set('project', 'test');
-      const segmentMeta = { title: 'T', log_id: 'x', summary: 'S' };
+      const segmentMeta = { title: 'T', log_id: 'x' };
       const content = '## Summary\ntext';
 
       const result = attachFrontmatter(content, fm, segmentMeta);
@@ -333,7 +249,7 @@ describe('attachFrontmatter', () => {
     });
 
     it('[Normal] T-12-03-02: コンテンツボディがフロントマターブロックの後に重複なく続く', () => {
-      const segmentMeta = { title: 'T', log_id: 'x', summary: 'S' };
+      const segmentMeta = { title: 'T', log_id: 'x' };
       const content = '## Summary\ntext';
 
       const result = attachFrontmatter(content, fm, segmentMeta);
@@ -351,502 +267,16 @@ describe('attachFrontmatter', () => {
       fm = new ChatlogFrontmatter('');
     });
 
-    it('[Edge] T-12-02-01: 出力フロントマターが AI 生成フィールド（title・log_id・summary）のみを含む', () => {
-      const segmentMeta = { title: 'Topic', log_id: 'aaabbbb', summary: 'Summary' };
+    it('[Edge] T-12-02-01: 出力フロントマターが AI 生成フィールド（title・log_id）のみを含む', () => {
+      const segmentMeta = { title: 'Topic', log_id: 'aaabbbb' };
       const content = '## Summary\nTopic content';
 
       const result = attachFrontmatter(content, fm, segmentMeta);
 
       assert(result.includes('title: "Topic"'));
       assert(result.includes('log_id: "aaabbbb"'));
-      assert(result.includes('summary: "Summary"'));
+      assertFalse(result.includes('summary:'));
       assertFalse(result.includes('project:'));
-    });
-  });
-});
-
-// ─── segmentChatlogs tests ────────────────────────────────────────────────────
-
-/**
- * `segmentChatlogs` のユニットテストスイート。
- *
- * 複数ファイルをまとめて1回のAI呼び出しでセグメント分割する関数の
- * 正常系・異常系・エッジケースを検証する。
- *
- * テスト ID 範囲: T-SC-01-01, T-SC-05-01, T-SC-05-02, T-SCB-01-01 〜 T-SCB-05-02, T-SIO-LR-14, T-SIO-LR-19 〜 T-SIO-LR-25, T-SIO-LOG-01 〜 T-SIO-LOG-02
- *
- * @see segmentChatlogs
- */
-describe('segmentChatlogs', () => {
-  let mockHandle: CommandMockHandle;
-
-  afterEach(() => {
-    mockHandle?.restore();
-  });
-
-  describe('When: 正常系', () => {
-    it('[Normal] T-SC-01-01: 1要素入力でAIが有効なJSON(envelope形式)を返すとき Segment[]をMapで返す', async () => {
-      // arrange
-      const aiResult = [
-        {
-          filePath: 'test.md',
-          segments: [
-            { title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 },
-            { title: 'Topic 2', summary: 'Summary 2', startLine: 2, endLine: 2 },
-          ],
-        },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs([{ filePath: 'test.md', content: 'Body 1\nBody 2' }]);
-
-      // assert
-      assertEquals(result.get('test.md'), [
-        { title: 'Topic 1', summary: 'Summary 1', content: 'Body 1', startLine: 1, endLine: 1 },
-        { title: 'Topic 2', summary: 'Summary 2', content: 'Body 2', startLine: 2, endLine: 2 },
-      ]);
-    });
-
-    it('[Normal] T-SCB-01-01: 2ファイル入力でAIが有効なJSONを返すとき各ファイルのSegment[]をMapで返す', async () => {
-      // arrange
-      const inputs = [
-        { filePath: 'a.md', content: 'C1' },
-        { filePath: 'b.md', content: 'C2' },
-      ];
-      const aiResult = [
-        { filePath: 'a.md', segments: [{ title: 'T1', summary: 'S1', startLine: 1, endLine: 1 }] },
-        { filePath: 'b.md', segments: [{ title: 'T2', summary: 'S2', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('a.md'), [{ title: 'T1', summary: 'S1', content: 'C1', startLine: 1, endLine: 1 }]);
-      assertEquals(result.get('b.md'), [{ title: 'T2', summary: 'S2', content: 'C2', startLine: 1, endLine: 1 }]);
-    });
-
-    it('[Normal] T-SCB-01-02: 1ファイルでAIが12セグメントを返すとき先頭5件に制限される（MAX_SEGMENTS上限）', async () => {
-      // arrange
-      const content = Array.from({ length: 12 }, (_, i) => `l${i + 1}`).join('\n');
-      const inputs = [{ filePath: 'big.md', content }];
-      const manySegments = Array.from({ length: 12 }, (_, i) => ({
-        title: `Topic ${i + 1}`,
-        summary: `Summary ${i + 1}`,
-        startLine: i + 1,
-        endLine: i + 1,
-      }));
-      const aiResult = [{ filePath: 'big.md', segments: manySegments }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('big.md')?.length, 5);
-      assertEquals(result.get('big.md')?.[0].title, 'Topic 1');
-      assertEquals(result.get('big.md')?.[4].title, 'Topic 5');
-    });
-  });
-
-  /** model オプションを指定・省略したときの Deno.Command args 検証ケース。 */
-  describe('When: 正常系 — model 指定', () => {
-    it('[Normal] T-SC-05-01: model を明示指定したとき Deno.Command args に --model <指定モデル> が含まれる', async () => {
-      // arrange
-      const aiResult = [
-        { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      const capturedArgs: { value: string[] } = { value: [] };
-      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
-
-      // act
-      await segmentChatlogs([{ filePath: 'test.md', content: 'content' }], { model: 'claude-sonnet-4-6' });
-
-      // assert
-      const modelIndex = capturedArgs.value.indexOf('--model');
-      assertNotEquals(modelIndex, -1);
-      assertEquals(capturedArgs.value[modelIndex + 1], 'claude-sonnet-4-6');
-    });
-
-    it('[Normal] T-SC-05-02: model を省略したとき Deno.Command args に --model DEFAULT_AI_MODEL が含まれる', async () => {
-      // arrange
-      const aiResult = [
-        { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      const capturedArgs: { value: string[] } = { value: [] };
-      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
-
-      // act
-      await segmentChatlogs([{ filePath: 'test.md', content: 'content' }]);
-
-      // assert
-      const modelIndex = capturedArgs.value.indexOf('--model');
-      assertNotEquals(modelIndex, -1);
-      assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
-    });
-  });
-
-  describe('When: 異常系', () => {
-    it('[Error] T-SCB-02-01: AIが非ゼロ exit のとき全ファイルが null の Map を返す', async () => {
-      // arrange
-      const inputs = [
-        { filePath: 'a.md', content: 'content a' },
-        { filePath: 'b.md', content: 'content b' },
-      ];
-      mockHandle = installCommandMock(makeFailMock(1));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertNull(result.get('a.md'));
-      assertNull(result.get('b.md'));
-    });
-
-    it('[Error] T-SCB-02-02: AIが不正JSONを返すとき全ファイルが null の Map を返す', async () => {
-      // arrange
-      const inputs = [{ filePath: 'a.md', content: 'content a' }];
-      const stdout = new TextEncoder().encode('not valid json');
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertNull(result.get('a.md'));
-    });
-
-    it('[Error] T-SCB-WL-01: AI が非ゼロ exit のとき logger.warn が呼ばれる', async () => {
-      // arrange
-      const inputs = [{ filePath: 'file-a.md', content: 'content a' }];
-      mockHandle = installCommandMock(makeFailMock(1));
-      let warnStub: Stub | undefined;
-
-      try {
-        warnStub = stub(logger, 'warn');
-
-        // act
-        await segmentChatlogs(inputs);
-
-        // assert — warn が 1 回呼ばれ、ファイル名（拡張子なし）がメッセージに含まれる
-        assertEquals(warnStub.calls.length, 1);
-        assert(warnStub.calls[0].args[0].includes('file-a'));
-      } finally {
-        warnStub?.restore();
-      }
-    });
-
-    it('[Error] T-SCB-WL-02: AI が不正 JSON を返すとき logger.warn が呼ばれる', async () => {
-      // arrange
-      const inputs = [{ filePath: 'file-b.md', content: 'content b' }];
-      const stdout = new TextEncoder().encode('not valid json');
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-      let warnStub: Stub | undefined;
-
-      try {
-        warnStub = stub(logger, 'warn');
-
-        // act
-        await segmentChatlogs(inputs);
-
-        // assert — warn が 1 回呼ばれ、ファイル名（拡張子なし）がメッセージに含まれる
-        assertEquals(warnStub.calls.length, 1);
-        assert(warnStub.calls[0].args[0].includes('file-b'));
-      } finally {
-        warnStub?.restore();
-      }
-    });
-  });
-
-  describe('When: エッジケース', () => {
-    it('[Edge] T-SCB-03-01: 1ファイル入力でも正常動作する', async () => {
-      // arrange
-      const inputs = [{ filePath: 'solo.md', content: 'C' }];
-      const aiResult = [
-        { filePath: 'solo.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('solo.md'), [{ title: 'T', summary: 'S', content: 'C', startLine: 1, endLine: 1 }]);
-    });
-
-    it('[Edge] T-SCB-04-01: AIが返す filePath が inputs にない場合無視され、inputs にある filePath は null になる', async () => {
-      // arrange
-      const inputs = [{ filePath: 'known.md', content: 'content' }];
-      const aiResult = [
-        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertNull(result.get('known.md'));
-      assertFalse(result.has('unknown.md'));
-    });
-  });
-
-  /** userPrompt に行番号付きコンテンツが含まれることを検証するケース。 */
-  describe('When: userPrompt 行番号付きコンテンツ', () => {
-    it('[Normal] T-SIO-LR-14: userPrompt に行番号付きコンテンツが含まれる', async () => {
-      // arrange
-      const aiResult = [
-        { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 2 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      const captured: { instance: _StdinCaptureMock | null } = { instance: null };
-      mockHandle = installCommandMock(_makeStdinCaptureMock(stdout, captured));
-      const content = 'line A\nline B';
-
-      // act
-      await segmentChatlogs([{ filePath: 'test.md', content }]);
-
-      // assert — stdin には "1: line A\n2: line B" が含まれる
-      assert(captured.instance !== null, 'mock was not instantiated');
-      const written = captured.instance.capturedStdin.join('');
-      assert(written.includes('1: line A\n2: line B'), `expected line-numbered content in stdin, got: ${written}`);
-    });
-  });
-
-  /** 行番号範囲方式（_AiSegmentRange）: startLine/endLine でバッチ処理するケース。 */
-  describe('When: 行番号範囲方式（_AiSegmentRange）', () => {
-    it('[Normal] T-SIO-LR-19: 2ファイル入力でAIが {startLine,endLine} 返すとき各ファイルの Segment[] を Map で返す', async () => {
-      // arrange
-      const inputs = [
-        { filePath: 'a.md', content: 'a1\na2\na3' },
-        { filePath: 'b.md', content: 'b1\nb2' },
-      ];
-      const aiResult = [
-        { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 2 }] },
-        { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 1, endLine: 2 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('a.md')?.[0].content, 'a1\na2');
-      assertEquals(result.get('b.md')?.[0].content, 'b1\nb2');
-    });
-
-    it('[Normal] T-SIO-LR-20: 各ファイルの行番号は独立（ファイルごとにリセット）', async () => {
-      // arrange
-      const inputs = [
-        { filePath: 'a.md', content: 'lineA1\nlineA2' },
-        { filePath: 'b.md', content: 'lineB1\nlineB2\nlineB3' },
-      ];
-      const aiResult = [
-        { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 1 }] },
-        { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 2, endLine: 3 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('a.md')?.[0].content, 'lineA1');
-      assertEquals(result.get('b.md')?.[0].content, 'lineB2\nlineB3');
-    });
-
-    it('[Error] T-SIO-LR-21: AIが非ゼロ exit のとき全ファイルが null の Map を返す', async () => {
-      // arrange
-      const inputs = [
-        { filePath: 'a.md', content: 'content a' },
-        { filePath: 'b.md', content: 'content b' },
-      ];
-      mockHandle = installCommandMock(makeFailMock(1));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertNull(result.get('a.md'));
-      assertNull(result.get('b.md'));
-    });
-
-    it('[Error] T-SIO-LR-22: AIが不正 JSON を返すとき全ファイルが null の Map を返す', async () => {
-      // arrange
-      const inputs = [{ filePath: 'a.md', content: 'content a' }];
-      const stdout = new TextEncoder().encode('not valid json');
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertNull(result.get('a.md'));
-    });
-
-    it('[Edge] T-SIO-LR-23: AIが返す filePath が inputs にない場合無視され inputs 側は null になる', async () => {
-      // arrange
-      const inputs = [{ filePath: 'known.md', content: 'c' }];
-      const aiResult = [
-        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertNull(result.get('known.md'));
-      assertFalse(result.has('unknown.md'));
-    });
-
-    it('[Edge] T-SIO-LR-24: 1ファイルで6件のセグメントを返すとき先頭5件に制限される（MAX_SEGMENTS=5）', async () => {
-      // arrange
-      const inputs = [{ filePath: 'big.md', content: 'l1\nl2\nl3\nl4\nl5\nl6' }];
-      const aiSegments = Array.from({ length: 6 }, (_, i) => ({
-        title: `Topic ${i + 1}`,
-        summary: `Sum ${i + 1}`,
-        startLine: i + 1,
-        endLine: i + 1,
-      }));
-      const aiResult = [{ filePath: 'big.md', segments: aiSegments }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-
-      // act
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('big.md')?.length, 5);
-    });
-
-    it('[Edge] T-SIO-LR-25: timeoutMs:1 を渡すとタイムアウトして全ファイルが null の Map を返す', async () => {
-      // arrange — AI が 50ms 後に応答するモック
-      const inputs = [{ filePath: 'a.md', content: 'content a' }];
-      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
-
-      // act — 1ms タイムアウト: 50ms の遅延より先に abort される
-      const result = await segmentChatlogs(inputs, { timeoutMs: 1 });
-
-      // assert
-      assertNull(result.get('a.md'));
-    });
-  });
-
-  /** timeoutMs オプション転送: 指定・省略時の動作を検証するケース。 */
-  describe('When: timeoutMs オプション', () => {
-    it('[Normal] T-SCB-05-01: timeoutMs: 1 を渡すとタイムアウトして全ファイルが null の Map を返す', async () => {
-      // arrange — AI が 50ms 後に応答するモック
-      const inputs = [{ filePath: 'a.md', content: 'content a' }];
-      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
-
-      // act — 1ms タイムアウト: 50ms の遅延より先に abort される
-      const result = await segmentChatlogs(inputs, { timeoutMs: 1 });
-
-      // assert
-      assertNull(result.get('a.md'));
-    });
-
-    it('[Normal] T-SCB-05-02: timeoutMs を省略するとデフォルト(120s)が使われ正常にセグメントを返す', async () => {
-      // arrange — AI が 50ms 後に応答するモック
-      const inputs = [{ filePath: 'a.md', content: 'C' }];
-      const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
-
-      // act — timeoutMs 省略: デフォルト 120s >> 50ms 遅延
-      const result = await segmentChatlogs(inputs);
-
-      // assert
-      assertEquals(result.get('a.md'), [{ title: 'T', summary: 'S', content: 'C', startLine: 1, endLine: 1 }]);
-    });
-  });
-
-  /** systemPrompt の内容検証: 「必ず 1 件以上返す」指示が含まれることを確認するケース。 */
-  describe('When: systemPrompt 内容検証', () => {
-    it('[Normal] T-SCB-SP-01: systemPrompt に "at least 1 segment" が含まれる', async () => {
-      // arrange
-      const aiResult = [
-        { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      const capturedArgs: { value: string[] } = { value: [] };
-      mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
-
-      // act
-      await segmentChatlogs([{ filePath: 'test.md', content: 'single line' }]);
-
-      // assert — args must have been captured
-      assert(capturedArgs.value.length > 0, 'no args captured — mock did not fire');
-      const argsText = capturedArgs.value.join(' ');
-      assert(argsText.includes('at least 1 segment'), `expected "at least 1 segment" in args, got: ${argsText}`);
-    });
-  });
-
-  /** AI がエントリを返さなかった・空セグメントを返したときの warn ログ検証ケース。 */
-  describe('When: エッジケース — ログ出力', () => {
-    it('[Edge] T-SIO-LOG-01: AI が当該ファイルのエントリを返さなかったとき "no entry returned for" を含む warn が出る', async () => {
-      // arrange — input は known.md だが AI は unknown.md のエントリのみ返す
-      const inputs = [{ filePath: 'known.md', content: 'content' }];
-      const aiResult = [
-        { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-      let warnStub: Stub | undefined;
-
-      try {
-        warnStub = stub(logger, 'warn');
-
-        // act
-        await segmentChatlogs(inputs);
-
-        // assert
-        assertEquals(warnStub.calls.length, 1);
-        assert(warnStub.calls[0].args[0].includes('no entry returned for'));
-      } finally {
-        warnStub?.restore();
-      }
-    });
-
-    it('[Edge] T-SIO-LOG-02: AI が segments:[] を返したとき "empty segments returned for" を含む warn が出る', async () => {
-      // arrange — AI は known.md のエントリを返すが segments は空配列
-      const inputs = [{ filePath: 'known.md', content: 'content' }];
-      const aiResult = [
-        { filePath: 'known.md', segments: [] },
-      ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
-      let warnStub: Stub | undefined;
-
-      try {
-        warnStub = stub(logger, 'warn');
-
-        // act
-        await segmentChatlogs(inputs);
-
-        // assert
-        assertEquals(warnStub.calls.length, 1);
-        assert(warnStub.calls[0].args[0].includes('empty segments returned for'));
-      } finally {
-        warnStub?.restore();
-      }
     });
   });
 });

--- a/skills/normalize-chatlogs/scripts/modules/process-files.ts
+++ b/skills/normalize-chatlogs/scripts/modules/process-files.ts
@@ -1,6 +1,6 @@
 // src: skills/normalize-chatlogs/scripts/modules/process-files.ts
-// @(#): findFiles〜runConcurrent ブロックの processFiles 関数モジュール
-//       対象: processFiles, resolveOutputDir
+// @(#): findFiles〜phaseWrite ブロックの processFiles 関数モジュール
+//       対象: processFiles
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -11,45 +11,25 @@
 // constants
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
 // functions
-import { readTextFile } from '../../../_scripts/libs/file-io/read-utils.ts';
-import { extractChatlogPath } from '../../../_scripts/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../../_scripts/libs/file-ops/exists-utils.ts';
 import { findFiles } from '../../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
-import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getBasename, normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
 // types
 import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
 import type { NormalizeCache } from '../types/cache.types.ts';
-import type { NormalizeConfig, Segment, Stats } from '../types/normalize.types.ts';
+import type { NormalizeConfig, Stats } from '../types/normalize.types.ts';
 
 // classes
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
-import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 
 // --- internal modules
-import { extractLines, extractSegmentBaseName, segmentChatlogs, writeSegmentToFile } from './segment-io.ts';
-
-// constants
-import { BATCH_SIZE } from '../constants/normalize.constants.ts';
-
-/**
- * Resolves the output directory for a single chatlog file.
- *
- * If `filePath` contains `chatlogs/<agent>/<yyyy>/<yyyy-mm>`, returns
- * `<outputBase>/<agent>/<yyyy>/<yyyy-mm>/<project>`.
- * Otherwise returns `<outputBase>/<project>`.
- * Falls back to `'misc'` when `project` is undefined.
- */
-export const resolveOutputDir = (outputBase: string, filePath: string, project?: string): string => {
-  const chatlogPath = extractChatlogPath(filePath);
-  const effectiveProject = project ?? 'misc';
-  return chatlogPath
-    ? `${outputBase}/${chatlogPath}/${effectiveProject}`
-    : `${outputBase}/${effectiveProject}`;
-};
+import { phaseLoad } from '../phases/phase-load.ts';
+import { phasePlan } from '../phases/phase-plan.ts';
+import { phaseWrite } from '../phases/phase-write.ts';
+import { extractSegmentBaseName } from './segment-io.ts';
 
 /** Derives a cache key from a source chatlog file path (same normalization as {@link extractSegmentBaseName}). */
 const _toCacheKey = (filePath: string): string => extractSegmentBaseName(filePath);
@@ -61,19 +41,13 @@ type _PreparedFiles = {
 };
 
 /**
- * Phase 1: Validates inputDir/outputBase, discovers files, and partitions `findFiles(inputDir)`
- * results into already-normalized (skip) and pending files based on the cache.
+ * Phase 1: Validates inputDir/outputBase (existence, creation, containment).
+ * Runs before cache initialization since it has no dependency on the cache.
  *
  * @param inputDir   - Source directory (already normalized)
  * @param outputBase - Base output directory (already normalized)
- * @param cache      - Cache used to detect already-normalized files across runs
- * @returns Pending file paths and the number of files skipped as already-normalized
  */
-const _prepareFiles = async (
-  inputDir: string,
-  outputBase: string,
-  cache: ChatlogCache<NormalizeCache>,
-): Promise<_PreparedFiles> => {
+const _validateDirs = async (inputDir: string, outputBase: string): Promise<void> => {
   // inputDir 存在確認
   if (!await dirExists(inputDir)) {
     throw new ChatlogError('InputNotFound', 'InputDir', `inputDir not found or not a directory: ${inputDir}`);
@@ -93,9 +67,16 @@ const _prepareFiles = async (
       `outputBase must not be inside inputDir: ${outputBase}`,
     );
   }
+};
 
-  const mdFiles = await findFiles(inputDir);
-
+/**
+ * Phase 2: Partitions `mdFiles` into already-normalized (skip) and pending files based on the cache.
+ *
+ * @param mdFiles - Files discovered via `findFiles(inputDir)`
+ * @param cache   - Cache used to detect already-normalized files across runs
+ * @returns Pending file paths and the files skipped as already-normalized
+ */
+const _prepareFiles = (mdFiles: string[], cache: ChatlogCache<NormalizeCache>): _PreparedFiles => {
   // cache に status:'done' が記録済みのファイル（正規化済み）を pending から除外
   const skipFiles = mdFiles.filter((f) => cache.read(_toCacheKey(f)).status === 'done');
   const pendingFiles = mdFiles.filter((f) => cache.read(_toCacheKey(f)).status !== 'done');
@@ -103,158 +84,14 @@ const _prepareFiles = async (
   return { pendingFiles, skipFiles };
 };
 
-/** A single chatlog file's path and raw content, prepared as input for segment planning. */
-type _ChatlogInput = { filePath: string; content: string };
-
-/** Phase 2: Reads the Markdown content for each file in `filePaths`. */
-const _readInputs = (filePaths: string[]): Promise<_ChatlogInput[]> =>
-  Promise.all(
-    filePaths.map(async (filePath) => ({ filePath, content: await readTextFile(filePath) })),
-  );
-
-/**
- * Phase 3: Determines segment split plans for `inputs`, preferring cached `segments`
- * (resume support) over a fresh AI call, and persists newly-decided segments to the cache.
- *
- * For inputs with cached `segments`, ranges are re-sliced from the current file content via
- * {@link extractLines} (no AI call). For the remainder, `segmentChatlogs` is invoked; on
- * success, segment boundaries (`title`/`startLine`/`endLine`) are written to the cache —
- * even when `dryRun` is true, so a subsequent run does not re-invoke the AI. The cache
- * write in `dryRun` omits `status: 'done'` so the file is still writable in the following run.
- *
- * @param inputs  - Files with their Markdown content
- * @param config  - Model/timeout options forwarded to `segmentChatlogs`
- * @param cache   - Cache read for resume, written with decided segment boundaries
- * @returns Map from filePath to its planned `Segment[]`, or `null` when planning failed
- */
-const _planSegments = async (
-  inputs: _ChatlogInput[],
-  config: Pick<NormalizeConfig, 'model' | 'timeoutMs' | 'dryRun'>,
-  cache: ChatlogCache<NormalizeCache>,
-): Promise<Map<string, Segment[] | null>> => {
-  const _cachedInputs = inputs.filter((i) => cache.read(_toCacheKey(i.filePath)).segments !== undefined);
-  const _uncachedInputs = inputs.filter((i) => cache.read(_toCacheKey(i.filePath)).segments === undefined);
-
-  const _resultMap = new Map<string, Segment[] | null>(
-    _cachedInputs.map(({ filePath, content }) => {
-      const _lines = content.split('\n');
-      const _cachedSegments = cache.read(_toCacheKey(filePath)).segments!;
-      return [
-        filePath,
-        _cachedSegments.map((s) => ({
-          title: s.title,
-          summary: '',
-          content: extractLines(_lines, s.startLine, s.endLine),
-          startLine: s.startLine,
-          endLine: s.endLine,
-        })),
-      ];
-    }),
-  );
-
-  if (_uncachedInputs.length === 0) {
-    return _resultMap;
-  }
-
-  const _aiResultMap = await segmentChatlogs(_uncachedInputs, {
-    model: config.model,
-    ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
-  });
-
-  await Promise.all(
-    _uncachedInputs.map(async ({ filePath }) => {
-      const segments = _aiResultMap.get(filePath);
-      _resultMap.set(filePath, segments ?? null);
-      if (!segments || segments.some((s) => s.startLine === undefined || s.endLine === undefined)) {
-        return;
-      }
-      const _cacheEntry: Partial<NormalizeCache> = {
-        segments: segments.map((s) => ({ title: s.title, startLine: s.startLine!, endLine: s.endLine! })),
-      };
-      // write() (overwrite, not merge) is safe here: files reaching _planSegments always have
-      // status === undefined (status:'done' files are filtered into skipFiles by _prepareFiles).
-      await cache.write(_toCacheKey(filePath), _cacheEntry);
-    }),
-  );
-
-  return _resultMap;
-};
-
-/**
- * Phase 4: Writes planned segments to output files, applying the `--single-file` fallback
- * and `failFast` behavior, and marks the file `status: 'done'` in the cache once written
- * (skipped when `dryRun`).
- *
- * @param inputs      - Files with their Markdown content (fallback needs the raw content)
- * @param segmentsMap - Planned segments per filePath, from {@link _planSegments}
- * @param outputBase  - Base output directory
- * @param config      - Processing config (dryRun, failFast, singleFile)
- * @param stats       - Mutable counters updated in place
- * @param cache       - Cache marked `status: 'done'` on successful, non-dryRun writes
- * @param hashFn      - Optional hash generator for output file names (injectable for testing)
- */
-const _writeSegments = async (
-  inputs: _ChatlogInput[],
-  segmentsMap: Map<string, Segment[] | null>,
-  outputBase: string,
-  config: Pick<NormalizeConfig, 'dryRun' | 'failFast' | 'singleFile'>,
-  stats: Stats,
-  cache: ChatlogCache<NormalizeCache>,
-  hashFn?: HashProvider,
-): Promise<void> => {
-  for (const { filePath, content } of inputs) {
-    const _entry = new ChatlogEntry(content, { filePath });
-    const _projectVal = _entry.frontmatter.get('project');
-    const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
-    const outputDir = resolveOutputDir(outputBase, filePath, _project);
-    await Deno.mkdir(outputDir, { recursive: true });
-
-    let segments = segmentsMap.get(filePath) ?? null;
-
-    if (segments === null && config.singleFile) {
-      // fallback: content 全体を1セグメントとして使う
-      segments = [{
-        title: getBasename(filePath).replace(/-[0-9a-f]{7}$/, ''),
-        summary: '(auto-generated: AI segmentation failed)',
-        content: content,
-      }];
-      logger.info(`${LOGGER_TEXT.INDENT}fallback (1-segment): ${getBasename(filePath)}`);
-      stats.fallback++;
-    } else if (segments === null) {
-      logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
-      stats.fail++;
-      if (config.failFast) {
-        throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
-      }
-      continue;
-    }
-
-    for (let i = 0; i < segments.length; i++) {
-      await writeSegmentToFile(
-        outputDir,
-        filePath,
-        i,
-        segments[i],
-        _entry.frontmatter,
-        config.dryRun,
-        stats,
-        hashFn,
-      );
-    }
-
-    if (!config.dryRun) {
-      await cache.update(_toCacheKey(filePath), { status: 'done' });
-    }
-  }
-};
-
 /**
  * Processes markdown files under `inputDir` by segmenting each via AI and writing output.
  *
- * Flow: {@link _prepareFiles} (discover + skip already-normalized) → chunked
- * {@link _readInputs} → {@link _planSegments} (AI call, or cached segments on resume) →
- * {@link _writeSegments} (write output, update cache).
- * Updates `stats` in place: `fail` increments on AI error, `success` on each write.
+ * Flow: {@link _validateDirs} (validate, before cache init) → `findFiles` (discover) →
+ * {@link _prepareFiles} (skip already-normalized) → {@link phaseLoad} (load, partition
+ * load errors) → {@link phasePlan} (AI call, or cached segments on resume) →
+ * {@link phaseWrite} (write output, update cache).
+ * Updates `stats` in place: `fail` increments on load error or AI error, `success` on each write.
  *
  * @param inputDir   - Source directory (files are discovered here via findFiles)
  * @param outputBase - Base output directory
@@ -272,25 +109,20 @@ export const processFiles = async (
   const _inputDir = normalizePath(inputDir);
   const _outputBase = normalizePath(outputBase);
 
+  await _validateDirs(_inputDir, _outputBase);
+  const allFiles = await findFiles(_inputDir);
+
   const cache = new ChatlogCache<NormalizeCache>('normalize-cache');
   await cache.ready;
 
-  const { pendingFiles: _pendingFiles, skipFiles: _skipFiles } = await _prepareFiles(_inputDir, _outputBase, cache);
+  const { pendingFiles: _pendingFiles, skipFiles: _skipFiles } = _prepareFiles(allFiles, cache);
 
   for (const filePath of _skipFiles) {
     logger.info(`${LOGGER_TEXT.INDENT}skipped (already normalized): ${getBasename(filePath)}`);
   }
   stats.skip += _skipFiles.length;
 
-  const _chunkSize = config.singleFile ? 1 : BATCH_SIZE;
-  const _chunks = Array.from(
-    { length: Math.ceil(_pendingFiles.length / _chunkSize) },
-    (_, i) => _pendingFiles.slice(i * _chunkSize, (i + 1) * _chunkSize),
-  );
-
-  await runConcurrent(_chunks, async (chunk) => {
-    const _inputs = await _readInputs(chunk);
-    const _segmentsMap = await _planSegments(_inputs, config, cache);
-    await _writeSegments(_inputs, _segmentsMap, _outputBase, config, stats, cache, hashFn);
-  }, config.concurrency);
+  const { entries } = await phaseLoad(_pendingFiles, config.concurrency, config, stats);
+  const segmentsMap = await phasePlan(entries, config, cache);
+  await phaseWrite(entries, segmentsMap, _outputBase, config, stats, cache, config.concurrency, hashFn);
 };

--- a/skills/normalize-chatlogs/scripts/modules/segment-ai.ts
+++ b/skills/normalize-chatlogs/scripts/modules/segment-ai.ts
@@ -1,0 +1,173 @@
+// src: scripts/modules/segment-ai.ts
+// @(#): AI 呼び出しによるチャットログのトピック別セグメント分割
+//       対象: segmentChatlogs, extractLines
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── shared modules ───────────────────────────────────────────────────────────
+
+// classes
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+// types
+import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+
+// functions
+// --- ai ---
+import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
+
+// constants
+import { DEFAULT_AI_MODEL } from '../../../_scripts/constants/defaults.constants.ts';
+
+// --- io ---
+import { logger } from '../../../_scripts/libs/io/logger.ts';
+
+// --- text ---
+import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
+
+// --- path ---
+import { getBasename } from '../../../_scripts/libs/path-utils/path-utils.ts';
+
+// ─── internasl modules
+// types
+import type { Segment } from '../types/normalize.types.ts';
+
+// constants
+import { MAX_SEGMENTS } from '../constants/normalize.constants.ts';
+
+// ─── Line Number Helpers ──────────────────────────────────────────────────────
+
+const _addLineNumbers = (content: string): string => {
+  if (!content) { return ''; }
+  return content.split('\n').map((line, i) => `${i + 1}: ${line}`).join('\n');
+};
+
+/**
+ * Extracts the inclusive line range `[startLine, endLine]` (1-based) from `lines`, clamped to bounds.
+ *
+ * Used both for the initial AI response (segmentChatlogs) and for re-slicing content from
+ * cached `{startLine, endLine}` ranges on resume (process-files phase 4).
+ */
+export const extractLines = (lines: string[], startLine: number, endLine: number): string => {
+  const total = lines.length;
+  if (total === 0) { return ''; }
+  const start = Math.max(1, Math.min(startLine, total));
+  const end = Math.max(start, Math.min(endLine, total));
+  if (start > end) { return ''; }
+  return lines.slice(start - 1, end).join('\n');
+};
+
+// ─── AI Execution ─────────────────────────────────────────────────────────────
+
+/** AI が返す行番号範囲方式のセグメント定義。export しない内部型。 */
+type _AiSegmentRange = {
+  title: string;
+  summary: string;
+  startLine: number;
+  endLine: number;
+};
+
+/**
+ * Splits multiple chatlogs into topic-based segments in a single AI call.
+ *
+ * Sends all inputs to Claude as a combined prompt and returns a Map from
+ * filePath to its segments. Returns null for any filePath that the AI did not
+ * return results for, or if the AI call fails entirely.
+ *
+ * Line numbers (`startLine`/`endLine`) refer to `entry.content` (frontmatter excluded),
+ * not the raw file.
+ *
+ * @param inputs   - Array of `ChatlogEntry` to segment
+ * @param options  - Optional AI options (model, timeoutMs)
+ * @returns Map from filePath to Segment[] or null
+ */
+export const segmentChatlogs = async (
+  inputs: ChatlogEntry[],
+  options?: { model?: string; timeoutMs?: number },
+): Promise<Map<string, Segment[] | null>> => {
+  const _nullMap = (): Map<string, Segment[] | null> => {
+    const m = new Map<string, Segment[] | null>();
+    for (const entry of inputs) { m.set(entry.filePath!, null); }
+    return m;
+  };
+
+  const systemPrompt = 'You are a chatlog analyst. Split each given chatlog into 1 to 5 broad topic segments.\n'
+    + 'If the conversation covers only one topic, return exactly 1 segment covering the full content.\n'
+    + 'Never return an empty segments array — always return at least 1 segment per file.\n'
+    + 'Group minor subtopics under the nearest major theme — do NOT create a segment per small exchange.\n'
+    + 'Return ONLY a JSON array where each element has exactly two fields:\n'
+    + '"filePath" (the file path as given) and "segments" (array of segment objects).\n'
+    + 'Each segment object has exactly four fields:\n'
+    + '"title" (short topic title, 5 words or fewer),\n'
+    + '"summary" (one-sentence summary),\n'
+    + '"startLine" (integer, 1-based, inclusive),\n'
+    + '"endLine" (integer, 1-based, inclusive).\n'
+    + 'Ranges must be contiguous and non-overlapping. Cover the full conversation.\n'
+    + 'Do not include any explanation or markdown fences — respond with the JSON array only.';
+
+  const userPrompt = inputs
+    .map((entry, i) => `File ${i + 1}: ${entry.filePath}\n${_addLineNumbers(entry.content)}`)
+    .join('\n\n---\n\n');
+
+  let _raw: string;
+  try {
+    _raw = await runAI(systemPrompt, userPrompt, {
+      model: options?.model ?? DEFAULT_AI_MODEL,
+      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+    });
+  } catch (e) {
+    const _paths = inputs.map((entry) => getBasename(entry.filePath!)).join(', ');
+    if (e instanceof ChatlogError && e.kind === 'TimedOut') {
+      logger.warn(`segmentChatlogs: timed out — ${_paths}`);
+    } else {
+      logger.warn(`segmentChatlogs: AI error — ${_paths}`);
+    }
+    return _nullMap();
+  }
+
+  const _parsed = parseAiJsonArray(_raw);
+  if (_parsed === null) {
+    const _paths = inputs.map((entry) => getBasename(entry.filePath!)).join(', ');
+    logger.warn(`segmentChatlogs: invalid JSON response — ${_paths}`);
+    return _nullMap();
+  }
+
+  const _validPaths = new Set(inputs.map((entry) => entry.filePath));
+  const _result = new Map<string, Segment[] | null>();
+  for (const entry of inputs) { _result.set(entry.filePath!, null); }
+
+  for (const aiEntry of _parsed as Array<{ filePath: string; segments: _AiSegmentRange[] }>) {
+    if (!_validPaths.has(aiEntry.filePath)) { continue; }
+    const _inputContent = inputs.find((entry) => entry.filePath === aiEntry.filePath)!.content;
+    const _lines = _inputContent.split('\n');
+    const _segments = Array.isArray(aiEntry.segments) ? aiEntry.segments : [];
+    _result.set(
+      aiEntry.filePath,
+      _segments.slice(0, MAX_SEGMENTS).map((r) => ({
+        title: r.title,
+        summary: r.summary,
+        content: extractLines(_lines, r.startLine, r.endLine),
+        startLine: r.startLine,
+        endLine: r.endLine,
+      })),
+    );
+  }
+
+  // null のまま残ったファイルまたは空セグメントのファイルに対してログ出力
+  for (const entry of inputs) {
+    const filePath = entry.filePath!;
+    const _segments = _result.get(filePath);
+    if (_segments && _segments.length > 0) { continue; }
+    const _aiEntry = (_parsed as Array<{ filePath: string; segments: unknown[] }>)
+      .find((e) => e.filePath === filePath);
+    if (!_aiEntry) {
+      logger.warn(`segmentChatlogs: no entry returned for — ${getBasename(filePath)}`);
+    } else {
+      logger.warn(`segmentChatlogs: empty segments returned for — ${getBasename(filePath)}`);
+    }
+  }
+
+  return _result;
+};

--- a/skills/normalize-chatlogs/scripts/modules/segment-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/segment-io.ts
@@ -1,6 +1,6 @@
 // src: scripts/modules/segment-io.ts
-// @(#): セグメント分割・ファイル生成・フロントマター付与・ファイル書き出しに関する関数群
-//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, segmentChatlogs, _writeSegmentToFile
+// @(#): セグメントファイル生成・フロントマター付与・ファイル書き出しに関する関数群
+//       対象: extractSegmentBaseName, generateOutputFileName, generateSegmentFile, attachFrontmatter, writeSegmentToFile
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -16,19 +16,8 @@ import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { ChatlogFrontmatter } from '../../../_scripts/classes/ChatlogFrontmatter.class.ts';
 
-// functions
-// --- ai ---
-import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
-
-// constants
-import { DEFAULT_AI_MODEL } from '../../../_scripts/constants/defaults.constants.ts';
-
 // --- io ---
 import { generateHash } from '../../../_scripts/libs/io/hash.ts';
-import { logger } from '../../../_scripts/libs/io/logger.ts';
-
-// --- text ---
-import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
 
 // --- path ---
 import { getBasename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -36,9 +25,6 @@ import { getBasename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 // ─── internasl modules
 // types
 import type { Segment, Stats } from '../types/normalize.types.ts';
-
-// constants
-import { MAX_SEGMENTS } from '../constants/normalize.constants.ts';
 
 // functions
 import { writeOutput } from './file-io.ts';
@@ -57,7 +43,6 @@ const _ATTACH_FIELD_ORDER = [
   'slug',
   'type',
   'category',
-  'summary',
   'log_id',
   'topics',
   'tags',
@@ -129,161 +114,23 @@ export const generateSegmentFile = (segment: Segment): string => {
 /**
  * Attaches a YAML frontmatter block to the given Markdown content.
  *
- * Sets AI-generated fields (`title`, `log_id`, `summary`) onto `frontmatter`,
+ * Sets AI-generated fields (`title`, `log_id`) onto `frontmatter`,
  * serialize it via `toFrontmatter()`, and prepends the result to `content`.
  *
  * @param content - The Markdown body to attach frontmatter to
  * @param frontmatter - `ChatlogFrontmatter` instance propagated from the source file
- * @param segmentMeta - AI-generated fields (`title`, `log_id`, `summary`)
+ * @param segmentMeta - AI-generated fields (`title`, `log_id`)
  * @returns Markdown string with frontmatter prepended
  */
 export const attachFrontmatter = (
   content: string,
   frontmatter: ChatlogFrontmatter,
-  segmentMeta: { title: string; log_id: string; summary: string },
+  segmentMeta: { title: string; log_id: string },
 ): string => {
   frontmatter.set('title', segmentMeta.title);
   frontmatter.set('log_id', segmentMeta.log_id);
-  frontmatter.set('summary', segmentMeta.summary);
   const fmText = frontmatter.toFrontmatter(_ATTACH_FIELD_ORDER, { addTagHashes: true });
   return `${fmText}\n${content}`;
-};
-
-// ─── Line Number Helpers ──────────────────────────────────────────────────────
-
-const _addLineNumbers = (content: string): string => {
-  if (!content) { return ''; }
-  return content.split('\n').map((line, i) => `${i + 1}: ${line}`).join('\n');
-};
-
-/**
- * Extracts the inclusive line range `[startLine, endLine]` (1-based) from `lines`, clamped to bounds.
- *
- * Used both for the initial AI response (segmentChatlogs) and for re-slicing content from
- * cached `{startLine, endLine}` ranges on resume (process-files phase 4).
- */
-export const extractLines = (lines: string[], startLine: number, endLine: number): string => {
-  const total = lines.length;
-  if (total === 0) { return ''; }
-  const start = Math.max(1, Math.min(startLine, total));
-  const end = Math.max(start, Math.min(endLine, total));
-  if (start > end) { return ''; }
-  return lines.slice(start - 1, end).join('\n');
-};
-
-// ─── AI Execution ─────────────────────────────────────────────────────────────
-
-/** AI が返す行番号範囲方式のセグメント定義。export しない内部型。 */
-type _AiSegmentRange = {
-  title: string;
-  summary: string;
-  startLine: number;
-  endLine: number;
-};
-
-/** バッチ処理用の入力1件。 */
-export type ChatlogInput = {
-  filePath: string;
-  content: string;
-};
-
-/**
- * Splits multiple chatlogs into topic-based segments in a single AI call.
- *
- * Sends all inputs to Claude as a combined prompt and returns a Map from
- * filePath to its segments. Returns null for any filePath that the AI did not
- * return results for, or if the AI call fails entirely.
- *
- * @param inputs   - Array of `{ filePath, content }` to segment
- * @param options  - Optional AI options (model, timeoutMs)
- * @returns Map from filePath to Segment[] or null
- */
-export const segmentChatlogs = async (
-  inputs: ChatlogInput[],
-  options?: { model?: string; timeoutMs?: number },
-): Promise<Map<string, Segment[] | null>> => {
-  const _nullMap = (): Map<string, Segment[] | null> => {
-    const m = new Map<string, Segment[] | null>();
-    for (const { filePath } of inputs) { m.set(filePath, null); }
-    return m;
-  };
-
-  const systemPrompt = 'You are a chatlog analyst. Split each given chatlog into 1 to 5 broad topic segments.\n'
-    + 'If the conversation covers only one topic, return exactly 1 segment covering the full content.\n'
-    + 'Never return an empty segments array — always return at least 1 segment per file.\n'
-    + 'Group minor subtopics under the nearest major theme — do NOT create a segment per small exchange.\n'
-    + 'Return ONLY a JSON array where each element has exactly two fields:\n'
-    + '"filePath" (the file path as given) and "segments" (array of segment objects).\n'
-    + 'Each segment object has exactly four fields:\n'
-    + '"title" (short topic title, 5 words or fewer),\n'
-    + '"summary" (one-sentence summary),\n'
-    + '"startLine" (integer, 1-based, inclusive),\n'
-    + '"endLine" (integer, 1-based, inclusive).\n'
-    + 'Ranges must be contiguous and non-overlapping. Cover the full conversation.\n'
-    + 'Do not include any explanation or markdown fences — respond with the JSON array only.';
-
-  const userPrompt = inputs
-    .map(({ filePath, content }, i) => `File ${i + 1}: ${filePath}\n${_addLineNumbers(content)}`)
-    .join('\n\n---\n\n');
-
-  let _raw: string;
-  try {
-    _raw = await runAI(systemPrompt, userPrompt, {
-      model: options?.model ?? DEFAULT_AI_MODEL,
-      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-    });
-  } catch (e) {
-    const _paths = inputs.map((i) => getBasename(i.filePath)).join(', ');
-    if (e instanceof ChatlogError && e.kind === 'TimedOut') {
-      logger.warn(`segmentChatlogs: timed out — ${_paths}`);
-    } else {
-      logger.warn(`segmentChatlogs: AI error — ${_paths}`);
-    }
-    return _nullMap();
-  }
-
-  const _parsed = parseAiJsonArray(_raw);
-  if (_parsed === null) {
-    const _paths = inputs.map((i) => getBasename(i.filePath)).join(', ');
-    logger.warn(`segmentChatlogs: invalid JSON response — ${_paths}`);
-    return _nullMap();
-  }
-
-  const _validPaths = new Set(inputs.map((i) => i.filePath));
-  const _result = new Map<string, Segment[] | null>();
-  for (const { filePath } of inputs) { _result.set(filePath, null); }
-
-  for (const entry of _parsed as Array<{ filePath: string; segments: _AiSegmentRange[] }>) {
-    if (!_validPaths.has(entry.filePath)) { continue; }
-    const _inputContent = inputs.find((i) => i.filePath === entry.filePath)!.content;
-    const _lines = _inputContent.split('\n');
-    const _segments = Array.isArray(entry.segments) ? entry.segments : [];
-    _result.set(
-      entry.filePath,
-      _segments.slice(0, MAX_SEGMENTS).map((r) => ({
-        title: r.title,
-        summary: r.summary,
-        content: extractLines(_lines, r.startLine, r.endLine),
-        startLine: r.startLine,
-        endLine: r.endLine,
-      })),
-    );
-  }
-
-  // null のまま残ったファイルまたは空セグメントのファイルに対してログ出力
-  for (const { filePath } of inputs) {
-    const _segments = _result.get(filePath);
-    if (_segments && _segments.length > 0) { continue; }
-    const _entry = (_parsed as Array<{ filePath: string; segments: unknown[] }>)
-      .find((e) => e.filePath === filePath);
-    if (!_entry) {
-      logger.warn(`segmentChatlogs: no entry returned for — ${getBasename(filePath)}`);
-    } else {
-      logger.warn(`segmentChatlogs: empty segments returned for — ${getBasename(filePath)}`);
-    }
-  }
-
-  return _result;
 };
 
 // ─── Segment File Write ───────────────────────────────────────────────────────
@@ -320,7 +167,6 @@ export const writeSegmentToFile = async (
   const fullContent = attachFrontmatter(segmentContent, frontmatter, {
     title: segment.title,
     log_id: getBasename(outputFileName),
-    summary: segment.summary,
   });
   const outputPath = `${outputDir}/${outputFileName}`;
   if (outputPath.includes(filePath)) {

--- a/skills/normalize-chatlogs/scripts/phases/phase-load.ts
+++ b/skills/normalize-chatlogs/scripts/phases/phase-load.ts
@@ -1,0 +1,58 @@
+// src: skills/normalize-chatlogs/scripts/phases/phase-load.ts
+// @(#): pendingFiles 読み込みフェーズ
+//       対象: phaseLoad
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared scripts
+// constants
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
+// functions
+import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { getBasename } from '../../../_scripts/libs/path-utils/path-utils.ts';
+// classes
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+// types
+import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+
+// ─── Local
+import { loadEntries } from '../libs/load-entries.ts';
+// types
+import type { LoadEntryFailure } from '../types/load-entry.types.ts';
+import type { NormalizeConfig, Stats } from '../types/normalize.types.ts';
+
+/**
+ * Loads `pendingFiles` into `ChatlogEntry` objects, logging and counting load failures.
+ *
+ * Failures are collected into `errors` and each increments `stats.fail`. When
+ * `config.failFast` is true and at least one load failure occurred, throws
+ * `ChatlogError('FailFast', 'LoadFailed', ...)` referencing the first failed file.
+ *
+ * @param pendingFiles - File paths to load
+ * @param concurrency  - Parallelism forwarded to `loadEntries`
+ * @param config       - Processing config (failFast)
+ * @param stats        - Mutable counters updated in place
+ * @returns Successfully loaded entries and load failures
+ */
+export const phaseLoad = async (
+  pendingFiles: string[],
+  concurrency: number,
+  config: Pick<NormalizeConfig, 'failFast'>,
+  stats: Stats,
+): Promise<{ entries: ChatlogEntry[]; errors: LoadEntryFailure[] }> => {
+  const { entries, errors } = await loadEntries(pendingFiles, concurrency);
+
+  for (const { filePath, error } of errors) {
+    logger.warn(`${LOGGER_TEXT.INDENT}failed (load error: ${error.message}): ${getBasename(filePath)}`);
+  }
+  stats.fail += errors.length;
+
+  if (config.failFast && errors.length > 0) {
+    throw new ChatlogError('FailFast', 'LoadFailed', `fail-fast triggered by: ${getBasename(errors[0].filePath)}`);
+  }
+
+  return { entries, errors };
+};

--- a/skills/normalize-chatlogs/scripts/phases/phase-plan.ts
+++ b/skills/normalize-chatlogs/scripts/phases/phase-plan.ts
@@ -1,0 +1,109 @@
+// src: skills/normalize-chatlogs/scripts/phases/phase-plan.ts
+// @(#): AI セグメント分割計画フェーズ
+//       対象: phasePlan
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared scripts
+// classes
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
+// types
+import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+
+// ─── Local
+import { extractLines, segmentChatlogs } from '../modules/segment-ai.ts';
+import { extractSegmentBaseName } from '../modules/segment-io.ts';
+// constants
+import { BATCH_SIZE } from '../constants/normalize.constants.ts';
+// types
+import type { NormalizeCache } from '../types/cache.types.ts';
+import type { NormalizeConfig, Segment } from '../types/normalize.types.ts';
+
+/** Derives a cache key from a source chatlog file path (same normalization as {@link extractSegmentBaseName}). */
+const _toCacheKey = (filePath: string): string => extractSegmentBaseName(filePath);
+
+/**
+ * Determines segment split plans for `entries`, preferring cached `segments`
+ * (resume support) over a fresh AI call, and persists newly-decided segments to the cache.
+ *
+ * For entries with cached `segments`, ranges are re-sliced from the current entry content via
+ * {@link extractLines} (no AI call). The remainder is chunked into groups of at most
+ * `BATCH_SIZE` (or 1 when `config.singleFile` is true) and each chunk is sent to
+ * `segmentChatlogs` in turn to bound prompt size and timeout risk; results are merged
+ * into the same result map. On success, segment boundaries (`title`/`startLine`/`endLine`)
+ * are written to the cache — even when `dryRun` is true, so a subsequent run does not
+ * re-invoke the AI. The cache write in `dryRun` omits `status: 'done'` so the file is
+ * still writable in the following run.
+ *
+ * Segment boundaries are line numbers within `ChatlogEntry.content` (frontmatter excluded),
+ * not the raw file.
+ *
+ * @param entries - Files loaded as `ChatlogEntry`
+ * @param config  - Model/timeout/singleFile options forwarded to `segmentChatlogs` and chunking
+ * @param cache   - Cache read for resume, written with decided segment boundaries
+ * @returns Map from filePath to its planned `Segment[]`, or `null` when planning failed
+ */
+export const phasePlan = async (
+  entries: ChatlogEntry[],
+  config: Pick<NormalizeConfig, 'model' | 'timeoutMs' | 'dryRun' | 'singleFile'>,
+  cache: ChatlogCache<NormalizeCache>,
+): Promise<Map<string, Segment[] | null>> => {
+  const _cachedEntries = entries.filter((e) => cache.read(_toCacheKey(e.filePath!)).segments !== undefined);
+  const _uncachedEntries = entries.filter((e) => cache.read(_toCacheKey(e.filePath!)).segments === undefined);
+
+  const _resultMap = new Map<string, Segment[] | null>(
+    _cachedEntries.map((entry) => {
+      const _lines = entry.content.split('\n');
+      const _cachedSegments = cache.read(_toCacheKey(entry.filePath!)).segments!;
+      return [
+        entry.filePath!,
+        _cachedSegments.map((s) => ({
+          title: s.title,
+          summary: '',
+          content: extractLines(_lines, s.startLine, s.endLine),
+          startLine: s.startLine,
+          endLine: s.endLine,
+        })),
+      ];
+    }),
+  );
+
+  if (_uncachedEntries.length === 0) {
+    return _resultMap;
+  }
+
+  const _chunkSize = config.singleFile ? 1 : BATCH_SIZE;
+  const _chunks = Array.from(
+    { length: Math.ceil(_uncachedEntries.length / _chunkSize) },
+    (_, i) => _uncachedEntries.slice(i * _chunkSize, (i + 1) * _chunkSize),
+  );
+
+  for (const chunk of _chunks) {
+    const _aiResultMap = await segmentChatlogs(chunk, {
+      model: config.model,
+      ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    });
+
+    await Promise.all(
+      chunk.map(async (entry) => {
+        const filePath = entry.filePath!;
+        const segments = _aiResultMap.get(filePath);
+        _resultMap.set(filePath, segments ?? null);
+        if (!segments || segments.some((s) => s.startLine === undefined || s.endLine === undefined)) {
+          return;
+        }
+        const _cacheEntry: Partial<NormalizeCache> = {
+          segments: segments.map((s) => ({ title: s.title, startLine: s.startLine!, endLine: s.endLine! })),
+        };
+        // write() (overwrite, not merge) is safe here: files reaching phasePlan always have
+        // status === undefined (status:'done' files are filtered into skipFiles by _prepareFiles).
+        await cache.write(_toCacheKey(filePath), _cacheEntry);
+      }),
+    );
+  }
+
+  return _resultMap;
+};

--- a/skills/normalize-chatlogs/scripts/phases/phase-write.ts
+++ b/skills/normalize-chatlogs/scripts/phases/phase-write.ts
@@ -1,0 +1,111 @@
+// src: skills/normalize-chatlogs/scripts/phases/phase-write.ts
+// @(#): セグメント書き込みフェーズ
+//       対象: phaseWrite, resolveOutputDir
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared scripts
+// constants
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
+// functions
+import { extractChatlogPath } from '../../../_scripts/libs/file-io/resolve-directory.ts';
+import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
+import { getBasename } from '../../../_scripts/libs/path-utils/path-utils.ts';
+// classes
+import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
+import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+// types
+import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
+import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
+
+// ─── Local
+import { extractSegmentBaseName, writeSegmentToFile } from '../modules/segment-io.ts';
+// types
+import type { NormalizeCache } from '../types/cache.types.ts';
+import type { NormalizeConfig, Segment, Stats } from '../types/normalize.types.ts';
+
+/**
+ * Resolves the output directory for a single chatlog file.
+ *
+ * If `filePath` contains `chatlogs/<agent>/<yyyy>/<yyyy-mm>`, returns
+ * `<outputBase>/<agent>/<yyyy>/<yyyy-mm>/<project>`.
+ * Otherwise returns `<outputBase>/<project>`.
+ * Falls back to `'misc'` when `project` is undefined.
+ */
+export const resolveOutputDir = (outputBase: string, filePath: string, project?: string): string => {
+  const chatlogPath = extractChatlogPath(filePath);
+  const effectiveProject = project ?? 'misc';
+  return chatlogPath
+    ? `${outputBase}/${chatlogPath}/${effectiveProject}`
+    : `${outputBase}/${effectiveProject}`;
+};
+
+/** Derives a cache key from a source chatlog file path (same normalization as {@link extractSegmentBaseName}). */
+const _toCacheKey = (filePath: string): string => extractSegmentBaseName(filePath);
+
+/**
+ * Writes planned segments to output files, applying the `--single-file` fallback
+ * and `failFast` behavior, and marks the file `status: 'done'` in the cache once written
+ * (skipped when `dryRun`).
+ *
+ * @param entries     - Files loaded as `ChatlogEntry` (fallback needs `entry.content`)
+ * @param segmentsMap - Planned segments per filePath, from {@link phasePlan}
+ * @param outputBase  - Base output directory
+ * @param config      - Processing config (dryRun, failFast, singleFile)
+ * @param stats       - Mutable counters updated in place
+ * @param cache       - Cache marked `status: 'done'` on successful, non-dryRun writes
+ * @param concurrency - Parallelism for writing segments across `entries`
+ * @param hashFn      - Optional hash generator for output file names (injectable for testing)
+ */
+export const phaseWrite = async (
+  entries: ChatlogEntry[],
+  segmentsMap: Map<string, Segment[] | null>,
+  outputBase: string,
+  config: Pick<NormalizeConfig, 'dryRun' | 'failFast' | 'singleFile'>,
+  stats: Stats,
+  cache: ChatlogCache<NormalizeCache>,
+  concurrency: number,
+  hashFn?: HashProvider,
+): Promise<void> => {
+  await runConcurrent(entries, async (entry) => {
+    const filePath = entry.filePath!;
+    const _projectVal = entry.frontmatter.get('project');
+    const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
+    const outputDir = resolveOutputDir(outputBase, filePath, _project);
+    await Deno.mkdir(outputDir, { recursive: true });
+
+    let segments = segmentsMap.get(filePath) ?? null;
+
+    if (segments === null && config.singleFile) {
+      // fallback: content 全体を1セグメントとして使う
+      segments = [{
+        title: getBasename(filePath).replace(/-[0-9a-f]{7}$/, ''),
+        summary: '(auto-generated: AI segmentation failed)',
+        content: entry.content,
+      }];
+      logger.info(`${LOGGER_TEXT.INDENT}fallback (1-segment): ${getBasename(filePath)}`);
+      stats.fallback++;
+    } else if (segments === null) {
+      logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
+      stats.fail++;
+      if (config.failFast) {
+        throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
+      }
+      return;
+    }
+
+    await Promise.all(
+      segments.map((segment, i) =>
+        writeSegmentToFile(outputDir, filePath, i, segment, entry.frontmatter, config.dryRun, stats, hashFn)
+      ),
+    );
+
+    if (!config.dryRun) {
+      await cache.update(_toCacheKey(filePath), { status: 'done' });
+    }
+  }, concurrency);
+};

--- a/skills/normalize-chatlogs/scripts/types/load-entry.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/load-entry.types.ts
@@ -1,0 +1,14 @@
+// src: skills/normalize-chatlogs/scripts/types/load-entry.types.ts
+// @(#): loadEntry 読み込み失敗結果の型定義
+//       対象: LoadEntryFailure
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/** `loadEntry` の読み込み失敗結果。 */
+export interface LoadEntryFailure {
+  filePath: string;
+  error: Error;
+}


### PR DESCRIPTION
## Overview

**Summary**
Split the monolithic `process-files` pipeline into explicit load/plan/write phases.

**Background / Motivation**
`process-files.ts` mixed file loading, AI segmentation planning, and output writing in one
module, making each step hard to test in isolation. This change decomposes it into three
phases and extracts AI segmentation into its own module, with no change to external behavior.

## Changes

### Core Changes

- Added `phases/phase-load.ts`, `phases/phase-plan.ts`, `phases/phase-write.ts` and reduced
  `process-files.ts` to delegate to them.
- Extracted AI-driven segmentation from `segment-io.ts` into a new `segment-ai.ts`.
- Added shared loader utilities `libs/load-entry.ts` and `libs/load-entries.ts`.
- Removed `summary` from frontmatter output (intentional).

### Test Updates

- Added unit tests for `load-entry`, `load-entries`, `process-files`, and `segment-ai`.
- Updated tests and fixtures to match the new module boundaries and frontmatter change.

### Removed

- AI segmentation logic removed from `segment-io.ts` (moved to `segment-ai.ts`).

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #349

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

No breaking changes. This is an internal restructuring of the `normalize-chatlogs`
processing pipeline; `resolveOutputDir` moved from `process-files.ts` to
`phases/phase-write.ts`, updating only internal imports.
