### PR TITLE
refactor(normalize-chatlogs): rework stats counters and cache statuses

### DIFF
--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
@@ -211,8 +211,8 @@ describe('normalize-chatlogs - full E2E', () => {
       loggerStub.infoLogs.splice(0);
       await main(['--input-dir', inputDir, '--output-dir', outputDir], fixedHash);
 
-      // reproducibility: 2 回目は skip=1
-      assertMatch(loggerStub.infoLogs.join('\n'), /skip=1/);
+      // reproducibility: 2 回目は done=1
+      assertMatch(loggerStub.infoLogs.join('\n'), /done=1/);
 
       // reproducibility: 入力ファイルは不変
       const afterContent = await readTextFile(`${inputDir}/chat.md`);

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
@@ -97,7 +97,7 @@ describe('main - reproducibility', () => {
 
     describe('When: main() を同一入力で 2 回呼び出す', () => {
       describe('Then: Task T-15-04-02 - 再実行時に normalize済みファイルをスキップする', () => {
-        it('T-15-04-02-01: 2 回目の呼び出しで skip=1 がレポートに含まれる', async () => {
+        it('T-15-04-02-01: 2 回目の呼び出しで done=1 がレポートに含まれる', async () => {
           // Fixed hash so both runs generate the same output filename
           const fixedHash: HashProvider = () => '0000000';
 
@@ -110,7 +110,7 @@ describe('main - reproducibility', () => {
           // Second run: should skip already-normalized file
           await main(['--input-dir', inputDir, '--output-dir', outputDir], fixedHash);
 
-          assertMatch(loggerStub.infoLogs.join('\n'), /skip=1/);
+          assertMatch(loggerStub.infoLogs.join('\n'), /done=1/);
         });
       });
     });

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/file-io.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/file-io.unit.spec.ts
@@ -134,7 +134,7 @@ describe('reportResults', () => {
   /** エッジケース: 全カウントが 0 でもスローせず出力する */
   describe('Given: 全カウントが 0 の stats', () => {
     it('[Edge] T-14-02-01: throw せずに stdout に出力される', () => {
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
 
       reportResults(stats);
 
@@ -146,12 +146,40 @@ describe('reportResults', () => {
   /** 正常系: fail が非ゼロのとき失敗件数を stdout に明示する */
   describe('Given: fail が非ゼロの stats', () => {
     it('[Normal] T-14-03-01: stdout に失敗件数が明示される', () => {
-      const stats: Stats = { success: 0, skip: 0, fail: 3, fallback: 0 };
+      const stats: Stats = { success: 0, fail: 3, done: 0, error: 0, skip: 0 };
 
       reportResults(stats);
 
       const output = loggerStub.warnLogs.join('\n');
       assertMatch(output, /fail.*3|3.*fail|失敗.*3|3.*失敗/i);
+    });
+  });
+
+  /** 正常系: 全5フィールドが出力文字列に含まれる。 */
+  describe('Given: 全フィールドが異なる値を持つ stats', () => {
+    it('[Normal] T-14-04-01: success/done/skip/fail/error すべてがレポートに含まれる', () => {
+      const stats: Stats = { success: 1, fail: 2, done: 3, error: 4, skip: 5 };
+
+      reportResults(stats);
+
+      const output = loggerStub.infoLogs.join('\n');
+      assertMatch(output, /success=1/);
+      assertMatch(output, /done=3/);
+      assertMatch(output, /skip=5/);
+      assertMatch(output, /fail=2/);
+      assertMatch(output, /error=4/);
+    });
+  });
+
+  /** エッジケース: error が非ゼロのときエラー件数を stdout に明示する */
+  describe('Given: error が非ゼロの stats', () => {
+    it('[Edge] T-14-05-01: stdout にエラー件数が明示される', () => {
+      const stats: Stats = { success: 0, fail: 0, done: 0, error: 2, skip: 0 };
+
+      reportResults(stats);
+
+      const output = loggerStub.warnLogs.join('\n');
+      assertMatch(output, /error.*2|2.*error/i);
     });
   });
 });

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
@@ -34,7 +34,7 @@ import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helper
 import { logger } from '../../../../../_scripts/libs/io/logger.ts';
 import { normalizePath } from '../../../../../_scripts/libs/path-utils/path-utils.ts';
 // types
-import type { NormalizeCache } from '../../../types/cache.types.ts';
+import type { NormalizeCache } from '../../../types/cache.const.type.ts';
 import type { NormalizeConfig, Stats } from '../../../types/normalize.types.ts';
 // constants
 import { BATCH_SIZE } from '../../../constants/normalize.constants.ts';
@@ -68,6 +68,7 @@ describe('processFiles', () => {
   let tmpDir: string;
   let outputDir: string;
   let cacheDir: string;
+  let stats: Stats;
   let mockHandle: CommandMockHandle | undefined;
 
   beforeEach(async () => {
@@ -76,6 +77,7 @@ describe('processFiles', () => {
     cacheDir = await Deno.makeTempDir({ prefix: 'process-files-cache-' });
     GlobalConfig.resetInstance();
     _makeGlobalConfig(cacheDir);
+    stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
   });
 
   afterEach(async () => {
@@ -97,7 +99,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -119,7 +120,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -143,7 +143,6 @@ describe('processFiles', () => {
 
       await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
       await Deno.writeTextFile(`${tmpDir}/file2.md`, '# File2\n\nContent2');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -160,7 +159,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeFailMock(1));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -180,7 +178,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -195,7 +192,6 @@ describe('processFiles', () => {
   describe('When: バリデーション', () => {
     it('[Error] T-PF-VAL-01: inputDir が存在しないとき ChatlogError(InputNotFound) を投げる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const nonExistentDir = `${tmpDir}/nonexistent`;
 
       // act & assert
@@ -207,7 +203,6 @@ describe('processFiles', () => {
 
     it('[Normal] T-PF-VAL-02: outputBase が存在しないとき自動作成されて正常処理される', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       // outputBase は inputDir(tmpDir) の外に配置する必要があるため
       // outputDir の親ディレクトリ配下に未作成のサブディレクトリを使う
       const nonExistentBase = `${outputDir}/nonexistent-base`;
@@ -217,12 +212,11 @@ describe('processFiles', () => {
 
       // assert — outputBase が作成されている
       await assertDirExist(nonExistentBase);
-      assertEquals(stats, { success: 0, skip: 0, fail: 0, fallback: 0 });
+      assertEquals(stats, { success: 0, fail: 0, done: 0, error: 0, skip: 0 });
     });
 
     it('[Error] T-PF-VAL-03: outputBase が inputDir 配下のとき ChatlogError(ForbiddenOutput) を投げる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const insideDir = `${tmpDir}/inside`;
       await Deno.mkdir(insideDir, { recursive: true });
 
@@ -235,7 +229,6 @@ describe('processFiles', () => {
 
     it('[Error] T-PF-VAL-04: outputBase === inputDir のとき ChatlogError(ForbiddenOutput) を投げる', async () => {
       // arrange
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act & assert
       await assertRejects(
@@ -256,7 +249,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
         dryRun: true,
         concurrency: 1,
@@ -281,7 +273,6 @@ describe('processFiles', () => {
 
       await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
       await Deno.writeTextFile(`${tmpDir}/file2.md`, '# File2\n\nContent2');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
         dryRun: true,
         concurrency: 1,
@@ -300,7 +291,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeFailMock(1));
 
       await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
         dryRun: true,
         concurrency: 1,
@@ -324,7 +314,6 @@ describe('processFiles', () => {
 
       const filePath = normalizePath(`${tmpDir}/target-file.md`);
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       let warnStub: Stub | undefined;
 
       try {
@@ -343,11 +332,10 @@ describe('processFiles', () => {
 
   /** 読み込みエラー: frontmatter パースエラー等、loadEntries が返す errors の扱い。 */
   describe('When: 読み込みエラー', () => {
-    it('[Error] T-PF-LE-01: フロントマターが不正なファイルは stats.fail が増加し logger.warn が呼ばれ、書き出し対象から除外される', async () => {
+    it('[Error] T-PF-LE-01: フロントマターが不正なファイルは stats.error が増加し logger.warn が呼ばれ、書き出し対象から除外される', async () => {
       // arrange
       const badFilePath = normalizePath(`${tmpDir}/bad-yaml.md`);
       await Deno.writeTextFile(badFilePath, '---\ntitle: [unclosed\n---\n本文');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       let warnStub: Stub | undefined;
 
       try {
@@ -356,8 +344,8 @@ describe('processFiles', () => {
         // act
         await processFiles(tmpDir, outputDir, _CONFIG, stats);
 
-        // assert — 読み込みエラーで fail が増加し、warn が呼ばれる
-        assertEquals(stats.fail, 1);
+        // assert — 読み込みエラーで error が増加し、warn が呼ばれる
+        assertEquals(stats.error, 1);
         assert(warnStub.calls.length > 0);
       } finally {
         warnStub?.restore();
@@ -368,7 +356,6 @@ describe('processFiles', () => {
       // arrange
       const badFilePath = normalizePath(`${tmpDir}/bad-yaml.md`);
       await Deno.writeTextFile(badFilePath, '---\ntitle: [unclosed\n---\n本文');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
         dryRun: true,
         concurrency: 1,
@@ -394,7 +381,6 @@ describe('processFiles', () => {
       const stdout = new TextEncoder().encode(JSON.stringify([{ filePath: goodFilePath, segments }]));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
         dryRun: true,
         concurrency: 2,
@@ -404,15 +390,14 @@ describe('processFiles', () => {
       // act
       await processFiles(tmpDir, outputDir, config, stats);
 
-      // assert — 読み込みエラーで fail が1増え、正常ファイルはエラーにならず処理される
-      assertEquals(stats.fail, 1);
+      // assert — 読み込みエラーで error が1増え、正常ファイルはエラーにならず処理される
+      assertEquals(stats.error, 1);
     });
 
     it('[Error] T-PF-LE-04: 読み込みエラーが1件のとき logger.error が失敗件数(1)付きで呼ばれる', async () => {
       // arrange
       const badFilePath = normalizePath(`${tmpDir}/bad-yaml.md`);
       await Deno.writeTextFile(badFilePath, '---\ntitle: [unclosed\n---\n本文');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       let errorStub: Stub | undefined;
 
       try {
@@ -447,7 +432,6 @@ describe('processFiles', () => {
       const stdout = new TextEncoder().encode(JSON.stringify(batch));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
         dryRun: true,
         concurrency: 2,
@@ -467,7 +451,7 @@ describe('processFiles', () => {
    * project frontmatter なし → project=undefined → outputDir は `${outputBase}/misc`。
    */
   describe('When: スキップ処理', () => {
-    it('[Normal] T-PF-SKIP-02: outputDir に baseName-*.md が存在しないとき stats.skip は増加しない', async () => {
+    it('[Normal] T-PF-SKIP-02: outputDir に baseName-*.md が存在しないとき stats.done は増加しない', async () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
@@ -477,18 +461,17 @@ describe('processFiles', () => {
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
       // 出力済みファイルなし
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 2 };
 
       // act
       await processFiles(tmpDir, outputDir, config, stats);
 
       // assert
-      assertEquals(stats.skip, 0);
+      assertEquals(stats.done, 0);
       assertEquals(stats.fail, 0);
     });
 
-    it('[Edge] T-PF-SKIP-03: outputDir が存在しないとき stats.skip は増加せずエラーにならない', async () => {
+    it('[Edge] T-PF-SKIP-03: outputDir が存在しないとき stats.done は増加せずエラーにならない', async () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
@@ -498,18 +481,17 @@ describe('processFiles', () => {
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
       // misc サブディレクトリを作成しない（outputDir 自体は存在する）
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 2 };
 
       // act — エラーなしで処理が完了するはず
       await processFiles(tmpDir, outputDir, config, stats);
 
       // assert
-      assertEquals(stats.skip, 0);
+      assertEquals(stats.done, 0);
       assertEquals(stats.fail, 0);
     });
 
-    it('[Edge] T-PF-SKIP-04: project が undefined のとき misc フォールバックで outputDir が解決され stats.skip は 0', async () => {
+    it('[Edge] T-PF-SKIP-04: project が undefined のとき misc フォールバックで outputDir が解決され stats.done は 0', async () => {
       // arrange — project frontmatter なしのファイル
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
@@ -519,21 +501,20 @@ describe('processFiles', () => {
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
       // misc ディレクトリにマッチするファイルなし
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 2 };
 
       // act
       await processFiles(tmpDir, outputDir, config, stats);
 
       // assert — misc フォールバックで解決されるが該当ファイルがないのでスキップなし
-      assertEquals(stats.skip, 0);
+      assertEquals(stats.done, 0);
       assertEquals(stats.fail, 0);
     });
   });
 
   /** --single-file モード: 1ファイルずつ個別に AI 呼び出しを行うケース。 */
   describe('When: --single-file モード', () => {
-    it('[Normal] T-PF-SF-01: singleFile=true で AI が正常にセグメントを返したとき stats.success が増え stats.fallback は増えない', async () => {
+    it('[Normal] T-PF-SF-01: singleFile=true で AI が正常にセグメントを返したとき stats.success が増える', async () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 3 }];
@@ -541,7 +522,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'singleFile'> = {
         dryRun: false,
         concurrency: 1,
@@ -551,32 +531,9 @@ describe('processFiles', () => {
       // act
       await processFiles(tmpDir, outputDir, config, stats);
 
-      // assert — AI が正常に返したので success が増え fallback は 0 のまま
+      // assert — AI が正常に返したので success が増える
       assertEquals(stats.success, 1);
-      assertEquals(stats.fallback, 0);
       assertEquals(stats.fail, 0);
-    });
-
-    it('[Error] T-PF-SF-02: singleFile=true で AI が null を返したとき stats.fallback が増え stats.fail は増えない、出力ファイルが1件生成される', async () => {
-      // arrange
-      mockHandle = installCommandMock(makeFailMock(1));
-
-      const filePath = normalizePath(`${tmpDir}/dummy.md`);
-      await Deno.writeTextFile(filePath, '# Test\n\nFallback content');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
-      const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'singleFile'> = {
-        dryRun: false,
-        concurrency: 1,
-        singleFile: true,
-      };
-
-      // act
-      await processFiles(tmpDir, outputDir, config, stats);
-
-      // assert — AI 失敗 → fallback で 1セグメント処理される
-      assertEquals(stats.fallback, 1);
-      assertEquals(stats.fail, 0);
-      assertEquals(stats.success, 1);
     });
   });
 
@@ -591,7 +548,7 @@ describe('processFiles', () => {
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
-      const stats1: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats1: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
 
       // act — 1回目: 実際に処理を成功させる
       await processFiles(tmpDir, outputDir, config, stats1);
@@ -601,12 +558,12 @@ describe('processFiles', () => {
       mockHandle.restore();
       const counter = { calls: 0 };
       mockHandle = installCommandMock(makeCountingMock('[]', counter));
-      const stats2: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats2: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
 
       await processFiles(tmpDir, outputDir, config, stats2);
 
       // assert
-      assertEquals(stats2.skip, 1);
+      assertEquals(stats2.done, 1);
       assertEquals(counter.calls, 0);
     });
 
@@ -618,20 +575,20 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats1: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats1: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
 
       // act — 1回目: dryRun=true で処理（キャッシュに書き込まれないはず）
       await processFiles(tmpDir, outputDir, _CONFIG, stats1);
       assertEquals(stats1.skip, 1);
 
       // 2回目: dryRun=false で同じファイルを処理 → キャッシュ未登録なのでスキップされず処理される
-      const stats2: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats2: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
 
       await processFiles(tmpDir, outputDir, config, stats2);
 
       // assert — dryRun の1回目はキャッシュに残らないため2回目はスキップされない
-      assertEquals(stats2.skip, 0);
+      assertEquals(stats2.done, 0);
       assertEquals(stats2.success, 1);
     });
 
@@ -641,7 +598,7 @@ describe('processFiles', () => {
 
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats1: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats1: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
 
       // act — 1回目: AI 失敗 → stats.fail が増加し、キャッシュに書き込まれない
       await processFiles(tmpDir, outputDir, _CONFIG, stats1);
@@ -652,13 +609,13 @@ describe('processFiles', () => {
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
       const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
-      const stats2: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+      const stats2: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 2 };
 
       await processFiles(tmpDir, outputDir, config, stats2);
 
       // assert
-      assertEquals(stats2.skip, 0);
+      assertEquals(stats2.done, 0);
     });
 
     it('[Normal] T-PF-CACHE-08: outputBase 配下に無関係な.mdファイルが存在してもキャッシュ未登録の入力ファイルはスキップされずAIが呼ばれる', async () => {
@@ -678,14 +635,13 @@ describe('processFiles', () => {
       await Deno.mkdir(notesDir, { recursive: true });
       await Deno.writeTextFile(`${notesDir}/report.md`, 'unrelated note, not a normalize output');
 
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 2 };
 
       // act
       await processFiles(tmpDir, outputDir, config, stats);
 
       // assert — 無関係な出力ファイルの存在によってスキップされず、AI が実際に呼ばれている
-      assertEquals(stats.skip, 0);
+      assertEquals(stats.done, 0);
       assertEquals(stats.fail, 0);
       assert(capturedArgs.value.length > 0);
     });
@@ -699,7 +655,6 @@ describe('processFiles', () => {
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, config, stats);
@@ -719,7 +674,6 @@ describe('processFiles', () => {
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act — dryRun=true
       await processFiles(tmpDir, outputDir, _CONFIG, stats);
@@ -746,7 +700,6 @@ describe('processFiles', () => {
       const counter = { calls: 0 };
       mockHandle = installCommandMock(makeCountingMock('[]', counter));
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 1 };
-      const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
 
       // act
       await processFiles(tmpDir, outputDir, config, stats);

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-io.unit.spec.ts
@@ -304,7 +304,7 @@ describe('writeSegmentToFile', () => {
 
   beforeEach(async () => {
     outputDir = await Deno.makeTempDir({ prefix: 'write-segment-test-' });
-    stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+    stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
     filePath = `${outputDir}/sample.md`;
     segment = { title: 'Test Title', summary: 'Test Summary', content: 'Test Content' };
     frontmatter = new ChatlogEntry('---\nproject: test\n---\n# body').frontmatter;

--- a/skills/normalize-chatlogs/scripts/modules/file-io.ts
+++ b/skills/normalize-chatlogs/scripts/modules/file-io.ts
@@ -63,18 +63,20 @@ export const writeOutput = async (
 /**
  * Outputs a summary report of batch processing results to stdout.
  *
- * Format: `Results: success=<n>, skip=<n>, fail=<n>`
- * When `stats.fail > 0`, an additional warning line is emitted to surface
- * the failure count explicitly.
+ * Format: `Results: success=<n>, done=<n>, skip=<n>, fail=<n>, error=<n>`
+ * When `stats.fail > 0` or `stats.error > 0`, an additional warning line is emitted to surface
+ * the count explicitly.
  *
  * @param stats - Counters collected across a batch run
  */
 export const reportResults = (stats: Stats): void => {
-  logger.info(`Results: success=${stats.success}, skip=${stats.skip}, fallback=${stats.fallback}, fail=${stats.fail}`);
-  if (stats.fallback > 0) {
-    logger.info(`::info:: ${stats.fallback} file(s) processed via fallback (1-segment)`);
-  }
+  logger.info(
+    `Results: success=${stats.success}, done=${stats.done}, skip=${stats.skip}, fail=${stats.fail}, error=${stats.error}`,
+  );
   if (stats.fail > 0) {
     logger.warn(`WARNING: ${stats.fail} file(s) failed`);
+  }
+  if (stats.error > 0) {
+    logger.warn(`WARNING: ${stats.error} file(s) errored`);
   }
 };

--- a/skills/normalize-chatlogs/scripts/modules/process-files.ts
+++ b/skills/normalize-chatlogs/scripts/modules/process-files.ts
@@ -16,9 +16,12 @@ import { findFiles } from '../../../_scripts/libs/file-ops/find-files.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { getBasename, normalizePath } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
+// constants
+import { NORMALIZE_CACHE_STATUSES } from '../types/cache.const.type.ts';
+
 // types
 import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
-import type { NormalizeCache } from '../types/cache.types.ts';
+import type { NormalizeCache } from '../types/cache.const.type.ts';
 import type { NormalizeConfig, Stats } from '../types/normalize.types.ts';
 
 // classes
@@ -75,8 +78,8 @@ const _validateDirs = async (inputDir: string, outputBase: string): Promise<void
  */
 const _prepareFiles = (mdFiles: string[], cache: ChatlogCache<NormalizeCache>): _PreparedFiles => {
   // cache に status:'done' が記録済みのファイル（正規化済み）を pending から除外
-  const skipFiles = mdFiles.filter((f) => cache.read(toCacheKey(f)).status === 'done');
-  const pendingFiles = mdFiles.filter((f) => cache.read(toCacheKey(f)).status !== 'done');
+  const skipFiles = mdFiles.filter((f) => cache.read(toCacheKey(f)).status === NORMALIZE_CACHE_STATUSES.DONE);
+  const pendingFiles = mdFiles.filter((f) => cache.read(toCacheKey(f)).status !== NORMALIZE_CACHE_STATUSES.DONE);
 
   return { pendingFiles, skipFiles };
 };
@@ -89,7 +92,8 @@ const _prepareFiles = (mdFiles: string[], cache: ChatlogCache<NormalizeCache>): 
  * load errors) → {@link phaseSegment} (AI call, or cached segments on resume; writes planned
  * segments to the cache) → {@link phaseWrite} (rebuild segments from cache, write output,
  * update cache).
- * Updates `stats` in place: `fail` increments on load error or AI error, `success` on each write.
+ * Updates `stats` in place: `done` increments on already-normalized skip, `error` on load error,
+ * `fail` on AI error, `success` on each write.
  *
  * @param inputDir   - Source directory (files are discovered here via findFiles)
  * @param outputBase - Base output directory
@@ -118,7 +122,7 @@ export const processFiles = async (
   for (const filePath of _skipFiles) {
     logger.info(`${LOGGER_TEXT.INDENT}skipped (already normalized): ${getBasename(filePath)}`);
   }
-  stats.skip += _skipFiles.length;
+  stats.done += _skipFiles.length;
 
   const { entries: allEntries, errors: _errors } = await phaseLoad(
     _pendingFiles,

--- a/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
+++ b/skills/normalize-chatlogs/scripts/normalize-chatlogs.ts
@@ -64,7 +64,7 @@ export const main = async (argv?: string[], hashFn?: HashProvider): Promise<void
   if (!dirExistsSync(inputDir)) {
     throw new ChatlogError('InputNotFound', 'NotFound', `directory not found: ${inputDir}`);
   }
-  const stats: Stats = { success: 0, skip: 0, fail: 0, fallback: 0 };
+  const stats: Stats = { success: 0, fail: 0, done: 0, error: 0, skip: 0 };
   await processFiles(inputDir, config.outputDir!, config, stats, hashFn);
   reportResults(stats);
 };

--- a/skills/normalize-chatlogs/scripts/phases/__tests__/unit/phase-segment.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/phases/__tests__/unit/phase-segment.unit.spec.ts
@@ -32,7 +32,7 @@ import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class
 import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 import { BATCH_SIZE } from '../../../constants/normalize.constants.ts';
 // types
-import type { NormalizeCache } from '../../../types/cache.types.ts';
+import type { NormalizeCache } from '../../../types/cache.const.type.ts';
 
 // ─── Internal Helpers
 

--- a/skills/normalize-chatlogs/scripts/phases/__tests__/unit/phase-write.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/phases/__tests__/unit/phase-write.unit.spec.ts
@@ -21,7 +21,7 @@ import { toCacheKey } from '../../../modules/segment-io.ts';
 import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 // types
-import type { NormalizeCache } from '../../../types/cache.types.ts';
+import type { NormalizeCache } from '../../../types/cache.const.type.ts';
 
 // ─── Internal Helpers
 

--- a/skills/normalize-chatlogs/scripts/phases/phase-load.ts
+++ b/skills/normalize-chatlogs/scripts/phases/phase-load.ts
@@ -27,7 +27,7 @@ import type { NormalizeConfig, Stats } from '../types/normalize.types.ts';
 /**
  * Loads `pendingFiles` into `ChatlogEntry` objects, logging and counting load failures.
  *
- * Failures are collected into `errors` and each increments `stats.fail`. When
+ * Failures are collected into `errors` and each increments `stats.error`. When
  * `config.failFast` is true and at least one load failure occurred, throws
  * `ChatlogError('FailFast', 'LoadFailed', ...)` referencing the first failed file.
  *
@@ -48,7 +48,7 @@ export const phaseLoad = async (
   for (const { filePath, error } of errors) {
     logger.warn(`${LOGGER_TEXT.INDENT}failed (load error: ${error.message}): ${getBasename(filePath)}`);
   }
-  stats.fail += errors.length;
+  stats.error += errors.length;
 
   if (config.failFast && errors.length > 0) {
     throw new ChatlogError('FailFast', 'LoadFailed', `fail-fast triggered by: ${getBasename(errors[0].filePath)}`);

--- a/skills/normalize-chatlogs/scripts/phases/phase-segment.ts
+++ b/skills/normalize-chatlogs/scripts/phases/phase-segment.ts
@@ -18,10 +18,11 @@ import { segmentChatlogs } from '../modules/segment-ai.ts';
 import { toCacheKey } from '../modules/segment-io.ts';
 // constants
 import { BATCH_SIZE } from '../constants/normalize.constants.ts';
+import { NORMALIZE_CACHE_STATUSES } from '../types/cache.const.type.ts';
 // libs
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 // types
-import type { NormalizeCache } from '../types/cache.types.ts';
+import type { NormalizeCache } from '../types/cache.const.type.ts';
 import type { NormalizeConfig } from '../types/normalize.types.ts';
 
 /**
@@ -56,7 +57,7 @@ const _processChunk = async (
         return null;
       }
       const _cacheEntry: Partial<NormalizeCache> = {
-        status: 'set',
+        status: NORMALIZE_CACHE_STATUSES.SET,
         segments: segments.map((s) => ({
           title: s.title,
           summary: s.summary,

--- a/skills/normalize-chatlogs/scripts/phases/phase-write.ts
+++ b/skills/normalize-chatlogs/scripts/phases/phase-write.ts
@@ -25,8 +25,10 @@ import type { HashProvider } from '../../../_scripts/types/providers.types.ts';
 // ─── Local
 import { extractLines } from '../modules/segment-ai.ts';
 import { toCacheKey, writeSegmentToFile } from '../modules/segment-io.ts';
+// constants
+import { NORMALIZE_CACHE_STATUSES } from '../types/cache.const.type.ts';
 // types
-import type { NormalizeCache } from '../types/cache.types.ts';
+import type { NormalizeCache } from '../types/cache.const.type.ts';
 import type { NormalizeConfig, Segment, Stats } from '../types/normalize.types.ts';
 
 /**
@@ -113,73 +115,44 @@ const _writePlannedEntry = async (
   );
 
   if (!config.dryRun) {
-    await cache.update(toCacheKey(filePath), { status: 'done' });
+    await cache.update(toCacheKey(filePath), { status: NORMALIZE_CACHE_STATUSES.DONE });
   }
 };
 
 /**
- * Applies the `--single-file` fallback (1-segment write from raw content) or, absent that,
- * the fail/fail-fast accounting for an entry whose segment planning did not succeed
+ * Applies the fail/fail-fast accounting for an entry whose segment planning did not succeed
  * (no cache hit — AI returned no segments, or a segment missing `startLine`/`endLine`).
  *
- * @param entry       - Entry whose planning failed (no `segments` in the cache)
- * @param outputBase  - Base output directory
- * @param config      - Processing config (dryRun, failFast, singleFile)
- * @param stats       - Mutable counters updated in place
- * @param hashFn      - Optional hash generator for output file names (injectable for testing)
+ * @param entry  - Entry whose planning failed (no `segments` in the cache)
+ * @param config - Processing config (failFast)
+ * @param stats  - Mutable counters updated in place
  */
-const _writeFailedEntry = async (
+const _writeFailedEntry = (
   entry: ChatlogEntry,
-  outputBase: string,
-  config: Pick<NormalizeConfig, 'dryRun' | 'failFast' | 'singleFile'>,
+  config: Pick<NormalizeConfig, 'failFast'>,
   stats: Stats,
-  hashFn?: HashProvider,
 ): Promise<void> => {
   const filePath = entry.filePath!;
-
-  if (!config.singleFile) {
-    logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
-    stats.fail++;
-    if (config.failFast) {
-      throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
-    }
-    return;
+  logger.warn(`${LOGGER_TEXT.INDENT}failed (no segments returned): ${getBasename(filePath)}`);
+  stats.fail++;
+  if (config.failFast) {
+    throw new ChatlogError('FailFast', 'SegmentFailed', `fail-fast triggered by: ${getBasename(filePath)}`);
   }
-
-  // fallback: content 全体を1セグメントとして使う
-  const _projectVal = entry.frontmatter.get('project');
-  const _project = typeof _projectVal === 'string' ? _projectVal : undefined;
-  const outputDir = resolveOutputDir(outputBase, filePath, _project);
-  await Deno.mkdir(outputDir, { recursive: true });
-
-  const segments: Segment[] = [{
-    title: getBasename(filePath).replace(/-[0-9a-f]{7}$/, ''),
-    summary: '(auto-generated: AI segmentation failed)',
-    content: entry.content,
-  }];
-  logger.info(`${LOGGER_TEXT.INDENT}fallback (1-segment): ${getBasename(filePath)}`);
-  stats.fallback++;
-
-  await Promise.all(
-    segments.map((segment, i) =>
-      writeSegmentToFile(outputDir, filePath, i, segment, entry.frontmatter, config.dryRun, stats, hashFn)
-    ),
-  );
+  return Promise.resolve();
 };
 
 /**
- * Writes planned segments to output files, applying the `--single-file` fallback
- * and `failFast` behavior, and marks the file `status: 'done'` in the cache once written
- * (skipped when `dryRun`).
+ * Writes planned segments to output files, applying `failFast` behavior, and marks the file
+ * `status: 'done'` in the cache once written (skipped when `dryRun`).
  *
  * `entries` is partitioned up front by cache hit/miss (see {@link _hasSegments}) into planned
- * entries (segments rebuilt from the cache and written normally) and failed entries (fallback
- * or fail/failFast/warn accounting), so `entries` must be the full entry list (not filtered to
- * AI-planning successes) for cache-miss entries to reach the fail/fallback handling.
+ * entries (segments rebuilt from the cache and written normally) and failed entries
+ * (fail/failFast/warn accounting), so `entries` must be the full entry list (not filtered to
+ * AI-planning successes) for cache-miss entries to reach the fail handling.
  *
- * @param entries     - Files loaded as `ChatlogEntry` (fallback needs `entry.content`)
+ * @param entries     - Files loaded as `ChatlogEntry`
  * @param outputBase  - Base output directory
- * @param config      - Processing config (dryRun, failFast, singleFile)
+ * @param config      - Processing config (dryRun, failFast)
  * @param stats       - Mutable counters updated in place
  * @param cache       - Cache read for planned segments, marked `status: 'done'` on successful, non-dryRun writes
  * @param concurrency - Parallelism for writing segments across `entries`
@@ -188,7 +161,7 @@ const _writeFailedEntry = async (
 export const phaseWrite = async (
   entries: ChatlogEntry[],
   outputBase: string,
-  config: Pick<NormalizeConfig, 'dryRun' | 'failFast' | 'singleFile'>,
+  config: Pick<NormalizeConfig, 'dryRun' | 'failFast'>,
   stats: Stats,
   cache: ChatlogCache<NormalizeCache>,
   concurrency: number,
@@ -204,7 +177,7 @@ export const phaseWrite = async (
   );
   await runConcurrent(
     _failedEntries,
-    (entry) => _writeFailedEntry(entry, outputBase, config, stats, hashFn),
+    (entry) => _writeFailedEntry(entry, config, stats),
     concurrency,
   );
 };

--- a/skills/normalize-chatlogs/scripts/types/cache.const.type.ts
+++ b/skills/normalize-chatlogs/scripts/types/cache.const.type.ts
@@ -1,4 +1,4 @@
-// src: scripts/types/cache.types.ts
+// src: scripts/types/cache.const.type.ts
 // @(#): normalize-chatlogs キャッシュデータ型定義
 //       対象: NormalizeCache
 //
@@ -14,10 +14,19 @@ import type { SegmentPlan } from './normalize.types.ts';
  * を必須化した形（再分割に使用）。 */
 export type CachedSegment = Required<Pick<SegmentPlan, 'title' | 'summary' | 'startLine' | 'endLine'>>;
 
+/** NormalizeCache の status 識別子。'SET': AIがセグメント分割を決定済み（未出力）。'DONE': ファイル出力が完了済み。 */
+export const NORMALIZE_CACHE_STATUSES = {
+  SET: 'set',
+  DONE: 'done',
+} as const;
+
+/** `NORMALIZE_CACHE_STATUSES` の値から派生したユニオン型。`'set' | 'done'` と等価。 */
+export type NormalizeCacheStatus = typeof NORMALIZE_CACHE_STATUSES[keyof typeof NORMALIZE_CACHE_STATUSES];
+
 /** ChatlogCache が保存する正規化済み判定結果。 */
 export interface NormalizeCache {
   /** 'set': AIがセグメント分割を決定済み（未出力）。'done': ファイル出力が完了済み。 */
-  status: 'set' | 'done';
+  status: NormalizeCacheStatus;
   /** AI が決定したセグメント分割設定（再分割に使用）。 */
   segments?: CachedSegment[];
 }

--- a/skills/normalize-chatlogs/scripts/types/normalize.types.ts
+++ b/skills/normalize-chatlogs/scripts/types/normalize.types.ts
@@ -49,17 +49,19 @@ export type SegmentedFile = {
 };
 
 /**
- * バッチ処理結果の集計カウンター。{@link writeOutput} が直接更新する。
+ * バッチ処理結果の集計カウンター。{@link writeSegmentToFile} が直接更新する。
  */
 export type Stats = {
-  /** 正常に書き込まれたファイル数。 */
+  /** セグメント分割成功で書き込み完了したファイル数。 */
   success: number;
-  /** 既に正規化済みでスキップされたファイル数。 */
-  skip: number;
-  /** 失敗したファイル数（AI エラー・書き込みエラー等）。 */
+  /** AI がセグメント分割できなかった件数（segments 未返却）。 */
   fail: number;
-  /** AI 失敗 → 1セグメント強制で処理した件数（--single-file モード専用）。 */
-  fallback: number;
+  /** 既に分割済み（既正規化ファイル）でスキップされた件数。 */
+  done: number;
+  /** エントリー読み込み失敗などシステムエラーの件数。 */
+  error: number;
+  /** dry-run による分割スキップの件数。 */
+  skip: number;
 };
 
 export type NormalizeConfig = DefaultArgFields & {


### PR DESCRIPTION
## Overview

**Summary**
Make stats counting and cache status handling in `normalize-chatlogs` explicit and unambiguous.

**Background / Motivation**
The `Stats` fields overloaded meaning (`skip` covered both dry-run skips and already-normalized
files; `fail` covered both AI planning failures and system load errors), and cache status was
tracked with raw string literals. This made stats hard to read and hid a bug where load failures
were counted as `fail` instead of `error`.

## Changes

### Core Changes

- Added `NORMALIZE_CACHE_STATUSES` constant (`SET` / `DONE`) and `NormalizeCacheStatus` type,
  replacing raw string literals (`'set'`, `'done'`) in `phase-segment.ts`, `phase-write.ts`, and
  `process-files.ts`. Renamed `types/cache.types.ts` to `types/cache.const.type.ts`.
- Redefined `Stats` fields in `types/normalize.types.ts`:
  - `done`: already-normalized files skipped (previously counted under `skip`).
  - `error`: system-level failures (file load errors), now separate from AI planning failures.
  - `fail`: narrowed to mean "AI returned no segments" only.
  - `skip`: reserved for dry-run skips only.
- Fixed `phase-load.ts`: load failures now increment `stats.error` instead of `stats.fail`.
- Updated `file-io.ts`'s `reportResults` to report `done` and `error`, with a warning line when
  `stats.fail > 0` or `stats.error > 0`.
- Updated `process-files.ts` so already-normalized skips increment `stats.done` instead of
  `stats.skip`.

### Test Updates

- Updated unit fixtures and expectations in `process-files.unit.spec.ts`,
  `segment-io.unit.spec.ts`, `phase-segment.unit.spec.ts`, `phase-write.unit.spec.ts`, and
  `file-io.unit.spec.ts` for the new `done`/`error` fields and removed `fallback` cases.
- Updated e2e reproducibility assertions (`full.e2e.spec.ts`, `reproducibility.e2e.spec.ts`) to
  expect `done=1` instead of `skip=1` on re-run.

### Removed

- Removed the `--single-file` fallback path in `phase-write.ts`. Previously, when AI segment
  planning failed, the pipeline wrote the whole file as a single segment (tracked via
  `stats.fallback`). This path and the `fallback` stat field are gone; failed segment planning is
  now only counted as `stats.fail` (or triggers `failFast`), with no fallback output written.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

- The `--single-file` fallback is removed. Files that used to get a 1-segment fallback output
  when AI segmentation failed are now only logged as failed, with no output file written.
- The `Results:` log line format changed (new `done`/`error` fields, `fallback` removed). Scripts
  that parse this log line should be updated.

## Additional Notes

This branch bundles 10 commits under one theme: making `normalize-chatlogs` stats counting
precise (`done` vs `error` vs `fail` vs `skip`) and replacing cache status string literals with
typed constants. The `phase-load.ts` fix (routing load failures to `stats.error`) was a
correctness bug found while doing this refactor, not a separate feature.
