### PR TITLE
fix(libs/json-utils): strip fenced json before array parsing

### DIFF
--- a/skills/_scripts/libs/text/__tests__/unit/json-utils.unit.spec.ts
+++ b/skills/_scripts/libs/text/__tests__/unit/json-utils.unit.spec.ts
@@ -24,7 +24,7 @@ import { assertNotNull, assertNull } from '../../../../__tests__/helpers/assert.
  *
  * 3段階フォールバック（直接パース / non-greedy / greedy）の各パスを網羅する。
  *
- * テスト ID 範囲: T-LIB-J-01 〜 T-LIB-J-18
+ * テスト ID 範囲: T-LIB-J-01 〜 T-LIB-J-19
  *
  * @see parseAiJsonArray
  */
@@ -93,6 +93,14 @@ describe('parseAiJsonArray', () => {
       assertNotNull(_result);
       assertEquals(_result!.length, 1);
       assertEquals(_result![0].filePath, 'a.md');
+    });
+
+    it('[Normal] T-LIB-J-19: 先頭が素の配列で後方に無関係なコードフェンス例示がある場合は先頭配列を返す', () => {
+      const _raw = '[{"file":"real.md"}]\n...\n```json\n[{"file":"example.md"}]\n```';
+      const _result = parseAiJsonArray<{ file: string }>(_raw);
+      assertNotNull(_result);
+      assertEquals(_result!.length, 1);
+      assertEquals(_result![0].file, 'real.md');
     });
 
     it('[Normal] T-LIB-J-09: 改行・インデントを含む整形済み JSON 配列がパースできる', () => {

--- a/skills/_scripts/libs/text/__tests__/unit/json-utils.unit.spec.ts
+++ b/skills/_scripts/libs/text/__tests__/unit/json-utils.unit.spec.ts
@@ -24,7 +24,7 @@ import { assertNotNull, assertNull } from '../../../../__tests__/helpers/assert.
  *
  * 3段階フォールバック（直接パース / non-greedy / greedy）の各パスを網羅する。
  *
- * テスト ID 範囲: T-LIB-J-01 〜 T-LIB-J-15
+ * テスト ID 範囲: T-LIB-J-01 〜 T-LIB-J-18
  *
  * @see parseAiJsonArray
  */
@@ -61,6 +61,38 @@ describe('parseAiJsonArray', () => {
       const _result = parseAiJsonArray('result: [{"a":1},{"a":2}] end');
       assert(Array.isArray(_result));
       assertEquals((_result as unknown[]).length, 2);
+    });
+
+    it('[Normal] T-LIB-J-16: コードフェンス内のネスト配列を含む応答は外側配列を正しく返す', () => {
+      const _raw = '```json\n'
+        + '[{"filePath":"a.md","segments":[{"x":1}]},{"filePath":"b.md","segments":[{"y":2}]}]\n'
+        + '```';
+      const _result = parseAiJsonArray<{ filePath: string; segments: unknown[] }>(_raw);
+      assertNotNull(_result);
+      assertEquals(_result!.length, 2);
+      assertEquals(_result![0].filePath, 'a.md');
+      assertEquals(_result![1].filePath, 'b.md');
+    });
+
+    it('[Normal] T-LIB-J-17: フェンス前後に説明文がある場合もネスト配列を含む外側配列を正しく返す', () => {
+      const _raw = 'Here is the result:\n'
+        + '```json\n'
+        + '[{"filePath":"a.md","segments":[{"x":1}]},{"filePath":"b.md","segments":[{"y":2}]}]\n'
+        + '```\n'
+        + 'Done.';
+      const _result = parseAiJsonArray<{ filePath: string; segments: unknown[] }>(_raw);
+      assertNotNull(_result);
+      assertEquals(_result!.length, 2);
+      assertEquals(_result![0].filePath, 'a.md');
+      assertEquals(_result![1].filePath, 'b.md');
+    });
+
+    it('[Normal] T-LIB-J-18: 言語タグなしのコードフェンスも除去して外側配列を返す', () => {
+      const _raw = '```\n[{"filePath":"a.md","segments":[{"x":1}]}]\n```';
+      const _result = parseAiJsonArray<{ filePath: string; segments: unknown[] }>(_raw);
+      assertNotNull(_result);
+      assertEquals(_result!.length, 1);
+      assertEquals(_result![0].filePath, 'a.md');
     });
 
     it('[Normal] T-LIB-J-09: 改行・インデントを含む整形済み JSON 配列がパースできる', () => {

--- a/skills/_scripts/libs/text/json-utils.ts
+++ b/skills/_scripts/libs/text/json-utils.ts
@@ -21,11 +21,16 @@ const _stripCodeFence = (raw: string): string => {
   return matched ? matched[1] : raw;
 };
 
-/** 段階1: 文字列が `[` で始まる場合に直接パースを試みる。コードフェンスは事前に除去する。 */
+/** 段階1: 文字列が `[` で始まる場合に直接パースを試みる。`[` で始まらない場合のみコードフェンスを除去して再試行する。 */
 const _parseDirectArray = <T>(raw: string): T[] | null => {
-  const trimmed = _stripCodeFence(raw).trim();
-  if (!trimmed.startsWith('[')) { return null; }
-  return _tryParseNonEmptyArray<T>(trimmed);
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    return _tryParseNonEmptyArray<T>(trimmed);
+  }
+
+  const stripped = _stripCodeFence(raw).trim();
+  if (!stripped.startsWith('[')) { return null; }
+  return _tryParseNonEmptyArray<T>(stripped);
 };
 
 /** 段階2: non-greedy マッチで最初にパースできた非空配列を返す。 */

--- a/skills/_scripts/libs/text/json-utils.ts
+++ b/skills/_scripts/libs/text/json-utils.ts
@@ -15,9 +15,15 @@ const _tryParseNonEmptyArray = <T>(text: string): T[] | null => {
   return null;
 };
 
-/** 段階1: 文字列が `[` で始まる場合に直接パースを試みる。 */
+/** コードフェンス（\`\`\`json ... \`\`\`）が含まれる場合、内部テキストのみを抽出する。含まれない場合は raw をそのまま返す。 */
+const _stripCodeFence = (raw: string): string => {
+  const matched = raw.match(/```[^\n]*\n([\s\S]*?)```/);
+  return matched ? matched[1] : raw;
+};
+
+/** 段階1: 文字列が `[` で始まる場合に直接パースを試みる。コードフェンスは事前に除去する。 */
 const _parseDirectArray = <T>(raw: string): T[] | null => {
-  const trimmed = raw.trim();
+  const trimmed = _stripCodeFence(raw).trim();
   if (!trimmed.startsWith('[')) { return null; }
   return _tryParseNonEmptyArray<T>(trimmed);
 };


### PR DESCRIPTION
## Overview

**Summary**
Strip Markdown code fences before parsing AI responses as JSON arrays.

**Background / Motivation**
`parseAiJsonArray` failed when an AI/CLI response wrapped its JSON output in a Markdown code fence
(e.g. Claude CLI returning ` ```json\n[...]\n``` ` instead of a bare `[...]`). The direct-array parse
path checked `raw.trim().startsWith('[')` on the raw text, so a fenced response never matched and the
array was not parsed.

## Changes

### Core Changes

- `skills/_scripts/libs/text/json-utils.ts`: added `_stripCodeFence` to extract the inner text of a
  code fence (with or without a language tag), and applied it in `_parseDirectArray` before the
  `startsWith('[')` check.

### Test Updates

- `skills/_scripts/libs/text/__tests__/unit/json-utils.unit.spec.ts`: added T-LIB-J-16 to T-LIB-J-18,
  covering a fenced array with nested objects, a fenced array with surrounding prose, and a fenced
  array with no language tag.

### Removed

None.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

This is an internal parsing fix; the public `parseAiJsonArray` signature and behavior for unfenced
input are unchanged.
