### PR TITLE
refactor(set-frontmatter): pass config object to phase functions

### DIFF
--- a/skills/set-frontmatter/scripts/phases/__tests__/fixtures/phase-frontmatter.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/fixtures/phase-frontmatter.fixtures.spec.ts
@@ -160,8 +160,7 @@ describe('cache-hit fixtures', () => {
           _MAX_CONTENT_LENGTH,
           _makeDics(),
           _makePrompts(),
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           generateStub,
         );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/fixtures/phase-review.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/fixtures/phase-review.fixtures.spec.ts
@@ -159,8 +159,7 @@ describe('cache-hit fixtures', () => {
           cache,
           _makeDics(),
           _makePrompts(),
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           reviewStub,
         );
 
@@ -177,8 +176,7 @@ describe('cache-hit fixtures', () => {
           cache,
           _makeDics(),
           _makePrompts(),
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           reviewStub,
         );
 
@@ -201,8 +199,7 @@ describe('cache-hit fixtures', () => {
           cache,
           _makeDics(),
           _makePrompts(),
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _reviewWithCorrection,
         );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/fixtures/phase-type-category.fixtures.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/fixtures/phase-type-category.fixtures.spec.ts
@@ -161,8 +161,7 @@ describe('_phaseTypeAndCategory fixtures', () => {
           _MAX_CONTENT_LENGTH,
           _makeDics(),
           _makePrompts(),
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           judgeStub,
         );
 
@@ -188,8 +187,7 @@ describe('_phaseTypeAndCategory fixtures', () => {
           _MAX_CONTENT_LENGTH,
           _makeDics(),
           _makePrompts(),
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           judgeStub,
         );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-frontmatter-process.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-frontmatter-process.functional.spec.ts
@@ -200,8 +200,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         generateStub,
       );
 
@@ -226,8 +225,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         generateStub,
       );
 
@@ -257,8 +255,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         failGenerate,
       );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-frontmatter.functional.spec.ts
@@ -273,8 +273,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -292,8 +291,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -310,8 +308,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -328,8 +325,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -346,8 +342,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -364,8 +359,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -382,8 +376,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -403,8 +396,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -421,8 +413,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -439,8 +430,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -460,8 +450,7 @@ describe('_phaseFrontmatter', () => {
         _MAX_CONTENT_LENGTH,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeGenerateStub(counter),
       );
 
@@ -500,8 +489,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeGenerateStub(counter),
         );
 
@@ -542,8 +530,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeGenerateStub(counter),
         );
 
@@ -566,8 +553,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeGenerateStub(counter),
         );
 
@@ -590,8 +576,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeGenerateStub(counter),
         );
 
@@ -613,8 +598,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeFullGenerateStub(counter),
         );
 
@@ -633,8 +617,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeFailGenerateStub(counter),
         );
 
@@ -653,8 +636,7 @@ describe('_phaseFrontmatter', () => {
           _MAX_CONTENT_LENGTH,
           _DICS,
           _PROMPTS,
-          _CONCURRENCY,
-          false,
+          { concurrency: _CONCURRENCY, dryRun: false },
           _makeGenerateStub(counter),
         );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-review.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-review.functional.spec.ts
@@ -144,8 +144,7 @@ describe('phaseReview', () => {
         cache,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makePassReviewStub(),
       );
 
@@ -169,8 +168,7 @@ describe('phaseReview', () => {
         cache,
         _DICS,
         _PROMPTS,
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         _makeFailReviewStub(['title が不正']),
       );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-type-category.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/functional/phase-type-category.functional.spec.ts
@@ -203,8 +203,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -229,8 +228,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -259,8 +257,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -288,8 +285,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -317,8 +313,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -345,8 +340,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -370,8 +364,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 
@@ -399,8 +392,7 @@ describe('_phaseTypeAndCategory', () => {
         _MAX_CONTENT_LENGTH,
         _makeDics(),
         _makePrompts(),
-        _CONCURRENCY,
-        false,
+        { concurrency: _CONCURRENCY, dryRun: false },
         judgeStub,
       );
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
@@ -127,7 +127,7 @@ describe('_phaseFrontmatter', () => {
       const { stub, getCount } = _makeGenerateStub(true);
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, 1, false, stub);
+      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(getCount(), 1);
     });
@@ -139,7 +139,7 @@ describe('_phaseFrontmatter', () => {
       const { stub } = _makeGenerateStub(true);
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, 1, false, stub);
+      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(cacheSpy.calls.length >= 1, true);
       cacheSpy.restore();
@@ -156,7 +156,7 @@ describe('_phaseFrontmatter', () => {
       const { stub, getCount } = _makeGenerateStub(true);
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, 1, true, stub);
+      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(getCount(), 0);
     });
@@ -168,7 +168,7 @@ describe('_phaseFrontmatter', () => {
       const { stub } = _makeGenerateStub(true);
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, 1, true, stub);
+      await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(cacheSpy.calls.length, 0);
       cacheSpy.restore();
@@ -185,7 +185,15 @@ describe('_phaseFrontmatter', () => {
       const cacheSpy = spy(cache, 'write');
       const { stub: generateStub } = _makeGenerateStub(true);
 
-      await phaseFrontmatter([], cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, 1, true, generateStub);
+      await phaseFrontmatter(
+        [],
+        cache,
+        1000,
+        _FAKE_DICS,
+        _FAKE_PROMPTS,
+        { concurrency: 1, dryRun: true },
+        generateStub,
+      );
 
       assertEquals(cacheSpy.calls.length, 0);
       cacheSpy.restore();
@@ -205,7 +213,15 @@ describe('_phaseFrontmatter', () => {
       const warnSpy = spy(logger, 'warn');
       const cacheSpy = spy(cache, 'write');
       try {
-        await phaseFrontmatter(entries, cache, 1000, _FAKE_DICS, _FAKE_PROMPTS, 2, false, _throwingStub);
+        await phaseFrontmatter(
+          entries,
+          cache,
+          1000,
+          _FAKE_DICS,
+          _FAKE_PROMPTS,
+          { concurrency: 2, dryRun: false },
+          _throwingStub,
+        );
         // Both entries fail (throw → catch in phase), no cache write happens
         assertEquals(cacheSpy.calls.length, 0);
         // logger.warn was called at least once (for each failing entry)

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
@@ -132,7 +132,7 @@ describe('phaseReview', () => {
       const { stub, getCount } = _makeReviewStub();
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseReview(entries, cache, _dics, _prompts, 1, false, stub);
+      await phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(getCount(), 1);
     });
@@ -143,7 +143,7 @@ describe('phaseReview', () => {
       const entries = [_makeEntry('/path/to/a.md')];
       const writeSpy = spy(cache, 'write');
 
-      await phaseReview(entries, cache, _dics, _prompts, 1, false, stub);
+      await phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(writeSpy.calls.length >= 1, true);
     });
@@ -158,7 +158,7 @@ describe('phaseReview', () => {
       const { stub, getCount } = _makeReviewStub();
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseReview(entries, cache, _dics, _prompts, 1, true, stub);
+      await phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(getCount(), 0);
     });
@@ -169,7 +169,7 @@ describe('phaseReview', () => {
       const entries = [_makeEntry('/path/to/a.md')];
       const writeSpy = spy(cache, 'write');
 
-      await phaseReview(entries, cache, _dics, _prompts, 1, true, stub);
+      await phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(writeSpy.calls.length, 0);
     });
@@ -183,7 +183,7 @@ describe('phaseReview', () => {
       const cache = await _makeCache();
       const { stub, getCount } = _makeReviewStub();
 
-      await phaseReview([], cache, _dics, _prompts, 1, true, stub);
+      await phaseReview([], cache, _dics, _prompts, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(getCount(), 0);
     });
@@ -202,7 +202,7 @@ describe('phaseReview', () => {
       const warnSpy = spy(logger, 'warn');
       try {
         // Should resolve without throwing (catch inside phase)
-        await phaseReview(entries, cache, _dics, _prompts, 2, false, _throwingStub);
+        await phaseReview(entries, cache, _dics, _prompts, { concurrency: 2, dryRun: false }, _throwingStub);
         assertEquals(warnSpy.calls.length >= 1, true);
       } finally {
         warnSpy.restore();
@@ -223,7 +223,7 @@ describe('phaseReview', () => {
         corrected: { type: 'tech', category: 'ai', title: 'T', topics: ['x'], tags: ['y'] },
       });
       const entry = _makeEntry(filePath);
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
       const fm = cache.read(filePath).frontmatter;
       assertEquals(fm?.['type'], 'tech');
       assertEquals(fm?.['category'], 'ai');
@@ -239,7 +239,7 @@ describe('phaseReview', () => {
         corrected: { type: 'tech', category: 'ai' },
       });
       const entry = _makeEntry(filePath);
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
       assertEquals(cache.read(filePath).type, 'tech');
       assertEquals(cache.read(filePath).category, 'ai');
     });
@@ -257,7 +257,7 @@ describe('phaseReview', () => {
         corrected: { title: '', type: 'tech' },
       });
       const entry = _makeEntry(filePath);
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
       assertEquals(cache.read(filePath).frontmatter?.['title'], 'cached-title');
     });
 
@@ -274,7 +274,7 @@ describe('phaseReview', () => {
         corrected: { type: '', category: 'ai' },
       });
       const entry = _makeEntry(filePath);
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
       assertEquals(cache.read(filePath).type, 'existing-type');
     });
 
@@ -291,7 +291,7 @@ describe('phaseReview', () => {
         corrected: { topics: [], type: 'tech' },
       });
       const entry = _makeEntry(filePath);
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
       assertEquals(cache.read(filePath).frontmatter?.['topics'], ['existing-topic']);
     });
   });
@@ -305,7 +305,7 @@ describe('phaseReview', () => {
       const filePath = '/path/to/a.md';
       const { stub } = _makeCorrectedStub({ validity: 'error', errors: ['review failed'] });
       const entry = _makeEntry(filePath);
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
       assertEquals(cache.read(filePath).status, 'review-failed');
     });
 
@@ -318,7 +318,7 @@ describe('phaseReview', () => {
       const { stub } = _makeCorrectedStub({ validity: 'error', errors: [] });
       const entry = _makeEntry(filePath);
       try {
-        await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+        await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
         assertEquals(deleteSpy.calls.length, 0);
       } finally {
         deleteSpy.restore();
@@ -343,7 +343,7 @@ describe('phaseReview', () => {
         .set('title', null);
 
       const { stub } = _makeReviewStub();
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(cache.read(filePath).frontmatter?.['title'], 'cached-title');
     });
@@ -360,7 +360,7 @@ describe('phaseReview', () => {
       entry.frontmatter.set('title', '');
 
       const { stub } = _makeReviewStub();
-      await phaseReview([entry], cache, _dics, _prompts, 1, false, stub);
+      await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(cache.read(filePath).frontmatter?.['title'], 'cached-title');
     });

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-type-category.unit.spec.ts
@@ -154,7 +154,7 @@ describe('_phaseTypeAndCategory', () => {
       const { stub, getCount } = _makeJudgeStub();
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(getCount(), 1);
     });
@@ -165,7 +165,7 @@ describe('_phaseTypeAndCategory', () => {
       const entries = [_makeEntry('/path/to/a.md')];
       const writeSpy = spy(cache, 'write');
 
-      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(writeSpy.calls.length >= 1, true);
       writeSpy.restore();
@@ -181,7 +181,7 @@ describe('_phaseTypeAndCategory', () => {
       const { stub, getCount } = _makeJudgeStub();
       const entries = [_makeEntry('/path/to/a.md')];
 
-      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, true, stub);
+      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(getCount(), 0);
     });
@@ -192,7 +192,7 @@ describe('_phaseTypeAndCategory', () => {
       const entries = [_makeEntry('/path/to/a.md')];
       const writeSpy = spy(cache, 'write');
 
-      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, true, stub);
+      await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(writeSpy.calls.length, 0);
       writeSpy.restore();
@@ -207,7 +207,7 @@ describe('_phaseTypeAndCategory', () => {
       const cache = await _makeCache();
       const { stub, getCount } = _makeJudgeStub();
 
-      await phaseTypeAndCategory([], cache, 1000, _DICS, _PROMPTS, 1, true, stub);
+      await phaseTypeAndCategory([], cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: true }, stub);
 
       assertEquals(getCount(), 0);
     });
@@ -230,7 +230,7 @@ describe('_phaseTypeAndCategory', () => {
           const { stub, getCount } = _makeJudgeStub();
           const entries = [_makeEntry(filePath)];
 
-          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
           assertEquals(getCount(), 1);
         },
@@ -247,7 +247,7 @@ describe('_phaseTypeAndCategory', () => {
           const { stub, getCount } = _makeJudgeStub();
           const entries = [_makeEntry(filePath)];
 
-          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
           assertEquals(getCount(), 0);
         },
@@ -261,7 +261,7 @@ describe('_phaseTypeAndCategory', () => {
           const { stub } = _makeJudgeStub();
           const entry = _makeEntry(filePath);
 
-          await phaseTypeAndCategory([entry], cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory([entry], cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
           assertEquals(entry.frontmatter.get('type'), 'cached-type');
           assertEquals(entry.frontmatter.get('category'), 'cached-cat');
@@ -278,7 +278,7 @@ describe('_phaseTypeAndCategory', () => {
           const { stub, getCount } = _makeJudgeStub();
           const entries = [_makeEntry('/path/to/c.md')];
 
-          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
           assertEquals(getCount(), 1);
         },
@@ -294,7 +294,7 @@ describe('_phaseTypeAndCategory', () => {
           const { stub, getCount } = _makeJudgeStub();
           const entries = [_makeEntry(filePath)];
 
-          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
           assertEquals(getCount(), 1);
         },
@@ -334,7 +334,10 @@ describe('_phaseTypeAndCategory', () => {
           const { stub, getCount } = _makeJudgeStub();
           const entries = [_makeEntry(filePath)];
 
-          await phaseTypeAndCategory(entries, cacheWithNoStatus, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory(entries, cacheWithNoStatus, 1000, _DICS, _PROMPTS, {
+            concurrency: 1,
+            dryRun: false,
+          }, stub);
 
           assertEquals(getCount(), 1);
         },
@@ -350,7 +353,7 @@ describe('_phaseTypeAndCategory', () => {
           const { stub, getCount } = _makeJudgeStub();
           const entries = [_makeEntry(filePath)];
 
-          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, 1, false, stub);
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
 
           assertEquals(getCount(), 1);
         },

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -20,6 +20,7 @@ import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types
 // ─── Local
 import { generateFrontmatter } from '../modules/setfm-frontmatter.ts';
 import { applyCacheToEntry, extractEntryFrontmatter } from '../modules/setfm-write.ts';
+import type { SetfmConfig } from '../types/args.types.ts';
 import type { SetfmCache } from '../types/cache.types.ts';
 import type { Dics, Prompts } from '../types/dics.types.ts';
 
@@ -39,11 +40,8 @@ export const phaseFrontmatter = async (
   maxContentLength: number,
   dics: Dics,
   prompts: Prompts,
-  concurrency: number,
-  dryRun: boolean,
+  config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'> & Partial<Pick<SetfmConfig, 'maxRetry'>>,
   generateProvider?: _GenerateProvider,
-  maxRetry = 0,
-  model?: string,
 ): Promise<void> => {
   const _isGenerated = (cache: SetfmCache): boolean => {
     return cache.status === CACHE_STATUSES.SET_TYPES && !!cache.frontmatter;
@@ -61,10 +59,10 @@ export const phaseFrontmatter = async (
   for (const e of _hits) {
     const _cached = cache.read(e.filePath!);
     applyCacheToEntry(e, _cached);
-    if (e.frontmatter.hasRequiredFields() && !dryRun) {
+    if (e.frontmatter.hasRequiredFields() && !config.dryRun) {
       await cache.write(e.filePath!, { ..._cached, status: CACHE_STATUSES.NEED_REVIEW });
     }
-    if (dryRun) {
+    if (config.dryRun) {
       logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter (cached): ${getFilename(e.filePath!)}`);
     } else {
       logger.info(`${LOGGER_TEXT.INDENT}generated (cached): ${getFilename(e.filePath!)}`);
@@ -79,32 +77,32 @@ export const phaseFrontmatter = async (
     async (entry) => {
       const _fmSnapshot = extractEntryFrontmatter(entry);
       const _existing = cache.read(entry.filePath!);
-      if (!dryRun) {
+      if (!config.dryRun) {
         await cache.write(entry.filePath!, {
           ..._existing,
           frontmatter: _fmSnapshot,
           status: CACHE_STATUSES.NEED_REVIEW,
         });
       }
-      if (dryRun) {
+      if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter (existing): ${getFilename(entry.filePath!)}`);
       } else {
         logger.info(`${LOGGER_TEXT.INDENT}frontmatter (existing): ${getFilename(entry.filePath!)}`);
       }
     },
-    concurrency,
+    config.concurrency,
   );
 
   const _generate = generateProvider ?? generateFrontmatter;
   await runConcurrent(
     _needsGenerate,
     async (entry) => {
-      if (dryRun) {
+      if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter: ${getFilename(entry.filePath!)}`);
       } else {
         let _ok: boolean;
         try {
-          _ok = await _generate(entry, maxContentLength, dics, prompts, maxRetry, model);
+          _ok = await _generate(entry, maxContentLength, dics, prompts, config.maxRetry ?? 0, config.model);
         } catch (e) {
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
@@ -120,6 +118,6 @@ export const phaseFrontmatter = async (
         }
       }
     },
-    concurrency,
+    config.concurrency,
   );
 };

--- a/skills/set-frontmatter/scripts/phases/phase-review.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-review.ts
@@ -20,6 +20,7 @@ import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types
 // ─── Local
 import { reviewFrontmatter } from '../modules/setfm-review.ts';
 import { extractEntryFrontmatter, filterFrontmatterFields } from '../modules/setfm-write.ts';
+import type { SetfmConfig } from '../types/args.types.ts';
 import type { SetfmCache } from '../types/cache.types.ts';
 import type { Dics, Prompts } from '../types/dics.types.ts';
 import type { ReviewResult } from '../types/phase.types.ts';
@@ -38,11 +39,8 @@ export const phaseReview = async (
   cache: ChatlogCache<SetfmCache>,
   dics: Dics,
   prompts: Prompts,
-  concurrency: number,
-  dryRun: boolean,
+  config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'> & Partial<Pick<SetfmConfig, 'maxRetry'>>,
   reviewProvider?: _ReviewProvider,
-  maxRetry = 0,
-  model?: string,
 ): Promise<void> => {
   const _hits = entries.filter((e) => cache.read(e.filePath!).status === CACHE_STATUSES.REVIEWED);
   const _misses = entries.filter((e) => cache.read(e.filePath!).status !== CACHE_STATUSES.REVIEWED);
@@ -55,12 +53,12 @@ export const phaseReview = async (
   await runConcurrent(
     _misses,
     async (entry) => {
-      if (dryRun) {
+      if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}review: ${getFilename(entry.filePath!)}`);
       } else {
         let r: ReviewResult;
         try {
-          r = await _review(entry, dics, prompts, maxRetry, model);
+          r = await _review(entry, dics, prompts, config.maxRetry ?? 0, config.model);
         } catch (e) {
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
@@ -103,6 +101,6 @@ export const phaseReview = async (
         }
       }
     },
-    concurrency,
+    config.concurrency,
   );
 };

--- a/skills/set-frontmatter/scripts/phases/phase-type-category.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-type-category.ts
@@ -19,6 +19,7 @@ import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 import { CACHE_STATUSES } from '../../../_scripts/types/cache-status.const.types.ts';
 // ─── Local
 import { judgeTypeAndCategory } from '../modules/setfm-type-category.ts';
+import type { SetfmConfig } from '../types/args.types.ts';
 import type { SetfmCache } from '../types/cache.types.ts';
 import type { Dics, Prompts } from '../types/dics.types.ts';
 
@@ -37,10 +38,8 @@ export const phaseTypeAndCategory = async (
   maxContentLength: number,
   dics: Dics,
   prompts: Prompts,
-  concurrency: number,
-  dryRun: boolean,
+  config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'>,
   judgeProvider?: _JudgeProvider,
-  model?: string,
 ): Promise<void> => {
   const _needsReJudge = (e: ChatlogEntry): boolean => {
     const _cached = cache.read(e.filePath!);
@@ -65,10 +64,10 @@ export const phaseTypeAndCategory = async (
   await runConcurrent(
     _misses,
     async (entry) => {
-      if (dryRun) {
+      if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}type/category: ${getFilename(entry.filePath!)}`);
       } else {
-        await _judge(entry, maxContentLength, dics, prompts, model);
+        await _judge(entry, maxContentLength, dics, prompts, config.model);
         const _type = entry.frontmatter.get('type') as string;
         const _category = entry.frontmatter.get('category') as string;
         if (_type && _category) {
@@ -83,6 +82,6 @@ export const phaseTypeAndCategory = async (
         );
       }
     },
-    concurrency,
+    config.concurrency,
   );
 };

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -148,10 +148,7 @@ export const main = async (args: string[]): Promise<void> => {
     maxContentLength,
     dics,
     prompts,
-    _config.concurrency,
-    _config.dryRun,
-    undefined,
-    _config.model,
+    _config,
   );
 
   // Phase 2.2: フロントマター生成（並列）
@@ -162,11 +159,7 @@ export const main = async (args: string[]): Promise<void> => {
     maxContentLength,
     dics,
     prompts,
-    _config.concurrency,
-    _config.dryRun,
-    undefined,
-    _config.maxRetry,
-    _config.model,
+    _config,
   );
 
   // Phase 2.3: ステータス設定
@@ -183,11 +176,7 @@ export const main = async (args: string[]): Promise<void> => {
       _cache,
       dics,
       prompts,
-      _config.concurrency,
-      _config.dryRun,
-      undefined,
-      _config.maxRetry,
-      _config.model,
+      _config,
     );
   } else {
     logger.info(`\nPhase 3.1: スキップ (--no-review)`);


### PR DESCRIPTION
## Overview

**Summary**
Pass a single config object to the set-frontmatter phase functions.

**Background / Motivation**
Each phase function took separate positional params (`concurrency`, `dryRun`, `maxRetry`, `model`). Callers had to pad unused positions with `undefined` and keep the argument order in sync across three phases. Passing one config object derived from `SetfmConfig` removes that juggling and makes each phase's config explicit. Behavior is unchanged.

## Changes

### Core Changes

- `phases/phase-frontmatter.ts`: take `config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'> & Partial<Pick<SetfmConfig, 'maxRetry'>>` instead of positional params.
- `phases/phase-review.ts`: same config-object migration.
- `phases/phase-type-category.ts`: take `config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'>` (no `maxRetry`).
- `set-frontmatter.ts`: pass `_config` directly to the three phase calls.

### Test Updates

Update fixtures, functional, and unit specs to use the new config-object form:

- `__tests__/fixtures/phase-{frontmatter,review,type-category}.fixtures.spec.ts`
- `__tests__/functional/phase-frontmatter-process.functional.spec.ts`
- `__tests__/functional/phase-{frontmatter,review,type-category}.functional.spec.ts`
- `__tests__/unit/phase-{frontmatter,review,type-category}.unit.spec.ts`

### Removed

N/A

## Change Type (optional)

- [x] Refactor
- [x] Test

## Related Issues

N/A

## Checklist

- [x] Formatting and lint checks pass (`dprint check`)
- [x] Tests pass (`deno task test:module unit set` → 24 passed / 0 failed)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows Conventional Commits
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Pure internal signature refactor.

## Additional Notes

14 files changed, +112 / -146.
