### PR TITLE
feat(types/ai): add fable model provider mapping

### DIFF
--- a/skills/_scripts/types/ai.const.types.ts
+++ b/skills/_scripts/types/ai.const.types.ts
@@ -66,6 +66,7 @@ export const AI_MODEL_TO_PROVIDER_MAP: AiModelToProvider[] = [
   // Anthropic claude
   { match: 'exact', value: 'default', provider: 'claude' },
   { match: 'exact', value: 'best', provider: 'claude' },
+  { match: 'exact', value: 'fable', provider: 'claude' },
   { match: 'exact', value: 'opus', provider: 'claude' },
   { match: 'exact', value: 'sonnet', provider: 'claude' },
   { match: 'exact', value: 'haiku', provider: 'claude' },


### PR DESCRIPTION
## Overview

**Summary**
Map the `fable` model to the `claude` provider.

**Background / Motivation**
`fable` was missing from `AI_MODEL_TO_PROVIDER_MAP`, so it was not recognized as a Claude model. This adds the mapping so it resolves correctly.

## Changes

### Core Changes

- `skills/_scripts/types/ai.const.types.ts`: add `{ match: 'exact', value: 'fable', provider: 'claude' }` to `AI_MODEL_TO_PROVIDER_MAP`, before the existing `opus`/`sonnet`/`haiku` entries.

### Test Updates

None.

### Removed

None.

## Change Type (optional)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

N/A
