### PR TITLE
fix(set-frontmatter): abort on fatal AI CLI errors instead of retrying

### DIFF
--- a/skills/_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts
@@ -1,6 +1,6 @@
 // src: skills/_scripts/libs/ai/__tests__/unit/rate-limit-utils.unit.spec.ts
 // @(#): rate-limit-utils のユニットテスト
-//       対象: isRateLimitError
+//       対象: isRateLimitError, isFatalAiError
 //
 // Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 //
@@ -12,7 +12,7 @@ import { assertEquals } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 
 // ─── Test target
-import { isRateLimitError } from '../../rate-limit-utils.ts';
+import { isFatalAiError, isRateLimitError } from '../../rate-limit-utils.ts';
 
 // ─── Helpers
 import { ChatlogError } from '../../../../classes/ChatlogError.class.ts';
@@ -95,6 +95,88 @@ describe('isRateLimitError', () => {
     for (const { id, label, desc, value } of _falseCases) {
       it(`[${label}] ${id}: ${desc}`, () => {
         assertEquals(isRateLimitError(value), false);
+      });
+    }
+  });
+});
+
+// ─── Internal Helpers (isFatalAiError)
+
+// constants
+/** `isFatalAiError` が `true` を返すべきケース（AiError の subindex を問わない致命エラー）。 */
+const _fatalTrueCases = [
+  {
+    id: 'T-LIB-AI-FA-01',
+    label: 'Normal',
+    desc: 'kind=AiError かつ subindex=ExitFailure の ChatlogError → true',
+    value: new ChatlogError('AiError', 'ExitFailure'),
+  },
+  {
+    id: 'T-LIB-AI-FA-02',
+    label: 'Normal',
+    desc: 'kind=AiError かつ subindex=RateLimit の ChatlogError → true',
+    value: new ChatlogError('AiError', 'RateLimit'),
+  },
+] as const;
+
+/** `isFatalAiError` が `false` を返すべきケース（非 AiError / 非 ChatlogError / 非 Error 値）。 */
+const _fatalFalseCases = [
+  {
+    id: 'T-LIB-AI-FA-03',
+    label: 'Error',
+    desc: 'kind 違いの ChatlogError（TimedOut/Timeout）→ false',
+    value: new ChatlogError('TimedOut', 'Timeout'),
+  },
+  {
+    id: 'T-LIB-AI-FA-04',
+    label: 'Error',
+    desc: 'ChatlogError 以外の Error → false',
+    value: new Error('AiError'),
+  },
+  {
+    id: 'T-LIB-AI-FA-05',
+    label: 'Edge',
+    desc: '非 Error 値（string）→ false',
+    value: 'AiError',
+  },
+  {
+    id: 'T-LIB-AI-FA-06',
+    label: 'Edge',
+    desc: '非 Error 値（null）→ false',
+    value: null,
+  },
+  {
+    id: 'T-LIB-AI-FA-07',
+    label: 'Edge',
+    desc: '非 Error 値（undefined）→ false',
+    value: undefined,
+  },
+] as const;
+
+/**
+ * `isFatalAiError` のユニットテストスイート。
+ *
+ * AI CLI が非0終了で落ちた致命的 `ChatlogError`（kind==='AiError'）を、
+ * subindex（ExitFailure / RateLimit 等）を問わず `true` と判定し、
+ * それ以外（kind 違い / 非 ChatlogError / 非 Error 値）は `false` になることを検証する。
+ *
+ * テスト ID 範囲: T-LIB-AI-FA-01 〜 T-LIB-AI-FA-07
+ *
+ * @see isFatalAiError
+ */
+describe('isFatalAiError', () => {
+  describe('When: 正常系', () => {
+    for (const { id, label, desc, value } of _fatalTrueCases) {
+      it(`[${label}] ${id}: ${desc}`, () => {
+        assertEquals(isFatalAiError(value), true);
+      });
+    }
+  });
+
+  describe('When: 異常系・エッジケース', () => {
+    for (const { id, label, desc, value } of _fatalFalseCases) {
+      it(`[${label}] ${id}: ${desc}`, () => {
+        assertEquals(isFatalAiError(value), false);
       });
     }
   });

--- a/skills/_scripts/libs/ai/rate-limit-utils.ts
+++ b/skills/_scripts/libs/ai/rate-limit-utils.ts
@@ -18,3 +18,14 @@ import { ChatlogError } from '../../classes/ChatlogError.class.ts';
  */
 export const isRateLimitError = (e: unknown): boolean =>
   e instanceof ChatlogError && e.kind === 'AiError' && e.subindex === 'RateLimit';
+
+/**
+ * 与えられた値が AI CLI の非0終了由来の致命的 `ChatlogError` かどうかを判定する。
+ *
+ * rate limit / exit failure など subindex を問わず `kind==='AiError'` を致命とみなす。
+ * リトライ・フォールバックせず即 abort すべきエラーの判定に用いる。
+ *
+ * @param e - 判定対象の値（catch 節で受け取る `unknown` を想定）
+ * @returns `kind==='AiError'` の `ChatlogError` なら `true`、それ以外は `false`
+ */
+export const isFatalAiError = (e: unknown): boolean => e instanceof ChatlogError && e.kind === 'AiError';

--- a/skills/set-frontmatter/scripts/__tests__/e2e/cache-dir.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/cache-dir.e2e.spec.ts
@@ -17,7 +17,7 @@ import { main } from '../../set-frontmatter.ts';
 import { installCommandMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
-import { _enc, _makeDicsDir, _makeSequentialMock } from '../helpers/setfm-e2e-helpers.ts';
+import { enc, makeDicsDir, makeSequentialMock } from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -41,14 +41,14 @@ describe('main - --cache-dir オプション', () => {
           inputDir = await Deno.makeTempDir();
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
+          dicsDir = await makeDicsDir();
 
           await Deno.writeTextFile(`${inputDir}/test.md`, '# テスト\n本文テキスト');
 
           commandHandle = installCommandMock(
-            _makeSequentialMock([
-              _enc.encode('research\ndevelopment'),
-              _enc.encode(
+            makeSequentialMock([
+              enc.encode('research\ndevelopment'),
+              enc.encode(
                 'title: Generated Title\ntopics:\n  - development\ntags:\n  - lang:typescript\n',
               ),
             ]),

--- a/skills/set-frontmatter/scripts/__tests__/e2e/dry-run.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/dry-run.e2e.spec.ts
@@ -18,11 +18,11 @@ import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__test
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import {
-  _enc,
-  _makeCacheDir,
-  _makeDicsDir,
-  _makeTargetDir,
-  _makeTwoFileDir,
+  enc,
+  makeCacheDir,
+  makeDicsDir,
+  makeTargetDir,
+  makeTwoFileDir,
 } from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -43,9 +43,9 @@ describe('main - dry-run モード', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
+          dicsDir = await makeDicsDir();
 
           // 各フェーズの応答を順番に返す（全呼び出しで成功）
           const callIdx = 0;
@@ -56,7 +56,7 @@ describe('main - dry-run モード', () => {
             'validity: pass',
           ];
           commandHandle = installCommandMock(
-            makeSuccessMock(_enc.encode(phaseResponses.join('\n')), { value: [] }),
+            makeSuccessMock(enc.encode(phaseResponses.join('\n')), { value: [] }),
           );
           void callIdx;
 
@@ -135,11 +135,11 @@ describe('main - dry-run モード', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir('---\ntitle: Test\n---\n# body\n');
+          inputDir = await makeTargetDir('---\ntitle: Test\n---\n# body\n');
           outputDir = await Deno.makeTempDir();
-          cacheDir = await _makeCacheDir(['test']);
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          cacheDir = await makeCacheDir(['test']);
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
           loggerStub = makeLoggerStub();
         });
 
@@ -200,11 +200,11 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTwoFileDir();
+          inputDir = await makeTwoFileDir();
           outputDir = await Deno.makeTempDir();
-          cacheDir = await _makeCacheDir(['written']);
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          cacheDir = await makeCacheDir(['written']);
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
           loggerStub = makeLoggerStub();
         });
 
@@ -249,11 +249,11 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          cacheDir = await _makeCacheDir(['test']);
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          cacheDir = await makeCacheDir(['test']);
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
           loggerStub = makeLoggerStub();
         });
 
@@ -298,11 +298,11 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
           loggerStub = makeLoggerStub();
         });
 
@@ -347,11 +347,11 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTwoFileDir();
+          inputDir = await makeTwoFileDir();
           outputDir = await Deno.makeTempDir();
-          cacheDir = await _makeCacheDir(['written']);
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          cacheDir = await makeCacheDir(['written']);
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
           loggerStub = makeLoggerStub();
         });
 
@@ -413,11 +413,11 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          cacheDir = await _makeCacheDir(['test']);
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('research')));
+          cacheDir = await makeCacheDir(['test']);
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
           loggerStub = makeLoggerStub();
         });
 
@@ -451,6 +451,183 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
   });
 });
 
+// ─── T-SF-DR-06: dry-run cached/skip 内訳集計 ────────────────────────────────
+
+describe('main - dry-run cached/skip 内訳 (T-SF-DR-06)', () => {
+  /**
+   * `--dry-run` 時、generateEntries をファイル単位で cached/skip に分類した内訳ログを検証する。
+   *
+   * cached: 再実行しても AI を呼ばないファイル。
+   * skip: 再実行すると AI を呼ぶファイル（3述語のいずれかが true）。
+   *
+   * テスト ID 範囲: T-SF-DR-06-01 〜 T-SF-DR-06-02
+   */
+  describe('Given: cache エントリなしの .md 1件（全 target = AI 判定対象）', () => {
+    describe('When: main([--dry-run, --no-review, ...]) を呼び出す', () => {
+      describe('Then: T-SF-DR-06-01 - 内訳ログに cached=0 skip=1 が含まれる', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Normal] T-SF-DR-06-01: infoLogs に "dry-run 内訳: cached=0 skip=1" が含まれる', async () => {
+          await main([
+            '--input-dir',
+            inputDir,
+            '--output-dir',
+            outputDir,
+            '--cache-dir',
+            cacheDir,
+            '--dry-run',
+            '--no-review',
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(
+            loggerStub.infoLogs.some((l) => l.includes('dry-run 内訳: cached=0 skip=1')),
+            true,
+          );
+        });
+      });
+    });
+  });
+
+  describe('Given: cache に 1件 need-review+frontmatter（cached）+ 1件 cache miss（skip）', () => {
+    describe('When: main([--dry-run, --cache-dir, --no-review, ...]) を呼び出す', () => {
+      describe('Then: T-SF-DR-06-03 - 内訳ログに cached=1 skip=1 が含まれる', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTwoFileDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          // target.md を「生成済み（need-review + 全5フィールド frontmatter）」で登録 → cached。
+          // written.md は cache 未登録 → cache miss → skip。
+          const fmCacheDir = `${cacheDir}/fm-cache`;
+          await Deno.mkdir(fmCacheDir, { recursive: true });
+          await Deno.writeTextFile(
+            `${fmCacheDir}/target.json`,
+            JSON.stringify({
+              status: 'need-review',
+              type: 'tech',
+              category: 'backend',
+              frontmatter: { type: 'tech', category: 'backend', title: 't', topics: ['a'], tags: ['b'] },
+            }),
+          );
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Normal] T-SF-DR-06-03: infoLogs に "dry-run 内訳: cached=1 skip=1" が含まれる', async () => {
+          await main([
+            '--input-dir',
+            inputDir,
+            '--output-dir',
+            outputDir,
+            '--cache-dir',
+            cacheDir,
+            '--dry-run',
+            '--no-review',
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(
+            loggerStub.infoLogs.some((l) => l.includes('dry-run 内訳: cached=1 skip=1')),
+            true,
+          );
+        });
+      });
+    });
+  });
+
+  describe('Given: dry-run フラグなし（通常実行）', () => {
+    describe('When: main([--no-review, ...]) を dry-run なしで呼び出す', () => {
+      describe('Then: T-SF-DR-06-02 - 内訳ログを出力しない', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Normal] T-SF-DR-06-02: infoLogs に "dry-run 内訳:" が含まれない', async () => {
+          await main([
+            '--input-dir',
+            inputDir,
+            '--output-dir',
+            outputDir,
+            '--cache-dir',
+            cacheDir,
+            '--no-review',
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(
+            loggerStub.infoLogs.every((l) => !l.includes('dry-run 内訳:')),
+            true,
+          );
+        });
+      });
+    });
+  });
+});
+
 // ─── T-SF-E2E-DR-05: dry-run → FAIL(yaml空) が出ない ────────────────────────
 
 describe('main - dry-run FAIL抑制 (T-SF-E2E-DR-05)', () => {
@@ -470,12 +647,12 @@ describe('main - dry-run FAIL抑制 (T-SF-E2E-DR-05)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
+          dicsDir = await makeDicsDir();
           // 全フェーズで空文字を返す（status が空になる条件）
           commandHandle = installCommandMock(
-            makeSuccessMock(_enc.encode('')),
+            makeSuccessMock(enc.encode('')),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
@@ -18,7 +18,14 @@ import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts
 // ─── Helpers
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
-import { _enc, _makeDicsDir, _makeRateLimitMock, _makeTargetDir } from '../helpers/setfm-e2e-helpers.ts';
+import {
+  enc,
+  makeBannerFailOnNthMock,
+  makeDicsDir,
+  makeRateLimitMock,
+  makeSuccessThenBannerFailMock,
+  makeTargetDir,
+} from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -38,12 +45,12 @@ describe('main - yaml 生成失敗', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
+          dicsDir = await makeDicsDir();
           // 全フェーズで空文字を返す（title: なし → cleanYaml で空になる）
           commandHandle = installCommandMock(
-            makeSuccessMock(_enc.encode('')),
+            makeSuccessMock(enc.encode('')),
           );
           loggerStub = makeLoggerStub();
         });
@@ -89,10 +96,10 @@ describe('main - rate limit 貫通 (T-SF-E2E-13)', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
-          commandHandle = installCommandMock(_makeRateLimitMock());
+          dicsDir = await makeDicsDir();
+          commandHandle = installCommandMock(makeRateLimitMock());
           loggerStub = makeLoggerStub();
         });
 
@@ -121,6 +128,214 @@ describe('main - rate limit 貫通 (T-SF-E2E-13)', () => {
           ) as ChatlogError;
           assertEquals(_err.kind, 'AiError');
           assertEquals(_err.subindex, 'RateLimit');
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-16: exit failure(sandbox バナー) が Phase 2.1 で main を reject（バグの発生箇所） ─
+
+/**
+ * バグ再現テスト。Phase 2.1（type/category）の最初の runAI が exit 1 + sandbox バナー
+ * （rate limit 文字列なし）で落ちたとき、以前はデフォルト type/category を黙って書き込んでいた。
+ * 修正後は `ExitFailure` が judgeTypeAndCategory(即throw) → phaseTypeAndCategory(try/catchなし・素通し)
+ * → withConcurrency abort → main と貫通し、`main()` が `ChatlogError(AiError/ExitFailure)` で reject する。
+ *
+ * テスト ID 範囲: T-SF-E2E-16-01
+ */
+describe('main - exit failure 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-16)', () => {
+  describe('Given: Phase2.1 最初の runAI が sandbox バナー exit failure を返すモック', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--cache-dir", ..., "--no-review", "--dics", ...]) を呼び出す', () => {
+      describe('Then: T-SF-E2E-16 - main が ChatlogError(AiError/ExitFailure) で reject する', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          // 1回目(type/category)のみ banner exit failure。以降(frontmatter)は success。
+          // Phase 2.1 が握りつぶすと後続が成功し main は resolve するため、Phase 2.1 の
+          // abort ゲート単体を分離検証できる（gate 未修正なら resolve = RED）。
+          commandHandle = installCommandMock(
+            makeBannerFailOnNthMock(
+              1,
+              'type: research\ncategory: development\ntitle: "t"\ntopics:\n  - ai\ntags:\n  - test\n',
+            ),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Error] T-SF-E2E-16-01: Phase 2.1 の exit failure が貫通し ChatlogError(AiError/ExitFailure) で reject する', async () => {
+          const _err = await assertRejects(
+            () =>
+              main([
+                '--input-dir',
+                inputDir,
+                '--output-dir',
+                outputDir,
+                '--cache-dir',
+                cacheDir,
+                '--no-review',
+                '--dics',
+                dicsDir,
+              ]),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-14: exit failure(sandbox バナー) が frontmatter フェーズを貫通して main を reject ─
+
+/**
+ * Phase 2.1（type/category）は成功し、Phase 2.2（frontmatter 生成）の runAI が
+ * exit 1 + sandbox バナー（rate limit 文字列なし）で落ちたとき、`ExitFailure` が
+ * generateFrontmatter(即throw) → phaseFrontmatter の abort ゲート → withConcurrency abort → main
+ * と貫通し、`main()` が `ChatlogError(AiError/ExitFailure)` で reject することを検証する。
+ *
+ * テスト ID 範囲: T-SF-E2E-14-01
+ */
+describe('main - exit failure 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', () => {
+  describe('Given: Phase2.1 成功・Phase2.2 で sandbox バナー exit failure を返すモック', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", "--dics", ...]) を呼び出す', () => {
+      describe('Then: T-SF-E2E-14 - main が ChatlogError(AiError/ExitFailure) で reject する', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          // 1回目(type/category)成功、2回目以降(frontmatter)を banner exit failure にする
+          commandHandle = installCommandMock(
+            makeSuccessThenBannerFailMock(1, 'type: research\ncategory: development'),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Error] T-SF-E2E-14-01: frontmatter フェーズの exit failure が貫通し ChatlogError(AiError/ExitFailure) で reject する', async () => {
+          const _err = await assertRejects(
+            () =>
+              main([
+                '--input-dir',
+                inputDir,
+                '--output-dir',
+                outputDir,
+                '--cache-dir',
+                cacheDir,
+                '--no-review',
+                '--dics',
+                dicsDir,
+              ]),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-15: exit failure(sandbox バナー) が review フェーズを貫通して main を reject ─
+
+/**
+ * Phase 2.1（type/category）と Phase 2.2（frontmatter）は成功し、Phase 3.1（review）の
+ * runAI が exit 1 + sandbox バナー（rate limit 文字列なし）で落ちたとき、`ExitFailure` が
+ * reviewFrontmatter(即throw) → phaseReview の abort ゲート → withConcurrency abort → main
+ * と貫通し、`main()` が `ChatlogError(AiError/ExitFailure)` で reject することを検証する。
+ *
+ * review フェーズを実行するため `--no-review` は付けない。
+ *
+ * テスト ID 範囲: T-SF-E2E-15-01
+ */
+describe('main - exit failure 貫通 (review フェーズ) (T-SF-E2E-15)', () => {
+  describe('Given: Phase2.1/2.2 成功・Phase3.1(review) で sandbox バナー exit failure を返すモック', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--dics", ...]) を呼び出す', () => {
+      describe('Then: T-SF-E2E-15 - main が ChatlogError(AiError/ExitFailure) で reject する', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          // 1回目(type/category)+2回目(frontmatter)成功、3回目以降(review)を banner exit failure にする。
+          // frontmatter フェーズが必須フィールドを生成できるよう title/topics/tags を返す。
+          commandHandle = installCommandMock(
+            makeSuccessThenBannerFailMock(
+              2,
+              'type: research\ncategory: development\ntitle: "t"\ntopics:\n  - ai\ntags:\n  - test\n',
+            ),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Error] T-SF-E2E-15-01: review フェーズの exit failure が貫通し ChatlogError(AiError/ExitFailure) で reject する', async () => {
+          const _err = await assertRejects(
+            () =>
+              main([
+                '--input-dir',
+                inputDir,
+                '--output-dir',
+                outputDir,
+                '--cache-dir',
+                cacheDir,
+                '--dics',
+                dicsDir,
+              ]),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
         });
       });
     });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/input-dir.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/input-dir.e2e.spec.ts
@@ -17,7 +17,7 @@ import { main } from '../../set-frontmatter.ts';
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
-import { _enc, _makeDicsDir } from '../helpers/setfm-e2e-helpers.ts';
+import { enc, makeDicsDir } from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -49,7 +49,7 @@ describe('main - --input-dir 未指定（デフォルト絞り込み）', () => 
           await Deno.writeTextFile(`${agentDir}/test.md`, '# テスト\n本文テキスト');
 
           outputDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
+          dicsDir = await makeDicsDir();
 
           GlobalConfig.resetInstance();
           await GlobalConfig.getInstance({
@@ -58,7 +58,7 @@ describe('main - --input-dir 未指定（デフォルト絞り込み）', () => 
           });
 
           commandHandle = installCommandMock(
-            makeSuccessMock(_enc.encode('research\ndevelopment'), { value: [] }),
+            makeSuccessMock(enc.encode('research\ndevelopment'), { value: [] }),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/review.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/review.e2e.spec.ts
@@ -16,7 +16,7 @@ import { main } from '../../set-frontmatter.ts';
 // ─── Helpers
 import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
-import { _enc, _makeDicsDir, _makeTargetDir } from '../helpers/setfm-e2e-helpers.ts';
+import { enc, makeDicsDir, makeTargetDir } from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -36,11 +36,11 @@ describe('main - --no-review モード', () => {
         let loggerStub: LoggerStub;
 
         beforeEach(async () => {
-          inputDir = await _makeTargetDir();
+          inputDir = await makeTargetDir();
           outputDir = await Deno.makeTempDir();
-          dicsDir = await _makeDicsDir();
+          dicsDir = await makeDicsDir();
           commandHandle = installCommandMock(
-            makeSuccessMock(_enc.encode('research')),
+            makeSuccessMock(enc.encode('research')),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
+++ b/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
@@ -11,14 +11,14 @@ import { BaseMockCommand } from '../../../../_scripts/__tests__/helpers/deno-com
 // types
 import type { DenoCommandLike } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
-export const _enc = new TextEncoder();
+export const enc = new TextEncoder();
 
 /**
  * dics + prompts ディレクトリを作成し、最低限のファイルを配置する。
  * loadDics は dicsDir の末尾 "dics" を "prompts" に置換して promptsDir を決定するため、
  * baseDir/dics の形式でディレクトリを作成する。
  */
-export async function _makeDicsDir(): Promise<string> {
+export async function makeDicsDir(): Promise<string> {
   const baseDir = await Deno.makeTempDir();
   const dicsDir = `${baseDir}/dics`;
   const promptsDir = `${baseDir}/prompts`;
@@ -59,7 +59,7 @@ export async function _makeDicsDir(): Promise<string> {
 }
 
 /** .md ファイルを持つ targetDir を作成する */
-export async function _makeTargetDir(content?: string): Promise<string> {
+export async function makeTargetDir(content?: string): Promise<string> {
   const targetDir = await Deno.makeTempDir();
   const mdContent = content ?? '# テスト\n本文テキスト';
   await Deno.writeTextFile(`${targetDir}/test.md`, mdContent);
@@ -70,7 +70,7 @@ export async function _makeTargetDir(content?: string): Promise<string> {
  * 2件の .md ファイルを持つ inputDir を作成する。
  * `written.md` と `target.md` を配置する。
  */
-export const _makeTwoFileDir = async (): Promise<string> => {
+export const makeTwoFileDir = async (): Promise<string> => {
   const dir = await Deno.makeTempDir();
   await Deno.writeTextFile(`${dir}/written.md`, '# written\n本文');
   await Deno.writeTextFile(`${dir}/target.md`, '# target\n本文');
@@ -81,7 +81,7 @@ export const _makeTwoFileDir = async (): Promise<string> => {
  * キャッシュディレクトリを作成し、指定キーに `{ status: 'written' }` の JSON を書き込む。
  * @param basenames - 拡張子なしファイル名（例: `['written']`）
  */
-export const _makeCacheDir = async (basenames: string[]): Promise<string> => {
+export const makeCacheDir = async (basenames: string[]): Promise<string> => {
   const cacheDir = await Deno.makeTempDir();
   const fmCacheDir = `${cacheDir}/fm-cache`;
   await Deno.mkdir(fmCacheDir, { recursive: true });
@@ -96,7 +96,7 @@ export const _makeCacheDir = async (basenames: string[]): Promise<string> => {
  *
  * `responses` の順番に応答し、範囲外のインデックスは最後の応答を返す。
  */
-export const _makeSequentialMock = (responses: Uint8Array[]): DenoCommandLike => {
+export const makeSequentialMock = (responses: Uint8Array[]): DenoCommandLike => {
   let callCount = 0;
   return class extends BaseMockCommand {
     private readonly _stdout: Uint8Array;
@@ -121,15 +121,88 @@ export const _makeSequentialMock = (responses: Uint8Array[]): DenoCommandLike =>
  * @param stdout - rate limit を示す stdout 文字列（既定: "Claude usage limit reached"）
  * @returns rate limit 応答を返す `DenoCommandLike` モッククラス
  */
-export const _makeRateLimitMock = (stdout = 'Claude usage limit reached'): DenoCommandLike => {
+export const makeRateLimitMock = (stdout = 'Claude usage limit reached'): DenoCommandLike => {
   return class extends BaseMockCommand {
     protected makeOutput() {
       return Promise.resolve({
         success: false,
         code: 1,
-        stdout: _enc.encode(stdout),
+        stdout: enc.encode(stdout),
         stderr: new Uint8Array(),
       });
+    }
+  } as unknown as DenoCommandLike;
+};
+
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+export const SANDBOX_BANNER =
+  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+
+/**
+ * 最初の `okCount` 回は指定 stdout で成功し、それ以降は exit 1 + sandbox バナー（stderr）で失敗するモック。
+ *
+ * バナーは rate limit 文字列を含まないため `runAI` で `ExitFailure` に分類される。
+ * Phase 2.1（type/category）を成功させてから後続フェーズ（frontmatter / review）で
+ * exit failure を発生させ、fatal 伝播でバッチが abort することを検証するために使用する。
+ *
+ * @param okCount - 成功させる先頭呼び出し回数
+ * @param okStdout - 成功時に返す stdout 文字列
+ * @returns `DenoCommandLike` モッククラス
+ */
+export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string): DenoCommandLike => {
+  let callCount = 0;
+  const _okBytes = enc.encode(okStdout);
+  return class extends BaseMockCommand {
+    private readonly _fail: boolean;
+    constructor(_cmd: string, _opts: unknown) {
+      super();
+      this._fail = callCount >= okCount;
+      callCount++;
+    }
+    protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+      if (this._fail) {
+        return Promise.resolve({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: enc.encode(SANDBOX_BANNER),
+        });
+      }
+      return Promise.resolve({ success: true, code: 0, stdout: _okBytes, stderr: new Uint8Array() });
+    }
+  } as unknown as DenoCommandLike;
+};
+
+/**
+ * `failOn`（1始まり）番目の呼び出しだけ exit 1 + sandbox バナーで失敗し、他は success を返すモック。
+ *
+ * 特定フェーズ 1 箇所だけを exit failure にして、そのフェーズの abort ゲート単体が
+ * バッチを止めることを分離検証するために使用する（後続フェーズが救済しない構成）。
+ *
+ * @param failOn - 失敗させる呼び出し番号（1始まり）
+ * @param okStdout - success 時に返す stdout 文字列
+ * @returns `DenoCommandLike` モッククラス
+ */
+export const makeBannerFailOnNthMock = (failOn: number, okStdout: string): DenoCommandLike => {
+  let callCount = 0;
+  const _okBytes = enc.encode(okStdout);
+  return class extends BaseMockCommand {
+    private readonly _fail: boolean;
+    constructor(_cmd: string, _opts: unknown) {
+      super();
+      callCount++;
+      this._fail = callCount === failOn;
+    }
+    protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+      if (this._fail) {
+        return Promise.resolve({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: enc.encode(SANDBOX_BANNER),
+        });
+      }
+      return Promise.resolve({ success: true, code: 0, stdout: _okBytes, stderr: new Uint8Array() });
     }
   } as unknown as DenoCommandLike;
 };

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -84,6 +84,28 @@ class _RateLimitMockCommand extends BaseMockCommand {
   }
 }
 
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+const _SANDBOX_BANNER =
+  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+
+/**
+ * claude CLI が exit 1 で落ち、stderr に rate limit 文字列を含まない sandbox バナーのみを返すモック。
+ *
+ * `runAI` の `_RATE_LIMIT_PATTERN` にヒットしないため `ChatlogError('AiError', 'ExitFailure', ...)` に
+ * 分類される。実際に観測された rate limit 落ち（バナーのみ）を再現し、fatal 伝播を検証する。
+ */
+class _SandboxBannerFailMock extends BaseMockCommand {
+  /** 常に exit 1 + stderr に sandbox バナーのみを返す。 */
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: _enc.encode(_SANDBOX_BANNER),
+    });
+  }
+}
+
 // functions
 
 /**
@@ -422,19 +444,36 @@ describe('judgeTypeAndCategory', () => {
   // ─── エラー耐性 ─────────────────────────────────────────────────────────────
 
   /**
-   * AI が失敗（例外）したとき、フォールバック値がセットされ例外が投げられないことを検証する。
+   * AI CLI が非0終了で失敗したとき、フォールバックに落とさず fatal な `ChatlogError` を
+   * 再 throw することを検証する（rate limit を content 失敗と区別できないため fail-first）。
    */
   describe('When: 異常系', () => {
     it(
-      '[Error] T-SF-TC-14: AI が失敗（exit code=1） → フォールバック値がセットされる（例外なし）',
+      '[Error] T-SF-TC-14: AI が失敗（exit code=1） → フォールバックせず ChatlogError(AiError) を throw',
       async () => {
         commandHandle = installCommandMock(makeFailMock(1));
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
-        await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts());
+        const _err = await assertRejects(
+          () => judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts()),
+          ChatlogError,
+        ) as ChatlogError;
+        assertEquals(_err.kind, 'AiError');
+      },
+    );
 
-        assertEquals(_entry.frontmatter.get('type') as string, 'research');
-        assertEquals(_entry.frontmatter.get('category') as string, 'development');
+    it(
+      '[Error] T-SF-TC-23: CLI が exit 1 + sandbox バナーのみ（rate limit 文字列なし） → ChatlogError(AiError/ExitFailure) を throw',
+      async () => {
+        commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
+
+        const _entry = _makeChatlogEntry('# テスト\n本文');
+        const _err = await assertRejects(
+          () => judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts()),
+          ChatlogError,
+        ) as ChatlogError;
+        assertEquals(_err.kind, 'AiError');
+        assertEquals(_err.subindex, 'ExitFailure');
       },
     );
   });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
@@ -109,6 +109,27 @@ class _CountingRateLimitMock extends BaseMockCommand {
   }
 }
 
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+const _SANDBOX_BANNER =
+  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+
+/**
+ * claude CLI が exit 1 で落ち、stderr に rate limit 文字列を含まない sandbox バナーのみを返すモック。
+ *
+ * `runAI` の `_RATE_LIMIT_PATTERN` にヒットしないため `ChatlogError('AiError', 'ExitFailure', ...)` に
+ * 分類される。fatal 伝播（リトライで成功に化けないこと）を検証する。
+ */
+class _SandboxBannerFailMock extends BaseMockCommand {
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: _enc.encode(_SANDBOX_BANNER),
+    });
+  }
+}
+
 // functions
 
 /**
@@ -223,19 +244,37 @@ describe('generateFrontmatter', () => {
   });
 
   /**
-   * リトライ後に成功するケース。
+   * AiError（CLI 非0終了）はリトライで救済されず、2回目が成功しうる設定でも即 throw されるケース。
+   *
+   * rate limit を content 起因の単発失敗と区別できないため、fail-first で 1回目の AiError を
+   * そのまま throw する（リトライして成功に化けさせない）。
    */
-  describe('When: リトライ成功', () => {
-    it('[Normal] T-SF-FM-04-01: maxRetry=1, 1回目が AiError, 2回目成功 → true を返す', async () => {
+  describe('When: AiError はリトライで救済されない', () => {
+    it('[Error] T-SF-FM-04-01: maxRetry=1, 1回目が AiError（2回目は成功しうる） → 救済せず ChatlogError(AiError) を throw', async () => {
       commandHandle = installCommandMock(
         makeFirstNFailMock(1, 'title: "retry success"\ntopics:\n  - ai\ntags:\n  - test\n'),
       );
 
       const _entry = _makeChatlogEntry();
-      const result = await generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 1);
+      const _err = await assertRejects(
+        () => generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 1),
+        ChatlogError,
+      ) as ChatlogError;
+      assertEquals(_err.kind, 'AiError');
+      // 救済されていれば title がセットされるはず → セットされていないことを確認
+      assertEquals(_entry.frontmatter.get('title'), undefined);
+    });
 
-      assertEquals(result, true);
-      assertEquals(_entry.frontmatter.get('title'), 'retry success');
+    it('[Error] T-SF-FM-04-03: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/ExitFailure) を throw', async () => {
+      commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
+
+      const _entry = _makeChatlogEntry();
+      const _err = await assertRejects(
+        () => generateFrontmatter(_entry, _MAX_CONTENT_LENGTH, _mockDics, _mockPrompts, 2),
+        ChatlogError,
+      ) as ChatlogError;
+      assertEquals(_err.kind, 'AiError');
+      assertEquals(_err.subindex, 'ExitFailure');
     });
   });
 

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -102,6 +102,27 @@ class _CountingRateLimitMock extends BaseMockCommand {
   }
 }
 
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+const _SANDBOX_BANNER =
+  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+
+/**
+ * claude CLI が exit 1 で落ち、stderr に rate limit 文字列を含まない sandbox バナーのみを返すモック。
+ *
+ * `runAI` の `_RATE_LIMIT_PATTERN` にヒットしないため `ChatlogError('AiError', 'ExitFailure', ...)` に
+ * 分類される。fatal 伝播（`{ validity: 'error' }` に握りつぶさず即 throw すること）を検証する。
+ */
+class _SandboxBannerFailMock extends BaseMockCommand {
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: _enc.encode(_SANDBOX_BANNER),
+    });
+  }
+}
+
 // functions
 
 /**
@@ -197,18 +218,35 @@ describe('reviewFrontmatter', () => {
   });
 
   /**
-   * リトライ後に成功するケース。
+   * AiError（CLI 非0終了）はリトライで救済されず、2回目が成功しうる設定でも即 throw されるケース。
+   *
+   * rate limit を content 起因の単発失敗と区別できないため、fail-first で 1回目の AiError を
+   * そのまま throw する（リトライして pass に化けさせない）。
    */
-  describe('When: リトライ成功', () => {
-    it('[Normal] T-SF-RV-11-01: maxRetry=1, 1回目が AiError, 2回目成功 → { validity: pass, errors: [] } を返す', async () => {
+  describe('When: AiError はリトライで救済されない', () => {
+    it('[Error] T-SF-RV-11-01: maxRetry=1, 1回目が AiError（2回目は成功しうる） → 救済せず ChatlogError(AiError) を throw', async () => {
       commandHandle = installCommandMock(
         makeFirstNFailMock(1, 'validity: pass\n'),
       );
 
       const _entry = _makeChatlogEntry();
-      const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 1);
+      const _err = await assertRejects(
+        () => reviewFrontmatter(_entry, _mockDics, _mockPrompts, 1),
+        ChatlogError,
+      ) as ChatlogError;
+      assertEquals(_err.kind, 'AiError');
+    });
 
-      assertEquals(result, { validity: 'pass', errors: [] });
+    it('[Error] T-SF-RV-11-02: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/ExitFailure) を throw', async () => {
+      commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
+
+      const _entry = _makeChatlogEntry();
+      const _err = await assertRejects(
+        () => reviewFrontmatter(_entry, _mockDics, _mockPrompts, 2),
+        ChatlogError,
+      ) as ChatlogError;
+      assertEquals(_err.kind, 'AiError');
+      assertEquals(_err.subindex, 'ExitFailure');
     });
   });
 
@@ -216,12 +254,15 @@ describe('reviewFrontmatter', () => {
    * AiError → retry 枯渇後 error を返すケース。
    */
   describe('When: 異常系', () => {
-    it('[Error] T-SF-RV-01-01: maxRetry=0, runAI が AiError → { validity: error } を返す (throw しない)', async () => {
+    it('[Error] T-SF-RV-01-01: maxRetry=0, runAI が AiError → 握りつぶさず ChatlogError(AiError) を throw', async () => {
       commandHandle = installCommandMock(makeFailMock(1));
 
       const _entry = _makeChatlogEntry();
-      const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
-      assertEquals(result.validity, 'error');
+      const _err = await assertRejects(
+        () => reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0),
+        ChatlogError,
+      ) as ChatlogError;
+      assertEquals(_err.kind, 'AiError');
     });
 
     it('[Error] T-SF-RV-03-01: runAI が validity: fail + errors を返す (corrected_frontmatter なし) → { validity: error, errors: [wrong type] } を返す', async () => {
@@ -378,14 +419,18 @@ describe('reviewFrontmatter', () => {
   });
 
   /**
-   * retry 枯渇 → throw ではなく { validity: 'error' } を返す。
+   * AiError（CLI 非0終了）は握りつぶさず throw する（fail-first）。
+   * InvalidYaml リトライ枯渇時のみ `{ validity: 'error' }` を返す（別テストで検証）。
    */
-  describe('When: retry 枯渇 → error 返却', () => {
-    it('[Error] T-02-04-01: maxRetry=0, AI が AiError → { validity: error } を返す (throw しない)', async () => {
+  describe('When: AiError → throw', () => {
+    it('[Error] T-02-04-01: maxRetry=0, AI が AiError → 握りつぶさず ChatlogError(AiError) を throw', async () => {
       commandHandle = installCommandMock(makeFailMock(1));
       const _entry = _makeChatlogEntry();
-      const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
-      assertEquals(result.validity, 'error');
+      const _err = await assertRejects(
+        () => reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0),
+        ChatlogError,
+      ) as ChatlogError;
+      assertEquals(_err.kind, 'AiError');
     });
   });
 

--- a/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-frontmatter.ts
@@ -13,7 +13,6 @@
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_FALLBACK_CATEGORY, DEFAULT_FALLBACK_TYPE } from '../../../_scripts/constants/defaults.constants.ts';
-import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { extractYaml, hasFrontmatterFields } from '../../../_scripts/libs/text/frontmatter-utils.ts';
@@ -57,20 +56,9 @@ export const generateFrontmatter = async (
   let _parsed: FrontmatterFields | undefined;
 
   for (let attempt = 0; attempt <= _maxRetry; attempt++) {
-    let _raw: string;
-    try {
-      _raw = await runAI(system, user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
-    } catch (e) {
-      if (isRateLimitError(e) || signal?.aborted) {
-        throw e;
-      }
-      if (e instanceof ChatlogError && e.kind === 'AiError') {
-        logger.warn(`generateFrontmatter: AI call failed (attempt ${attempt + 1}): ${e}`);
-        _lastError = e;
-        continue;
-      }
-      throw e;
-    }
+    // AI CLI 呼び出しのエラー（rate limit / exit failure 等）はリトライせず即 throw する。
+    // YAML パース失敗のみ下で catch してリトライ対象とする。
+    const _raw = await runAI(system, user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
     const _fmResult = extractYaml(_raw, 'title');
     if (!_fmResult.ok) {
       logger.warn(`generateFrontmatter: YAML parse failed (attempt ${attempt + 1}): ${_fmResult.error.message}`);

--- a/skills/set-frontmatter/scripts/modules/setfm-review.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-review.ts
@@ -12,7 +12,6 @@
 // ─── Shared scripts
 import type { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
-import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { extractYaml } from '../../../_scripts/libs/text/frontmatter-utils.ts';
@@ -56,20 +55,9 @@ export const reviewFrontmatter = async (
   let _result: ReviewResult | undefined;
 
   for (let attempt = 0; attempt <= _maxRetry; attempt++) {
-    let _raw: string;
-    try {
-      _raw = await runAI(system, user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
-    } catch (e) {
-      if (isRateLimitError(e) || signal?.aborted) {
-        throw e;
-      }
-      if (e instanceof ChatlogError && e.kind === 'AiError') {
-        logger.warn(`reviewFrontmatter: AI call failed (attempt ${attempt + 1}): ${e}`);
-        _lastError = e;
-        continue;
-      }
-      throw e;
-    }
+    // AI CLI 呼び出しのエラー（rate limit / exit failure 等）はリトライせず即 throw する。
+    // YAML パース失敗のみ下で catch してリトライ対象とする。
+    const _raw = await runAI(system, user, { ...(model ? { model } : {}), ...(signal ? { signal } : {}) });
 
     const _reviewResult = extractYaml(_raw, 'validity');
     if (!_reviewResult.ok) {

--- a/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
@@ -13,7 +13,7 @@
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_FALLBACK_CATEGORY, DEFAULT_FALLBACK_TYPE } from '../../../_scripts/constants/defaults.constants.ts';
-import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
+import { isFatalAiError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
 
 // ─── Local
@@ -49,8 +49,9 @@ const _buildTypeCategorySystemPrompt = (systemTemplate: string, dics: Dics, cate
  * category: <category_key>
  * ```
  *
- * 判定失敗・通常 AI エラー時はフォールバック値をセットする。
- * ただし RateLimit エラーおよび abort 済み signal の場合は、フォールバックに落とさず例外を再 throw する。
+ * 判定失敗（有効キー不一致など）時はフォールバック値をセットする。
+ * ただし AI CLI が非0終了した致命的エラー（rate limit / exit failure）および abort 済み signal の
+ * 場合は、フォールバックに落とさず例外を再 throw する。
  */
 export const judgeTypeAndCategory = async (
   entry: ChatlogEntry,
@@ -97,7 +98,7 @@ export const judgeTypeAndCategory = async (
       category = _parsedCategory;
     }
   } catch (e) {
-    if (isRateLimitError(e) || signal?.aborted) {
+    if (isFatalAiError(e) || signal?.aborted) {
       throw e;
     }
     // fall through to fallback values

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
@@ -16,9 +16,10 @@ import { describe, it } from '@std/testing/bdd';
 import { spy } from '@std/testing/mock';
 
 // ─── Test target
-import { phaseFrontmatter } from '../../phase-frontmatter.ts';
+import { needsFrontmatterAi, phaseFrontmatter } from '../../phase-frontmatter.ts';
 
 // ─── Helpers
+import { stringify } from '@std/yaml';
 import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
@@ -85,6 +86,28 @@ const _makeEntry = (filePath: string): ChatlogEntry => {
 };
 
 /**
+ * `hasRequiredFields()` を満たす全5フィールド入り frontmatter を持つテスト用 `ChatlogEntry` を生成する。
+ *
+ * @param filePath - エントリのファイルパス
+ * @returns type/category/title/topics/tags を持つ `ChatlogEntry`
+ */
+const _makeFilledEntry = (filePath: string): ChatlogEntry => {
+  const _md = [
+    '---',
+    'type: tech',
+    'category: backend',
+    'title: Filled',
+    'topics:',
+    '  - topic-a',
+    'tags:',
+    '  - tag-a',
+    '---',
+    '# body',
+  ].join('\n');
+  return new ChatlogEntry(_md, { filePath });
+};
+
+/**
  * 呼び出し回数をカウントするスタブ generateProvider を返す。
  *
  * @param returns - スタブが返す値（デフォルト true）
@@ -104,15 +127,40 @@ const _makeGenerateStub = (returns = true): { stub: _GenerateProvider; getCount:
   return { stub, getCount: () => _count };
 };
 
+/** `hasRequiredFields()` を満たす全5フィールド（type/category/title/topics/tags）の frontmatter。 */
+const _FULL_FRONTMATTER = {
+  type: 'tech',
+  category: 'backend',
+  title: 'Cached Title',
+  topics: ['topic-a'],
+  tags: ['tag-a'],
+} as const;
+
+/**
+ * 単一エントリ（basename=`a`）のキャッシュを指定 status・frontmatter で初期化した YAML を返す。
+ *
+ * `ChatlogCache` は basename をキーに使うため、`/path/to/a.md` は `a` に対応する。
+ *
+ * @param status - キャッシュエントリの status 値（例: `'need-review'` / `'set-types'`）
+ * @param withFrontmatter - true のとき全5フィールドの frontmatter を含める
+ * @returns `_makeCache` に渡す YAML 文字列
+ */
+const _cacheYaml = (status: string, withFrontmatter: boolean): string => {
+  const _entry: Record<string, unknown> = { status };
+  if (withFrontmatter) { _entry.frontmatter = { ..._FULL_FRONTMATTER }; }
+  return stringify({ a: _entry });
+};
+
 // ─── Tests
 
 /**
- * `phaseFrontmatter` の dryRun パラメータに関するユニットテストスイート。
+ * `phaseFrontmatter` のユニットテストスイート。
  *
  * `_needsGenerate` パス（キャッシュミス・フロントマターフィールドなし）における
- * generateProvider と cache.write の呼び出し回数を検証する。
+ * generateProvider と cache.write の呼び出し回数、および
+ * キャッシュヒット判定（`_isGenerated`）による生成スキップ・frontmatter 復元を検証する。
  *
- * テスト ID 範囲: T-02-01 〜 T-02-03
+ * テスト ID 範囲: T-02-01 〜 T-02-06
  *
  * @see phaseFrontmatter
  */
@@ -201,13 +249,16 @@ describe('_phaseFrontmatter', () => {
   });
 
   /**
-   * generateProvider が throw したとき phase が継続するケース。
+   * generateProvider が非 fatal エラー（AiError 以外）を throw したとき phase が継続するケース。
+   *
+   * fatal な AiError はバッチを abort する（別ケース T-02-05-01 で検証）。
+   * 非 fatal なエラー（例: content 起因の想定外例外）は握りつぶして他エントリの処理を継続する。
    */
-  describe('When: generateProvider が throw する', () => {
-    it('[Normal] T-02-04-01: generateProvider が throw しても他エントリは処理継続し warn ログが出る', async () => {
+  describe('When: generateProvider が非 fatal エラーを throw する', () => {
+    it('[Normal] T-02-04-01: generateProvider が非 fatal エラーを throw → abort せず他エントリ継続・warn ログが出る', async () => {
       const cache = await _makeCache();
       const _throwingStub: _GenerateProvider = (_entry, _maxLen, _dics, _prompts) => {
-        throw new ChatlogError('AiError', 'ExitFailure', 'simulated AI failure');
+        throw new Error('simulated non-fatal failure');
       };
       const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
       const warnSpy = spy(logger, 'warn');
@@ -230,6 +281,30 @@ describe('_phaseFrontmatter', () => {
         warnSpy.restore();
         cacheSpy.restore();
       }
+    });
+
+    it('[Error] T-02-04-02: generateProvider が AiError/ExitFailure を throw → 握りつぶさず再 throw（abort）', async () => {
+      const cache = await _makeCache();
+      const _throwingStub: _GenerateProvider = (_entry, _maxLen, _dics, _prompts) => {
+        throw new ChatlogError('AiError', 'ExitFailure', 'simulated exit failure');
+      };
+      const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
+
+      const error = await assertRejects(
+        () =>
+          phaseFrontmatter(
+            entries,
+            cache,
+            1000,
+            _FAKE_DICS,
+            _FAKE_PROMPTS,
+            { concurrency: 1, dryRun: false },
+            _throwingStub,
+          ),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'AiError');
+      assertEquals(error.subindex, 'ExitFailure');
     });
   });
 
@@ -262,6 +337,106 @@ describe('_phaseFrontmatter', () => {
       );
       assertEquals(error.kind, 'AiError');
       assertEquals(_count, 1);
+    });
+  });
+
+  /**
+   * キャッシュヒット判定（`_isGenerated`）に関するテスト。
+   *
+   * status=`need-review`（frontmatter 保存済みの中間状態）および status=`set-types` の
+   * キャッシュがヒット扱いされ、AI 再生成をスキップして frontmatter が復元されることを検証する。
+   */
+  describe('キャッシュヒット判定（_isGenerated）', () => {
+    /** frontmatter を保持したキャッシュがヒット扱いされ、生成がスキップされる正常系。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-02-06-01: status=need-review + frontmatter あり → generateProvider 0回・frontmatter 復元', async () => {
+        const cache = await _makeCache(_cacheYaml('need-review', true));
+        const { stub, getCount } = _makeGenerateStub(true);
+        const entry = _makeEntry('/path/to/a.md');
+
+        await phaseFrontmatter(
+          [entry],
+          cache,
+          1000,
+          _FAKE_DICS,
+          _FAKE_PROMPTS,
+          { concurrency: 1, dryRun: false },
+          stub,
+        );
+
+        assertEquals(getCount(), 0);
+        assertEquals(entry.frontmatter.hasRequiredFields(), true);
+        assertEquals(entry.frontmatter.get('title'), _FULL_FRONTMATTER.title);
+      });
+
+      it('[Normal] T-02-06-03: status=set-types + frontmatter あり → generateProvider 0回', async () => {
+        const cache = await _makeCache(_cacheYaml('set-types', true));
+        const { stub, getCount } = _makeGenerateStub(true);
+        const entry = _makeEntry('/path/to/a.md');
+
+        await phaseFrontmatter(
+          [entry],
+          cache,
+          1000,
+          _FAKE_DICS,
+          _FAKE_PROMPTS,
+          { concurrency: 1, dryRun: false },
+          stub,
+        );
+
+        assertEquals(getCount(), 0);
+        assertEquals(entry.frontmatter.hasRequiredFields(), true);
+      });
+    });
+
+    /** frontmatter が保存されていない need-review はヒット扱いされず生成経路へ入る境界ケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-02-06-02: status=need-review + frontmatter なし → generateProvider が呼ばれる', async () => {
+        const cache = await _makeCache(_cacheYaml('need-review', false));
+        const { stub, getCount } = _makeGenerateStub(true);
+        const entry = _makeEntry('/path/to/a.md');
+
+        await phaseFrontmatter(
+          [entry],
+          cache,
+          1000,
+          _FAKE_DICS,
+          _FAKE_PROMPTS,
+          { concurrency: 1, dryRun: false },
+          stub,
+        );
+
+        assertEquals(getCount(), 1);
+      });
+    });
+  });
+
+  /**
+   * `needsFrontmatterAi` 述語のユニットテスト。
+   *
+   * dry-run 内訳集計で「再実行時にフロントマターを AI 生成するか」を entry と cache から純粋判定する。
+   * キャッシュが生成済み（`_isGenerated`）または entry に必須フィールドが既記入なら AI 不要（false）。
+   */
+  describe('needsFrontmatterAi', () => {
+    /** キャッシュ生成済み・entry 既記入で AI 不要な正常系。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-02-07-01: status=need-review + frontmatter あり（生成済み）→ false', async () => {
+        const cache = await _makeCache(_cacheYaml('need-review', true));
+        assertEquals(needsFrontmatterAi(_makeEntry('/path/to/a.md'), cache), false);
+      });
+
+      it('[Normal] T-02-07-02: cache miss + entry に必須フィールド既記入 → false', async () => {
+        const cache = await _makeCache();
+        assertEquals(needsFrontmatterAi(_makeFilledEntry('/path/to/a.md'), cache), false);
+      });
+    });
+
+    /** キャッシュ未生成かつ entry 未記入で AI 必要なエッジケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-02-07-03: cache miss + entry フィールドなし → true', async () => {
+        const cache = await _makeCache();
+        assertEquals(needsFrontmatterAi(_makeEntry('/path/to/a.md'), cache), true);
+      });
     });
   });
 });

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
@@ -16,7 +16,7 @@ import { describe, it } from '@std/testing/bdd';
 import { spy } from '@std/testing/mock';
 
 // ─── Test target
-import { phaseReview } from '../../phase-review.ts';
+import { needsReviewAi, phaseReview } from '../../phase-review.ts';
 
 // ─── Helpers
 import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
@@ -190,13 +190,16 @@ describe('phaseReview', () => {
   });
 
   /**
-   * reviewProvider が throw したとき phase が継続するケース。
+   * reviewProvider が非 fatal エラー（AiError 以外）を throw したとき phase が継続するケース。
+   *
+   * fatal な AiError はバッチを abort する（別ケース T-04-05-01 / T-04-04-02 で検証）。
+   * 非 fatal なエラーは握りつぶして他エントリの処理を継続する。
    */
-  describe('When: reviewProvider が throw する', () => {
-    it('[Normal] T-04-04-01: reviewProvider が throw しても他エントリは処理継続する', async () => {
+  describe('When: reviewProvider がエラーを throw する', () => {
+    it('[Normal] T-04-04-01: reviewProvider が非 fatal エラーを throw → abort せず他エントリ継続', async () => {
       const cache = await _makeCache();
       const _throwingStub: _ReviewProvider = (_entry, _dics, _prompts) => {
-        throw new ChatlogError('AiError', 'ExitFailure', 'simulated AI failure');
+        throw new Error('simulated non-fatal failure');
       };
       const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
       const warnSpy = spy(logger, 'warn');
@@ -207,6 +210,21 @@ describe('phaseReview', () => {
       } finally {
         warnSpy.restore();
       }
+    });
+
+    it('[Error] T-04-04-02: reviewProvider が AiError/ExitFailure を throw → 握りつぶさず再 throw（abort）', async () => {
+      const cache = await _makeCache();
+      const _throwingStub: _ReviewProvider = (_entry, _dics, _prompts) => {
+        throw new ChatlogError('AiError', 'ExitFailure', 'simulated exit failure');
+      };
+      const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
+
+      const error = await assertRejects(
+        () => phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: false }, _throwingStub),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'AiError');
+      assertEquals(error.subindex, 'ExitFailure');
     });
   });
 
@@ -386,6 +404,34 @@ describe('phaseReview', () => {
       );
       assertEquals(error.kind, 'AiError');
       assertEquals(_count, 1);
+    });
+  });
+
+  /**
+   * `needsReviewAi` 述語のユニットテスト。
+   *
+   * dry-run 内訳集計で「再実行時にレビュー AI を呼ぶか」を entry と cache から純粋判定する。
+   * キャッシュ status が `reviewed` のときのみ AI 不要（false）。
+   */
+  describe('needsReviewAi', () => {
+    /** status=reviewed で AI 不要な正常系。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-04-06-01: status=reviewed → false', async () => {
+        const filePath = '/path/to/a.md';
+        const cache = await _makeCache();
+        await cache.write(filePath, { status: 'reviewed' as const });
+        assertEquals(needsReviewAi(_makeEntry(filePath), cache), false);
+      });
+    });
+
+    /** status!=reviewed で AI 必要なエッジケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-04-06-02: status=need-review → true', async () => {
+        const filePath = '/path/to/b.md';
+        const cache = await _makeCache();
+        await cache.write(filePath, { status: 'need-review' as const });
+        assertEquals(needsReviewAi(_makeEntry(filePath), cache), true);
+      });
     });
   });
 });

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-type-category.unit.spec.ts
@@ -16,7 +16,7 @@ import { describe, it } from '@std/testing/bdd';
 import { spy } from '@std/testing/mock';
 
 // ─── Test target
-import { phaseTypeAndCategory } from '../../phase-type-category.ts';
+import { needsTypeCategoryAi, phaseTypeAndCategory } from '../../phase-type-category.ts';
 
 // ─── Helpers
 import { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
@@ -99,6 +99,24 @@ const _makeCache = async (yaml?: string): Promise<ChatlogCache<SetfmCache>> => {
  * @returns 最小限のフロントマターを持つ `ChatlogEntry`
  */
 const _makeEntry = (filePath: string): ChatlogEntry => new ChatlogEntry('---\ntitle: test\n---\n# body', { filePath });
+
+/**
+ * 既存 frontmatter に type/category を持つテスト用 `ChatlogEntry` を生成する。
+ *
+ * `type` / `category` に空文字を渡すと当該フィールドを省略でき、片方欠けのケースを再現できる。
+ *
+ * @param filePath - エントリのファイルパス
+ * @param type - frontmatter に設定する type 値（空文字なら省略）
+ * @param category - frontmatter に設定する category 値（空文字なら省略）
+ * @returns 指定した type/category を持つ `ChatlogEntry`
+ */
+const _makeEntryWithFrontmatter = (filePath: string, type: string, category: string): ChatlogEntry => {
+  const _lines = ['---', 'title: test'];
+  if (type) { _lines.push(`type: ${type}`); }
+  if (category) { _lines.push(`category: ${category}`); }
+  _lines.push('---', '# body');
+  return new ChatlogEntry(_lines.join('\n'), { filePath });
+};
 
 /**
  * 指定ステータスで type/category をキャッシュに書き込み済みの `ChatlogCache` を返す。
@@ -424,6 +442,110 @@ describe('_phaseTypeAndCategory', () => {
       );
 
       assert(_captured instanceof AbortSignal, 'signal was not forwarded to judgeProvider');
+    });
+  });
+
+  /**
+   * キャッシュミス時に entry の既存 type/category を尊重するテスト。
+   *
+   * 既存 frontmatter に type/category が両方あれば AI 判定（judgeProvider）をスキップし、
+   * 既存値を SET_TYPES ステータスでキャッシュに書き込む。片方でも欠けていれば従来どおり再判定する。
+   */
+  /**
+   * `needsTypeCategoryAi` 述語のユニットテスト。
+   *
+   * dry-run 内訳集計で「再実行時に type/category を AI 判定するか」を entry と cache から純粋判定する。
+   * `_needsReJudge` と同一の判定ロジックを外部公開する。
+   */
+  describe('needsTypeCategoryAi', () => {
+    /** キャッシュに type/category が有効に揃っており AI 不要な正常系。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-01-08-01: status=set-types + type/category あり → false', async () => {
+        const filePath = '/path/to/ok.md';
+        const cache = await _makeCacheWithEntry(filePath, CACHE_STATUSES.SET_TYPES);
+        assertEquals(needsTypeCategoryAi(_makeEntry(filePath), cache), false);
+      });
+    });
+
+    /** キャッシュミス・再判定ステータスで AI 必要な異常系/エッジケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-01-08-02: cache miss（status undefined）→ true', async () => {
+        const cache = await _makeCache();
+        assertEquals(needsTypeCategoryAi(_makeEntry('/path/to/miss.md'), cache), true);
+      });
+
+      it('[Edge] T-01-08-03: status=review-failed + type/category あり → true', async () => {
+        const filePath = '/path/to/rf.md';
+        const cache = await _makeCacheWithEntry(filePath, CACHE_STATUSES.REVIEW_FAILED);
+        assertEquals(needsTypeCategoryAi(_makeEntry(filePath), cache), true);
+      });
+    });
+  });
+
+  describe('既存 type/category による AI スキップ', () => {
+    /** 既存 type/category が両方そろっており AI をスキップする正常系。 */
+    describe('When: 正常系', () => {
+      it(
+        '[Normal] T-01-07-01: cache miss + 既存 type/category あり → judgeProvider が 0 回呼ばれる',
+        async () => {
+          const filePath = '/path/to/existing.md';
+          const cache = await _makeCache();
+          const { stub, getCount } = _makeJudgeStub();
+          const entries = [_makeEntryWithFrontmatter(filePath, 'existing-type', 'existing-cat')];
+
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
+
+          assertEquals(getCount(), 0);
+        },
+      );
+
+      it(
+        '[Normal] T-01-07-02: cache miss + 既存 type/category あり → キャッシュに既存値と SET_TYPES が書かれる',
+        async () => {
+          const filePath = '/path/to/existing.md';
+          const cache = await _makeCache();
+          const { stub } = _makeJudgeStub();
+          const entries = [_makeEntryWithFrontmatter(filePath, 'existing-type', 'existing-cat')];
+
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
+
+          const _cached = cache.read(filePath);
+          assertEquals(_cached.type, 'existing-type');
+          assertEquals(_cached.category, 'existing-cat');
+          assertEquals(_cached.status, CACHE_STATUSES.SET_TYPES);
+        },
+      );
+    });
+
+    /** 既存 type/category が片方欠けており従来どおり再判定する回帰確認。 */
+    describe('When: エッジケース', () => {
+      it(
+        '[Edge] T-01-07-03: cache miss + category なし（片方欠け）→ judgeProvider が 1 回呼ばれる',
+        async () => {
+          const filePath = '/path/to/partial-existing.md';
+          const cache = await _makeCache();
+          const { stub, getCount } = _makeJudgeStub();
+          const entries = [_makeEntryWithFrontmatter(filePath, 'existing-type', '')];
+
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
+
+          assertEquals(getCount(), 1);
+        },
+      );
+
+      it(
+        '[Edge] T-01-07-04: status=review-failed + 既存 type/category あり → judgeProvider が 1 回呼ばれる（AI 再判定）',
+        async () => {
+          const filePath = '/path/to/review-failed-existing.md';
+          const cache = await _makeCacheWithEntry(filePath, CACHE_STATUSES.REVIEW_FAILED);
+          const { stub, getCount } = _makeJudgeStub();
+          const entries = [_makeEntryWithFrontmatter(filePath, 'existing-type', 'existing-cat')];
+
+          await phaseTypeAndCategory(entries, cache, 1000, _DICS, _PROMPTS, { concurrency: 1, dryRun: false }, stub);
+
+          assertEquals(getCount(), 1);
+        },
+      );
     });
   });
 });

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -13,7 +13,7 @@
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
-import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
+import { isFatalAiError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -36,6 +36,35 @@ type _GenerateProvider = (
   signal?: AbortSignal,
 ) => Promise<boolean>;
 
+/**
+ * キャッシュがフロントマター生成済みかを判定する。
+ *
+ * `status` が `SET_TYPES` または `NEED_REVIEW` で、かつ `frontmatter` が保存されているとき `true`。
+ *
+ * @param cache - 判定対象のキャッシュエントリ
+ * @returns 生成済みなら `true`
+ */
+const _isGenerated = (cache: SetfmCache): boolean => {
+  return (cache.status === CACHE_STATUSES.SET_TYPES || cache.status === CACHE_STATUSES.NEED_REVIEW)
+    && !!cache.frontmatter;
+};
+
+/**
+ * 再実行時にフロントマターを AI 生成する必要があるかを entry と cache から純粋判定する。
+ *
+ * キャッシュが生成済み（`_isGenerated`）、または entry に必須フィールドが既記入なら AI 不要（`false`）。
+ *
+ * @param entry - 判定対象のエントリ
+ * @param cache - フェーズキャッシュ
+ * @returns AI 生成が必要なら `true`
+ */
+export const needsFrontmatterAi = (
+  entry: ChatlogEntry,
+  cache: ChatlogCache<SetfmCache>,
+): boolean => {
+  return !_isGenerated(cache.read(entry.filePath!)) && !entry.frontmatter.hasRequiredFields();
+};
+
 export const phaseFrontmatter = async (
   entries: ChatlogEntry[],
   cache: ChatlogCache<SetfmCache>,
@@ -45,10 +74,6 @@ export const phaseFrontmatter = async (
   config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'> & Partial<Pick<SetfmConfig, 'maxRetry'>>,
   generateProvider?: _GenerateProvider,
 ): Promise<void> => {
-  const _isGenerated = (cache: SetfmCache): boolean => {
-    return cache.status === CACHE_STATUSES.SET_TYPES && !!cache.frontmatter;
-  };
-
   const _hits = entries.filter((e) => {
     const _cached = cache.read(e.filePath!);
     return _isGenerated(_cached);
@@ -106,7 +131,7 @@ export const phaseFrontmatter = async (
         try {
           _ok = await _generate(entry, maxContentLength, dics, prompts, config.maxRetry ?? 0, config.model, ctl.signal);
         } catch (e) {
-          if (isRateLimitError(e) || ctl.signal.aborted) {
+          if (isFatalAiError(e) || ctl.signal.aborted) {
             throw e;
           }
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);

--- a/skills/set-frontmatter/scripts/phases/phase-review.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-review.ts
@@ -13,7 +13,7 @@
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
-import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
+import { isFatalAiError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -36,6 +36,22 @@ type _ReviewProvider = (
   signal?: AbortSignal,
 ) => Promise<ReviewResult>;
 
+/**
+ * 再実行時にレビュー AI を呼ぶ必要があるかを entry と cache から純粋判定する。
+ *
+ * キャッシュ status が `REVIEWED` 以外のとき `true`（AI レビューが必要）。
+ *
+ * @param entry - 判定対象のエントリ
+ * @param cache - フェーズキャッシュ
+ * @returns AI レビューが必要なら `true`
+ */
+export const needsReviewAi = (
+  entry: ChatlogEntry,
+  cache: ChatlogCache<SetfmCache>,
+): boolean => {
+  return cache.read(entry.filePath!).status !== CACHE_STATUSES.REVIEWED;
+};
+
 export const phaseReview = async (
   entries: ChatlogEntry[],
   cache: ChatlogCache<SetfmCache>,
@@ -44,8 +60,8 @@ export const phaseReview = async (
   config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'> & Partial<Pick<SetfmConfig, 'maxRetry'>>,
   reviewProvider?: _ReviewProvider,
 ): Promise<void> => {
-  const _hits = entries.filter((e) => cache.read(e.filePath!).status === CACHE_STATUSES.REVIEWED);
-  const _misses = entries.filter((e) => cache.read(e.filePath!).status !== CACHE_STATUSES.REVIEWED);
+  const _hits = entries.filter((e) => !needsReviewAi(e, cache));
+  const _misses = entries.filter((e) => needsReviewAi(e, cache));
 
   _hits.forEach((e) => {
     logger.info(`${LOGGER_TEXT.INDENT}review (cached): ${getFilename(e.filePath!)}`);
@@ -62,7 +78,7 @@ export const phaseReview = async (
         try {
           r = await _review(entry, dics, prompts, config.maxRetry ?? 0, config.model, ctl.signal);
         } catch (e) {
-          if (isRateLimitError(e) || ctl.signal.aborted) {
+          if (isFatalAiError(e) || ctl.signal.aborted) {
             throw e;
           }
           logger.warn(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);

--- a/skills/set-frontmatter/scripts/phases/phase-type-category.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-type-category.ts
@@ -33,6 +33,31 @@ type _JudgeProvider = (
   signal?: AbortSignal,
 ) => Promise<void>;
 
+/**
+ * 再実行時に type/category を AI 判定する必要があるかを entry と cache から純粋判定する。
+ *
+ * 次のいずれかを満たすとき `true`（AI 判定が必要）を返す。
+ * - キャッシュミス（`status === undefined`）
+ * - `status` が `EMPTY` または `REVIEW_FAILED`
+ * - キャッシュに type または category が欠けている
+ *
+ * @param entry - 判定対象のエントリ
+ * @param cache - フェーズキャッシュ
+ * @returns AI 判定が必要なら `true`
+ */
+export const needsTypeCategoryAi = (
+  entry: ChatlogEntry,
+  cache: ChatlogCache<SetfmCache>,
+): boolean => {
+  const _cached = cache.read(entry.filePath!);
+  return (
+    _cached.status === undefined
+    || _cached.status === CACHE_STATUSES.EMPTY
+    || _cached.status === CACHE_STATUSES.REVIEW_FAILED
+    || !(_cached.type && _cached.category)
+  );
+};
+
 export const phaseTypeAndCategory = async (
   entries: ChatlogEntry[],
   cache: ChatlogCache<SetfmCache>,
@@ -42,15 +67,7 @@ export const phaseTypeAndCategory = async (
   config: Pick<SetfmConfig, 'concurrency' | 'dryRun' | 'model'>,
   judgeProvider?: _JudgeProvider,
 ): Promise<void> => {
-  const _needsReJudge = (e: ChatlogEntry): boolean => {
-    const _cached = cache.read(e.filePath!);
-    return (
-      _cached.status === undefined
-      || _cached.status === CACHE_STATUSES.EMPTY
-      || _cached.status === CACHE_STATUSES.REVIEW_FAILED
-      || !(_cached.type && _cached.category)
-    );
-  };
+  const _needsReJudge = (e: ChatlogEntry): boolean => needsTypeCategoryAi(e, cache);
   const _hits = entries.filter((e) => !_needsReJudge(e));
   const _misses = entries.filter(_needsReJudge);
 
@@ -68,6 +85,18 @@ export const phaseTypeAndCategory = async (
       if (config.dryRun) {
         logger.dryrun(`${LOGGER_TEXT.INDENT}type/category: ${getFilename(entry.filePath!)}`);
       } else {
+        const _cachedStatus = cache.read(entry.filePath!).status;
+        const _existingType = entry.frontmatter.get('type') as string | undefined;
+        const _existingCategory = entry.frontmatter.get('category') as string | undefined;
+        if (_cachedStatus !== CACHE_STATUSES.REVIEW_FAILED && _existingType && _existingCategory) {
+          await cache.write(entry.filePath!, {
+            type: _existingType,
+            category: _existingCategory,
+            status: CACHE_STATUSES.SET_TYPES,
+          });
+          logger.info(`${LOGGER_TEXT.INDENT}type+category (existing): ${getFilename(entry.filePath!)}`);
+          return;
+        }
         await _judge(entry, maxContentLength, dics, prompts, config.model, ctl.signal);
         const _type = entry.frontmatter.get('type') as string;
         const _category = entry.frontmatter.get('category') as string;

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -37,10 +37,10 @@ import { getFilename } from '../../_scripts/libs/path-utils/path-utils.ts';
 import { ChatlogCache } from '../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../_scripts/classes/ChatlogEntry.class.ts';
 import { loadDics, loadPrompts } from './modules/setfm-assets-loader.ts';
-import { phaseFrontmatter } from './phases/phase-frontmatter.ts';
-import { phaseReview } from './phases/phase-review.ts';
+import { needsFrontmatterAi, phaseFrontmatter } from './phases/phase-frontmatter.ts';
+import { needsReviewAi, phaseReview } from './phases/phase-review.ts';
 import { phaseStatus } from './phases/phase-status.ts';
-import { phaseTypeAndCategory } from './phases/phase-type-category.ts';
+import { needsTypeCategoryAi, phaseTypeAndCategory } from './phases/phase-type-category.ts';
 import { filterWriteEntry, phaseWrite } from './phases/phase-write.ts';
 // types
 import { CACHE_STATUSES } from '../../_scripts/types/cache-status.const.types.ts';
@@ -138,6 +138,15 @@ export const main = async (args: string[]): Promise<void> => {
     `分割: written=${writtenEntries.length}件 reviewed=${reviewedEntries.length}件 generate=${generateEntries.length}件`,
   );
 
+  // dry-run 内訳集計: generateEntries をファイル単位で cached/skip に分類する。
+  // フェーズがエントリを変異させる前（キャッシュ・frontmatter が再実行相当の状態）に算出する。
+  const _needsAi = (e: ChatlogEntry): boolean =>
+    needsTypeCategoryAi(e, _cache)
+    || needsFrontmatterAi(e, _cache)
+    || (_config.review && needsReviewAi(e, _cache));
+  const _skipCount = generateEntries.filter(_needsAi).length;
+  const _cachedCount = generateEntries.length - _skipCount;
+
   // Phase 2.1: type・category同時判定（並列）
   logger.info(
     `\nPhase 2.1: type・category判定開始 (${generateEntries.length}件 × 並列度${_config.concurrency})`,
@@ -197,6 +206,10 @@ export const main = async (args: string[]): Promise<void> => {
   logger.info(
     `\n完了: total=${stats.total} success=${stats.success} fail=${stats.fail} skip=${stats.skip} written=${stats.written} target=${_candidateEntries.length}`,
   );
+
+  if (_config.dryRun) {
+    logger.info(`dry-run 内訳: cached=${_cachedCount} skip=${_skipCount}（skip=再実行時にAI判定する対象）`);
+  }
 };
 
 if (import.meta.main) {


### PR DESCRIPTION
## Overview

**Summary**
Abort on fatal AI CLI errors instead of retrying in the `set-frontmatter` skill.

**Background / Motivation**
When the AI CLI exited with a fatal error (non-zero exit or rate-limit exhaustion), the skill retried it. This wasted AI calls and hid unrecoverable errors. Now fatal errors fail fast, while recoverable errors (such as malformed YAML) are still retried.

## Changes

### Core Changes

- `libs/ai/rate-limit-utils.ts`: add `isFatalAiError` to detect fatal AI errors (rate limit / exit failure).
- `phases/phase-type-category.ts`, `phases/phase-frontmatter.ts`, `phases/phase-review.ts`: propagate fatal AI errors, reuse cached results, and export `needsTypeCategoryAi` / `needsFrontmatterAi` / `needsReviewAi` predicates.
- `modules/setfm-type-category.ts`, `modules/setfm-frontmatter.ts`, `modules/setfm-review.ts`: stop retrying AI CLI failures; keep retrying only YAML parse errors.
- `set-frontmatter.ts`: report a `cached` / `skip` breakdown on dry runs using the new `needs*Ai` predicates.

### Test Updates

- Add unit coverage for `ExitFailure` handling and fatal AI error propagation across phases and modules.
- Add E2E coverage for `ExitFailure` handling and the dry-run cached/skipped breakdown (and verify it is omitted in normal runs).
- `setfm-e2e-helpers.ts`: drop the leading underscore from exported helper names, rename the `TextEncoder` export to `enc`, and add sandbox banner constants and banner-failure mock helpers.

### Removed

N/A

## Change Type (optional)

- [x] Bug fix
- [x] Test

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Fatal AI errors now surface instead of being retried, and the exported-helper rename is test-internal only.

## Additional Notes

21 files changed, +1241 / -157.
