### PR TITLE
fix(set-frontmatter): propagate rate limit and abort signals

### DIFF
--- a/skills/_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts
@@ -1,0 +1,101 @@
+// src: skills/_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts
+// @(#): rate-limit-utils のユニットテスト
+//       対象: isRateLimitError
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { isRateLimitError } from '../../rate-limit-utils.ts';
+
+// ─── Helpers
+import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
+
+// ─── Internal Helpers
+
+// constants
+/** `isRateLimitError` が `true` を返すべき正常系ケース。 */
+const _trueCases = [
+  {
+    id: 'T-LIB-AI-RL-01',
+    desc: 'kind=AiError かつ subindex=RateLimit の ChatlogError → true',
+    value: new ChatlogError('AiError', 'RateLimit'),
+  },
+] as const;
+
+/** `isRateLimitError` が `false` を返すべき異常系・エッジケース。 */
+const _falseCases = [
+  {
+    id: 'T-LIB-AI-RL-02',
+    label: 'Error',
+    desc: 'kind=AiError だが subindex 違いの ChatlogError → false',
+    value: new ChatlogError('AiError', 'TimedOut'),
+  },
+  {
+    id: 'T-LIB-AI-RL-03',
+    label: 'Error',
+    desc: 'subindex=RateLimit だが kind 違いの ChatlogError → false',
+    value: new ChatlogError('TimedOut', 'RateLimit'),
+  },
+  {
+    id: 'T-LIB-AI-RL-04',
+    label: 'Error',
+    desc: 'ChatlogError 以外の Error → false',
+    value: new Error('RateLimit'),
+  },
+  {
+    id: 'T-LIB-AI-RL-05',
+    label: 'Edge',
+    desc: '非 Error 値（string）→ false',
+    value: 'RateLimit',
+  },
+  {
+    id: 'T-LIB-AI-RL-06',
+    label: 'Edge',
+    desc: '非 Error 値（null）→ false',
+    value: null,
+  },
+  {
+    id: 'T-LIB-AI-RL-07',
+    label: 'Edge',
+    desc: '非 Error 値（undefined）→ false',
+    value: undefined,
+  },
+] as const;
+
+// ─── Tests
+
+/**
+ * `isRateLimitError` のユニットテストスイート。
+ *
+ * AI レートリミット由来の `ChatlogError` のみを判定し、
+ * それ以外（kind 違い / subindex 違い / 非 ChatlogError / 非 Error 値）は
+ * すべて `false` になることを検証する。
+ *
+ * テスト ID 範囲: T-LIB-AI-RL-01 〜 T-LIB-AI-RL-07
+ *
+ * @see isRateLimitError
+ */
+describe('isRateLimitError', () => {
+  describe('When: 正常系', () => {
+    for (const { id, desc, value } of _trueCases) {
+      it(`[Normal] ${id}: ${desc}`, () => {
+        assertEquals(isRateLimitError(value), true);
+      });
+    }
+  });
+
+  describe('When: 異常系・エッジケース', () => {
+    for (const { id, label, desc, value } of _falseCases) {
+      it(`[${label}] ${id}: ${desc}`, () => {
+        assertEquals(isRateLimitError(value), false);
+      });
+    }
+  });
+});

--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -69,11 +69,31 @@ const _makeRejectingCommandStub = () => {
 };
 
 // constants
-/** レートリミット検出のテーブル駆動ケース (RA-13, RA-14, RA-15)。 */
+/** レートリミット検出のテーブル駆動ケース (RA-13〜15, RA-21, RA-22)。stdout / stderr の両ストリームを検査対象とする。 */
 const _rateLimitCases = [
-  { id: 'T-LIB-AI-RA-13', label: 'Error', stderr: 'You have hit the rate limit', desc: '"rate limit"' },
-  { id: 'T-LIB-AI-RA-14', label: 'Error', stderr: 'HTTP 429 Too Many Requests', desc: '"429"' },
-  { id: 'T-LIB-AI-RA-15', label: 'Edge', stderr: 'Error code 4290', desc: '"4290" (部分マッチ仕様)' },
+  {
+    id: 'T-LIB-AI-RA-13',
+    label: 'Error',
+    stdout: '',
+    stderr: 'You have hit the rate limit',
+    desc: 'stderr に "rate limit"',
+  },
+  { id: 'T-LIB-AI-RA-14', label: 'Error', stdout: '', stderr: 'HTTP 429 Too Many Requests', desc: 'stderr に "429"' },
+  {
+    id: 'T-LIB-AI-RA-15',
+    label: 'Edge',
+    stdout: '',
+    stderr: 'Error code 4290',
+    desc: 'stderr に "4290" (部分マッチ仕様)',
+  },
+  {
+    id: 'T-LIB-AI-RA-21',
+    label: 'Error',
+    stdout: 'Claude usage limit reached',
+    stderr: '',
+    desc: 'stdout に "Claude usage limit reached" (stderr 空)',
+  },
+  { id: 'T-LIB-AI-RA-22', label: 'Error', stdout: '', stderr: 'usage limit exceeded', desc: 'stderr に "usage limit"' },
 ] as const;
 
 const _cases: Array<{ model: string; expected: CommandSpec }> = [
@@ -228,13 +248,13 @@ describe('runAI', () => {
   describe('CLI execution', () => {
     /** CLI 非ゼロ終了時のエラーケース。 */
     describe('When: 異常系', () => {
-      for (const { id, label, stderr, desc } of _rateLimitCases) {
-        it(`[${label}] ${id}: runAI — stderr に ${desc} → AiError/RateLimit`, async () => {
+      for (const { id, label, stdout, stderr, desc } of _rateLimitCases) {
+        it(`[${label}] ${id}: runAI — ${desc} → AiError/RateLimit`, async () => {
           const _origCommand = Deno.Command;
           Deno.Command = _makeCommandStub({
             success: false,
             code: 1,
-            stdout: new Uint8Array(),
+            stdout: new TextEncoder().encode(stdout),
             stderr: new TextEncoder().encode(stderr),
             signal: null,
           }) as unknown as typeof Deno.Command;
@@ -288,6 +308,26 @@ describe('runAI', () => {
         try {
           const _result = await runAI('sys', 'user', { model: 'sonnet' });
           assertEquals(_result, 'hello');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+    });
+
+    /** 正常終了(exit 0)の stdout はレートリミット検査対象外（誤検出防止）のエッジケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-LIB-AI-RA-23: runAI — 正常終了 かつ stdout に "usage limit" を含む → RateLimit にならず stdout を返す', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode('the response mentions a usage limit topic'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _result = await runAI('sys', 'user', { model: 'sonnet' });
+          assertEquals(_result, 'the response mentions a usage limit topic');
         } finally {
           Deno.Command = _origCommand;
         }

--- a/skills/_scripts/libs/ai/rate-limit-utils.ts
+++ b/skills/_scripts/libs/ai/rate-limit-utils.ts
@@ -1,0 +1,20 @@
+// src: skills/_scripts/libs/ai/rate-limit-utils.ts
+// @(#): AI レートリミットエラー判定ユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── Shared libraries
+// functions
+import { ChatlogError } from '../../classes/ChatlogError.class.ts';
+
+/**
+ * 与えられた値が AI レートリミット由来の `ChatlogError` かどうかを判定する。
+ *
+ * @param e - 判定対象の値（catch 節で受け取る `unknown` を想定）
+ * @returns `kind==='AiError'` かつ `subindex==='RateLimit'` の `ChatlogError` なら `true`、それ以外は `false`
+ */
+export const isRateLimitError = (e: unknown): boolean =>
+  e instanceof ChatlogError && e.kind === 'AiError' && e.subindex === 'RateLimit';

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -29,6 +29,9 @@ export type RunAIOptions = {
 
 type _CommandSpec = { command: AiBackendCommand; args: string[]; hasSystemPromptWithArgs: boolean };
 
+/** レートリミット検出パターン。CLI は文言を stdout / stderr のいずれにも出しうる。`i` フラグのみ（`g` を付けると `.test()` がステートフルになる）。 */
+const _RATE_LIMIT_PATTERN = /rate.?limit|429|usage limit/i;
+
 // ─── Functions
 
 /**
@@ -155,7 +158,8 @@ export const runAI = async (
     const _output = await _process.output();
     if (!_output.success) {
       const _stderr = new TextDecoder().decode(_output.stderr).trim();
-      const _isRateLimit = /rate.?limit|429/i.test(_stderr);
+      const _stdout = new TextDecoder().decode(_output.stdout).trim();
+      const _isRateLimit = _RATE_LIMIT_PATTERN.test(_stderr) || _RATE_LIMIT_PATTERN.test(_stdout);
       throw new ChatlogError(
         'AiError',
         _isRateLimit ? 'RateLimit' : 'ExitFailure',

--- a/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
@@ -10,6 +10,7 @@
 // cspell:words MoveByAI
 
 // ─── Shared scripts
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runChunked } from '../../../_scripts/libs/parallel/concurrency.ts';
@@ -18,7 +19,6 @@ import { parseAiJsonArray } from '../../../_scripts/libs/text/json-utils.ts';
 // ─── Local
 import type { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
-import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 // types
 import type {
   ClassifyCache,
@@ -122,7 +122,7 @@ export const processChunk = async (
   try {
     rawResult = await runAI(_systemPrompt, _batchPrompt, { model, signal: ctl.signal });
   } catch (e) {
-    if (e instanceof ChatlogError && e.kind === 'AiError' && e.subindex === 'RateLimit') {
+    if (isRateLimitError(e)) {
       throw e;
     }
     const _reason = `claude CLI 実行失敗: ${e}`;

--- a/skills/normalize-chatlogs/scripts/modules/segment-ai.ts
+++ b/skills/normalize-chatlogs/scripts/modules/segment-ai.ts
@@ -16,6 +16,7 @@ import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.
 
 // functions
 // --- ai ---
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 
 // constants
@@ -113,7 +114,7 @@ export const segmentChatlogs = async (
       ...(options?.signal !== undefined ? { signal: options.signal } : {}),
     });
   } catch (e) {
-    if (e instanceof ChatlogError && e.kind === 'AiError' && e.subindex === 'RateLimit') {
+    if (isRateLimitError(e)) {
       throw e;
     }
     const _paths = inputs.map((entry) => getBasename(entry.filePath!)).join(', ');

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm sess
 
 // ─── BDD modules
-import { assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
+import { assert, assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
 import { afterEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -21,11 +21,15 @@ import {
 
 // ─── Helpers
 import {
+  BaseMockCommand,
   installCommandMock,
   makeFailMock,
   makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type {
+  CommandMockHandle,
+  DenoCommandLike,
+} from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 // constants
@@ -39,7 +43,67 @@ import type { DicEntry, Dics, Prompts } from '../../../types/dics.types.ts';
 const _enc = new TextEncoder();
 const _MAX_CONTENT_LENGTH = 5000;
 
+/**
+ * `Deno.Command` に渡された `opts.signal` をキャプチャする成功モック。
+ *
+ * `runAI` は内部タイムアウト用 signal を `AbortSignal.any()` で合成して渡すため、
+ * 単なる `signal !== undefined` は無意味。外部 `AbortController` を `abort()` した後に
+ * キャプチャした合成 signal の `.aborted === true` を確認することでリレーの有無を判別する。
+ */
+class _SignalCaptureMock extends BaseMockCommand {
+  private readonly stdout: Uint8Array;
+  readonly signal?: AbortSignal;
+
+  /** 合成 signal と stdout を受け取り、後段の検査用に signal を保持する。 */
+  constructor(_cmd: string, opts: { signal?: AbortSignal }, stdout: Uint8Array) {
+    super();
+    this.stdout = stdout;
+    this.signal = opts.signal;
+  }
+
+  /** 常に成功レスポンス（exit 0 + 指定 stdout）を返す。 */
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
+  }
+}
+
+/**
+ * 常に rate limit エラー（非ゼロ exit + stderr に "rate limit"）を返すモック。
+ *
+ * `runAI` の rate limit 判定を発火させて `ChatlogError('AiError', 'RateLimit', ...)` を throw させる。
+ */
+class _RateLimitMockCommand extends BaseMockCommand {
+  /** 常に exit 1 + stderr "rate limit exceeded" を返す。 */
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: _enc.encode('rate limit exceeded'),
+    });
+  }
+}
+
 // functions
+
+/**
+ * `_SignalCaptureMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param stdout - AI が返す stdout バイト列
+ * @param captured - モックインスタンスの受け渡し先（呼び出し後に signal を検査するための出口）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeSignalCaptureMock = (
+  stdout: Uint8Array,
+  captured: { instance: _SignalCaptureMock | null },
+): DenoCommandLike => {
+  return class extends _SignalCaptureMock {
+    constructor(cmd: string, opts: { signal?: AbortSignal }) {
+      super(cmd, opts, stdout);
+      captured.instance = this;
+    }
+  } as unknown as DenoCommandLike;
+};
 
 /**
  * テスト用 `DicEntry` を生成する。
@@ -434,6 +498,46 @@ describe('judgeTypeAndCategory', () => {
       const modelIndex = capturedArgs.value.indexOf('--model');
       assertEquals(modelIndex !== -1, true);
       assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
+    });
+  });
+
+  // ─── RateLimit / signal 転送 ─────────────────────────────────────────────
+
+  /**
+   * RateLimit エラーの即時伝播と `signal` 転送を検証するケース。
+   *
+   * RateLimit は握りつぶさず即 throw され、外部 `AbortSignal` は `runAI` へリレーされる。
+   */
+  describe('When: RateLimit / signal 転送', () => {
+    it('[Error] T-SF-TC-21: runAI が RateLimit → フォールバックせず ChatlogError を再 throw', async () => {
+      commandHandle = installCommandMock(_RateLimitMockCommand as unknown as DenoCommandLike);
+
+      const _entry = _makeChatlogEntry('# テスト\n本文');
+      await assertRejects(
+        () => judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts()),
+        ChatlogError,
+      );
+    });
+
+    it('[Normal] T-SF-TC-22: signal を渡すと runAI に転送され、外部 abort で内部 signal も aborted になる', async () => {
+      const _goodYaml = _enc.encode('type: discussion\ncategory: development');
+      const captured: { instance: _SignalCaptureMock | null } = { instance: null };
+      commandHandle = installCommandMock(_makeSignalCaptureMock(_goodYaml, captured));
+      const controller = new AbortController();
+
+      const _entry = _makeChatlogEntry('# テスト\n本文');
+      await judgeTypeAndCategory(
+        _entry,
+        _MAX_CONTENT_LENGTH,
+        _makeDics(),
+        _makePrompts(),
+        undefined,
+        controller.signal,
+      );
+      controller.abort();
+
+      assert(captured.instance !== null, 'mock was not instantiated');
+      assertEquals(captured.instance.signal?.aborted, true);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm sess
 
 // ─── BDD modules
-import { assertEquals, assertRejects } from '@std/assert';
+import { assert, assertEquals, assertRejects } from '@std/assert';
 import { afterEach, describe, it } from '@std/testing/bdd';
 // stub
 import { stub } from '@std/testing/mock';
@@ -22,13 +22,17 @@ import { generateFrontmatter } from '../../setfm-frontmatter.ts';
 
 // ─── Helpers
 import {
+  BaseMockCommand,
   installCommandMock,
   makeFailMock,
   makeFirstNFailMock,
   makeSequencedSuccessMock,
   makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type {
+  CommandMockHandle,
+  DenoCommandLike,
+} from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 // constants
@@ -60,7 +64,85 @@ const _mockPrompts: Prompts = {
   ]),
 };
 
+/**
+ * `Deno.Command` に渡された `opts.signal` をキャプチャする成功モック。
+ *
+ * `runAI` は内部タイムアウト用 signal を `AbortSignal.any()` で合成して渡すため、
+ * 単なる `signal !== undefined` は無意味。外部 `AbortController` を `abort()` した後に
+ * キャプチャした合成 signal の `.aborted === true` を確認することでリレーの有無を判別する。
+ */
+class _SignalCaptureMock extends BaseMockCommand {
+  private readonly stdout: Uint8Array;
+  readonly signal?: AbortSignal;
+
+  constructor(_cmd: string, opts: { signal?: AbortSignal }, stdout: Uint8Array) {
+    super();
+    this.stdout = stdout;
+    this.signal = opts.signal;
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
+  }
+}
+
+/**
+ * 常に rate limit エラー（非ゼロ exit + stderr に "rate limit"）を返し、構築回数を数えるモック。
+ *
+ * `runAI` の `_isRateLimit` 判定を発火させて `ChatlogError('AiError', 'RateLimit', ...)` を
+ * throw させる。`counter.calls` で `runAI` 呼び出し回数を検証し、RateLimit がリトライを
+ * 発生させないこと（1回で throw されること）を判別する。
+ */
+class _CountingRateLimitMock extends BaseMockCommand {
+  constructor(_cmd: string, _opts: unknown, counter: { calls: number }) {
+    super();
+    counter.calls++;
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: _enc.encode('rate limit exceeded'),
+    });
+  }
+}
+
 // functions
+
+/**
+ * `_SignalCaptureMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param stdout - AI が返す stdout バイト列
+ * @param captured - モックインスタンスの受け渡し先（呼び出し後に signal を検査するための出口）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeSignalCaptureMock = (
+  stdout: Uint8Array,
+  captured: { instance: _SignalCaptureMock | null },
+): DenoCommandLike => {
+  return class extends _SignalCaptureMock {
+    constructor(cmd: string, opts: { signal?: AbortSignal }) {
+      super(cmd, opts, stdout);
+      captured.instance = this;
+    }
+  } as unknown as DenoCommandLike;
+};
+
+/**
+ * `_CountingRateLimitMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param counter - `runAI` 呼び出し回数のカウンタ（構築ごとに `calls` を加算）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeCountingRateLimitMock = (counter: { calls: number }): DenoCommandLike => {
+  return class extends _CountingRateLimitMock {
+    constructor(cmd: string, opts: unknown) {
+      super(cmd, opts, counter);
+    }
+  } as unknown as DenoCommandLike;
+};
 
 /**
  * テスト用 `ChatlogEntry` を生成する。
@@ -295,6 +377,39 @@ describe('generateFrontmatter', () => {
       const modelIndex = capturedArgs.value.indexOf('--model');
       assertEquals(modelIndex !== -1, true);
       assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
+    });
+  });
+
+  /**
+   * RateLimit エラーの即時伝播と `signal` 転送を検証するケース。
+   *
+   * RateLimit はリトライ対象外として即 throw され、外部 `AbortSignal` は `runAI` へリレーされる。
+   */
+  describe('When: RateLimit / signal 転送', () => {
+    it('[Error] T-SF-FM-06-01: runAI が RateLimit → リトライせず即 throw（maxRetry=2 でも runAI は 1 回のみ）', async () => {
+      const counter = { calls: 0 };
+      commandHandle = installCommandMock(_makeCountingRateLimitMock(counter));
+
+      const _entry = _makeChatlogEntry();
+      await assertRejects(
+        () => generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 2),
+        ChatlogError,
+      );
+      assertEquals(counter.calls, 1);
+    });
+
+    it('[Normal] T-SF-FM-06-02: signal を渡すと runAI に転送され、外部 abort で内部 signal も aborted になる', async () => {
+      const _goodYaml = _enc.encode('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n');
+      const captured: { instance: _SignalCaptureMock | null } = { instance: null };
+      commandHandle = installCommandMock(_makeSignalCaptureMock(_goodYaml, captured));
+      const controller = new AbortController();
+
+      const _entry = _makeChatlogEntry();
+      await generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 0, undefined, controller.signal);
+      controller.abort();
+
+      assert(captured.instance !== null, 'mock was not instantiated');
+      assertEquals(captured.instance.signal?.aborted, true);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm sess
 
 // ─── BDD modules
-import { assertEquals, assertRejects } from '@std/assert';
+import { assert, assertEquals, assertRejects } from '@std/assert';
 import { afterEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -18,13 +18,18 @@ import { reviewFrontmatter } from '../../setfm-review.ts';
 
 // ─── Helpers
 import {
+  BaseMockCommand,
   installCommandMock,
   makeFailMock,
   makeFirstNFailMock,
   makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type {
+  CommandMockHandle,
+  DenoCommandLike,
+} from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 // constants
 import { DEFAULT_AI_MODEL } from '../../../../../_scripts/constants/defaults.constants.ts';
 // types
@@ -52,7 +57,85 @@ const _mockPrompts: Prompts = {
   ]),
 };
 
+/**
+ * `Deno.Command` に渡された `opts.signal` をキャプチャする成功モック。
+ *
+ * `runAI` は内部タイムアウト用 signal を `AbortSignal.any()` で合成して渡すため、
+ * 単なる `signal !== undefined` は無意味。外部 `AbortController` を `abort()` した後に
+ * キャプチャした合成 signal の `.aborted === true` を確認することでリレーの有無を判別する。
+ */
+class _SignalCaptureMock extends BaseMockCommand {
+  private readonly stdout: Uint8Array;
+  readonly signal?: AbortSignal;
+
+  constructor(_cmd: string, opts: { signal?: AbortSignal }, stdout: Uint8Array) {
+    super();
+    this.stdout = stdout;
+    this.signal = opts.signal;
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
+    return Promise.resolve({ success: true, code: 0, stdout: this.stdout });
+  }
+}
+
+/**
+ * 常に rate limit エラー（非ゼロ exit + stderr に "rate limit"）を返し、構築回数を数えるモック。
+ *
+ * `runAI` の `_isRateLimit` 判定を発火させて `ChatlogError('AiError', 'RateLimit', ...)` を
+ * throw させる。`counter.calls` で `runAI` 呼び出し回数を検証し、RateLimit がリトライを
+ * 発生させないこと（1回で throw されること）を判別する。
+ */
+class _CountingRateLimitMock extends BaseMockCommand {
+  constructor(_cmd: string, _opts: unknown, counter: { calls: number }) {
+    super();
+    counter.calls++;
+  }
+
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: _enc.encode('rate limit exceeded'),
+    });
+  }
+}
+
 // functions
+
+/**
+ * `_SignalCaptureMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param stdout - AI が返す stdout バイト列
+ * @param captured - モックインスタンスの受け渡し先（呼び出し後に signal を検査するための出口）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeSignalCaptureMock = (
+  stdout: Uint8Array,
+  captured: { instance: _SignalCaptureMock | null },
+): DenoCommandLike => {
+  return class extends _SignalCaptureMock {
+    constructor(cmd: string, opts: { signal?: AbortSignal }) {
+      super(cmd, opts, stdout);
+      captured.instance = this;
+    }
+  } as unknown as DenoCommandLike;
+};
+
+/**
+ * `_CountingRateLimitMock` を `DenoCommandLike` として返すファクトリヘルパー。
+ *
+ * @param counter - `runAI` 呼び出し回数のカウンタ（構築ごとに `calls` を加算）
+ * @returns `DenoCommandLike` クラス
+ */
+const _makeCountingRateLimitMock = (counter: { calls: number }): DenoCommandLike => {
+  return class extends _CountingRateLimitMock {
+    constructor(cmd: string, opts: unknown) {
+      super(cmd, opts, counter);
+    }
+  } as unknown as DenoCommandLike;
+};
 
 /**
  * テスト用 `ChatlogEntry` を生成する。
@@ -375,6 +458,40 @@ describe('reviewFrontmatter', () => {
       const modelIndex = capturedArgs.value.indexOf('--model');
       assertEquals(modelIndex !== -1, true);
       assertEquals(capturedArgs.value[modelIndex + 1], DEFAULT_AI_MODEL);
+    });
+  });
+
+  /**
+   * RateLimit エラーの即時伝播と `signal` 転送を検証するケース。
+   *
+   * 通常 AiError はリトライ枯渇後に `{ validity: 'error' }` を返すが、RateLimit は
+   * リトライ対象外として即 throw される。外部 `AbortSignal` は `runAI` へリレーされる。
+   */
+  describe('When: RateLimit / signal 転送', () => {
+    it('[Error] T-SF-RV-14-01: runAI が RateLimit → リトライせず即 throw（maxRetry=2 でも runAI は 1 回のみ）', async () => {
+      const counter = { calls: 0 };
+      commandHandle = installCommandMock(_makeCountingRateLimitMock(counter));
+
+      const _entry = _makeChatlogEntry();
+      await assertRejects(
+        () => reviewFrontmatter(_entry, _mockDics, _mockPrompts, 2),
+        ChatlogError,
+      );
+      assertEquals(counter.calls, 1);
+    });
+
+    it('[Normal] T-SF-RV-14-02: signal を渡すと runAI に転送され、外部 abort で内部 signal も aborted になる', async () => {
+      const _goodYaml = _enc.encode('validity: pass\n');
+      const captured: { instance: _SignalCaptureMock | null } = { instance: null };
+      commandHandle = installCommandMock(_makeSignalCaptureMock(_goodYaml, captured));
+      const controller = new AbortController();
+
+      const _entry = _makeChatlogEntry();
+      await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0, undefined, controller.signal);
+      controller.abort();
+
+      assert(captured.instance !== null, 'mock was not instantiated');
+      assertEquals(captured.instance.signal?.aborted, true);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
@@ -13,6 +13,7 @@
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_FALLBACK_CATEGORY, DEFAULT_FALLBACK_TYPE } from '../../../_scripts/constants/defaults.constants.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { extractYaml, hasFrontmatterFields } from '../../../_scripts/libs/text/frontmatter-utils.ts';
@@ -36,6 +37,7 @@ export const generateFrontmatter = async (
   prompts: Prompts,
   maxRetry: number,
   model?: string,
+  signal?: AbortSignal,
 ): Promise<boolean> => {
   const type = (entry.frontmatter.get('type') as string) ?? DEFAULT_FALLBACK_TYPE;
   const category = (entry.frontmatter.get('category') as string) ?? DEFAULT_FALLBACK_CATEGORY;
@@ -57,8 +59,11 @@ export const generateFrontmatter = async (
   for (let attempt = 0; attempt <= _maxRetry; attempt++) {
     let _raw: string;
     try {
-      _raw = await runAI(system, user, { ...(model ? { model } : {}) });
+      _raw = await runAI(system, user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
     } catch (e) {
+      if (isRateLimitError(e) || signal?.aborted) {
+        throw e;
+      }
       if (e instanceof ChatlogError && e.kind === 'AiError') {
         logger.warn(`generateFrontmatter: AI call failed (attempt ${attempt + 1}): ${e}`);
         _lastError = e;

--- a/skills/set-frontmatter/scripts/modules/setfm-review.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-review.ts
@@ -12,6 +12,7 @@
 // ─── Shared scripts
 import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { extractYaml } from '../../../_scripts/libs/text/frontmatter-utils.ts';
@@ -34,6 +35,7 @@ export const reviewFrontmatter = async (
   prompts: Prompts,
   maxRetry: number,
   model?: string,
+  signal?: AbortSignal,
 ): Promise<ReviewResult> => {
   const tmpl = prompts.prompts.get('review') ?? { system: '', user: '' };
   const typeList = formatDicEntries(dics.typeEntries);
@@ -56,8 +58,11 @@ export const reviewFrontmatter = async (
   for (let attempt = 0; attempt <= _maxRetry; attempt++) {
     let _raw: string;
     try {
-      _raw = await runAI(system, user, { ...(model ? { model } : {}) });
+      _raw = await runAI(system, user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
     } catch (e) {
+      if (isRateLimitError(e) || signal?.aborted) {
+        throw e;
+      }
       if (e instanceof ChatlogError && e.kind === 'AiError') {
         logger.warn(`reviewFrontmatter: AI call failed (attempt ${attempt + 1}): ${e}`);
         _lastError = e;

--- a/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
@@ -13,6 +13,7 @@
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_FALLBACK_CATEGORY, DEFAULT_FALLBACK_TYPE } from '../../../_scripts/constants/defaults.constants.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 
 // ─── Local
@@ -48,7 +49,8 @@ const _buildTypeCategorySystemPrompt = (systemTemplate: string, dics: Dics, cate
  * category: <category_key>
  * ```
  *
- * 判定失敗・AI エラー時はフォールバック値をセットする（例外は throw しない）。
+ * 判定失敗・通常 AI エラー時はフォールバック値をセットする。
+ * ただし RateLimit エラーおよび abort 済み signal の場合は、フォールバックに落とさず例外を再 throw する。
  */
 export const judgeTypeAndCategory = async (
   entry: ChatlogEntry,
@@ -56,6 +58,7 @@ export const judgeTypeAndCategory = async (
   dics: Dics,
   prompts: Prompts,
   model?: string,
+  signal?: AbortSignal,
 ): Promise<void> => {
   const tmpl = prompts.prompts.get('type-category');
   if (!tmpl) {
@@ -79,7 +82,7 @@ export const judgeTypeAndCategory = async (
   let category = DEFAULT_FALLBACK_CATEGORY;
 
   try {
-    const _raw = await runAI(_system, _user, { ...(model ? { model } : {}) });
+    const _raw = await runAI(_system, _user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
     const _lines = _raw.trim().split('\n');
     const _typeMatch = _lines.find((l) => l.startsWith('type:'));
     const _catMatch = _lines.find((l) => l.startsWith('category:'));
@@ -93,7 +96,10 @@ export const judgeTypeAndCategory = async (
     if (_parsedCategory && _validCategories.has(_parsedCategory)) {
       category = _parsedCategory;
     }
-  } catch {
+  } catch (e) {
+    if (isRateLimitError(e) || signal?.aborted) {
+      throw e;
+    }
     // fall through to fallback values
     type = DEFAULT_FALLBACK_TYPE;
     category = DEFAULT_FALLBACK_CATEGORY;

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 // stub
 import { spy } from '@std/testing/mock';
@@ -230,6 +230,38 @@ describe('_phaseFrontmatter', () => {
         warnSpy.restore();
         cacheSpy.restore();
       }
+    });
+  });
+
+  /**
+   * 先頭ファイルが RateLimit を throw したとき、残りのファイルの生成が中断されるケース。
+   */
+  describe('When: generateProvider が RateLimit を throw する', () => {
+    it('[Error] T-02-05-01: 先頭が RateLimit → 2 番目以降の generateProvider が呼ばれず ChatlogError を再 throw', async () => {
+      const cache = await _makeCache();
+      let _count = 0;
+      const _rateLimitStub: _GenerateProvider = (_entry, _maxLen, _dics, _prompts) => {
+        _count++;
+        throw new ChatlogError('AiError', 'RateLimit', 'simulated rate limit');
+      };
+      const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
+
+      // concurrency=1 で逐次実行 → 先頭 throw で abort し 2 番目は着手されない
+      const error = await assertRejects(
+        () =>
+          phaseFrontmatter(
+            entries,
+            cache,
+            1000,
+            _FAKE_DICS,
+            _FAKE_PROMPTS,
+            { concurrency: 1, dryRun: false },
+            _rateLimitStub,
+          ),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'AiError');
+      assertEquals(_count, 1);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 // stub
 import { spy } from '@std/testing/mock';
@@ -363,6 +363,29 @@ describe('phaseReview', () => {
       await phaseReview([entry], cache, _dics, _prompts, { concurrency: 1, dryRun: false }, stub);
 
       assertEquals(cache.read(filePath).frontmatter?.['title'], 'cached-title');
+    });
+  });
+
+  /**
+   * 先頭ファイルが RateLimit を throw したとき、残りのファイルのレビューが中断されるケース。
+   */
+  describe('When: reviewProvider が RateLimit を throw する', () => {
+    it('[Error] T-04-05-01: 先頭が RateLimit → 2 番目以降の reviewProvider が呼ばれず ChatlogError を再 throw', async () => {
+      const cache = await _makeCache();
+      let _count = 0;
+      const _rateLimitStub: _ReviewProvider = (_entry, _dics, _prompts) => {
+        _count++;
+        throw new ChatlogError('AiError', 'RateLimit', 'simulated rate limit');
+      };
+      const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
+
+      // concurrency=1 で逐次実行 → 先頭 throw で abort し 2 番目は着手されない
+      const error = await assertRejects(
+        () => phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: false }, _rateLimitStub),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'AiError');
+      assertEquals(_count, 1);
     });
   });
 });

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-type-category.unit.spec.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assert, assertEquals, assertRejects } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 // stub
 import { spy } from '@std/testing/mock';
@@ -21,6 +21,7 @@ import { phaseTypeAndCategory } from '../../phase-type-category.ts';
 // ─── Helpers
 import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 // constants
 import { CACHE_STATUSES } from '../../../../../_scripts/types/cache-status.const.types.ts';
 // types
@@ -36,6 +37,8 @@ type _JudgeProvider = (
   maxContentLength: number,
   dics: Dics,
   prompts: Prompts,
+  model?: string,
+  signal?: AbortSignal,
 ) => Promise<void>;
 
 // constants
@@ -358,6 +361,69 @@ describe('_phaseTypeAndCategory', () => {
           assertEquals(getCount(), 1);
         },
       );
+    });
+  });
+
+  /**
+   * 先頭ファイルが RateLimit を throw したとき、残りのファイルの判定が中断されるケース。
+   */
+  describe('When: judgeProvider が RateLimit を throw する', () => {
+    it('[Error] T-01-05-01: 先頭が RateLimit → 2 番目以降の judgeProvider が呼ばれず ChatlogError を再 throw', async () => {
+      const cache = await _makeCache();
+      let _count = 0;
+      const _rateLimitStub: _JudgeProvider = (_entry, _maxLen, _dics, _prompts) => {
+        _count++;
+        throw new ChatlogError('AiError', 'RateLimit', 'simulated rate limit');
+      };
+      const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
+
+      // concurrency=1 で逐次実行 → 先頭 throw で abort し 2 番目は着手されない
+      const error = await assertRejects(
+        () =>
+          phaseTypeAndCategory(
+            entries,
+            cache,
+            1000,
+            _DICS,
+            _PROMPTS,
+            { concurrency: 1, dryRun: false },
+            _rateLimitStub,
+          ),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'AiError');
+      assertEquals(_count, 1);
+    });
+  });
+
+  /**
+   * worker が `runConcurrent` の `ctl.signal` を judgeProvider へ転送するケース。
+   *
+   * この転送があることで、兄弟ファイルが RateLimit で abort したとき in-flight の judge が signal を受け取れる。
+   */
+  describe('When: signal 転送', () => {
+    it('[Normal] T-01-06-01: judgeProvider に AbortSignal が転送される', async () => {
+      const cache = await _makeCache();
+      let _captured: AbortSignal | undefined;
+      const _captureStub: _JudgeProvider = (entry, _maxLen, _dics, _prompts, _model, signal) => {
+        _captured = signal;
+        entry.frontmatter.set('type', 'stub');
+        entry.frontmatter.set('category', 'stub');
+        return Promise.resolve();
+      };
+      const entries = [_makeEntry('/path/to/a.md')];
+
+      await phaseTypeAndCategory(
+        entries,
+        cache,
+        1000,
+        _DICS,
+        _PROMPTS,
+        { concurrency: 1, dryRun: false },
+        _captureStub,
+      );
+
+      assert(_captured instanceof AbortSignal, 'signal was not forwarded to judgeProvider');
     });
   });
 });

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -13,6 +13,7 @@
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -32,6 +33,7 @@ type _GenerateProvider = (
   prompts: Prompts,
   maxRetry: number,
   model?: string,
+  signal?: AbortSignal,
 ) => Promise<boolean>;
 
 export const phaseFrontmatter = async (
@@ -96,14 +98,17 @@ export const phaseFrontmatter = async (
   const _generate = generateProvider ?? generateFrontmatter;
   await runConcurrent(
     _needsGenerate,
-    async (entry) => {
+    async (entry, ctl) => {
       if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}frontmatter: ${getFilename(entry.filePath!)}`);
       } else {
         let _ok: boolean;
         try {
-          _ok = await _generate(entry, maxContentLength, dics, prompts, config.maxRetry ?? 0, config.model);
+          _ok = await _generate(entry, maxContentLength, dics, prompts, config.maxRetry ?? 0, config.model, ctl.signal);
         } catch (e) {
+          if (isRateLimitError(e) || ctl.signal.aborted) {
+            throw e;
+          }
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
         }

--- a/skills/set-frontmatter/scripts/phases/phase-review.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-review.ts
@@ -13,6 +13,7 @@
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -32,6 +33,7 @@ type _ReviewProvider = (
   prompts: Prompts,
   maxRetry: number,
   model?: string,
+  signal?: AbortSignal,
 ) => Promise<ReviewResult>;
 
 export const phaseReview = async (
@@ -52,14 +54,17 @@ export const phaseReview = async (
   const _review = reviewProvider ?? reviewFrontmatter;
   await runConcurrent(
     _misses,
-    async (entry) => {
+    async (entry, ctl) => {
       if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}review: ${getFilename(entry.filePath!)}`);
       } else {
         let r: ReviewResult;
         try {
-          r = await _review(entry, dics, prompts, config.maxRetry ?? 0, config.model);
+          r = await _review(entry, dics, prompts, config.maxRetry ?? 0, config.model, ctl.signal);
         } catch (e) {
+          if (isRateLimitError(e) || ctl.signal.aborted) {
+            throw e;
+          }
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
         }

--- a/skills/set-frontmatter/scripts/phases/phase-type-category.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-type-category.ts
@@ -30,6 +30,7 @@ type _JudgeProvider = (
   dics: Dics,
   prompts: Prompts,
   model?: string,
+  signal?: AbortSignal,
 ) => Promise<void>;
 
 export const phaseTypeAndCategory = async (
@@ -63,11 +64,11 @@ export const phaseTypeAndCategory = async (
   const _judge = judgeProvider ?? judgeTypeAndCategory;
   await runConcurrent(
     _misses,
-    async (entry) => {
+    async (entry, ctl) => {
       if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}type/category: ${getFilename(entry.filePath!)}`);
       } else {
-        await _judge(entry, maxContentLength, dics, prompts, config.model);
+        await _judge(entry, maxContentLength, dics, prompts, config.model, ctl.signal);
         const _type = entry.frontmatter.get('type') as string;
         const _category = entry.frontmatter.get('category') as string;
         if (_type && _category) {


### PR DESCRIPTION
## Overview

**Summary**
Propagate rate-limit and abort errors from AI execution instead of masking them as fallbacks.

**Background / Motivation**
AI/CLI runs in the `set-frontmatter` skill and the shared `_scripts/libs/ai/` helpers
used to swallow every failure and return fallback values. This hid usage-limit
(429 / rate limit) responses and user aborts, so they looked like successful runs.
Following the fail-first principle, rate-limit errors and aborted signals now
surface to the caller. Ordinary AI failures keep their existing fallback behavior.

## Changes

### Core Changes

Shared AI library (`skills/_scripts/libs/ai/`):

- `rate-limit-utils.ts` (new): adds `isRateLimitError` to detect rate-limit `ChatlogError` instances.
- `run-ai.ts`: detects rate-limit / 429 / usage-limit output in both stdout and stderr (previously stderr only).

`set-frontmatter` modules and phases:

- `modules/setfm-type-category.ts`, `modules/setfm-frontmatter.ts`, `modules/setfm-review.ts`:
  accept an optional `AbortSignal` and re-throw rate-limit / abort errors instead of applying fallbacks.
- `phases/phase-frontmatter.ts`, `phases/phase-review.ts`, `phases/phase-type-category.ts`:
  propagate rate-limit and abort errors from the underlying modules.

`classify-chatlogs` (shares the same AI helpers):

- `modules/segment-ai.ts`, `phases/phase-classify-ai.ts`: refactored to use the shared rate-limit utility.

### Test Updates

- `_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts` (new)
- `_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts`
- `set-frontmatter` module tests: `judge-type-category`, `setfm-frontmatter`, `setfm-review`
- `set-frontmatter` phase tests: `phase-frontmatter`, `phase-review`, `phase-type-category`

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. No commit carries a `BREAKING CHANGE:` footer or `!` marker, and the new
`AbortSignal` parameters are optional, so existing call signatures stay
backward-compatible. Note that RateLimit and abort errors now propagate rather
than being swallowed, so callers that relied on these functions never throwing
will now see the error surface.

## Additional Notes

The intent is to stop treating transient usage-limit responses and user aborts as
normal AI failures. Masking them as fallbacks hid retry opportunities and made
abort ineffective; propagating them lets the caller decide how to handle a rate
limit or a cancelled run.

(10 commits, 18 files changed, +681 / -31.)
