### PR TITLE
feat(filter-chatlogs): add single-file processing flag

### DIFF
--- a/skills/filter-chatlogs/SKILL.md
+++ b/skills/filter-chatlogs/SKILL.md
@@ -5,7 +5,7 @@ description: >
   再利用価値の低いファイル（DISCARD）を削除する。
   /filter-chatlogs で呼び出す。
   KEEP/DISCARD判定にはclaude CLIを使用するため ANTHROPIC_API_KEY 不要。
-argument-hint: "[noise-filter|filter] [agent] [YYYY-MM [project]] [--dry-run]"
+argument-hint: "[noise-filter|filter] [agent] [YYYY-MM [project]] [--dry-run] [--single-file]"
 allowed-tools: Bash, Glob
 ---
 
@@ -37,6 +37,7 @@ allowed-tools: Bash, Glob
 - `agent YYYY-MM`（例: `chatgpt 2026-03`）→ 指定 agent・指定月
 - `agent YYYY-MM project`（例: `chatgpt 2026-03 aplys`）→ 指定 agent・指定月・プロジェクト
 - `--dry-run` → 削除せず判定結果のみ表示
+- `--single-file` → 1ファイルずつ判定（chunkSize を 1 に固定）
 
 **noise-filter モードの引数解析**（`noise-filter` トークンを除いた残りの引数に適用）:
 
@@ -104,6 +105,7 @@ deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" $ARGS
 - `agent YYYY-MM` → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt 2026-03`
 - `agent YYYY-MM project` → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt 2026-03 aplys`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
+- `--single-file` を含む → 末尾に `--single-file` を追加
 
 スクリプトは以下の基準でKEEP/DISCARDを判定し、DISCARDかつ confidence >= 0.7 のファイルを削除する:
 

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -1682,3 +1682,74 @@ describe('main - 判定集計ログ（全ファイルキャッシュ済み）', 
     });
   });
 });
+
+// ─── T-FL-E2E-22: --single-file 指定 → chunkSize が1に上書きされる ──────────
+
+/**
+ * `main` 関数の E2E テストスイート（--single-file フラグ）。
+ *
+ * `--single-file` を指定した場合、GlobalConfig の chunkSize 設定によらず
+ * 実効 chunkSize が 1 に強制上書きされることを検証する。
+ *
+ * GlobalConfig の chunkSize はデフォルト（10）のまま `--single-file` のみを指定し、
+ * 3 件のファイルのうち 1 チャンク目がレートリミットで失敗した場合に
+ * 残り 2 チャンク（2 ファイル）が未実行になる（= 1 ファイルずつ 3 チャンクに
+ * 分割された）ことを確認する。chunkSize が上書きされなければ 3 件は 1 チャンクに
+ * まとまり、レートリミット発生時に未実行ファイルは 0 件になるため、このテストは
+ * `--single-file` の上書きが機能しているかを判別できる。
+ *
+ * テスト ID 範囲: T-FL-E2E-22
+ *
+ * @see main
+ */
+describe('main - --single-file フラグ', () => {
+  /**
+   * 3 件の .md ファイルが存在し、claude CLI の 1 回目呼び出しがレートリミットで失敗する前提。
+   *
+   * GlobalConfig の chunkSize はデフォルトのまま `--single-file` のみを CLI 引数で指定する。
+   */
+  describe('Given: 3 件の .md ファイルと --single-file・レートリミットモック（GlobalConfig の chunkSize は未設定）', () => {
+    /** `main([...args, "--single-file"])` を dryRun=false で呼び出すとき。 */
+    describe('When: main([...args, "--single-file"]) を呼び出す', () => {
+      /** 未実行チャンク分の 2 ファイルが stats.skip に計上されること（chunkSize=1 に上書きされた証跡）。 */
+      describe('Then: T-FL-E2E-22 - 未実行チャンクが stats.skip に計上される', () => {
+        let tempDir: string;
+        let chatlogsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+        let counter: { calls: number };
+
+        beforeEach(async () => {
+          ({ tempDir, chatlogsDir } = await _makeTestDirs());
+          counter = { calls: 0 };
+          commandHandle = installCommandMock(_makeRateLimitThenEmptyMock(counter));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          GlobalConfig.resetInstance();
+          await Deno.remove(tempDir, { recursive: true });
+        });
+
+        describe('Given: file1.md, file2.md, file3.md を chatlogsDir に配置（chunkSize は GlobalConfig デフォルト）', () => {
+          beforeEach(async () => {
+            await Deno.writeTextFile(`${chatlogsDir}/file1.md`, _makeValidContent('file1'));
+            await Deno.writeTextFile(`${chatlogsDir}/file2.md`, _makeValidContent('file2'));
+            await Deno.writeTextFile(`${chatlogsDir}/file3.md`, _makeValidContent('file3'));
+            // 判定結果キャッシュを tempDir 配下に隔離し、他テストの残留キャッシュの影響を防ぐ
+            // chunkSize は指定しない（GlobalConfig デフォルト値のまま）
+            await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'\nconcurrency: 1`);
+          });
+
+          it('T-FL-E2E-22-01: 未実行チャンク分の 2 ファイルが stats.skip に計上される', async () => {
+            await main(['claude', '2026-03', '--input-dir', chatlogsDir, '--single-file']);
+
+            assertEquals(loggerStub.infoLogs.some((l) => l.includes('skip=2')), true);
+          });
+        });
+      });
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/functional/filter/build-config.functional.spec.ts
@@ -74,7 +74,7 @@ const _CUSTOM_DEFAULTS: FilterConfig = {
  * - `concurrency`/`minCharCount`/`minAssistantChars`/`discardThreshold` は
  *   `_SCHEMA` に CLI オプション定義が無いため、GlobalConfig > defaults の優先順位のみ検証する。
  *
- * テスト ID 範囲: T-FL-BC-01 〜 T-FL-BC-38
+ * テスト ID 範囲: T-FL-BC-01 〜 T-FL-BC-40
  *
  * @see buildConfig
  */
@@ -610,6 +610,44 @@ describe('buildConfig', () => {
         it('T-FL-BC-41: model 未設定 → result.model === DEFAULT_CONFIG_VALUES.model', () => {
           const result = buildConfig([]);
           assertEquals(result.model, DEFAULT_CONFIG_VALUES.model);
+        });
+      });
+    });
+  });
+
+  // ─── singleFile ─────────────────────────────────────────────────────────────
+
+  /**
+   * CLI 引数で `--single-file` が指定されている前提条件グループ。
+   */
+  describe('Given: CLI 引数で --single-file が指定されている', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** `result.singleFile === true` になることを検証する。 */
+      describe('Then: T-FL-BC-39 - result.singleFile === true', () => {
+        beforeEach(async () => {
+          await GlobalConfig.getInstance();
+        });
+        it('T-FL-BC-39: args=[--single-file] → result.singleFile === true', () => {
+          const result = buildConfig(['--single-file']);
+          assertEquals(result.singleFile, true);
+        });
+      });
+    });
+  });
+
+  /**
+   * CLI 引数で `--single-file` が未指定の前提条件グループ。
+   */
+  describe('Given: CLI 引数で --single-file が未指定', () => {
+    describe('When: buildConfig を呼び出す', () => {
+      /** デフォルト値 false が使われることを検証する。 */
+      describe('Then: T-FL-BC-40 - result.singleFile === false', () => {
+        beforeEach(async () => {
+          await GlobalConfig.getInstance();
+        });
+        it('T-FL-BC-40: singleFile 未指定 → result.singleFile === false', () => {
+          const result = buildConfig([]);
+          assertEquals(result.singleFile, false);
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/constants/common.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/common.constants.ts
@@ -42,6 +42,7 @@ export const DEFAULT_FILTER_CONFIG: FilterConfig = {
   agent: DEFAULT_AGENT,
   chatlogsDir: DEFAULT_CHATLOGS_DIR,
   dryRun: false,
+  singleFile: false,
   // config.yaml only
   chunkSize: DEFAULT_CONFIG_VALUES.chunkSize,
   concurrency: DEFAULT_CONFIG_VALUES.concurrency,

--- a/skills/filter-chatlogs/scripts/filter-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/filter-chatlogs.ts
@@ -57,6 +57,7 @@ import type { FilterConfig, FilterParsedConfig } from './types/filter.types.ts';
 /** filter-chatlogs の引数スキーマ。 */
 const _SCHEMA: ArgSchema<FilterParsedConfig> = [
   { option: '--chunk-size', field: 'chunkSize', type: 'integer', min: 1, max: 10 },
+  { option: '--single-file', field: 'singleFile', type: 'flag' },
 ];
 
 // ─────────────────────────────────────────────
@@ -156,16 +157,19 @@ export const main = async (args?: string[]): Promise<void> => {
       stats.skip += targetEntries.length;
       logger.dryrun('判定済み: judged=0');
     } else {
+      // --single-file 指定時は chunkSize を強制的に 1 に上書きし、1 ファイルずつ判定させる
+      const _chunkSize = _config.singleFile ? 1 : _config.chunkSize;
+
       // チャンク分割して並列処理（判定結果はキャッシュに書き込むのみ。削除は後続のスイープで行う）
       const chunkResults = await runChunked(
         targetEntries,
-        _config.chunkSize,
-        (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl, _config.model),
+        _chunkSize,
+        (chunk, ctl) => processChunk(chunk, stats, _config.discardThreshold, _cache, ctl),
         _config.concurrency,
       );
 
       // レートリミット等で abort された後、未着手のまま残ったチャンクのファイル数を skip に計上する
-      const unexecutedFileCount = countUnexecutedChunkFiles(targetEntries, _config.chunkSize, chunkResults);
+      const unexecutedFileCount = countUnexecutedChunkFiles(targetEntries, _chunkSize, chunkResults);
       if (unexecutedFileCount > 0) {
         stats.skip += unexecutedFileCount;
         logger.warn(

--- a/skills/filter-chatlogs/scripts/types/filter.types.ts
+++ b/skills/filter-chatlogs/scripts/types/filter.types.ts
@@ -27,6 +27,8 @@ export interface FilterConfig {
   // flags
   /** `true` のときファイルを削除せず判定結果のみ表示する。 */
   dryRun: boolean;
+  /** `true` のとき chunkSize を強制的に 1 に上書きし、1 ファイルずつ claude CLI に判定させる。 */
+  singleFile: boolean;
 
   // config.yaml only
   /** バッチ処理 1 回あたりの最大ファイル数。 */


### PR DESCRIPTION
## Overview

**Summary**
Add a `--single-file` flag to force one-file-at-a-time processing in `filter-chatlogs`.

**Background / Motivation**
Batch processing with `chunkSize` can be too coarse for rate-limit control and per-file skip
tracking. This flag lets users opt into single-file processing without changing the default
batch behavior.

## Changes

### Core Changes

- `skills/filter-chatlogs/scripts/filter-chatlogs.ts`: add `--single-file` flag; override the
  effective `chunkSize` to `1` when enabled, before calling `runChunked` and
  `countUnexecutedChunkFiles`
- `skills/filter-chatlogs/scripts/types/filter.types.ts`: add `singleFile: boolean` to
  `FilterConfig`
- `skills/filter-chatlogs/scripts/constants/common.constants.ts`: add `singleFile: false` default
  to `DEFAULT_FILTER_CONFIG`

### Test Updates

- `build-config.functional.spec.ts`: cover `--single-file` present/absent resolving
  `result.singleFile`
- `main.e2e.spec.ts`: cover `--single-file` overriding effective `chunkSize` to `1`

### Removed

None.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. `singleFile` defaults to `false`; existing batch behavior is unchanged when the flag is
not specified.

## Additional Notes

None.
