### PR TITLE
fix(run-ai): classify sandbox disabled banner as rate limit

### DIFF
--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -69,7 +69,7 @@ const _makeRejectingCommandStub = () => {
 };
 
 // constants
-/** レートリミット検出のテーブル駆動ケース (RA-13〜15, RA-21, RA-22)。stdout / stderr の両ストリームを検査対象とする。 */
+/** レートリミット検出のテーブル駆動ケース (RA-13〜15, RA-21, RA-22, RA-24)。stdout / stderr の両ストリームを検査対象とする。 */
 const _rateLimitCases = [
   {
     id: 'T-LIB-AI-RA-13',
@@ -94,6 +94,14 @@ const _rateLimitCases = [
     desc: 'stdout に "Claude usage limit reached" (stderr 空)',
   },
   { id: 'T-LIB-AI-RA-22', label: 'Error', stdout: '', stderr: 'usage limit exceeded', desc: 'stderr に "usage limit"' },
+  {
+    id: 'T-LIB-AI-RA-24',
+    label: 'Error',
+    stdout: '',
+    stderr:
+      '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)',
+    desc: 'stderr に sandbox disabled バナー (rate limit 文字列なし)',
+  },
 ] as const;
 
 const _cases: Array<{ model: string; expected: CommandSpec }> = [
@@ -314,7 +322,16 @@ describe('runAI', () => {
       });
     });
 
-    /** 正常終了(exit 0)の stdout はレートリミット検査対象外（誤検出防止）のエッジケース。 */
+    /**
+     * レートリミット判定の誤検出防止に関するエッジケース。
+     *
+     * - 正常終了(exit 0)の stdout はレートリミット検査対象外である（RA-23）。
+     * - sandbox バナー衝突: "disabled" を含まない "sandbox is enabled but not active" は
+     *   RateLimit に誤分類されず ExitFailure のままである（RA-25）。
+     * - 大文字小文字の区別: 小文字 "sandbox disabled" はマッチせず ExitFailure のままである（RA-26）。
+     * - バナー本文全体判定: "Sandbox disabled:" で始まっても後続がバナー本文と異なればマッチせず
+     *   ExitFailure のままである（RA-27）。
+     */
     describe('When: エッジケース', () => {
       it('[Edge] T-LIB-AI-RA-23: runAI — 正常終了 かつ stdout に "usage limit" を含む → RateLimit にならず stdout を返す', async () => {
         const _origCommand = Deno.Command;
@@ -328,6 +345,69 @@ describe('runAI', () => {
         try {
           const _result = await runAI('sys', 'user', { model: 'sonnet' });
           assertEquals(_result, 'the response mentions a usage limit topic');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-25: runAI — stderr が "sandbox is enabled but not active" のみ ("disabled" なし) → RateLimit にならず AiError/ExitFailure', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode('sandbox is enabled but not active'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-26: runAI — stderr が小文字 "sandbox disabled" のみ（先頭 s 小文字）→ 大文字小文字を区別しマッチせず AiError/ExitFailure', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode('sandbox disabled'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-27: runAI — stderr が "Sandbox disabled: something else entirely"（前方一致するがバナー本文と異なる）→ 本文全体で判定しマッチせず AiError/ExitFailure', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode('Sandbox disabled: something else entirely'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
         } finally {
           Deno.Command = _origCommand;
         }

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -32,6 +32,10 @@ type _CommandSpec = { command: AiBackendCommand; args: string[]; hasSystemPrompt
 /** レートリミット検出パターン。CLI は文言を stdout / stderr のいずれにも出しうる。`i` フラグのみ（`g` を付けると `.test()` がステートフルになる）。 */
 const _RATE_LIMIT_PATTERN = /rate.?limit|429|usage limit/i;
 
+/** rate limit で落ちた Claude CLI の起動バナー "⚠ Sandbox disabled: ..." を検出する。
+ *  非ASCII の警告記号(⚠)は含めず、バナー本文(ASCII)で詳細にマッチする。大文字・小文字は厳密に区別する。 */
+const _SANDBOX_DISABLED_PATTERN = /Sandbox disabled: sandbox is enabled but the Windows sandbox is not active/;
+
 // ─── Functions
 
 /**
@@ -159,7 +163,8 @@ export const runAI = async (
     if (!_output.success) {
       const _stderr = new TextDecoder().decode(_output.stderr).trim();
       const _stdout = new TextDecoder().decode(_output.stdout).trim();
-      const _isRateLimit = _RATE_LIMIT_PATTERN.test(_stderr) || _RATE_LIMIT_PATTERN.test(_stdout);
+      const _isRateLimit = _RATE_LIMIT_PATTERN.test(_stderr) || _RATE_LIMIT_PATTERN.test(_stdout)
+        || _SANDBOX_DISABLED_PATTERN.test(_stderr) || _SANDBOX_DISABLED_PATTERN.test(_stdout);
       throw new ChatlogError(
         'AiError',
         _isRateLimit ? 'RateLimit' : 'ExitFailure',

--- a/skills/classify-chatlogs/scripts/phases/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/functional/process-chunk.functional.spec.ts
@@ -283,6 +283,33 @@ describe('processChunk', () => {
       );
       assertEquals(cache.read('/tmp/input/a.md'), {});
     });
+
+    it('[Error] T-CL-PC-09-01: 外部 signal が abort 済み → ChatlogError(Aborted/ExternalAbort) を握りつぶさず re-throw する', async () => {
+      const metas = [_makeClassifyChatlogEntry('a.md')];
+      const projects: ProjectDicEntry = { app1: {}, misc: {} };
+      const ctl = new AbortController();
+      ctl.abort();
+
+      const error = await assertRejects(
+        () => processChunk(metas, projects, model, cache, ctl),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'Aborted');
+      assertEquals(error.subindex, 'ExternalAbort');
+    });
+
+    it('[Error] T-CL-PC-09-02: 外部 signal が abort 済み → cache には ERROR が書き込まれない', async () => {
+      const metas = [_makeClassifyChatlogEntry('a.md')];
+      const projects: ProjectDicEntry = { app1: {}, misc: {} };
+      const ctl = new AbortController();
+      ctl.abort();
+
+      await assertRejects(
+        () => processChunk(metas, projects, model, cache, ctl),
+        ChatlogError,
+      );
+      assertEquals(cache.read('/tmp/input/a.md'), {});
+    });
   });
 
   /**

--- a/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
+++ b/skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts
@@ -122,7 +122,7 @@ export const processChunk = async (
   try {
     rawResult = await runAI(_systemPrompt, _batchPrompt, { model, signal: ctl.signal });
   } catch (e) {
-    if (isRateLimitError(e)) {
+    if (isRateLimitError(e) || ctl.signal.aborted) {
       throw e;
     }
     const _reason = `claude CLI 実行失敗: ${e}`;

--- a/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
@@ -147,20 +147,20 @@ describe('main - rate limit 貫通 (T-SF-E2E-13)', () => {
   });
 });
 
-// ─── T-SF-E2E-16: exit failure(sandbox バナー) が Phase 2.1 で main を reject（バグの発生箇所） ─
+// ─── T-SF-E2E-16: rate limit(sandbox バナー) が Phase 2.1 で main を reject（バグの発生箇所） ─
 
 /**
  * バグ再現テスト。Phase 2.1（type/category）の最初の runAI が exit 1 + sandbox バナー
- * （rate limit 文字列なし）で落ちたとき、以前はデフォルト type/category を黙って書き込んでいた。
- * 修正後は `ExitFailure` が judgeTypeAndCategory(即throw) → phaseTypeAndCategory(try/catchなし・素通し)
- * → withConcurrency abort → main と貫通し、`main()` が `ChatlogError(AiError/ExitFailure)` で reject する。
+ * （バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定）で落ちたとき、以前はデフォルト type/category を黙って書き込んでいた。
+ * 修正後は `RateLimit` が judgeTypeAndCategory(即throw) → phaseTypeAndCategory(try/catchなし・素通し)
+ * → withConcurrency abort → main と貫通し、`main()` が `ChatlogError(AiError/RateLimit)` で reject する。
  *
  * テスト ID 範囲: T-SF-E2E-16-01
  */
-describe('main - exit failure 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-16)', () => {
-  describe('Given: Phase2.1 最初の runAI が sandbox バナー exit failure を返すモック', () => {
+describe('main - rate limit(sandbox バナー) 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-16)', () => {
+  describe('Given: Phase2.1 最初の runAI が sandbox バナー rate limit を返すモック', () => {
     describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--cache-dir", ..., "--no-review", "--dics", ...]) を呼び出す', () => {
-      describe('Then: T-SF-E2E-16 - main が ChatlogError(AiError/ExitFailure) で reject する', () => {
+      describe('Then: T-SF-E2E-16 - main が ChatlogError(AiError/RateLimit) で reject する', () => {
         let inputDir: string;
         let outputDir: string;
         let cacheDir: string;
@@ -173,7 +173,7 @@ describe('main - exit failure 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          // 1回目(type/category)のみ banner exit failure。以降(frontmatter)は success。
+          // 1回目(type/category)のみ banner rate limit。以降(frontmatter)は success。
           // Phase 2.1 が握りつぶすと後続が成功し main は resolve するため、Phase 2.1 の
           // abort ゲート単体を分離検証できる（gate 未修正なら resolve = RED）。
           commandHandle = installCommandMock(
@@ -194,7 +194,7 @@ describe('main - exit failure 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Error] T-SF-E2E-16-01: Phase 2.1 の exit failure が貫通し ChatlogError(AiError/ExitFailure) で reject する', async () => {
+        it('[Error] T-SF-E2E-16-01: Phase 2.1 の rate limit(sandbox バナー) が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
           const _err = await assertRejects(
             () =>
               main([
@@ -211,27 +211,27 @@ describe('main - exit failure 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-
             ChatlogError,
           ) as ChatlogError;
           assertEquals(_err.kind, 'AiError');
-          assertEquals(_err.subindex, 'ExitFailure');
+          assertEquals(_err.subindex, 'RateLimit');
         });
       });
     });
   });
 });
 
-// ─── T-SF-E2E-14: exit failure(sandbox バナー) が frontmatter フェーズを貫通して main を reject ─
+// ─── T-SF-E2E-14: rate limit(sandbox バナー) が frontmatter フェーズを貫通して main を reject ─
 
 /**
  * Phase 2.1（type/category）は成功し、Phase 2.2（frontmatter 生成）の runAI が
- * exit 1 + sandbox バナー（rate limit 文字列なし）で落ちたとき、`ExitFailure` が
+ * exit 1 + sandbox バナー（バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定）で落ちたとき、`RateLimit` が
  * generateFrontmatter(即throw) → phaseFrontmatter の abort ゲート → withConcurrency abort → main
- * と貫通し、`main()` が `ChatlogError(AiError/ExitFailure)` で reject することを検証する。
+ * と貫通し、`main()` が `ChatlogError(AiError/RateLimit)` で reject することを検証する。
  *
  * テスト ID 範囲: T-SF-E2E-14-01
  */
-describe('main - exit failure 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', () => {
-  describe('Given: Phase2.1 成功・Phase2.2 で sandbox バナー exit failure を返すモック', () => {
+describe('main - rate limit(sandbox バナー) 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', () => {
+  describe('Given: Phase2.1 成功・Phase2.2 で sandbox バナー rate limit を返すモック', () => {
     describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", "--dics", ...]) を呼び出す', () => {
-      describe('Then: T-SF-E2E-14 - main が ChatlogError(AiError/ExitFailure) で reject する', () => {
+      describe('Then: T-SF-E2E-14 - main が ChatlogError(AiError/RateLimit) で reject する', () => {
         let inputDir: string;
         let outputDir: string;
         let cacheDir: string;
@@ -244,7 +244,7 @@ describe('main - exit failure 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', 
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          // 1回目(type/category)成功、2回目以降(frontmatter)を banner exit failure にする
+          // 1回目(type/category)成功、2回目以降(frontmatter)を banner rate limit にする
           commandHandle = installCommandMock(
             makeSuccessThenBannerFailMock(1, 'type: research\ncategory: development'),
           );
@@ -260,7 +260,7 @@ describe('main - exit failure 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', 
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Error] T-SF-E2E-14-01: frontmatter フェーズの exit failure が貫通し ChatlogError(AiError/ExitFailure) で reject する', async () => {
+        it('[Error] T-SF-E2E-14-01: frontmatter フェーズの rate limit(sandbox バナー) が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
           const _err = await assertRejects(
             () =>
               main([
@@ -277,29 +277,29 @@ describe('main - exit failure 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', 
             ChatlogError,
           ) as ChatlogError;
           assertEquals(_err.kind, 'AiError');
-          assertEquals(_err.subindex, 'ExitFailure');
+          assertEquals(_err.subindex, 'RateLimit');
         });
       });
     });
   });
 });
 
-// ─── T-SF-E2E-15: exit failure(sandbox バナー) が review フェーズを貫通して main を reject ─
+// ─── T-SF-E2E-15: rate limit(sandbox バナー) が review フェーズを貫通して main を reject ─
 
 /**
  * Phase 2.1（type/category）と Phase 2.2（frontmatter）は成功し、Phase 3.1（review）の
- * runAI が exit 1 + sandbox バナー（rate limit 文字列なし）で落ちたとき、`ExitFailure` が
+ * runAI が exit 1 + sandbox バナー（バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定）で落ちたとき、`RateLimit` が
  * reviewFrontmatter(即throw) → phaseReview の abort ゲート → withConcurrency abort → main
- * と貫通し、`main()` が `ChatlogError(AiError/ExitFailure)` で reject することを検証する。
+ * と貫通し、`main()` が `ChatlogError(AiError/RateLimit)` で reject することを検証する。
  *
  * review フェーズを実行するため `--no-review` は付けない。
  *
  * テスト ID 範囲: T-SF-E2E-15-01
  */
-describe('main - exit failure 貫通 (review フェーズ) (T-SF-E2E-15)', () => {
-  describe('Given: Phase2.1/2.2 成功・Phase3.1(review) で sandbox バナー exit failure を返すモック', () => {
+describe('main - rate limit(sandbox バナー) 貫通 (review フェーズ) (T-SF-E2E-15)', () => {
+  describe('Given: Phase2.1/2.2 成功・Phase3.1(review) で sandbox バナー rate limit を返すモック', () => {
     describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--dics", ...]) を呼び出す', () => {
-      describe('Then: T-SF-E2E-15 - main が ChatlogError(AiError/ExitFailure) で reject する', () => {
+      describe('Then: T-SF-E2E-15 - main が ChatlogError(AiError/RateLimit) で reject する', () => {
         let inputDir: string;
         let outputDir: string;
         let cacheDir: string;
@@ -312,7 +312,7 @@ describe('main - exit failure 貫通 (review フェーズ) (T-SF-E2E-15)', () =>
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          // 1回目(type/category)+2回目(frontmatter)成功、3回目以降(review)を banner exit failure にする。
+          // 1回目(type/category)+2回目(frontmatter)成功、3回目以降(review)を banner rate limit にする。
           // frontmatter フェーズが必須フィールドを生成できるよう title/topics/tags を返す。
           commandHandle = installCommandMock(
             makeSuccessThenBannerFailMock(
@@ -332,7 +332,7 @@ describe('main - exit failure 貫通 (review フェーズ) (T-SF-E2E-15)', () =>
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Error] T-SF-E2E-15-01: review フェーズの exit failure が貫通し ChatlogError(AiError/ExitFailure) で reject する', async () => {
+        it('[Error] T-SF-E2E-15-01: review フェーズの rate limit(sandbox バナー) が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
           const _err = await assertRejects(
             () =>
               main([
@@ -348,7 +348,7 @@ describe('main - exit failure 貫通 (review フェーズ) (T-SF-E2E-15)', () =>
             ChatlogError,
           ) as ChatlogError;
           assertEquals(_err.kind, 'AiError');
-          assertEquals(_err.subindex, 'ExitFailure');
+          assertEquals(_err.subindex, 'RateLimit');
         });
       });
     });

--- a/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
+++ b/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
@@ -134,16 +134,16 @@ export const makeRateLimitMock = (stdout = 'Claude usage limit reached'): DenoCo
   } as unknown as DenoCommandLike;
 };
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
 export const SANDBOX_BANNER =
   '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
 
 /**
  * 最初の `okCount` 回は指定 stdout で成功し、それ以降は exit 1 + sandbox バナー（stderr）で失敗するモック。
  *
- * バナーは rate limit 文字列を含まないため `runAI` で `ExitFailure` に分類される。
+ * バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットするため `RateLimit` に分類される。
  * Phase 2.1（type/category）を成功させてから後続フェーズ（frontmatter / review）で
- * exit failure を発生させ、fatal 伝播でバッチが abort することを検証するために使用する。
+ * rate limit(sandbox バナー) を発生させ、fatal 伝播でバッチが abort することを検証するために使用する。
  *
  * @param okCount - 成功させる先頭呼び出し回数
  * @param okStdout - 成功時に返す stdout 文字列
@@ -176,7 +176,7 @@ export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string)
 /**
  * `failOn`（1始まり）番目の呼び出しだけ exit 1 + sandbox バナーで失敗し、他は success を返すモック。
  *
- * 特定フェーズ 1 箇所だけを exit failure にして、そのフェーズの abort ゲート単体が
+ * 特定フェーズ 1 箇所だけを rate limit(sandbox バナー) にして、そのフェーズの abort ゲート単体が
  * バッチを止めることを分離検証するために使用する（後続フェーズが救済しない構成）。
  *
  * @param failOn - 失敗させる呼び出し番号（1始まり）

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -84,14 +84,14 @@ class _RateLimitMockCommand extends BaseMockCommand {
   }
 }
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
 const _SANDBOX_BANNER =
   '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
 
 /**
- * claude CLI が exit 1 で落ち、stderr に rate limit 文字列を含まない sandbox バナーのみを返すモック。
+ * claude CLI が exit 1 で落ち、stderr に sandbox バナーのみを返すモック。
  *
- * `runAI` の `_RATE_LIMIT_PATTERN` にヒットしないため `ChatlogError('AiError', 'ExitFailure', ...)` に
+ * sandbox バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
  * 分類される。実際に観測された rate limit 落ち（バナーのみ）を再現し、fatal 伝播を検証する。
  */
 class _SandboxBannerFailMock extends BaseMockCommand {
@@ -463,7 +463,7 @@ describe('judgeTypeAndCategory', () => {
     );
 
     it(
-      '[Error] T-SF-TC-23: CLI が exit 1 + sandbox バナーのみ（rate limit 文字列なし） → ChatlogError(AiError/ExitFailure) を throw',
+      '[Error] T-SF-TC-23: CLI が exit 1 + sandbox バナーのみ（rate limit 文字列なし） → ChatlogError(AiError/RateLimit) を throw',
       async () => {
         commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
 
@@ -473,7 +473,7 @@ describe('judgeTypeAndCategory', () => {
           ChatlogError,
         ) as ChatlogError;
         assertEquals(_err.kind, 'AiError');
-        assertEquals(_err.subindex, 'ExitFailure');
+        assertEquals(_err.subindex, 'RateLimit');
       },
     );
   });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
@@ -109,14 +109,14 @@ class _CountingRateLimitMock extends BaseMockCommand {
   }
 }
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
 const _SANDBOX_BANNER =
   '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
 
 /**
- * claude CLI が exit 1 で落ち、stderr に rate limit 文字列を含まない sandbox バナーのみを返すモック。
+ * claude CLI が exit 1 で落ち、stderr に sandbox バナーのみを返すモック。
  *
- * `runAI` の `_RATE_LIMIT_PATTERN` にヒットしないため `ChatlogError('AiError', 'ExitFailure', ...)` に
+ * sandbox バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
  * 分類される。fatal 伝播（リトライで成功に化けないこと）を検証する。
  */
 class _SandboxBannerFailMock extends BaseMockCommand {
@@ -265,7 +265,7 @@ describe('generateFrontmatter', () => {
       assertEquals(_entry.frontmatter.get('title'), undefined);
     });
 
-    it('[Error] T-SF-FM-04-03: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/ExitFailure) を throw', async () => {
+    it('[Error] T-SF-FM-04-03: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/RateLimit) を throw', async () => {
       commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
 
       const _entry = _makeChatlogEntry();
@@ -274,7 +274,7 @@ describe('generateFrontmatter', () => {
         ChatlogError,
       ) as ChatlogError;
       assertEquals(_err.kind, 'AiError');
-      assertEquals(_err.subindex, 'ExitFailure');
+      assertEquals(_err.subindex, 'RateLimit');
     });
   });
 

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -102,14 +102,14 @@ class _CountingRateLimitMock extends BaseMockCommand {
   }
 }
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。rate limit 文字列を含まない。 */
+/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
 const _SANDBOX_BANNER =
   '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
 
 /**
- * claude CLI が exit 1 で落ち、stderr に rate limit 文字列を含まない sandbox バナーのみを返すモック。
+ * claude CLI が exit 1 で落ち、stderr に sandbox バナーのみを返すモック。
  *
- * `runAI` の `_RATE_LIMIT_PATTERN` にヒットしないため `ChatlogError('AiError', 'ExitFailure', ...)` に
+ * sandbox バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
  * 分類される。fatal 伝播（`{ validity: 'error' }` に握りつぶさず即 throw すること）を検証する。
  */
 class _SandboxBannerFailMock extends BaseMockCommand {
@@ -237,7 +237,7 @@ describe('reviewFrontmatter', () => {
       assertEquals(_err.kind, 'AiError');
     });
 
-    it('[Error] T-SF-RV-11-02: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/ExitFailure) を throw', async () => {
+    it('[Error] T-SF-RV-11-02: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/RateLimit) を throw', async () => {
       commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
 
       const _entry = _makeChatlogEntry();
@@ -246,7 +246,7 @@ describe('reviewFrontmatter', () => {
         ChatlogError,
       ) as ChatlogError;
       assertEquals(_err.kind, 'AiError');
-      assertEquals(_err.subindex, 'ExitFailure');
+      assertEquals(_err.subindex, 'RateLimit');
     });
   });
 


### PR DESCRIPTION
## Overview

**Summary**
Classify the Windows sandbox disabled banner as a rate limit error, and propagate aborted signals in `processChunk`.

**Background / Motivation**
On Windows, the Claude CLI can exit non-zero with a startup banner (`⚠ Sandbox disabled: ...`) when the sandbox is inactive. This was treated as a non-retryable `ExitFailure`, so runs failed instead of retrying. Separately, `processChunk` swallowed exceptions on an already-aborted signal and wrote an `ERROR` to the cache, which should not happen on abort.

## Changes

### Core Changes

- `skills/_scripts/libs/ai/run-ai.ts`: Add `_SANDBOX_DISABLED_PATTERN` and classify matching output as `RateLimit` instead of `ExitFailure`.
- `skills/classify-chatlogs/scripts/phases/phase-classify-ai.ts`: Add `ctl.signal.aborted` to the failure check so an aborted signal re-throws the caught error and writes no `ERROR` to the cache.

### Test Updates

- Change expectations from `AiError/ExitFailure` to `AiError/RateLimit` in the affected suites:
  - `skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts`
  - `skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts`
  - `skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts`
  - `skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts`
  - `skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts`
  - `skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts`
- Add functional tests for aborted external signals:
  - `skills/classify-chatlogs/scripts/phases/__tests__/functional/process-chunk.functional.spec.ts`

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Both changes only affect error classification and signal handling on failure paths.

## Additional Notes

The PR title names the primary fix only; the aborted-signal fix is described in the Summary and Changes above.
