### PR TITLE
feat(ai): add model option, wire through filter/frontmatter

### DIFF
--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -9,13 +9,21 @@
 
 // ─── BDD modules
 import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
-import { describe, it } from '@std/testing/bdd';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import { _buildCommand, runAI } from '../../run-ai.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../../../classes/GlobalConfig.class.ts';
+// types
+import type { CommandMockHandle } from '../../../../__tests__/helpers/deno-command-mock.ts';
+import {
+  installCommandMock,
+  makeDelayedSuccessMock,
+  makeSuccessMock,
+} from '../../../../__tests__/helpers/deno-command-mock.ts';
 
 // ─── Internal Helpers
 
@@ -105,6 +113,16 @@ const _cases: Array<{ model: string; expected: CommandSpec }> = [
 ];
 
 // ─── Tests
+
+// GlobalConfig はシングルトンのため、他のテストへの状態漏れを防ぐために
+// ファイル全体で毎回リセットする（このファイル内の全 describe に適用）。
+beforeEach(() => {
+  GlobalConfig.resetInstance();
+});
+
+afterEach(() => {
+  GlobalConfig.resetInstance();
+});
 
 /**
  * `_buildCommand` 関数のユニットテストスイート。
@@ -315,6 +333,61 @@ describe('runAI', () => {
         } finally {
           Deno.Command = _origCommand;
         }
+      });
+    });
+  });
+
+  /**
+   * `options.model` / `options.timeoutMs` 省略時の GlobalConfig フォールバック検証。
+   *
+   * `GlobalConfig.getInstance()` の設定値が options 未指定時に使われること、
+   * および `??` によって `timeoutMs: 0` が明示指定された場合は
+   * GlobalConfig の値で上書きされないことを確認する。
+   */
+  describe('GlobalConfig fallback', () => {
+    let commandHandle: CommandMockHandle;
+
+    afterEach(() => {
+      commandHandle?.restore();
+    });
+
+    /** options 省略時に GlobalConfig の設定値へフォールバックするケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-LIB-AI-RA-18: options.model 省略 → GlobalConfig の model ("opus") が CLI 引数に使われる', async () => {
+        GlobalConfig.getInstance({ yaml: 'model: opus' });
+        const _capturedArgs: { value: string[] } = { value: [] };
+        commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('ok'), _capturedArgs));
+
+        await runAI('sys', 'user');
+
+        assertEquals(_capturedArgs.value.includes('--model'), true);
+        assertEquals(_capturedArgs.value[_capturedArgs.value.indexOf('--model') + 1], 'opus');
+      });
+    });
+
+    /** options 省略時に GlobalConfig の timeoutMs 設定値でタイムアウトが発生するケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-LIB-AI-RA-19: options.timeoutMs 省略 → GlobalConfig の timeoutMs (1ms) でタイムアウトする', async () => {
+        GlobalConfig.getInstance({ yaml: 'timeoutMs: 1' });
+        commandHandle = installCommandMock(makeDelayedSuccessMock(100, new TextEncoder().encode('ok')));
+
+        const _err = await assertRejects(
+          () => runAI('sys', 'user', { model: 'sonnet' }),
+          ChatlogError,
+        ) as ChatlogError;
+        assertEquals(_err.kind, 'TimedOut');
+      });
+    });
+
+    /** `options.timeoutMs: 0` は GlobalConfig の値で上書きされない（`??` の 0 特別扱い）エッジケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-LIB-AI-RA-20: options.timeoutMs=0 かつ GlobalConfig.timeoutMs が非ゼロ → タイムアウトしない', async () => {
+        GlobalConfig.getInstance({ yaml: 'timeoutMs: 50' });
+        commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('ok')));
+
+        const _result = await runAI('sys', 'user', { model: 'sonnet', timeoutMs: 0 });
+
+        assertEquals(_result, 'ok');
       });
     });
   });

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -11,13 +11,13 @@
 // ─── Shared libraries
 // functions
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+import { GlobalConfig } from '../../classes/GlobalConfig.class.ts';
 import { getAiBackend, isValidModel, parseModel } from './model-utils.ts';
 
 // types
 import type { AiBackendCommand } from '../../types/ai.const.types.ts';
 
 // constants
-import { DEFAULT_AI_MODEL, DEFAULT_TIMEOUT_MS } from '../../constants/defaults.constants.ts';
 import { AI_BACKEND_COMMAND_MAP } from '../../types/ai.const.types.ts';
 
 // internal types
@@ -122,7 +122,10 @@ export const runAI = async (
   userPrompt: string,
   options?: RunAIOptions,
 ): Promise<string> => {
-  const _options = { model: DEFAULT_AI_MODEL, timeoutMs: DEFAULT_TIMEOUT_MS, ...options };
+  const _globalConfig = GlobalConfig.getInstance();
+  const _model = options?.model ?? (_globalConfig.get('model') as string);
+  const _timeoutMs = options?.timeoutMs ?? (_globalConfig.get('timeoutMs') as number);
+  const _options = { ...options, model: _model, timeoutMs: _timeoutMs };
   if (!isValidModel(_options.model)) {
     throw new ChatlogError(
       'UnknownModel',

--- a/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_scripts/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -916,6 +916,38 @@ describe('parseArgsToConfig', () => {
     });
   });
 
+  // ─── T-PA-37: --model オプションの解析 ──────────────────────────────────
+
+  /**
+   * `parseArgsToConfig` の `--model` オプション解析テスト。
+   *
+   * デフォルトスキーマに追加された `--model` オプションが CLI から解析され、
+   * CLI 未指定時は GlobalConfig の `model` フィールドがマージされることを検証する。
+   *
+   * テスト ID 範囲: T-PA-37-01 〜 T-PA-37-03
+   */
+  describe('Given: --model オプション', () => {
+    describe('When: 正常系', () => {
+      it('[Normal] T-PA-37-01: --model opus → model が "opus" になる', () => {
+        const result = parseArgs<TestConfig & { model?: string }>(['--model', 'opus'], TEST_SCHEMA);
+        assertEquals(result.model, 'opus');
+      });
+    });
+
+    describe('When: エッジケース', () => {
+      it('[Edge] T-PA-37-02: --model 未指定 → GlobalConfig の model がマージされる', () => {
+        GlobalConfig.getInstance({ yaml: 'model: haiku\n' });
+        const result = parseArgs<TestConfig & { model?: string }>([], TEST_SCHEMA);
+        assertEquals(result.model, 'haiku');
+      });
+
+      it('[Edge] T-PA-37-03: --model 未指定・config.yaml 未指定 → GlobalConfig デフォルト値 "sonnet" になる', () => {
+        const result = parseArgs<TestConfig & { model?: string }>([], TEST_SCHEMA);
+        assertEquals(result.model, 'sonnet');
+      });
+    });
+  });
+
   // ─── T-PA-33: agent の次に agent 名（period でない）を渡した場合はエラー ──
 
   /**

--- a/skills/_scripts/libs/io/parse-args.ts
+++ b/skills/_scripts/libs/io/parse-args.ts
@@ -41,6 +41,7 @@ const _DEFAULT_ARG_SCHEMA: ArgSchema<DefaultArgFields> = [
   { option: '--dry-run', field: 'dryRun', type: 'flag' },
   { option: '--input-dir', field: 'inputDir', type: 'directory' },
   { option: '--output-dir', field: 'outputDir', type: 'directory' },
+  { option: '--model', field: 'model', type: 'string' },
 ];
 
 /**

--- a/skills/_scripts/types/args-schema.types.ts
+++ b/skills/_scripts/types/args-schema.types.ts
@@ -29,6 +29,7 @@ export type DefaultArgFields = {
   dryRun?: boolean;
   inputDir?: string;
   outputDir?: string;
+  model?: string;
 };
 
 /** parseArgs 内部でパース中に使う値の型（文字列・真偽値・数値のいずれか）。 */

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -329,6 +329,73 @@ describe('main - KEEP 判定', () => {
   });
 });
 
+// ─── T-FL-E2E-14: model 配線 ─────────────────────────────────────────────────
+
+/**
+ * `main` 関数の E2E テストスイート（model 配線）。
+ *
+ * config.yaml の `model` 設定が claude CLI 起動引数の `--model` にそのまま反映されることを検証する。
+ *
+ * テスト ID 範囲: T-FL-E2E-14
+ *
+ * @see main
+ */
+describe('main - model 配線', () => {
+  /**
+   * config.yaml に `model: haiku` を設定し、1 件の KEEP 判定ファイルが存在する前提。
+   *
+   * claude CLI の起動引数に `--model haiku` が反映されることを確認する。
+   */
+  describe('Given: config.yaml に model: haiku を設定・keep.md（KEEP判定）を配置', () => {
+    /** `main([...args])` を呼び出すとき。 */
+    describe('When: main([...args]) を呼び出す', () => {
+      /** claude CLI の起動引数に --model haiku が含まれること。 */
+      describe('Then: T-FL-E2E-14 - claude CLI の起動引数に --model haiku が含まれる', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let capturedArgs: { value: string[] };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'\nmodel: haiku`);
+          capturedArgs = { value: [] };
+          commandHandle = installCommandMock(
+            makeSuccessMock(
+              new TextEncoder().encode(
+                JSON.stringify([{
+                  file: 'keep.md',
+                  decision: FILTER_DECISIONS.KEEP,
+                  confidence: 0.9,
+                  reason: 'valuable',
+                }]),
+              ),
+              capturedArgs,
+            ),
+          );
+          loggerStub = makeLoggerStub();
+          await Deno.writeTextFile(`${chatlogsDir}/keep.md`, _makeValidContent());
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        it('T-FL-E2E-14-01: capturedArgs に --model と haiku が含まれる', async () => {
+          await main(['claude', '2026-03', '--input-dir', chatlogsDir]);
+
+          const modelIndex = capturedArgs.value.indexOf('--model');
+          assertEquals(modelIndex !== -1, true);
+          assertEquals(capturedArgs.value[modelIndex + 1], 'haiku');
+        });
+      });
+    });
+  });
+});
+
 // ─── T-FL-E2E-04: 対象ファイルなし → Deno.exit(0) ───────────────────────────
 
 /**

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -18,6 +18,7 @@ import type { FilterConfig } from '../../../types/filter.types.ts';
 
 // ─── Helpers
 // constants
+import { DEFAULT_CONFIG_VALUES } from '../../../../../_scripts/constants/config-schema.constants.ts';
 import { DEFAULT_FILTER_CONFIG } from '../../../constants/common.constants.ts';
 // classes
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
@@ -554,6 +555,61 @@ describe('buildConfig', () => {
         it('T-FL-BC-29: discardThreshold 未設定 → result.discardThreshold === DEFAULT_FILTER_CONFIG.discardThreshold', () => {
           const result = buildConfig([]);
           assertEquals(result.discardThreshold, DEFAULT_FILTER_CONFIG.discardThreshold);
+        });
+      });
+    });
+  });
+
+  // ─── model 優先順位 ─────────────────────────────────────────────────────────
+
+  /**
+   * CLI 引数で `--model` が指定されている前提条件グループ。
+   *
+   * CLI 引数の model が GlobalConfig より優先されることを検証する。
+   */
+  describe('Given: CLI 引数で --model が指定されている', () => {
+    describe('When: GlobalConfig にも model が設定されている', () => {
+      /** CLI 引数の model が優先されることを検証する。 */
+      describe('Then: T-FL-BC-39 - CLI 引数の model が優先される', () => {
+        beforeEach(async () => {
+          await _makeGlobalConfig('model: haiku');
+        });
+        it('T-FL-BC-39: args=[--model, opus] → result.model === opus', () => {
+          const result = buildConfig(['--model', 'opus']);
+          assertEquals(result.model, 'opus');
+        });
+      });
+    });
+  });
+
+  /**
+   * CLI 引数で `--model` が未指定の前提条件グループ。
+   *
+   * GlobalConfig の model が使われることを検証する。
+   */
+  describe('Given: CLI 引数で --model が未指定', () => {
+    describe('When: GlobalConfig に model が設定されている', () => {
+      /** GlobalConfig の model が使われることを検証する。 */
+      describe('Then: T-FL-BC-40 - GlobalConfig の model が使われる', () => {
+        beforeEach(async () => {
+          await _makeGlobalConfig('model: haiku');
+        });
+        it('T-FL-BC-40: globalConfig.model=haiku → result.model === haiku', () => {
+          const result = buildConfig([]);
+          assertEquals(result.model, 'haiku');
+        });
+      });
+    });
+
+    describe('When: GlobalConfig にも model が設定されていない', () => {
+      /** GlobalConfig のデフォルト model（DEFAULT_CONFIG_VALUES.model）が使われることを検証する。 */
+      describe('Then: T-FL-BC-41 - GlobalConfig のデフォルト model が使われる', () => {
+        beforeEach(async () => {
+          await GlobalConfig.getInstance();
+        });
+        it('T-FL-BC-41: model 未設定 → result.model === DEFAULT_CONFIG_VALUES.model', () => {
+          const result = buildConfig([]);
+          assertEquals(result.model, DEFAULT_CONFIG_VALUES.model);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -160,7 +160,7 @@ export const main = async (args?: string[]): Promise<void> => {
       const chunkResults = await runChunked(
         targetEntries,
         _config.chunkSize,
-        (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl),
+        (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl, _config.model),
         _config.concurrency,
       );
 

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -29,6 +29,7 @@ import { ChatlogCache } from '../../../../../../_scripts/classes/ChatlogCache.cl
 import { ChatlogEntry } from '../../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_CONFIG_VALUES } from '../../../../../../_scripts/constants/config-schema.constants.ts';
+import { DEFAULT_AI_MODEL } from '../../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type {
   CommandMockHandle,
@@ -737,6 +738,78 @@ describe('processChunk', () => {
             Deno.errors.NotFound,
           );
           errStub.restore();
+        });
+      });
+    });
+  });
+
+  /**
+   * `model` を指定して processChunk を呼び出す前提条件グループ。
+   *
+   * 指定した `model` が claude CLI の起動引数（`--model`）にそのまま渡ることを検証する。
+   */
+  describe('Given: model="haiku" を指定', () => {
+    /** processChunk([file], stats, threshold, cache, ctl, 'haiku') を呼び出すとき。 */
+    describe('When: processChunk([file], stats, threshold, cache, ctl, "haiku") を呼び出す', () => {
+      /** claude CLI の起動引数に --model haiku が含まれることを検証する。 */
+      describe('Then: T-FL-PCK-12 - claude CLI の起動引数に --model haiku が含まれる', () => {
+        it('T-FL-PCK-12-01: capturedArgs に --model と haiku が含まれる', async () => {
+          const filePath = await _createTempFile('m1.md');
+          const entry = new ChatlogEntry(_TEMP_CONTENT, { filePath });
+          const response = JSON.stringify([
+            { file: 'm1.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
+          ]);
+          const capturedArgs: { value: string[] } = { value: [] };
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode(response), capturedArgs),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+
+          await processChunk([entry], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl, 'haiku');
+          errStub.restore();
+
+          const modelIndex = capturedArgs.value.indexOf('--model');
+          assertEquals(modelIndex !== -1, true);
+          assertEquals(capturedArgs.value[modelIndex + 1], 'haiku');
+        });
+      });
+    });
+  });
+
+  /**
+   * `model` を省略して processChunk を呼び出す前提条件グループ。
+   *
+   * `model` 省略時は runAI 側のデフォルトモデル（DEFAULT_AI_MODEL）にフォールバックすることを検証する。
+   */
+  describe('Given: model を省略', () => {
+    /** processChunk([file], stats, threshold, cache, ctl) を呼び出すとき。 */
+    describe('When: processChunk([file], stats, threshold, cache, ctl) を呼び出す', () => {
+      /** claude CLI の起動引数に --model DEFAULT_AI_MODEL が含まれることを検証する。 */
+      describe('Then: T-FL-PCK-13 - claude CLI の起動引数に --model DEFAULT_AI_MODEL が含まれる', () => {
+        it('T-FL-PCK-13-01: capturedArgs に --model と DEFAULT_AI_MODEL が含まれる', async () => {
+          const filePath = await _createTempFile('m2.md');
+          const entry = new ChatlogEntry(_TEMP_CONTENT, { filePath });
+          const response = JSON.stringify([
+            { file: 'm2.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
+          ]);
+          const capturedArgs: { value: string[] } = { value: [] };
+          commandHandle = installCommandMock(
+            makeSuccessMock(new TextEncoder().encode(response), capturedArgs),
+          );
+          const errStub = stub(console, 'error', () => {});
+          const stats = _makeStats();
+          const cache = await _makeEmptyCache();
+          const ctl = new AbortController();
+
+          await processChunk([entry], stats, DEFAULT_CONFIG_VALUES.discardThreshold as number, cache, ctl);
+          errStub.restore();
+
+          const modelIndex = capturedArgs.value.indexOf('--model');
+          assertEquals(modelIndex !== -1, true);
+          assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/process-chunk.ts
@@ -49,12 +49,13 @@ export const processChunk = async (
   discardThreshold: number,
   cache: ChatlogCache<CLEResult>,
   ctl: AbortController,
+  model?: string,
 ): Promise<ChatlogError | undefined> => {
   const batchPrompt = buildBatchPrompt(chunkEntries);
 
   let rawResult: string;
   try {
-    rawResult = await runAI(_SYSTEM_PROMPT, batchPrompt, { signal: ctl.signal });
+    rawResult = await runAI(_SYSTEM_PROMPT, batchPrompt, { ...(model ? { model } : {}), signal: ctl.signal });
   } catch (e) {
     if (!(e instanceof ChatlogError)) { throw e; }
     logger.warn(`${LOGGER_TEXT.INDENT}claude CLI 実行失敗。チャンク内ファイルをすべて error 扱い`);

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -39,6 +39,8 @@ export interface FilterConfig {
   minAssistantChars: number;
   /** DISCARD 判定に必要な最低信頼度スコア。 */
   discardThreshold: number;
+  /** claude CLI 判定に使用する AI モデル名（例: `sonnet`, `haiku`）。省略時は runAI 側のデフォルトを使用する。 */
+  model?: string;
 }
 
 /** `parseArgs` の戻り値型。引数で指定されたフィールドのみ含む。 */

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -28,6 +28,8 @@ import {
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+// constants
+import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { DicEntry, Dics, Prompts } from '../../../types/dics.types.ts';
 
@@ -397,6 +399,41 @@ describe('judgeTypeAndCategory', () => {
           ChatlogError,
         );
       });
+    });
+  });
+
+  // ─── model 引数の配線 ───────────────────────────────────────────────────────
+
+  /**
+   * `model` 引数が claude CLI の起動引数にそのまま渡ることを検証するケース。
+   */
+  describe('When: model を指定/省略して呼び出す', () => {
+    it('[Normal] T-SF-TC-19: model="haiku" を指定 → capturedArgs に --model haiku が含まれる', async () => {
+      const capturedArgs: { value: string[] } = { value: [] };
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('type: discussion\ncategory: development'), capturedArgs),
+      );
+
+      const _entry = _makeChatlogEntry('# テスト\n本文');
+      await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts(), 'haiku');
+
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertEquals(modelIndex !== -1, true);
+      assertEquals(capturedArgs.value[modelIndex + 1], 'haiku');
+    });
+
+    it('[Normal] T-SF-TC-20: model 省略 → capturedArgs に --model DEFAULT_AI_MODEL が含まれる', async () => {
+      const capturedArgs: { value: string[] } = { value: [] };
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('type: discussion\ncategory: development'), capturedArgs),
+      );
+
+      const _entry = _makeChatlogEntry('# テスト\n本文');
+      await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts());
+
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertEquals(modelIndex !== -1, true);
+      assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
@@ -31,6 +31,8 @@ import {
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
+// constants
+import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 import { logger } from '../../../../../_scripts/libs/io/logger.ts';
 // types
 import type { Dics, Prompts } from '../../../types/dics.types.ts';
@@ -260,6 +262,39 @@ describe('generateFrontmatter', () => {
       } finally {
         warnStub?.restore();
       }
+    });
+  });
+
+  /**
+   * `model` 引数が claude CLI の起動引数にそのまま渡ることを検証するケース。
+   */
+  describe('When: model を指定/省略して呼び出す', () => {
+    it('[Normal] T-SF-FM-05-01: model="haiku" を指定 → capturedArgs に --model haiku が含まれる', async () => {
+      const capturedArgs: { value: string[] } = { value: [] };
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n'), capturedArgs),
+      );
+
+      const _entry = _makeChatlogEntry();
+      await generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 0, 'haiku');
+
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertEquals(modelIndex !== -1, true);
+      assertEquals(capturedArgs.value[modelIndex + 1], 'haiku');
+    });
+
+    it('[Normal] T-SF-FM-05-02: model 省略 → capturedArgs に --model DEFAULT_AI_MODEL が含まれる', async () => {
+      const capturedArgs: { value: string[] } = { value: [] };
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n'), capturedArgs),
+      );
+
+      const _entry = _makeChatlogEntry();
+      await generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 0);
+
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertEquals(modelIndex !== -1, true);
+      assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -25,6 +25,8 @@ import {
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+// constants
+import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
 import type { Dics, Prompts } from '../../../types/dics.types.ts';
 
@@ -340,6 +342,39 @@ describe('reviewFrontmatter', () => {
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
       assertEquals(_entry.frontmatter.get('type'), 'research'); // NOT 'tech'
       assertEquals(result.validity, 'error');
+    });
+  });
+
+  /**
+   * `model` 引数が claude CLI の起動引数にそのまま渡ることを検証するケース。
+   */
+  describe('When: model を指定/省略して呼び出す', () => {
+    it('[Normal] T-SF-RV-13-01: model="haiku" を指定 → capturedArgs に --model haiku が含まれる', async () => {
+      const capturedArgs: { value: string[] } = { value: [] };
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('validity: pass\n'), capturedArgs),
+      );
+
+      const _entry = _makeChatlogEntry();
+      await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0, 'haiku');
+
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertEquals(modelIndex !== -1, true);
+      assertEquals(capturedArgs.value[modelIndex + 1], 'haiku');
+    });
+
+    it('[Normal] T-SF-RV-13-02: model 省略 → capturedArgs に --model DEFAULT_AI_MODEL が含まれる', async () => {
+      const capturedArgs: { value: string[] } = { value: [] };
+      commandHandle = installCommandMock(
+        makeSuccessMock(_enc.encode('validity: pass\n'), capturedArgs),
+      );
+
+      const _entry = _makeChatlogEntry();
+      await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
+
+      const modelIndex = capturedArgs.value.indexOf('--model');
+      assertEquals(modelIndex !== -1, true);
+      assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
@@ -35,6 +35,7 @@ export const generateFrontmatter = async (
   dics: Dics,
   prompts: Prompts,
   maxRetry: number,
+  model?: string,
 ): Promise<boolean> => {
   const type = (entry.frontmatter.get('type') as string) ?? DEFAULT_FALLBACK_TYPE;
   const category = (entry.frontmatter.get('category') as string) ?? DEFAULT_FALLBACK_CATEGORY;
@@ -56,7 +57,7 @@ export const generateFrontmatter = async (
   for (let attempt = 0; attempt <= _maxRetry; attempt++) {
     let _raw: string;
     try {
-      _raw = await runAI(system, user);
+      _raw = await runAI(system, user, { ...(model ? { model } : {}) });
     } catch (e) {
       if (e instanceof ChatlogError && e.kind === 'AiError') {
         logger.warn(`generateFrontmatter: AI call failed (attempt ${attempt + 1}): ${e}`);

--- a/skills/set-frontmatter/scripts/modules/setfm-review.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-review.ts
@@ -33,6 +33,7 @@ export const reviewFrontmatter = async (
   dics: Dics,
   prompts: Prompts,
   maxRetry: number,
+  model?: string,
 ): Promise<ReviewResult> => {
   const tmpl = prompts.prompts.get('review') ?? { system: '', user: '' };
   const typeList = formatDicEntries(dics.typeEntries);
@@ -55,7 +56,7 @@ export const reviewFrontmatter = async (
   for (let attempt = 0; attempt <= _maxRetry; attempt++) {
     let _raw: string;
     try {
-      _raw = await runAI(system, user);
+      _raw = await runAI(system, user, { ...(model ? { model } : {}) });
     } catch (e) {
       if (e instanceof ChatlogError && e.kind === 'AiError') {
         logger.warn(`reviewFrontmatter: AI call failed (attempt ${attempt + 1}): ${e}`);

--- a/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
@@ -55,6 +55,7 @@ export const judgeTypeAndCategory = async (
   maxContentLength: number,
   dics: Dics,
   prompts: Prompts,
+  model?: string,
 ): Promise<void> => {
   const tmpl = prompts.prompts.get('type-category');
   if (!tmpl) {
@@ -78,7 +79,7 @@ export const judgeTypeAndCategory = async (
   let category = DEFAULT_FALLBACK_CATEGORY;
 
   try {
-    const _raw = await runAI(_system, _user);
+    const _raw = await runAI(_system, _user, { ...(model ? { model } : {}) });
     const _lines = _raw.trim().split('\n');
     const _typeMatch = _lines.find((l) => l.startsWith('type:'));
     const _catMatch = _lines.find((l) => l.startsWith('category:'));

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -30,6 +30,7 @@ type _GenerateProvider = (
   dics: Dics,
   prompts: Prompts,
   maxRetry: number,
+  model?: string,
 ) => Promise<boolean>;
 
 export const phaseFrontmatter = async (
@@ -42,6 +43,7 @@ export const phaseFrontmatter = async (
   dryRun: boolean,
   generateProvider?: _GenerateProvider,
   maxRetry = 0,
+  model?: string,
 ): Promise<void> => {
   const _isGenerated = (cache: SetfmCache): boolean => {
     return cache.status === CACHE_STATUSES.SET_TYPES && !!cache.frontmatter;
@@ -102,7 +104,7 @@ export const phaseFrontmatter = async (
       } else {
         let _ok: boolean;
         try {
-          _ok = await _generate(entry, maxContentLength, dics, prompts, maxRetry);
+          _ok = await _generate(entry, maxContentLength, dics, prompts, maxRetry, model);
         } catch (e) {
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;

--- a/skills/set-frontmatter/scripts/phases/phase-review.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-review.ts
@@ -30,6 +30,7 @@ type _ReviewProvider = (
   dics: Dics,
   prompts: Prompts,
   maxRetry: number,
+  model?: string,
 ) => Promise<ReviewResult>;
 
 export const phaseReview = async (
@@ -41,6 +42,7 @@ export const phaseReview = async (
   dryRun: boolean,
   reviewProvider?: _ReviewProvider,
   maxRetry = 0,
+  model?: string,
 ): Promise<void> => {
   const _hits = entries.filter((e) => cache.read(e.filePath!).status === CACHE_STATUSES.REVIEWED);
   const _misses = entries.filter((e) => cache.read(e.filePath!).status !== CACHE_STATUSES.REVIEWED);
@@ -58,7 +60,7 @@ export const phaseReview = async (
       } else {
         let r: ReviewResult;
         try {
-          r = await _review(entry, dics, prompts, maxRetry);
+          r = await _review(entry, dics, prompts, maxRetry, model);
         } catch (e) {
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;

--- a/skills/set-frontmatter/scripts/phases/phase-type-category.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-type-category.ts
@@ -28,6 +28,7 @@ type _JudgeProvider = (
   maxContentLength: number,
   dics: Dics,
   prompts: Prompts,
+  model?: string,
 ) => Promise<void>;
 
 export const phaseTypeAndCategory = async (
@@ -39,6 +40,7 @@ export const phaseTypeAndCategory = async (
   concurrency: number,
   dryRun: boolean,
   judgeProvider?: _JudgeProvider,
+  model?: string,
 ): Promise<void> => {
   const _needsReJudge = (e: ChatlogEntry): boolean => {
     const _cached = cache.read(e.filePath!);
@@ -66,7 +68,7 @@ export const phaseTypeAndCategory = async (
       if (dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}type/category: ${getFilename(entry.filePath!)}`);
       } else {
-        await _judge(entry, maxContentLength, dics, prompts);
+        await _judge(entry, maxContentLength, dics, prompts, model);
         const _type = entry.frontmatter.get('type') as string;
         const _category = entry.frontmatter.get('category') as string;
         if (_type && _category) {

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -150,6 +150,8 @@ export const main = async (args: string[]): Promise<void> => {
     prompts,
     _config.concurrency,
     _config.dryRun,
+    undefined,
+    _config.model,
   );
 
   // Phase 2.2: フロントマター生成（並列）
@@ -164,6 +166,7 @@ export const main = async (args: string[]): Promise<void> => {
     _config.dryRun,
     undefined,
     _config.maxRetry,
+    _config.model,
   );
 
   // Phase 2.3: ステータス設定
@@ -184,6 +187,7 @@ export const main = async (args: string[]): Promise<void> => {
       _config.dryRun,
       undefined,
       _config.maxRetry,
+      _config.model,
     );
   } else {
     logger.info(`\nPhase 3.1: スキップ (--no-review)`);


### PR DESCRIPTION
## Overview

**Summary**
Add a `--model` CLI option and pass it through to `runAI`.

**Background / Motivation**
Users could not choose which AI model to use per run. This change adds a `model` field to the args schema and threads it from CLI parsing down through the `filter-chatlogs` and `set-frontmatter` skills to `runAI`, falling back to `GlobalConfig` defaults when not set.

## Changes

### Core Changes

- `skills/_scripts/libs/io/parse-args.ts` — parse `--model`
- `skills/_scripts/types/args-schema.types.ts` — add `model` field
- `skills/_scripts/libs/ai/run-ai.ts` — use `GlobalConfig` defaults when model/timeout are omitted
- `skills/filter-chatlogs/scripts/filter-chatlogs.ts`, `modules/filter/process-chunk.ts`, `types/filter.types.ts` — pass model through chunk processing
- `skills/set-frontmatter/scripts/set-frontmatter.ts`, `phases/phase-frontmatter.ts`, `phase-review.ts`, `phase-type-category.ts` — pass model to each phase
- `skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts`, `setfm-review.ts`, `setfm-type-category.ts` — accept model and pass it to `runAI`

### Test Updates

- Added/updated unit, functional, and e2e tests for model option parsing, precedence, and propagation

### Removed

None.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [x] Bug fix
- [x] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. `model` is optional everywhere; existing callers keep working unchanged.

## Additional Notes

21 files changed (+440/-11).
