### PR TITLE
refactor(run-ai): detect AI result and error from claude JSON output

### DIFF
--- a/skills/_scripts/__tests__/helpers/__tests__/deno-command-mock.unit.spec.ts
+++ b/skills/_scripts/__tests__/helpers/__tests__/deno-command-mock.unit.spec.ts
@@ -1,0 +1,47 @@
+// src: skills/_scripts/__tests__/helpers/__tests__/deno-command-mock.unit.spec.ts
+// @(#): deno-command-mock ヘルパー関数ユニットテスト
+//       対象: wrapClaudeJson
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─── BDD modules
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+
+// ─── Test target
+import { wrapClaudeJson } from '../deno-command-mock.ts';
+
+// ─── Internal Helpers
+
+// constants
+/** `wrapClaudeJson` の入力 payload と期待エンベロープの対応表。 */
+const _cases = [
+  { payload: 'hello', expected: '{"result":"hello"}' },
+  { payload: '[{"a":1}]', expected: '{"result":"[{\\"a\\":1}]"}' },
+] as const;
+
+// ─── Tests
+
+/**
+ * `wrapClaudeJson` のユニットテストスイート。
+ *
+ * claude `--output-format json` の成功 stdout エンベロープ組み立てを検証する。
+ *
+ * テスト ID 範囲: T-DCM-WCJ-01 〜 T-DCM-WCJ-02
+ *
+ * @see wrapClaudeJson
+ */
+describe('wrapClaudeJson', () => {
+  /** payload を `{"result":<payload>}` エンベロープに変換する正常系。 */
+  describe('When: 正常系', () => {
+    for (const { payload, expected } of _cases) {
+      it(`[Normal] T-DCM-WCJ: payload=${payload} → ${expected}`, () => {
+        // act & assert
+        assertEquals(wrapClaudeJson(payload), expected);
+      });
+    }
+  });
+});

--- a/skills/_scripts/__tests__/helpers/deno-command-mock.ts
+++ b/skills/_scripts/__tests__/helpers/deno-command-mock.ts
@@ -187,6 +187,15 @@ export function makeSuccessMock(
   };
 }
 
+/** claude --output-format json の成功 stdout エンベロープを組み立てる純粋関数。 */
+export const wrapClaudeJson = (payload: string): string => JSON.stringify({ result: payload });
+
+/** wrapClaudeJson を stdout に格納する成功系モック。makeSuccessMock の薄いラッパ。 */
+export const makeClaudeJsonMock = (
+  payload: string,
+  capturedArgs?: { value: string[] },
+): DenoCommandLike => makeSuccessMock(new TextEncoder().encode(wrapClaudeJson(payload)), capturedArgs);
+
 /** FailMockCommand を DenoCommandLike として返すヘルパー。 */
 export function makeFailMock(code: number): DenoCommandLike {
   return class extends FailMockCommand {

--- a/skills/_scripts/libs/ai/__tests__/integration/run-ai.integration.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/integration/run-ai.integration.spec.ts
@@ -39,11 +39,13 @@ afterEach(() => {
 describe('runAI', () => {
   // ─── 空白付き stdout の trim ─────────────────────────────────────────────
 
-  describe('Given: Claude CLI が空白付き "  research  \\n" を返す成功モック', () => {
+  describe('Given: Claude CLI が先頭バナー付き JSON `{"result":"research"}` を返す成功モック', () => {
     describe('When: runAI(system, user) を呼び出す', () => {
-      describe('Then: T-LIB-AI-RA-IT-02 - trim されて "research" が返る', () => {
+      describe('Then: T-LIB-AI-RA-IT-02 - バナー除去 + .result 抽出で "research" が返る', () => {
         beforeEach(() => {
-          commandHandle = installCommandMock(makeSuccessMock(_enc.encode('  research  \n')));
+          const _banner =
+            '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+          commandHandle = installCommandMock(makeSuccessMock(_enc.encode(`${_banner}\n{"result":"research"}`)));
         });
 
         it('T-LIB-AI-RA-IT-02-01: 返り値が "research" になる', async () => {

--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -24,6 +24,7 @@ import {
   makeDelayedSuccessMock,
   makeSuccessMock,
 } from '../../../../__tests__/helpers/deno-command-mock.ts';
+import { makeLoggerStub } from '../../../../__tests__/helpers/logger-stub.ts';
 
 // ─── Internal Helpers
 
@@ -110,11 +111,11 @@ const _cases: Array<{ model: string; expected: CommandSpec }> = [
     expected: {
       command: 'claude',
       args: [
-        '-p',
+        '--print',
+        '--output-format',
+        'json',
         '--system-prompt',
         'sys',
-        '--output-format',
-        'text',
         '--permission-mode',
         'acceptEdits',
         '--strict-mcp-config',
@@ -214,6 +215,13 @@ describe('_buildCommand', () => {
       assertEquals(result.args[result.args.indexOf('--model') + 1], 'claude-3');
       assertEquals(result.hasSystemPromptWithArgs, true);
     });
+
+    it('[Normal] T-LIB-AI-RA-28: model=sonnet → claude args に --output-format json が含まれる', () => {
+      const result = _buildCommand('sonnet', 'sys');
+      assertEquals(result.command, 'claude');
+      assertEquals(result.args.includes('--output-format'), true);
+      assertEquals(result.args[result.args.indexOf('--output-format') + 1], 'json');
+    });
   });
 });
 
@@ -300,22 +308,338 @@ describe('runAI', () => {
           Deno.Command = _origCommand;
         }
       });
+
+      it('[Error] T-LIB-AI-RA-33: runAI — CLI 失敗時 stderr が logger.error に "(stderr)" ラベル付きで出力される', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode('model not found'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        const _loggerStub = makeLoggerStub();
+        try {
+          await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          );
+          const _hasStderrLog = _loggerStub.errorLogs.some((m) =>
+            m.includes('(stderr):') && m.includes('model not found')
+          );
+          assertEquals(_hasStderrLog, true);
+        } finally {
+          _loggerStub.restore();
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-34: runAI — CLI 失敗時 stdout(JSON) が logger.error に "(stdout)" ラベル付きで丸ごと出力される', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout = '{"type":"result","subtype":"error","is_error":true,"api_error_status":429}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new TextEncoder().encode('some error'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        const _loggerStub = makeLoggerStub();
+        try {
+          await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          );
+          const _stdoutLog = _loggerStub.errorLogs.find((m) => m.includes('(stdout):'));
+          assertStringIncludes(_stdoutLog ?? '', _stdout);
+        } finally {
+          _loggerStub.restore();
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-35: runAI — stderr 空 かつ stdout に JSON のみ → stdout JSON がログされ stderr 行はスキップされる', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout = '{"type":"result","subtype":"error","is_error":true,"api_error_status":429}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        const _loggerStub = makeLoggerStub();
+        try {
+          await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          );
+          const _hasStdoutLog = _loggerStub.errorLogs.some((m) => m.includes('(stdout):') && m.includes(_stdout));
+          const _hasStderrLog = _loggerStub.errorLogs.some((m) => m.includes('(stderr):'));
+          assertEquals(_hasStdoutLog, true);
+          assertEquals(_hasStderrLog, false);
+        } finally {
+          _loggerStub.restore();
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-36: runAI — exit 1 かつ claude JSON is_error:true/api_error_status:429 → AiError/RateLimit', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout =
+          '{"is_error":true,"api_error_status":429,"subtype":"success","terminal_reason":"api_error","result":"You\'ve hit your monthly spend limit · raise it at claude.ai/settings/usage"}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'RateLimit');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-39: runAI — exit 1 かつ claude JSON is_error:true/api_error_status:500 (429以外) → AiError/ExitFailure', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode('{"is_error":true,"api_error_status":500,"result":"boom"}'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-40: runAI — exit 1 かつ stdout がプレーンテキスト(JSON パース不能) → フォールバックで AiError/ExitFailure', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode('plain text crash dump'),
+          stderr: new TextEncoder().encode('crash'),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-42: runAI — exit 1 かつ ケースA完全JSON → message に "429" と result 文言 ("monthly spend limit") の両方が含まれる', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout =
+          '{"is_error":true,"api_error_status":429,"subtype":"success","terminal_reason":"api_error","result":"You\'ve hit your monthly spend limit · raise it at claude.ai/settings/usage"}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertStringIncludes(_err.message, '429');
+          assertStringIncludes(_err.message, 'monthly spend limit');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-43: runAI — exit 1 かつ api_error_status:null/terminal_reason あり → message に result ("boom") は含まれ status 数値部分は含まれない', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(
+            '{"is_error":true,"api_error_status":null,"terminal_reason":"api_error","result":"boom"}',
+          ),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertStringIncludes(_err.message, 'boom');
+          assertEquals(_err.message.includes('status'), false);
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-44: runAI — exit 1 かつ status/terminal_reason 両欠損 → message に result ("partial") 含み例外なく throw される', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode('{"is_error":true,"result":"partial"}'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertStringIncludes(_err.message, 'partial');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
     });
 
-    /** CLI 正常終了時の正常ケース。 */
+    /** CLI 正常終了時（claude backend）の正常ケース。claude は `--output-format json` の構造化 JSON を返し、runAI はその `.result` を抽出して返す。 */
     describe('When: 正常系', () => {
-      it('[Normal] T-LIB-AI-RA-12: runAI — CLI が正常終了 → stdout 文字列を返す', async () => {
+      it('[Normal] T-LIB-AI-RA-12: runAI — claude が JSON `{"result":"hello"}` を返す → .result ("hello") を返す', async () => {
         const _origCommand = Deno.Command;
         Deno.Command = _makeCommandStub({
           success: true,
           code: 0,
-          stdout: new TextEncoder().encode('hello'),
+          stdout: new TextEncoder().encode('{"result":"hello"}'),
           stderr: new Uint8Array(),
           signal: null,
         }) as unknown as typeof Deno.Command;
         try {
           const _result = await runAI('sys', 'user', { model: 'sonnet' });
           assertEquals(_result, 'hello');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Normal] T-LIB-AI-RA-29: runAI — claude stdout 先頭にサンドボックスバナー + 末尾に JSON → バナーを除去して .result を抽出する', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout =
+          '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)\n{"result":"answer"}';
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _result = await runAI('sys', 'user', { model: 'sonnet' });
+          assertEquals(_result, 'answer');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Normal] T-LIB-AI-RA-37: runAI — exit 1 だが claude JSON is_error:false/result あり → throw せず .result を返す', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout =
+          '{"is_error":false,"api_error_status":null,"subtype":"success","terminal_reason":"completed","result":"title: hello"}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _result = await runAI('sys', 'user', { model: 'sonnet' });
+          assertEquals(_result, 'title: hello');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Normal] T-LIB-AI-RA-38: runAI — exit 1 だが claude JSON is_error:false → logger.error が呼ばれない (errorLogs 空)', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout =
+          '{"is_error":false,"api_error_status":null,"subtype":"success","terminal_reason":"completed","result":"title: hello"}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        const _loggerStub = makeLoggerStub();
+        try {
+          await runAI('sys', 'user', { model: 'sonnet' });
+          assertEquals(_loggerStub.errorLogs.length, 0);
+        } finally {
+          _loggerStub.restore();
+          Deno.Command = _origCommand;
+        }
+      });
+    });
+
+    /**
+     * claude JSON パース失敗時の異常ケース。
+     *
+     * 成功終了(exit 0)でも stdout が JSON として解釈できない、または `.result`
+     * が文字列でない場合は fail-first で ChatlogError(AiError/InvalidFormat) を throw する。
+     */
+    describe('When: 異常系', () => {
+      it('[Error] T-LIB-AI-RA-30: runAI — claude stdout に "{" が無く JSON パース不能 → ChatlogError(AiError/InvalidFormat)', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode('not a json output'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'InvalidFormat');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-31: runAI — claude JSON が有効だが .result が文字列でない → ChatlogError(AiError/InvalidFormat)', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode('{"noResult":123}'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'InvalidFormat');
         } finally {
           Deno.Command = _origCommand;
         }
@@ -333,18 +657,35 @@ describe('runAI', () => {
      *   ExitFailure のままである（RA-27）。
      */
     describe('When: エッジケース', () => {
-      it('[Edge] T-LIB-AI-RA-23: runAI — 正常終了 かつ stdout に "usage limit" を含む → RateLimit にならず stdout を返す', async () => {
+      it('[Edge] T-LIB-AI-RA-23: runAI — 正常終了 かつ .result に "usage limit" を含む → RateLimit 判定されず .result を返す', async () => {
         const _origCommand = Deno.Command;
         Deno.Command = _makeCommandStub({
           success: true,
           code: 0,
-          stdout: new TextEncoder().encode('the response mentions a usage limit topic'),
+          stdout: new TextEncoder().encode('{"result":"the response mentions a usage limit topic"}'),
           stderr: new Uint8Array(),
           signal: null,
         }) as unknown as typeof Deno.Command;
         try {
           const _result = await runAI('sys', 'user', { model: 'sonnet' });
           assertEquals(_result, 'the response mentions a usage limit topic');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-32: runAI — claude 以外のバックエンド(codex) → JSON パースせず生 stdout を trim して返す', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode('  plain codex output  \n'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _result = await runAI('sys', 'user', { model: 'gpt-5' });
+          assertEquals(_result, 'plain codex output');
         } finally {
           Deno.Command = _origCommand;
         }
@@ -408,6 +749,23 @@ describe('runAI', () => {
           ) as ChatlogError;
           assertEquals(_err.kind, 'AiError');
           assertEquals(_err.subindex, 'ExitFailure');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-41: runAI — exit 0 かつ claude JSON is_error:false/result:"ok" → .result ("ok") を返す', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: true,
+          code: 0,
+          stdout: new TextEncoder().encode('{"is_error":false,"result":"ok"}'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _result = await runAI('sys', 'user', { model: 'sonnet' });
+          assertEquals(_result, 'ok');
         } finally {
           Deno.Command = _origCommand;
         }
@@ -476,7 +834,9 @@ describe('runAI', () => {
       it('[Normal] T-LIB-AI-RA-18: options.model 省略 → GlobalConfig の model ("opus") が CLI 引数に使われる', async () => {
         GlobalConfig.getInstance({ yaml: 'model: opus' });
         const _capturedArgs: { value: string[] } = { value: [] };
-        commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('ok'), _capturedArgs));
+        commandHandle = installCommandMock(
+          makeSuccessMock(new TextEncoder().encode('{"result":"ok"}'), _capturedArgs),
+        );
 
         await runAI('sys', 'user');
 
@@ -503,7 +863,7 @@ describe('runAI', () => {
     describe('When: エッジケース', () => {
       it('[Edge] T-LIB-AI-RA-20: options.timeoutMs=0 かつ GlobalConfig.timeoutMs が非ゼロ → タイムアウトしない', async () => {
         GlobalConfig.getInstance({ yaml: 'timeoutMs: 50' });
-        commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('ok')));
+        commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('{"result":"ok"}')));
 
         const _result = await runAI('sys', 'user', { model: 'sonnet', timeoutMs: 0 });
 

--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -428,6 +428,71 @@ describe('runAI', () => {
         }
       });
 
+      it('[Error] T-LIB-AI-RA-45: runAI — exit 1 かつ is_error:true/api_error_status:null/result:"...monthly spend limit..." → AiError/RateLimit', async () => {
+        const _origCommand = Deno.Command;
+        const _stdout =
+          '{"is_error":true,"api_error_status":null,"result":"You\'ve hit your monthly spend limit · raise it at claude.ai/settings/usage"}';
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode(_stdout),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'RateLimit');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-46: runAI — exit 1 かつ is_error:true/api_error_status:null/result:"usage limit reached" → AiError/RateLimit', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode('{"is_error":true,"api_error_status":null,"result":"usage limit reached"}'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'RateLimit');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Edge] T-LIB-AI-RA-47: runAI — exit 1 かつ is_error:true/api_error_status:null/result:"boom" (レートリミット表現なし) → AiError/ExitFailure (誤検出しない)', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new TextEncoder().encode('{"is_error":true,"api_error_status":null,"result":"boom"}'),
+          stderr: new Uint8Array(),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
       it('[Error] T-LIB-AI-RA-40: runAI — exit 1 かつ stdout がプレーンテキスト(JSON パース不能) → フォールバックで AiError/ExitFailure', async () => {
         const _origCommand = Deno.Command;
         Deno.Command = _makeCommandStub({

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -12,6 +12,7 @@
 // functions
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../classes/GlobalConfig.class.ts';
+import { logger } from '../io/logger.ts';
 import { getAiBackend, isValidModel, parseModel } from './model-utils.ts';
 
 // types
@@ -53,6 +54,8 @@ export const _buildCommand = (model: string, systemPrompt: string): _CommandSpec
         command: _command,
         args: [
           '--print',
+          '--output-format',
+          'json',
           '--disable-slash-commands',
           '--permission-mode',
           'acceptEdits',
@@ -121,6 +124,79 @@ export const _buildCommand = (model: string, systemPrompt: string): _CommandSpec
 };
 
 /**
+ * claude CLI (`--output-format json`) の stdout を JSON 本体としてパースする。
+ *
+ * stdout 先頭にはサンドボックスバナー（`⚠ Sandbox disabled: ...` など）が
+ * 混入しうるため、最初の `{` 以降を JSON 本体として `JSON.parse` する。
+ *
+ * **never-throw**: `{` が無い場合・パース失敗の場合はいずれも `null` を返す。
+ * これにより exit≠0 のフォールバック（正規表現パス）が機能する。
+ *
+ * exported for testing — internal use only (do not rely on outside tests)
+ *
+ * @param stdout - trim 済みの claude CLI stdout
+ * @returns JSON 本体のオブジェクト、またはパース不能なら `null`
+ */
+export const _parseClaudeJson = (stdout: string): Record<string, unknown> | null => {
+  const _start = stdout.indexOf('{');
+  if (_start === -1) {
+    return null;
+  }
+  try {
+    return JSON.parse(stdout.slice(_start)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * `is_error:true` の claude JSON からエラー詳細メッセージを整形する。
+ *
+ * 生 JSON 全体は含めず、`api_error_status` / `terminal_reason` / `result` の要点のみを
+ * 欠損に強い形で組み立てる。status と terminal_reason は括弧内にカンマ区切りで並べ、
+ * 両方欠ければ括弧を省略する。`result` が文字列なら本文として `: <result>` を付ける。
+ *
+ * exported for testing — internal use only (do not rely on outside tests)
+ *
+ * @param parsed - `_parseClaudeJson` が返した claude JSON オブジェクト
+ * @returns 整形済みエラー詳細メッセージ
+ */
+export const _formatClaudeError = (parsed: Record<string, unknown>): string => {
+  const _status = parsed.api_error_status;
+  const _terminal = parsed.terminal_reason;
+  const _result = parsed.result;
+  const _parts = [
+    typeof _status === 'number' ? `status ${_status}` : undefined,
+    typeof _terminal === 'string' ? _terminal : undefined,
+  ].filter((p): p is string => p !== undefined);
+  const _prefix = _parts.length > 0 ? `claude API error (${_parts.join(', ')})` : 'claude API error';
+  return typeof _result === 'string' ? `${_prefix}: ${_result}` : _prefix;
+};
+
+/**
+ * claude JSON を解釈し、成功なら `.result` を返し、`is_error:true` なら throw する。
+ *
+ * exit code は一切見ない（claude CLI の exit code は信頼できないため）。判別は
+ * `is_error` / `api_error_status` のみで行う。error 分岐では生 stdout を `logger.error`
+ * に `(stdout):` ラベル付きで出力し、`_formatClaudeError` を詳細として throw する。
+ *
+ * @param parsed - `_parseClaudeJson` が返した claude JSON オブジェクト
+ * @param stdout - error 分岐でログ出力する生 stdout
+ * @returns 成功時の `.result` 文字列
+ */
+const _interpretClaudeOutput = (parsed: Record<string, unknown>, stdout: string): string => {
+  if (parsed.is_error === true) {
+    logger.error(`${AI_BACKEND_COMMAND_MAP.claude} error (stdout): ${stdout}`);
+    const _subindex = parsed.api_error_status === 429 ? 'RateLimit' : 'ExitFailure';
+    throw new ChatlogError('AiError', _subindex, _formatClaudeError(parsed));
+  }
+  if (typeof parsed.result !== 'string') {
+    throw new ChatlogError('AiError', 'InvalidFormat', `claude JSON has no string "result" field: ${stdout}`);
+  }
+  return parsed.result;
+};
+
+/**
  * Runs an AI CLI subprocess with the given system prompt and user prompt.
  * Returns the trimmed stdout text on success, or throws on failure.
  */
@@ -160,9 +236,24 @@ export const runAI = async (
     await _writer.write(new TextEncoder().encode(_input));
     await _writer.close();
     const _output = await _process.output();
+    const _stdout = new TextDecoder().decode(_output.stdout).trim();
+    const _stderr = new TextDecoder().decode(_output.stderr).trim();
+
+    // claude backend: JSON がパースできれば exit code は一切見ず、is_error で判別する。
+    if (_spec.command === 'claude') {
+      const _parsed = _parseClaudeJson(_stdout);
+      if (_parsed !== null) {
+        return _interpretClaudeOutput(_parsed, _stdout);
+      }
+      if (_output.success) {
+        throw new ChatlogError('AiError', 'InvalidFormat', `claude output is not JSON: ${_stdout}`);
+      }
+      // _parsed === null かつ exit≠0 → 従来の exit-code + 正規表現フォールバックへ流す。
+    }
+
     if (!_output.success) {
-      const _stderr = new TextDecoder().decode(_output.stderr).trim();
-      const _stdout = new TextDecoder().decode(_output.stdout).trim();
+      if (_stderr) { logger.error(`${_spec.command} exited with code ${_output.code} (stderr): ${_stderr}`); }
+      if (_stdout) { logger.error(`${_spec.command} exited with code ${_output.code} (stdout): ${_stdout}`); }
       const _isRateLimit = _RATE_LIMIT_PATTERN.test(_stderr) || _RATE_LIMIT_PATTERN.test(_stdout)
         || _SANDBOX_DISABLED_PATTERN.test(_stderr) || _SANDBOX_DISABLED_PATTERN.test(_stdout);
       throw new ChatlogError(
@@ -171,7 +262,7 @@ export const runAI = async (
         `${_spec.command} exited with code ${_output.code}: ${_stderr}`,
       );
     }
-    return new TextDecoder().decode(_output.stdout).trim();
+    return _stdout;
   } catch (e) {
     if (_options.signal?.aborted) {
       throw new ChatlogError('Aborted', 'ExternalAbort', `${_spec.command} was aborted by an external signal`);

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -31,7 +31,7 @@ export type RunAIOptions = {
 type _CommandSpec = { command: AiBackendCommand; args: string[]; hasSystemPromptWithArgs: boolean };
 
 /** レートリミット検出パターン。CLI は文言を stdout / stderr のいずれにも出しうる。`i` フラグのみ（`g` を付けると `.test()` がステートフルになる）。 */
-const _RATE_LIMIT_PATTERN = /rate.?limit|429|usage limit/i;
+const _RATE_LIMIT_PATTERN = /rate.?limit|429|usage limit|spend limit/i;
 
 /** rate limit で落ちた Claude CLI の起動バナー "⚠ Sandbox disabled: ..." を検出する。
  *  非ASCII の警告記号(⚠)は含めず、バナー本文(ASCII)で詳細にマッチする。大文字・小文字は厳密に区別する。 */
@@ -187,7 +187,9 @@ export const _formatClaudeError = (parsed: Record<string, unknown>): string => {
 const _interpretClaudeOutput = (parsed: Record<string, unknown>, stdout: string): string => {
   if (parsed.is_error === true) {
     logger.error(`${AI_BACKEND_COMMAND_MAP.claude} error (stdout): ${stdout}`);
-    const _subindex = parsed.api_error_status === 429 ? 'RateLimit' : 'ExitFailure';
+    const _isRateLimit = parsed.api_error_status === 429
+      || (typeof parsed.result === 'string' && _RATE_LIMIT_PATTERN.test(parsed.result));
+    const _subindex = _isRateLimit ? 'RateLimit' : 'ExitFailure';
     throw new ChatlogError('AiError', _subindex, _formatClaudeError(parsed));
   }
   if (typeof parsed.result !== 'string') {

--- a/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -26,6 +26,7 @@ import { main } from '../../classify-chatlogs.ts';
 // mocks
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeCountingMock,
   makeFailMock,
   makeSuccessMock,
@@ -98,7 +99,7 @@ describe('main - dry-run モード', () => {
           ]);
           resetProjectRoot(inputDir);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           loggerStub = makeLoggerStub();
           GlobalConfig.resetInstance();
@@ -153,7 +154,7 @@ describe('main - 正常分類', () => {
           ]);
           resetProjectRoot(inputDir);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           errStub = stub(console, 'error', () => {});
           GlobalConfig.resetInstance();
@@ -597,7 +598,7 @@ describe('main - 期間フィルタ', () => {
           ]);
           resetProjectRoot(inputDir);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           loggerStub = makeLoggerStub();
           errStub = stub(console, 'error', () => {});
@@ -723,7 +724,7 @@ describe('main - --input-dir フルパス直接指定', () => {
           ]);
           resetProjectRoot(inputDir);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           loggerStub = makeLoggerStub();
           GlobalConfig.resetInstance();

--- a/skills/classify-chatlogs/scripts/__tests__/unit/main.unit.spec.ts
+++ b/skills/classify-chatlogs/scripts/__tests__/unit/main.unit.spec.ts
@@ -19,6 +19,7 @@ import { main } from '../../classify-chatlogs.ts';
 // ─── Helpers
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeCountingMock,
   makeSuccessMock,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -98,7 +99,7 @@ describe('main', () => {
         { file: 'chat.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
       resetProjectRoot(inputDir);
-      const commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(response)));
+      const commandHandle = installCommandMock(makeClaudeJsonMock(response));
       const errStub = stub(console, 'error', () => {});
       GlobalConfig.resetInstance();
 
@@ -124,7 +125,7 @@ describe('main', () => {
         { file: 'chat.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
       resetProjectRoot(inputDir);
-      const commandHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(response)));
+      const commandHandle = installCommandMock(makeClaudeJsonMock(response));
       const loggerStub = makeLoggerStub();
       GlobalConfig.resetInstance();
 

--- a/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
@@ -28,8 +28,9 @@ import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
 // ─── Internal Helpers
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeCountingMock,
-  makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import {
   _makeClassifyChatlogEntry,
@@ -85,7 +86,7 @@ describe('classifyByAI', () => {
         { file: 'a.md', project: 'app1', confidence: 0.9, reason: 'matched' },
         { file: 'b.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
-      mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(response)));
+      mockHandle = installCommandMock(makeClaudeJsonMock(response));
 
       const targets: ChatlogEntry[] = [
         _makeClassifyChatlogEntry('a.md'),
@@ -103,7 +104,7 @@ describe('classifyByAI', () => {
       const response = JSON.stringify([
         { file: 'x.md', project: 'app1', confidence: 0.8, reason: 'matched' },
       ]);
-      mockHandle = installCommandMock(makeCountingMock(response, counter));
+      mockHandle = installCommandMock(makeCountingMock(wrapClaudeJson(response), counter));
 
       const targets: ChatlogEntry[] = ['a.md', 'b.md', 'c.md'].map((filename) => _makeClassifyChatlogEntry(filename));
 
@@ -120,7 +121,7 @@ describe('classifyByAI', () => {
       const response = JSON.stringify([
         { file: 'a.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
-      mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(response)));
+      mockHandle = installCommandMock(makeClaudeJsonMock(response));
 
       const targets: ChatlogEntry[] = [_makeClassifyChatlogEntry('a.md')];
 

--- a/skills/classify-chatlogs/scripts/phases/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/functional/process-chunk.functional.spec.ts
@@ -31,8 +31,8 @@ import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
 import {
   BaseMockCommand,
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
-  makeSuccessMock,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import {
@@ -101,7 +101,7 @@ describe('processChunk', () => {
         { file: 'a.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
       mockHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(response)),
+        makeClaudeJsonMock(response),
       );
     });
 
@@ -204,7 +204,7 @@ describe('processChunk', () => {
       loggerStub.restore();
       loggerStub = makeLoggerStub();
       mockHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+        makeClaudeJsonMock('これはJSONではありません'),
       );
 
       const metas = [_makeClassifyChatlogEntry('a.md')];
@@ -220,7 +220,7 @@ describe('processChunk', () => {
       loggerStub.restore();
       loggerStub = makeLoggerStub();
       mockHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+        makeClaudeJsonMock('これはJSONではありません'),
       );
 
       const metas = [_makeClassifyChatlogEntry('a.md')];
@@ -240,7 +240,7 @@ describe('processChunk', () => {
       loggerStub.restore();
       loggerStub = makeLoggerStub();
       mockHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+        makeClaudeJsonMock('これはJSONではありません'),
       );
 
       const metas = [_makeClassifyChatlogEntry('a.md')];
@@ -330,7 +330,7 @@ describe('processChunk', () => {
         { file: 'b.md', project: 'app1', confidence: 0.9, reason: 'matched' },
       ]);
       mockHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(response)),
+        makeClaudeJsonMock(response),
       );
     });
 
@@ -366,7 +366,7 @@ describe('processChunk', () => {
         { file: 'a.md', project: 'app2', confidence: 0.8, reason: 'matched second' },
       ]);
       mockHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(response)),
+        makeClaudeJsonMock(response),
       );
 
       const metas = [_makeClassifyChatlogEntry('a.md')];

--- a/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/e2e/main.e2e.spec.ts
@@ -30,10 +30,10 @@ import { LOGGER_HEADER } from '../../../../_scripts/constants/logger-header.cons
 // mocks
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeCountingMock,
   makeFailMock,
   makeNotFoundMock,
-  makeSuccessMock,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // stub
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -228,14 +228,14 @@ describe('main - DISCARD 判定', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
+            makeClaudeJsonMock(
               JSON.stringify([{
                 file: 'discard.md',
                 decision: FILTER_DECISIONS.DISCARD,
                 confidence: 0.9,
                 reason: 'trivial',
               }]),
-            )),
+            ),
           );
           loggerStub = makeLoggerStub();
         });
@@ -295,14 +295,14 @@ describe('main - KEEP 判定', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
+            makeClaudeJsonMock(
               JSON.stringify([{
                 file: 'keep.md',
                 decision: FILTER_DECISIONS.KEEP,
                 confidence: 0.9,
                 reason: 'valuable',
               }]),
-            )),
+            ),
           );
           loggerStub = makeLoggerStub();
         });
@@ -362,15 +362,13 @@ describe('main - model 配線', () => {
           await _makeGlobalConfig(`cacheDir: '${tempDir}/cache'\nmodel: haiku`);
           capturedArgs = { value: [] };
           commandHandle = installCommandMock(
-            makeSuccessMock(
-              new TextEncoder().encode(
-                JSON.stringify([{
-                  file: 'keep.md',
-                  decision: FILTER_DECISIONS.KEEP,
-                  confidence: 0.9,
-                  reason: 'valuable',
-                }]),
-              ),
+            makeClaudeJsonMock(
+              JSON.stringify([{
+                file: 'keep.md',
+                decision: FILTER_DECISIONS.KEEP,
+                confidence: 0.9,
+                reason: 'valuable',
+              }]),
               capturedArgs,
             ),
           );
@@ -427,7 +425,7 @@ describe('main - 対象ファイルなし', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('[]')),
+            makeClaudeJsonMock('[]'),
           );
           loggerStub = makeLoggerStub();
           exitStub = stub(Deno, 'exit');
@@ -481,12 +479,12 @@ describe('main - DISCARD + KEEP 混在', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
+            makeClaudeJsonMock(
               JSON.stringify([
                 { file: 'discard.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
                 { file: 'keep.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
               ]),
-            )),
+            ),
           );
           loggerStub = makeLoggerStub();
         });
@@ -553,14 +551,14 @@ describe('main - period 絞り込み', () => {
         beforeEach(async () => {
           tempDir = await Deno.makeTempDir();
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
+            makeClaudeJsonMock(
               JSON.stringify([{
                 file: 'march.md',
                 decision: FILTER_DECISIONS.DISCARD,
                 confidence: 0.9,
                 reason: 'trivial',
               }]),
-            )),
+            ),
           );
           loggerStub = makeLoggerStub();
         });
@@ -695,14 +693,14 @@ describe('main - confidence 閾値未満', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
+            makeClaudeJsonMock(
               JSON.stringify([{
                 file: 'low-conf.md',
                 decision: FILTER_DECISIONS.DISCARD,
                 confidence: 0.69,
                 reason: 'uncertain',
               }]),
-            )),
+            ),
           );
           loggerStub = makeLoggerStub();
         });
@@ -872,12 +870,12 @@ describe('main - period 未指定', () => {
         beforeEach(async () => {
           tempDir = await Deno.makeTempDir();
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(
+            makeClaudeJsonMock(
               JSON.stringify([
                 { file: 'march.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
                 { file: 'april.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
               ]),
-            )),
+            ),
           );
           loggerStub = makeLoggerStub();
         });
@@ -1398,7 +1396,7 @@ describe('main - 判定集計ログ（正常系）', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('[]')),
+            makeClaudeJsonMock('[]'),
           );
           loggerStub = makeLoggerStub();
         });
@@ -1535,7 +1533,7 @@ describe('main - 判定集計ログ（判定対象なし）', () => {
         beforeEach(async () => {
           ({ tempDir, chatlogsDir } = await _makeTestDirs());
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('[]')),
+            makeClaudeJsonMock('[]'),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/filter/__tests__/functional/process-chunk.functional.spec.ts
@@ -21,9 +21,9 @@ import type { FilterStats } from '../../../../types/stats.types.ts';
 // ─── Helpers
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
   makeNotFoundMock,
-  makeSuccessMock,
 } from '../../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { ChatlogCache } from '../../../../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../../../../_scripts/classes/ChatlogEntry.class.ts';
@@ -192,7 +192,7 @@ describe('processChunk', () => {
             },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});
@@ -219,7 +219,7 @@ describe('processChunk', () => {
             },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});
@@ -247,7 +247,7 @@ describe('processChunk', () => {
             },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});
@@ -286,7 +286,7 @@ describe('processChunk', () => {
             { file: 'd.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -306,7 +306,7 @@ describe('processChunk', () => {
             { file: 'd2.md', decision: FILTER_DECISIONS.KEEP, confidence: 0.9, reason: 'valuable' },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -340,7 +340,7 @@ describe('processChunk', () => {
             { file: 'e.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'low conf' },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -362,7 +362,7 @@ describe('processChunk', () => {
             { file: 'e2.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'low conf' },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -599,7 +599,7 @@ describe('processChunk', () => {
           const filePath = await _createTempFile('g.md');
           const entry = new ChatlogEntry(_TEMP_CONTENT, { filePath });
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+            makeClaudeJsonMock('これはJSONではありません'),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -617,7 +617,7 @@ describe('processChunk', () => {
           const filePath = await _createTempFile('g2.md');
           const entry = new ChatlogEntry(_TEMP_CONTENT, { filePath });
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+            makeClaudeJsonMock('これはJSONではありません'),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -641,7 +641,7 @@ describe('processChunk', () => {
           const filePath = await _createTempFile('g3.md');
           const entry = new ChatlogEntry(_TEMP_CONTENT, { filePath });
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+            makeClaudeJsonMock('これはJSONではありません'),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -660,7 +660,7 @@ describe('processChunk', () => {
           const file2 = await _createTempFile('g5.md');
           const entry2 = new ChatlogEntry(_TEMP_CONTENT, { filePath: file2 });
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode('これはJSONではありません')),
+            makeClaudeJsonMock('これはJSONではありません'),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -696,7 +696,7 @@ describe('processChunk', () => {
             { file: 'other.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.9, reason: 'trivial' },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -761,7 +761,7 @@ describe('processChunk', () => {
           ]);
           const capturedArgs: { value: string[] } = { value: [] };
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response), capturedArgs),
+            makeClaudeJsonMock(response, capturedArgs),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -797,7 +797,7 @@ describe('processChunk', () => {
           ]);
           const capturedArgs: { value: string[] } = { value: [] };
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response), capturedArgs),
+            makeClaudeJsonMock(response, capturedArgs),
           );
           const errStub = stub(console, 'error', () => {});
           const stats = _makeStats();
@@ -832,7 +832,7 @@ describe('processChunk', () => {
             { file: 'j.md', decision: FILTER_DECISIONS.DISCARD, confidence: 0.6, reason: 'trivial' },
           ]);
           commandHandle = installCommandMock(
-            makeSuccessMock(new TextEncoder().encode(response)),
+            makeClaudeJsonMock(response),
           );
           const errStub = stub(console, 'error', () => {});
           const logStub = stub(console, 'log', () => {});

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/aggregation.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/aggregation.e2e.spec.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
   makeSuccessMock,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
@@ -79,7 +80,7 @@ describe('main - aggregation', () => {
         })),
       );
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(batchResponse)),
+        makeClaudeJsonMock(batchResponse),
       );
       loggerStub = makeLoggerStub();
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/full.e2e.spec.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { main } from '../../normalize-chatlogs.ts';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeTempDirs, removeTempDirs } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { assertAllOutputFiles } from '../../../../_scripts/__tests__/helpers/output-validator.ts';
@@ -86,7 +86,7 @@ describe('normalize-chatlogs - full E2E', () => {
         { filePath: pathC, segments: [{ title: 'Topic C', summary: 'Summary C', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });
@@ -136,7 +136,7 @@ describe('normalize-chatlogs - full E2E', () => {
         },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });
@@ -189,7 +189,7 @@ describe('normalize-chatlogs - full E2E', () => {
         },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/io.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/io.e2e.spec.ts
@@ -15,7 +15,7 @@ import { after, afterEach, before, beforeEach, describe, it } from '@std/testing
 import { main } from '../../normalize-chatlogs.ts';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import {
   makeTempDirs,
   removeTempDirs,
@@ -84,7 +84,7 @@ describe('main - I/O', () => {
         { filePath: pathB, segments: [{ title: 'Topic B', summary: 'Summary B', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       logSilencer = silenceLog();
     });
@@ -142,7 +142,7 @@ describe('main - I/O', () => {
         { filePath: samplePath, segments: [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });
@@ -210,7 +210,7 @@ describe('main - I/O', () => {
         { filePath: chatPath, segments: [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       logSilencer = silenceLog();
     });
@@ -262,7 +262,7 @@ describe('main - I/O', () => {
         { filePath: chatPath, segments: [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       logSilencer = silenceLog();
     });
@@ -313,7 +313,7 @@ describe('main - I/O', () => {
         { filePath: chatPath, segments: [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       logSilencer = silenceLog();
     });
@@ -367,7 +367,7 @@ describe('main - I/O', () => {
         },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       logSilencer = silenceLog();
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
@@ -20,7 +20,7 @@ import type { Stub } from '@std/testing/mock';
 import { main } from '../../normalize-chatlogs.ts';
 
 // ─── Helpers
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
 import { findFiles } from '../../../../_scripts/libs/file-ops/find-files.ts';
@@ -80,7 +80,7 @@ describe('main', () => {
               },
             ]);
             commandHandle = installCommandMock(
-              makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+              makeClaudeJsonMock(segmentResponse),
             );
             loggerStub = makeLoggerStub();
             exitStub = stub(Deno, 'exit');
@@ -162,7 +162,7 @@ describe('main', () => {
               },
             ]);
             commandHandle = installCommandMock(
-              makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+              makeClaudeJsonMock(segmentResponse),
             );
             loggerStub = makeLoggerStub();
             exitStub = stub(Deno, 'exit');

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/output-structure.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/output-structure.e2e.spec.ts
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeTempDirs, removeTempDirs } from '../../../../_scripts/__tests__/helpers/e2e-setup.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -78,7 +78,7 @@ describe('main - output structure', () => {
         { filePath: pathB, segments: [{ title: 'Topic B', summary: 'Summary B', startLine: 1, endLine: 2 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });
@@ -129,7 +129,7 @@ describe('main - output structure', () => {
         },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/reproducibility.e2e.spec.ts
@@ -16,7 +16,7 @@ import { main } from '../../normalize-chatlogs.ts';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 // mock
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // stub
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 
@@ -83,7 +83,7 @@ describe('main - reproducibility', () => {
         { filePath: chatPath, segments: [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 5 }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       loggerStub = makeLoggerStub();
     });
@@ -138,7 +138,7 @@ describe('main - reproducibility', () => {
         { filePath: inputPath, segments: [{ title: 'Topic', summary: 'Summary', content: 'Body' }] },
       ]);
       commandHandle = installCommandMock(
-        makeSuccessMock(new TextEncoder().encode(segmentResponse)),
+        makeClaudeJsonMock(segmentResponse),
       );
       logSilencer = silenceLog();
     });

--- a/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-segments.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/fixtures/fixtures-segments.spec.ts
@@ -25,9 +25,9 @@ import { assertNull } from '../../../../_scripts/__tests__/helpers/assert.ts';
 // test helpers
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
   makeNotFoundMock,
-  makeSuccessMock,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { DenoCommandLike } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { findFixtureDirs } from '../../../../_scripts/__tests__/helpers/find-fixture-dirs.ts';
@@ -73,7 +73,7 @@ function _buildMock(output: FixtureOutput, filePath: string): DenoCommandLike {
       case 'external/not-found':
         return makeNotFoundMock();
       case 'internal/invalid-json':
-        return makeSuccessMock(new TextEncoder().encode('not-json'));
+        return makeClaudeJsonMock('not-json');
       default:
         return makeFailMock(1);
     }
@@ -84,7 +84,7 @@ function _buildMock(output: FixtureOutput, filePath: string): DenoCommandLike {
     content: `content-${i}`,
   }));
   const _aiResult = [{ filePath, segments: _mockSegments }];
-  return makeSuccessMock(new TextEncoder().encode(JSON.stringify(_aiResult)));
+  return makeClaudeJsonMock(JSON.stringify(_aiResult));
 }
 
 // ─── ファイル駆動 fixtures tests ──────────────────────────────────────────────

--- a/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/functional/normalize.functional.spec.ts
@@ -15,9 +15,11 @@ import { assertNull } from '../../../../_scripts/__tests__/helpers/assert.ts';
 // test helpers
 import {
   installCommandMock,
+  makeClaudeJsonMock,
   makeCountingMock,
   makeFailMock,
   makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
@@ -66,7 +68,7 @@ describe('segmentChatlogs', () => {
               ],
             },
           ];
-          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(aiSegments))));
+          mockHandle = installCommandMock(makeClaudeJsonMock(JSON.stringify(aiSegments)));
 
           const resultMap = await segmentChatlogs([_makeEntry(filePath, 'Body A\nBody B')]);
           const result = resultMap.get(filePath);
@@ -89,7 +91,7 @@ describe('segmentChatlogs', () => {
               ],
             },
           ];
-          mockHandle = installCommandMock(makeCountingMock(JSON.stringify(aiSegments), counter));
+          mockHandle = installCommandMock(makeCountingMock(wrapClaudeJson(JSON.stringify(aiSegments)), counter));
 
           await segmentChatlogs([_makeEntry(filePath, 'some chat content')]);
 
@@ -124,7 +126,7 @@ describe('segmentChatlogs', () => {
 
         it('T-09-02-02: runAI が "not json" を返す場合に null を返す', async () => {
           const filePath = 'path/to/file.md';
-          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode('not json')));
+          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(wrapClaudeJson('not json'))));
 
           const resultMap = await segmentChatlogs([_makeEntry(filePath, 'some chat content')]);
 
@@ -162,7 +164,7 @@ describe('segmentChatlogs', () => {
               })),
             },
           ];
-          mockHandle = installCommandMock(makeSuccessMock(new TextEncoder().encode(JSON.stringify(aiSegments))));
+          mockHandle = installCommandMock(makeClaudeJsonMock(JSON.stringify(aiSegments)));
 
           const resultMap = await segmentChatlogs([_makeEntry(filePath, content)]);
           const result = resultMap.get(filePath);

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/process-files.unit.spec.ts
@@ -29,6 +29,7 @@ import {
   makeCountingMock,
   makeFailMock,
   makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { logger } from '../../../../../_scripts/libs/io/logger.ts';
@@ -96,7 +97,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -117,7 +118,7 @@ describe('processFiles', () => {
         { title: 'Topic 2', summary: 'Summary 2', startLine: 2, endLine: 3 },
       ];
       const batch = [{ filePath, segments }];
-      const stdout = new TextEncoder().encode(JSON.stringify(batch));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(batch)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
@@ -139,7 +140,7 @@ describe('processFiles', () => {
         { filePath: filePath1, segments },
         { filePath: filePath2, segments },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(batch));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(batch)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/file1.md`, '# File1\n\nContent1');
@@ -176,7 +177,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const batch = [{ filePath, segments: [] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(batch));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(batch)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(`${tmpDir}/dummy.md`, '# Test\n\nContent');
@@ -246,7 +247,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
@@ -404,7 +405,7 @@ describe('processFiles', () => {
       await Deno.writeTextFile(goodFilePath, '# Test\n\nContent');
 
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath: goodFilePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath: goodFilePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model' | 'failFast'> = {
@@ -455,7 +456,7 @@ describe('processFiles', () => {
 
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
       const batch = filePaths.map((fp) => ({ filePath: fp, segments }));
-      const stdout = new TextEncoder().encode(JSON.stringify(batch));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(batch)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = {
@@ -481,7 +482,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -501,7 +502,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -521,7 +522,7 @@ describe('processFiles', () => {
       // arrange — project frontmatter なしのファイル
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -544,7 +545,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -569,7 +570,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -597,7 +598,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -633,7 +634,7 @@ describe('processFiles', () => {
       // 2回目: 同じファイルを処理 → キャッシュ未登録なのでスキップされない
       mockHandle.restore();
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
       const stats2: Stats = initStats();
       const config: Pick<NormalizeConfig, 'dryRun' | 'concurrency' | 'model'> = { dryRun: false, concurrency: 2 };
@@ -650,7 +651,7 @@ describe('processFiles', () => {
       // outputBase 側にファイルが存在するだけではスキップされてはならない。
       const filePath = normalizePath(`${tmpDir}/report.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 3 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
@@ -676,7 +677,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 2 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       await Deno.writeTextFile(filePath, '# Test\n\nContent');
@@ -696,7 +697,7 @@ describe('processFiles', () => {
       // arrange
       const filePath = normalizePath(`${tmpDir}/dummy.md`);
       const segments = [{ title: 'Topic', summary: 'Summary', startLine: 1, endLine: 2 }];
-      const stdout = new TextEncoder().encode(JSON.stringify([{ filePath, segments }]));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify([{ filePath, segments }])));
       const counter = { calls: 0 };
       mockHandle = installCommandMock(makeCountingMock(new TextDecoder().decode(stdout), counter));
 

--- a/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-ai.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/modules/__tests__/unit/segment-ai.unit.spec.ts
@@ -27,10 +27,12 @@ import { logger } from '../../../../../_scripts/libs/io/logger.ts';
 import {
   BaseMockCommand,
   installCommandMock,
+  makeClaudeJsonMock,
   makeDelayedSuccessMock,
   makeFailMock,
   makeNotFoundMock,
   makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // classes
@@ -225,8 +227,7 @@ describe('segmentChatlogs', () => {
           ],
         },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
-      mockHandle = installCommandMock(makeSuccessMock(stdout));
+      mockHandle = installCommandMock(makeClaudeJsonMock(JSON.stringify(aiResult)));
 
       // act
       const result = await segmentChatlogs([_makeEntry('test.md', 'Body 1\nBody 2')]);
@@ -248,7 +249,7 @@ describe('segmentChatlogs', () => {
         { filePath: 'a.md', segments: [{ title: 'T1', summary: 'S1', startLine: 1, endLine: 1 }] },
         { filePath: 'b.md', segments: [{ title: 'T2', summary: 'S2', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -270,7 +271,7 @@ describe('segmentChatlogs', () => {
         endLine: i + 1,
       }));
       const aiResult = [{ filePath: 'big.md', segments: manySegments }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -290,7 +291,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
@@ -308,7 +309,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'test.md', segments: [{ title: 'Topic 1', summary: 'Summary 1', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
@@ -342,7 +343,7 @@ describe('segmentChatlogs', () => {
     it('[Error] T-SCB-02-02: AIが不正JSONを返すとき全ファイルが null の Map を返す', async () => {
       // arrange
       const inputs = [_makeEntry('a.md', 'content a')];
-      const stdout = new TextEncoder().encode('not valid json');
+      const stdout = new TextEncoder().encode(wrapClaudeJson('not valid json'));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -375,7 +376,7 @@ describe('segmentChatlogs', () => {
     it('[Error] T-SCB-WL-02: AI が不正 JSON を返すとき logger.warn が呼ばれる', async () => {
       // arrange
       const inputs = [_makeEntry('file-b.md', 'content b')];
-      const stdout = new TextEncoder().encode('not valid json');
+      const stdout = new TextEncoder().encode(wrapClaudeJson('not valid json'));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
       let warnStub: Stub | undefined;
 
@@ -424,7 +425,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'solo.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -440,7 +441,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -459,7 +460,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 2 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       const captured: { instance: _StdinCaptureMock | null } = { instance: null };
       mockHandle = installCommandMock(_makeStdinCaptureMock(stdout, captured));
       const content = 'line A\nline B';
@@ -482,7 +483,7 @@ describe('segmentChatlogs', () => {
         const aiResult = [
           { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
         ];
-        const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+        const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
         const captured: { instance: _StdinCaptureMock | null } = { instance: null };
         mockHandle = installCommandMock(_makeStdinCaptureMock(stdout, captured));
         const content = Array.from({ length: lineIndex }, (_, i) => `L${i + 1}`).join('\n');
@@ -511,7 +512,7 @@ describe('segmentChatlogs', () => {
         { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 2 }] },
         { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 1, endLine: 2 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -532,7 +533,7 @@ describe('segmentChatlogs', () => {
         { filePath: 'a.md', segments: [{ title: 'AT', summary: 'AS', startLine: 1, endLine: 1 }] },
         { filePath: 'b.md', segments: [{ title: 'BT', summary: 'BS', startLine: 2, endLine: 3 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -562,7 +563,7 @@ describe('segmentChatlogs', () => {
     it('[Error] T-SIO-LR-22: AIが不正 JSON を返すとき全ファイルが null の Map を返す', async () => {
       // arrange
       const inputs = [_makeEntry('a.md', 'content a')];
-      const stdout = new TextEncoder().encode('not valid json');
+      const stdout = new TextEncoder().encode(wrapClaudeJson('not valid json'));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -578,7 +579,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -599,7 +600,7 @@ describe('segmentChatlogs', () => {
         endLine: i + 1,
       }));
       const aiResult = [{ filePath: 'big.md', segments: aiSegments }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
 
       // act
@@ -613,7 +614,7 @@ describe('segmentChatlogs', () => {
       // arrange — AI が 50ms 後に応答するモック
       const inputs = [_makeEntry('a.md', 'content a')];
       const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
 
       // act — 1ms タイムアウト: 50ms の遅延より先に abort される
@@ -630,7 +631,7 @@ describe('segmentChatlogs', () => {
       // arrange — AI が 50ms 後に応答するモック
       const inputs = [_makeEntry('a.md', 'content a')];
       const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', content: 'C' }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
 
       // act — 1ms タイムアウト: 50ms の遅延より先に abort される
@@ -644,7 +645,7 @@ describe('segmentChatlogs', () => {
       // arrange — AI が 50ms 後に応答するモック
       const inputs = [_makeEntry('a.md', 'C')];
       const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeDelayedSuccessMock(50, stdout));
 
       // act — timeoutMs 省略: デフォルト 120s >> 50ms 遅延
@@ -661,7 +662,7 @@ describe('segmentChatlogs', () => {
       // arrange
       const inputs = [_makeEntry('a.md', 'content a')];
       const aiResult = [{ filePath: 'a.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] }];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       const captured: { instance: _SignalCaptureMock | null } = { instance: null };
       mockHandle = installCommandMock(_makeSignalCaptureMock(stdout, captured));
       const controller = new AbortController();
@@ -683,7 +684,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'test.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       const capturedArgs: { value: string[] } = { value: [] };
       mockHandle = installCommandMock(makeSuccessMock(stdout, capturedArgs));
 
@@ -705,7 +706,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'unknown.md', segments: [{ title: 'T', summary: 'S', startLine: 1, endLine: 1 }] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
       let warnStub: Stub | undefined;
 
@@ -729,7 +730,7 @@ describe('segmentChatlogs', () => {
       const aiResult = [
         { filePath: 'known.md', segments: [] },
       ];
-      const stdout = new TextEncoder().encode(JSON.stringify(aiResult));
+      const stdout = new TextEncoder().encode(wrapClaudeJson(JSON.stringify(aiResult)));
       mockHandle = installCommandMock(makeSuccessMock(stdout));
       let warnStub: Stub | undefined;
 

--- a/skills/normalize-chatlogs/scripts/phases/__tests__/unit/phase-segment.unit.spec.ts
+++ b/skills/normalize-chatlogs/scripts/phases/__tests__/unit/phase-segment.unit.spec.ts
@@ -17,6 +17,7 @@ import {
   makeCountingMock,
   makeFailMock,
   makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // types
 import type {
@@ -56,16 +57,18 @@ const _makeEntry = (filePath: string, content: string): ChatlogEntry => new Chat
  * AI 応答 JSON（`segmentChatlogs` が期待する `{filePath, segments}[]` 形式）を文字列化する。
  *
  * @param aiEntries - `filePath` と `segments`（`startLine`/`endLine` を省略可能）の配列
- * @returns `Deno.Command` モックの stdout に渡す JSON 文字列
+ * @returns `Deno.Command` モックの stdout に渡す claude JSON エンベロープ文字列（`{"result":"<配列>"}`）
  */
 const _makeAiResponse = (
   aiEntries: Array<{ filePath: string; segments: Array<{ title: string; startLine?: number; endLine?: number }> }>,
 ): string =>
-  JSON.stringify(
-    aiEntries.map((e) => ({
-      filePath: e.filePath,
-      segments: e.segments.map((s) => ({ summary: 'summary', ...s })),
-    })),
+  wrapClaudeJson(
+    JSON.stringify(
+      aiEntries.map((e) => ({
+        filePath: e.filePath,
+        segments: e.segments.map((s) => ({ summary: 'summary', ...s })),
+      })),
+    ),
   );
 
 /**

--- a/skills/set-frontmatter/scripts/__tests__/e2e/dry-run.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/dry-run.e2e.spec.ts
@@ -14,11 +14,10 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { main } from '../../set-frontmatter.ts';
 
 // ─── Helpers
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { readTextFile } from '../../../../_scripts/libs/file-io/read-utils.ts';
 import {
-  enc,
   makeCacheDir,
   makeDicsDir,
   makeTargetDir,
@@ -60,7 +59,7 @@ describe('main - dry-run モード', () => {
             'validity: pass',
           ];
           commandHandle = installCommandMock(
-            makeSuccessMock(enc.encode(phaseResponses.join('\n')), { value: [] }),
+            makeClaudeJsonMock(phaseResponses.join('\n'), { value: [] }),
           );
           void callIdx;
 
@@ -150,7 +149,7 @@ describe('main - dry-run モード', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await makeCacheDir(['test']);
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -215,7 +214,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await makeCacheDir(['written']);
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -264,7 +263,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await makeCacheDir(['test']);
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -313,7 +312,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -362,7 +361,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await makeCacheDir(['written']);
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -448,7 +447,7 @@ describe('main - dry-run 完了ログ (T-SF-DR)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await makeCacheDir(['test']);
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -508,7 +507,7 @@ describe('main - dry-run ステータス別集計 (T-SF-DR-06)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -572,7 +571,7 @@ describe('main - dry-run ステータス別集計 (T-SF-DR-06)', () => {
             }),
           );
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -623,7 +622,7 @@ describe('main - dry-run ステータス別集計 (T-SF-DR-06)', () => {
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          commandHandle = installCommandMock(makeSuccessMock(enc.encode('research')));
+          commandHandle = installCommandMock(makeClaudeJsonMock('research'));
           loggerStub = makeLoggerStub();
         });
 
@@ -683,7 +682,7 @@ describe('main - dry-run FAIL抑制 (T-SF-E2E-DR-05)', () => {
           dicsDir = await makeDicsDir();
           // 全フェーズで空文字を返す（status が空になる条件）
           commandHandle = installCommandMock(
-            makeSuccessMock(enc.encode('')),
+            makeClaudeJsonMock(''),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
@@ -16,14 +16,14 @@ import { main } from '../../set-frontmatter.ts';
 import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts';
 
 // ─── Helpers
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import {
-  enc,
   makeBannerFailOnNthMock,
   makeDicsDir,
   makeRateLimitMock,
   makeSuccessThenBannerFailMock,
+  makeSuccessThenExitFailMock,
   makeTargetDir,
 } from '../helpers/setfm-e2e-helpers.ts';
 // types
@@ -52,7 +52,7 @@ describe('main - yaml 生成失敗', () => {
           dicsDir = await makeDicsDir();
           // 全フェーズで空文字を返す（title: なし → cleanYaml で空になる）
           commandHandle = installCommandMock(
-            makeSuccessMock(enc.encode('')),
+            makeClaudeJsonMock(''),
           );
           loggerStub = makeLoggerStub();
         });
@@ -349,6 +349,192 @@ describe('main - rate limit(sandbox バナー) 貫通 (review フェーズ) (T-S
           ) as ChatlogError;
           assertEquals(_err.kind, 'AiError');
           assertEquals(_err.subindex, 'RateLimit');
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-17: ExitFailure(非RateLimit) が Phase 2.1 で main を reject させず続行 ─
+
+/**
+ * Phase 2.1（type/category）の最初の runAI が非 RateLimit の AI エラー（claude JSON
+ * `is_error:true` / `api_error_status:500` → ExitFailure）で落ちたとき、`main()` が reject せず
+ * `logger.error` を出して続行することを検証する。
+ *
+ * ExitFailure は RateLimit と区別され、中断せず skip（type/category を書かない）される。
+ *
+ * テスト ID 範囲: T-SF-E2E-17-01
+ */
+describe('main - ExitFailure 続行 (Phase 2.1 type/category) (T-SF-E2E-17)', () => {
+  describe('Given: Phase2.1 最初の runAI が ExitFailure(is_error:true/status:500) を返すモック', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", "--dics", ...]) を呼び出す', () => {
+      describe('Then: T-SF-E2E-17 - main が reject せず resolve し error ログを出す', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          // okCount=0: 最初の呼び出し(type/category)から ExitFailure
+          commandHandle = installCommandMock(makeSuccessThenExitFailMock(0, 'type: research\ncategory: development'));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Error] T-SF-E2E-17-01: Phase 2.1 の ExitFailure で main が resolve し errorLogs に判定失敗ログが出る', async () => {
+          await main([
+            '--input-dir',
+            inputDir,
+            '--output-dir',
+            outputDir,
+            '--cache-dir',
+            cacheDir,
+            '--no-review',
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(loggerStub.errorLogs.some((l) => l.includes('type/category 判定失敗')), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-18: ExitFailure(非RateLimit) が frontmatter フェーズで main を reject させず続行 ─
+
+/**
+ * Phase 2.1（type/category）は成功し、Phase 2.2（frontmatter 生成）の runAI が非 RateLimit の
+ * AI エラー（ExitFailure）で落ちたとき、`main()` が reject せず `logger.error`（生成失敗）を出して
+ * 続行することを検証する。
+ *
+ * テスト ID 範囲: T-SF-E2E-18-01
+ */
+describe('main - ExitFailure 続行 (frontmatter フェーズ) (T-SF-E2E-18)', () => {
+  describe('Given: Phase2.1 成功・Phase2.2 で ExitFailure を返すモック', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", "--dics", ...]) を呼び出す', () => {
+      describe('Then: T-SF-E2E-18 - main が reject せず resolve し error ログ(生成失敗)を出す', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          // okCount=1: 1回目(type/category)成功、2回目以降(frontmatter)を ExitFailure にする
+          commandHandle = installCommandMock(makeSuccessThenExitFailMock(1, 'type: research\ncategory: development'));
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Error] T-SF-E2E-18-01: frontmatter フェーズの ExitFailure で main が resolve し errorLogs に生成失敗ログが出る', async () => {
+          await main([
+            '--input-dir',
+            inputDir,
+            '--output-dir',
+            outputDir,
+            '--cache-dir',
+            cacheDir,
+            '--no-review',
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(loggerStub.errorLogs.some((l) => l.includes('生成失敗')), true);
+        });
+      });
+    });
+  });
+});
+
+// ─── T-SF-E2E-19: ExitFailure(非RateLimit) が review フェーズで main を reject させず続行 ─
+
+/**
+ * Phase 2.1（type/category）と Phase 2.2（frontmatter）は成功し、Phase 3.1（review）の runAI が
+ * 非 RateLimit の AI エラー（ExitFailure）で落ちたとき、`main()` が reject せず
+ * `logger.error`（review 失敗）を出して続行することを検証する。
+ *
+ * review フェーズを実行するため `--no-review` は付けない。frontmatter が必須フィールドを生成できるよう
+ * title/topics/tags を含む rich stdout を返す。
+ *
+ * テスト ID 範囲: T-SF-E2E-19-01
+ */
+describe('main - ExitFailure 続行 (review フェーズ) (T-SF-E2E-19)', () => {
+  describe('Given: Phase2.1/2.2 成功・Phase3.1(review) で ExitFailure を返すモック', () => {
+    describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--dics", ...]) を呼び出す', () => {
+      describe('Then: T-SF-E2E-19 - main が reject せず resolve し error ログ(review 失敗)を出す', () => {
+        let inputDir: string;
+        let outputDir: string;
+        let cacheDir: string;
+        let dicsDir: string;
+        let commandHandle: CommandMockHandle;
+        let loggerStub: LoggerStub;
+
+        beforeEach(async () => {
+          inputDir = await makeTargetDir();
+          outputDir = await Deno.makeTempDir();
+          cacheDir = await Deno.makeTempDir();
+          dicsDir = await makeDicsDir();
+          // okCount=2: 1回目(type/category)+2回目(frontmatter)成功、3回目以降(review)を ExitFailure にする
+          commandHandle = installCommandMock(
+            makeSuccessThenExitFailMock(
+              2,
+              'type: research\ncategory: development\ntitle: "t"\ntopics:\n  - ai\ntags:\n  - test\n',
+            ),
+          );
+          loggerStub = makeLoggerStub();
+        });
+
+        afterEach(async () => {
+          commandHandle.restore();
+          loggerStub.restore();
+          await Deno.remove(inputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(outputDir, { recursive: true }).catch(() => {});
+          await Deno.remove(cacheDir, { recursive: true }).catch(() => {});
+          await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
+        });
+
+        it('[Error] T-SF-E2E-19-01: review フェーズの ExitFailure で main が resolve し errorLogs に review 失敗ログが出る', async () => {
+          await main([
+            '--input-dir',
+            inputDir,
+            '--output-dir',
+            outputDir,
+            '--cache-dir',
+            cacheDir,
+            '--dics',
+            dicsDir,
+          ]);
+
+          assertEquals(loggerStub.errorLogs.some((l) => l.includes('review 失敗')), true);
         });
       });
     });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/input-dir.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/input-dir.e2e.spec.ts
@@ -14,10 +14,10 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { main } from '../../set-frontmatter.ts';
 
 // ─── Helpers
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { GlobalConfig } from '../../../../_scripts/classes/GlobalConfig.class.ts';
-import { enc, makeDicsDir } from '../helpers/setfm-e2e-helpers.ts';
+import { makeDicsDir } from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -58,7 +58,7 @@ describe('main - --input-dir 未指定（デフォルト絞り込み）', () => 
           });
 
           commandHandle = installCommandMock(
-            makeSuccessMock(enc.encode('research\ndevelopment'), { value: [] }),
+            makeClaudeJsonMock('research\ndevelopment', { value: [] }),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/review.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/review.e2e.spec.ts
@@ -14,9 +14,9 @@ import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 import { main } from '../../set-frontmatter.ts';
 
 // ─── Helpers
-import { installCommandMock, makeSuccessMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
-import { enc, makeDicsDir, makeTargetDir } from '../helpers/setfm-e2e-helpers.ts';
+import { makeDicsDir, makeTargetDir } from '../helpers/setfm-e2e-helpers.ts';
 // types
 import type { CommandMockHandle } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
@@ -42,7 +42,7 @@ describe('main - --no-review モード', () => {
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
           commandHandle = installCommandMock(
-            makeSuccessMock(enc.encode('research')),
+            makeClaudeJsonMock('research'),
           );
           loggerStub = makeLoggerStub();
         });

--- a/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
+++ b/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
@@ -7,7 +7,7 @@
 // This software is released under the MIT License.
 
 // ─── Helpers
-import { BaseMockCommand } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { BaseMockCommand, wrapClaudeJson } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 // types
 import type { DenoCommandLike } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 
@@ -98,12 +98,13 @@ export const makeCacheDir = async (basenames: string[]): Promise<string> => {
  */
 export const makeSequentialMock = (responses: Uint8Array[]): DenoCommandLike => {
   let callCount = 0;
+  const _wrapped = responses.map((r) => enc.encode(wrapClaudeJson(new TextDecoder().decode(r))));
   return class extends BaseMockCommand {
     private readonly _stdout: Uint8Array;
     constructor(_cmd: string, _opts: unknown) {
       super();
-      const idx = callCount < responses.length ? callCount : responses.length - 1;
-      this._stdout = responses[idx];
+      const idx = callCount < _wrapped.length ? callCount : _wrapped.length - 1;
+      this._stdout = _wrapped[idx];
       callCount++;
     }
     protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array }> {
@@ -151,7 +152,7 @@ export const SANDBOX_BANNER =
  */
 export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string): DenoCommandLike => {
   let callCount = 0;
-  const _okBytes = enc.encode(okStdout);
+  const _okBytes = enc.encode(wrapClaudeJson(okStdout));
   return class extends BaseMockCommand {
     private readonly _fail: boolean;
     constructor(_cmd: string, _opts: unknown) {
@@ -173,6 +174,44 @@ export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string)
   } as unknown as DenoCommandLike;
 };
 
+/** claude JSON の非 RateLimit エラー応答（`is_error:true` / `api_error_status:500`）。429 でないため `runAI` は `ExitFailure` に分類する。 */
+export const EXIT_FAILURE_JSON = '{"is_error":true,"api_error_status":500,"result":"boom"}';
+
+/**
+ * 最初の `okCount` 回は指定 stdout で成功し、それ以降は exit 1 + claude JSON エラー（`is_error:true` /
+ * `api_error_status:500`）で失敗するモック。
+ *
+ * 失敗時 stdout の `api_error_status` が 429 ではないため `runAI` は `RateLimit` ではなく `ExitFailure`
+ * （非 RateLimit の AI エラー）に分類する。set-frontmatter の各フェーズで ExitFailure が発生したとき、
+ * `main()` が reject せず `logger.error` を出して続行することを検証するために使用する。
+ *
+ * @param okCount - 成功させる先頭呼び出し回数（type/category: 0 / frontmatter: 1 / review: 2）
+ * @param okStdout - 成功時に返す stdout 文字列
+ * @returns `DenoCommandLike` モッククラス
+ */
+export const makeSuccessThenExitFailMock = (okCount: number, okStdout: string): DenoCommandLike => {
+  let callCount = 0;
+  const _okBytes = enc.encode(wrapClaudeJson(okStdout));
+  const _failBytes = enc.encode(EXIT_FAILURE_JSON);
+  /** okCount 回成功→以降 ExitFailure JSON を返す `DenoCommandLike` モック。 */
+  return class extends BaseMockCommand {
+    private readonly _fail: boolean;
+    /** 呼び出し回数を数え、okCount 到達後は失敗フラグを立てる。 */
+    constructor(_cmd: string, _opts: unknown) {
+      super();
+      this._fail = callCount >= okCount;
+      callCount++;
+    }
+    /** 失敗時は exit 1 + ExitFailure JSON、成功時は exit 0 + wrapClaudeJson(okStdout) を返す。 */
+    protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+      if (this._fail) {
+        return Promise.resolve({ success: false, code: 1, stdout: _failBytes, stderr: new Uint8Array() });
+      }
+      return Promise.resolve({ success: true, code: 0, stdout: _okBytes, stderr: new Uint8Array() });
+    }
+  } as unknown as DenoCommandLike;
+};
+
 /**
  * `failOn`（1始まり）番目の呼び出しだけ exit 1 + sandbox バナーで失敗し、他は success を返すモック。
  *
@@ -185,7 +224,7 @@ export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string)
  */
 export const makeBannerFailOnNthMock = (failOn: number, okStdout: string): DenoCommandLike => {
   let callCount = 0;
-  const _okBytes = enc.encode(okStdout);
+  const _okBytes = enc.encode(wrapClaudeJson(okStdout));
   return class extends BaseMockCommand {
     private readonly _fail: boolean;
     constructor(_cmd: string, _opts: unknown) {

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -11,7 +11,7 @@
 
 // ─── BDD modules
 import { assert, assertEquals, assertRejects, assertStringIncludes } from '@std/assert';
-import { afterEach, describe, it } from '@std/testing/bdd';
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
 import {
@@ -23,13 +23,16 @@ import {
 import {
   BaseMockCommand,
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
-  makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type {
   CommandMockHandle,
   DenoCommandLike,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+import type { LoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 // constants
@@ -325,9 +328,15 @@ describe('_buildTypeCategorySystemPrompt', () => {
  */
 describe('judgeTypeAndCategory', () => {
   let commandHandle: CommandMockHandle;
+  let loggerStub: LoggerStub;
+
+  beforeEach(() => {
+    loggerStub = makeLoggerStub();
+  });
 
   afterEach(() => {
     commandHandle?.restore();
+    loggerStub.restore();
   });
 
   // ─── 正常系 ─────────────────────────────────────────────────────────────────
@@ -341,7 +350,7 @@ describe('judgeTypeAndCategory', () => {
       '[Normal] T-SF-TC-11: AI が "type: discussion\\ncategory: development" を返す → 両フィールドが entry.frontmatter にセットされる',
       async () => {
         commandHandle = installCommandMock(
-          makeSuccessMock(_enc.encode('type: discussion\ncategory: development')),
+          makeClaudeJsonMock('type: discussion\ncategory: development'),
         );
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -364,7 +373,7 @@ describe('judgeTypeAndCategory', () => {
       '[Edge] T-SF-TC-16: AI が "type: research" のみ（category なし）を返す → type=research, category=development（デフォルト）',
       async () => {
         commandHandle = installCommandMock(
-          makeSuccessMock(_enc.encode('type: research')),
+          makeClaudeJsonMock('type: research'),
         );
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -379,7 +388,7 @@ describe('judgeTypeAndCategory', () => {
       '[Edge] T-SF-TC-17: AI が "category: development" のみ（type なし）を返す → type=research（デフォルト）, category=development',
       async () => {
         commandHandle = installCommandMock(
-          makeSuccessMock(_enc.encode('category: development')),
+          makeClaudeJsonMock('category: development'),
         );
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -394,7 +403,7 @@ describe('judgeTypeAndCategory', () => {
       '[Edge] T-SF-TC-18: AI が逆順 "category: development\\ntype: research" を返す → 両方正しくセットされる',
       async () => {
         commandHandle = installCommandMock(
-          makeSuccessMock(_enc.encode('category: development\ntype: research')),
+          makeClaudeJsonMock('category: development\ntype: research'),
         );
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -409,7 +418,7 @@ describe('judgeTypeAndCategory', () => {
       '[Edge] T-SF-TC-12: 不正な type キー → フォールバック type がセットされる',
       async () => {
         commandHandle = installCommandMock(
-          makeSuccessMock(_enc.encode('type: unknown_type\ncategory: development')),
+          makeClaudeJsonMock('type: unknown_type\ncategory: development'),
         );
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -427,7 +436,7 @@ describe('judgeTypeAndCategory', () => {
       '[Edge] T-SF-TC-13: 不正な category キー → フォールバック category がセットされる',
       async () => {
         commandHandle = installCommandMock(
-          makeSuccessMock(_enc.encode('type: research\ncategory: unknown_category')),
+          makeClaudeJsonMock('type: research\ncategory: unknown_category'),
         );
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -444,21 +453,29 @@ describe('judgeTypeAndCategory', () => {
   // ─── エラー耐性 ─────────────────────────────────────────────────────────────
 
   /**
-   * AI CLI が非0終了で失敗したとき、フォールバックに落とさず fatal な `ChatlogError` を
-   * 再 throw することを検証する（rate limit を content 失敗と区別できないため fail-first）。
+   * AI CLI が非0終了で失敗したときのエラー分岐を検証する。
+   *
+   * 非 RateLimit の AI エラー（ExitFailure）は throw せず、type/category を書き込まずに skip し
+   * `logger.error` へ判定失敗ログを出す。RateLimit のみ再 throw で中断する（別ケース TC-21/23）。
    */
   describe('When: 異常系', () => {
     it(
-      '[Error] T-SF-TC-14: AI が失敗（exit code=1） → フォールバックせず ChatlogError(AiError) を throw',
+      '[Error] T-SF-TC-14: AI が失敗（exit code=1 / ExitFailure） → throw せず type/category 未設定・error ログを出す',
       async () => {
         commandHandle = installCommandMock(makeFailMock(1));
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
-        const _err = await assertRejects(
-          () => judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts()),
-          ChatlogError,
-        ) as ChatlogError;
-        assertEquals(_err.kind, 'AiError');
+        // throw しないこと（assertRejects を外し直接 await）
+        await judgeTypeAndCategory(_entry, _MAX_CONTENT_LENGTH, _makeDics(), _makePrompts());
+
+        // type/category は書き込まれない（skip）
+        assertEquals(_entry.frontmatter.get('type'), undefined);
+        assertEquals(_entry.frontmatter.get('category'), undefined);
+        // 判定失敗ログが 1 件以上（runAI 内部 error ログも同 stub に乗るため部分一致・件数下限で判定）
+        assertEquals(
+          loggerStub.errorLogs.some((l) => l.includes('type/category 判定失敗')),
+          true,
+        );
       },
     );
 
@@ -514,7 +531,7 @@ describe('judgeTypeAndCategory', () => {
     it('[Normal] T-SF-TC-19: model="haiku" を指定 → capturedArgs に --model haiku が含まれる', async () => {
       const capturedArgs: { value: string[] } = { value: [] };
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('type: discussion\ncategory: development'), capturedArgs),
+        makeClaudeJsonMock('type: discussion\ncategory: development', capturedArgs),
       );
 
       const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -528,7 +545,7 @@ describe('judgeTypeAndCategory', () => {
     it('[Normal] T-SF-TC-20: model 省略 → capturedArgs に --model DEFAULT_AI_MODEL が含まれる', async () => {
       const capturedArgs: { value: string[] } = { value: [] };
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('type: discussion\ncategory: development'), capturedArgs),
+        makeClaudeJsonMock('type: discussion\ncategory: development', capturedArgs),
       );
 
       const _entry = _makeChatlogEntry('# テスト\n本文');
@@ -559,7 +576,7 @@ describe('judgeTypeAndCategory', () => {
     });
 
     it('[Normal] T-SF-TC-22: signal を渡すと runAI に転送され、外部 abort で内部 signal も aborted になる', async () => {
-      const _goodYaml = _enc.encode('type: discussion\ncategory: development');
+      const _goodYaml = _enc.encode(wrapClaudeJson('type: discussion\ncategory: development'));
       const captured: { instance: _SignalCaptureMock | null } = { instance: null };
       commandHandle = installCommandMock(_makeSignalCaptureMock(_goodYaml, captured));
       const controller = new AbortController();

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
@@ -24,10 +24,11 @@ import { generateFrontmatter } from '../../setfm-frontmatter.ts';
 import {
   BaseMockCommand,
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
   makeFirstNFailMock,
   makeSequencedSuccessMock,
-  makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type {
   CommandMockHandle,
@@ -214,7 +215,7 @@ describe('generateFrontmatter', () => {
   describe('When: 正常系', () => {
     it('[Normal] T-SF-FM-01-01: runAI が有効な YAML を返す → true を返し entry.frontmatter に title がセットされる', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('title: "test title"\ntopics:\n  - ai\ntags:\n  - test\n')),
+        makeClaudeJsonMock('title: "test title"\ntopics:\n  - ai\ntags:\n  - test\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -226,10 +227,8 @@ describe('generateFrontmatter', () => {
 
     it('[Normal] T-SF-FM-01-02: runAI が type/category を含む YAML を返す → それらは entry.frontmatter に上書きされない', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(
-          _enc.encode(
-            'title: "overwrite test"\ntype: "new-type"\ncategory: "new-cat"\ntopics:\n  - ai\ntags:\n  - test\n',
-          ),
+        makeClaudeJsonMock(
+          'title: "overwrite test"\ntype: "new-type"\ncategory: "new-cat"\ntopics:\n  - ai\ntags:\n  - test\n',
         ),
       );
 
@@ -252,7 +251,7 @@ describe('generateFrontmatter', () => {
   describe('When: AiError はリトライで救済されない', () => {
     it('[Error] T-SF-FM-04-01: maxRetry=1, 1回目が AiError（2回目は成功しうる） → 救済せず ChatlogError(AiError) を throw', async () => {
       commandHandle = installCommandMock(
-        makeFirstNFailMock(1, 'title: "retry success"\ntopics:\n  - ai\ntags:\n  - test\n'),
+        makeFirstNFailMock(1, wrapClaudeJson('title: "retry success"\ntopics:\n  - ai\ntags:\n  - test\n')),
       );
 
       const _entry = _makeChatlogEntry();
@@ -294,7 +293,7 @@ describe('generateFrontmatter', () => {
 
     it('[Error] T-SF-FM-02-02: maxRetry=2, 3回すべて YAML パース失敗 → ChatlogError(InvalidYaml) を throw', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('title: test\n  invalid_indent: bad\n')),
+        makeClaudeJsonMock('title: test\n  invalid_indent: bad\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -306,7 +305,7 @@ describe('generateFrontmatter', () => {
 
     it('[Error] T-SF-FM-02-04: AI が必須フィールド不足の YAML を返す → false を返す', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('title: null\ntopics: null\n')),
+        makeClaudeJsonMock('title: null\ntopics: null\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -345,7 +344,7 @@ describe('generateFrontmatter', () => {
       const _badYaml = 'title: test\n  invalid_indent: bad\n';
       const _goodYaml = 'title: "finally succeeded"\ntopics:\n  - ai\ntags:\n  - test\n';
       commandHandle = installCommandMock(
-        makeSequencedSuccessMock([_badYaml, _badYaml, _goodYaml]),
+        makeSequencedSuccessMock([_badYaml, _badYaml, _goodYaml].map(wrapClaudeJson)),
       );
 
       const _entry = _makeChatlogEntry();
@@ -357,7 +356,7 @@ describe('generateFrontmatter', () => {
 
     it('[Edge] T-SF-FM-03-01: maxRetry=0, runAI が空文字列を返す → ChatlogError(InvalidYaml) を throw', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('')),
+        makeClaudeJsonMock(''),
       );
 
       const _entry = _makeChatlogEntry();
@@ -369,7 +368,7 @@ describe('generateFrontmatter', () => {
 
     it('[Edge] T-SF-FM-03-02: extractYaml が { ok: false } を返す → logger.warn が呼ばれ ChatlogError を throw', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('')),
+        makeClaudeJsonMock(''),
       );
       let warnStub: Stub<typeof logger, [string], void> | undefined;
       try {
@@ -393,7 +392,7 @@ describe('generateFrontmatter', () => {
     it('[Normal] T-SF-FM-05-01: model="haiku" を指定 → capturedArgs に --model haiku が含まれる', async () => {
       const capturedArgs: { value: string[] } = { value: [] };
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n'), capturedArgs),
+        makeClaudeJsonMock('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n', capturedArgs),
       );
 
       const _entry = _makeChatlogEntry();
@@ -407,7 +406,7 @@ describe('generateFrontmatter', () => {
     it('[Normal] T-SF-FM-05-02: model 省略 → capturedArgs に --model DEFAULT_AI_MODEL が含まれる', async () => {
       const capturedArgs: { value: string[] } = { value: [] };
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n'), capturedArgs),
+        makeClaudeJsonMock('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n', capturedArgs),
       );
 
       const _entry = _makeChatlogEntry();
@@ -438,7 +437,7 @@ describe('generateFrontmatter', () => {
     });
 
     it('[Normal] T-SF-FM-06-02: signal を渡すと runAI に転送され、外部 abort で内部 signal も aborted になる', async () => {
-      const _goodYaml = _enc.encode('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n');
+      const _goodYaml = _enc.encode(wrapClaudeJson('title: "t"\ntopics:\n  - ai\ntags:\n  - test\n'));
       const captured: { instance: _SignalCaptureMock | null } = { instance: null };
       commandHandle = installCommandMock(_makeSignalCaptureMock(_goodYaml, captured));
       const controller = new AbortController();

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -20,9 +20,10 @@ import { reviewFrontmatter } from '../../setfm-review.ts';
 import {
   BaseMockCommand,
   installCommandMock,
+  makeClaudeJsonMock,
   makeFailMock,
   makeFirstNFailMock,
-  makeSuccessMock,
+  wrapClaudeJson,
 } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type {
   CommandMockHandle,
@@ -207,7 +208,7 @@ describe('reviewFrontmatter', () => {
   describe('When: 正常系', () => {
     it('[Normal] T-SF-RV-02-01: runAI が validity: pass を返す → { validity: pass, errors: [] } を返す', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('validity: pass\n')),
+        makeClaudeJsonMock('validity: pass\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -226,7 +227,7 @@ describe('reviewFrontmatter', () => {
   describe('When: AiError はリトライで救済されない', () => {
     it('[Error] T-SF-RV-11-01: maxRetry=1, 1回目が AiError（2回目は成功しうる） → 救済せず ChatlogError(AiError) を throw', async () => {
       commandHandle = installCommandMock(
-        makeFirstNFailMock(1, 'validity: pass\n'),
+        makeFirstNFailMock(1, wrapClaudeJson('validity: pass\n')),
       );
 
       const _entry = _makeChatlogEntry();
@@ -267,9 +268,7 @@ describe('reviewFrontmatter', () => {
 
     it('[Error] T-SF-RV-03-01: runAI が validity: fail + errors を返す (corrected_frontmatter なし) → { validity: error, errors: [wrong type] } を返す', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(
-          _enc.encode('validity: fail\nerrors:\n  - wrong type\n'),
-        ),
+        makeClaudeJsonMock('validity: fail\nerrors:\n  - wrong type\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -305,7 +304,7 @@ describe('reviewFrontmatter', () => {
   describe('When: エッジケース', () => {
     it('[Edge] T-SF-RV-05-01: runAI が validity: キーなしの YAML を返す → デフォルト pass → { validity: pass, errors: [] }', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('type: research\ncategory: ai\n')),
+        makeClaudeJsonMock('type: research\ncategory: ai\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -316,9 +315,7 @@ describe('reviewFrontmatter', () => {
 
     it('[Edge] T-SF-RV-06-01: runAI が validity: fail + errors 2件を返す (corrected_frontmatter なし) → { validity: error, errors に2件 }', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(
-          _enc.encode('validity: fail\nerrors:\n  - wrong type\n  - wrong category\n'),
-        ),
+        makeClaudeJsonMock('validity: fail\nerrors:\n  - wrong type\n  - wrong category\n'),
       );
 
       const _entry = _makeChatlogEntry();
@@ -329,10 +326,8 @@ describe('reviewFrontmatter', () => {
 
     it('[Edge] T-SF-RV-08-01: runAI が validity: pass + corrected_frontmatter.topics を含む → entry.frontmatter.get(topics) は変更されない', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(
-          _enc.encode(
-            'validity: pass\nerrors: []\ncorrected_frontmatter:\n  topics:\n    - software-engineering\n',
-          ),
+        makeClaudeJsonMock(
+          'validity: pass\nerrors: []\ncorrected_frontmatter:\n  topics:\n    - software-engineering\n',
         ),
       );
 
@@ -345,10 +340,8 @@ describe('reviewFrontmatter', () => {
 
     it('[Edge] T-SF-RV-10-01: runAI が不正 YAML（インデント不整合）を返す → parseYaml が fail → { validity: error } を返す', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(
-          _enc.encode(
-            'validity: fail\ncorrected_frontmatter:\n  topics:\n - bad-indent\n',
-          ),
+        makeClaudeJsonMock(
+          'validity: fail\ncorrected_frontmatter:\n  topics:\n - bad-indent\n',
         ),
       );
 
@@ -366,9 +359,9 @@ describe('reviewFrontmatter', () => {
   describe('When: corrected_frontmatter → corrected フィールドへ', () => {
     it('[Normal] T-02-01-01: corrected_frontmatter に type/category/title → r.corrected に全フィールド', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode(
+        makeClaudeJsonMock(
           'validity: fail\nerrors:\n  - wrong\ncorrected_frontmatter:\n  type: tech\n  category: ai\n  title: New Title\n',
-        )),
+        ),
       );
       const _entry = _makeChatlogEntry();
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -380,9 +373,9 @@ describe('reviewFrontmatter', () => {
 
     it('[Normal] T-02-01-02: corrected_frontmatter に topics/tags → r.corrected に配列フィールド', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode(
+        makeClaudeJsonMock(
           'validity: fail\nerrors:\n  - wrong\ncorrected_frontmatter:\n  topics:\n    - software-engineering\n  tags:\n    - lang:typescript\n',
-        )),
+        ),
       );
       const _entry = _makeChatlogEntry();
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -393,9 +386,9 @@ describe('reviewFrontmatter', () => {
 
     it('[Normal] T-02-01-03: corrected_frontmatter 存在時 entry.frontmatter は変更されない', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode(
+        makeClaudeJsonMock(
           'validity: fail\nerrors:\n  - wrong\ncorrected_frontmatter:\n  type: tech\n',
-        )),
+        ),
       );
       const _entry = _makeChatlogEntry(); // initial type = 'research'
       await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -409,7 +402,7 @@ describe('reviewFrontmatter', () => {
   describe('When: fail + corrected_frontmatter なし → error', () => {
     it('[Error] T-02-03-01: validity: fail + corrected_frontmatter なし → { validity: error, errors: [...] }', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('validity: fail\nerrors:\n  - wrong type\n')),
+        makeClaudeJsonMock('validity: fail\nerrors:\n  - wrong type\n'),
       );
       const _entry = _makeChatlogEntry();
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -440,9 +433,9 @@ describe('reviewFrontmatter', () => {
   describe('When: corrected フィールドの trim/filter', () => {
     it('[Edge] T-02-05-01: corrected_frontmatter.title が空白のみ → r.corrected に title 含まれない', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode(
+        makeClaudeJsonMock(
           'validity: fail\nerrors:\n  - wrong\ncorrected_frontmatter:\n  title: "   "\n  type: tech\n',
-        )),
+        ),
       );
       const _entry = _makeChatlogEntry();
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -452,9 +445,9 @@ describe('reviewFrontmatter', () => {
 
     it('[Edge] T-02-05-02: corrected_frontmatter.topics に空文字列混在 → r.corrected.topics から除外', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode(
+        makeClaudeJsonMock(
           'validity: fail\nerrors:\n  - wrong\ncorrected_frontmatter:\n  topics:\n    - software-engineering\n    - ""\n    - behavior\n',
-        )),
+        ),
       );
       const _entry = _makeChatlogEntry();
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -464,7 +457,7 @@ describe('reviewFrontmatter', () => {
 
     it('[Edge] T-02-06-01: corrected オブジェクトのみ (corrected_frontmatter なし) → entry.frontmatter 変化なし + validity=error', async () => {
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('validity: fail\nerrors:\n  - wrong\ncorrected:\n  type: tech\n')),
+        makeClaudeJsonMock('validity: fail\nerrors:\n  - wrong\ncorrected:\n  type: tech\n'),
       );
       const _entry = _makeChatlogEntry(); // initial type = 'research'
       const result = await reviewFrontmatter(_entry, _mockDics, _mockPrompts, 0);
@@ -480,7 +473,7 @@ describe('reviewFrontmatter', () => {
     it('[Normal] T-SF-RV-13-01: model="haiku" を指定 → capturedArgs に --model haiku が含まれる', async () => {
       const capturedArgs: { value: string[] } = { value: [] };
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('validity: pass\n'), capturedArgs),
+        makeClaudeJsonMock('validity: pass\n', capturedArgs),
       );
 
       const _entry = _makeChatlogEntry();
@@ -494,7 +487,7 @@ describe('reviewFrontmatter', () => {
     it('[Normal] T-SF-RV-13-02: model 省略 → capturedArgs に --model DEFAULT_AI_MODEL が含まれる', async () => {
       const capturedArgs: { value: string[] } = { value: [] };
       commandHandle = installCommandMock(
-        makeSuccessMock(_enc.encode('validity: pass\n'), capturedArgs),
+        makeClaudeJsonMock('validity: pass\n', capturedArgs),
       );
 
       const _entry = _makeChatlogEntry();
@@ -526,7 +519,7 @@ describe('reviewFrontmatter', () => {
     });
 
     it('[Normal] T-SF-RV-14-02: signal を渡すと runAI に転送され、外部 abort で内部 signal も aborted になる', async () => {
-      const _goodYaml = _enc.encode('validity: pass\n');
+      const _goodYaml = _enc.encode(wrapClaudeJson('validity: pass\n'));
       const captured: { instance: _SignalCaptureMock | null } = { instance: null };
       commandHandle = installCommandMock(_makeSignalCaptureMock(_goodYaml, captured));
       const controller = new AbortController();

--- a/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-type-category.ts
@@ -13,8 +13,11 @@
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { ChatlogError } from '../../../_scripts/classes/ChatlogError.class.ts';
 import { DEFAULT_FALLBACK_CATEGORY, DEFAULT_FALLBACK_TYPE } from '../../../_scripts/constants/defaults.constants.ts';
-import { isFatalAiError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
+import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
+import { isFatalAiError, isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { runAI } from '../../../_scripts/libs/ai/run-ai.ts';
+import { logger } from '../../../_scripts/libs/io/logger.ts';
+import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
 
 // ─── Local
 import { formatDicEntries } from '../libs/dic-format-utils.ts';
@@ -50,8 +53,10 @@ const _buildTypeCategorySystemPrompt = (systemTemplate: string, dics: Dics, cate
  * ```
  *
  * 判定失敗（有効キー不一致など）時はフォールバック値をセットする。
- * ただし AI CLI が非0終了した致命的エラー（rate limit / exit failure）および abort 済み signal の
- * 場合は、フォールバックに落とさず例外を再 throw する。
+ * ただしエラー種別により挙動を分ける:
+ * - RateLimit / abort 済み signal → 例外を再 throw して中断する。
+ * - 非 RateLimit の AI エラー（exit failure 等）→ `logger.error` を出し、type/category を書かず skip する。
+ * - 非 AiError（パース失敗等）→ フォールバック値をセットする（後方互換）。
  */
 export const judgeTypeAndCategory = async (
   entry: ChatlogEntry,
@@ -98,10 +103,16 @@ export const judgeTypeAndCategory = async (
       category = _parsedCategory;
     }
   } catch (e) {
-    if (isFatalAiError(e) || signal?.aborted) {
+    // RateLimit / 外部 abort → 中断（isRateLimitError を isFatalAiError より先に判定する）
+    if (isRateLimitError(e) || signal?.aborted) {
       throw e;
     }
-    // fall through to fallback values
+    // 非 RateLimit の AI エラー → error ログを出し type/category を書かず skip
+    if (isFatalAiError(e)) {
+      logger.error(`${LOGGER_TEXT.INDENT}FAIL (type/category 判定失敗): ${getFilename(entry.filePath!)} — ${e}`);
+      return;
+    }
+    // 非 AiError（パース失敗等）→ フォールバック値をセット（後方互換）
     type = DEFAULT_FALLBACK_TYPE;
     category = DEFAULT_FALLBACK_CATEGORY;
   }

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-frontmatter.unit.spec.ts
@@ -251,19 +251,20 @@ describe('_phaseFrontmatter', () => {
   });
 
   /**
-   * generateProvider が非 fatal エラー（AiError 以外）を throw したとき phase が継続するケース。
+   * generateProvider が RateLimit 以外のエラー（非 AiError / AiError/ExitFailure）を throw したとき
+   * phase が abort せず継続し `logger.error` にログを出すケース。
    *
-   * fatal な AiError はバッチを abort する（別ケース T-02-05-01 で検証）。
-   * 非 fatal なエラー（例: content 起因の想定外例外）は握りつぶして他エントリの処理を継続する。
+   * RateLimit のみバッチを abort する（別ケース T-02-05-01 で検証）。
+   * 非 RateLimit のエラーは握りつぶして他エントリの処理を継続する。
    */
-  describe('When: generateProvider が非 fatal エラーを throw する', () => {
-    it('[Normal] T-02-04-01: generateProvider が非 fatal エラーを throw → abort せず他エントリ継続・warn ログが出る', async () => {
+  describe('When: generateProvider が非 RateLimit エラーを throw する', () => {
+    it('[Normal] T-02-04-01: generateProvider が非 AiError を throw → abort せず他エントリ継続・error ログが出る', async () => {
       const cache = await _makeCache();
       const _throwingStub: _GenerateProvider = (_entry, _maxLen, _dics, _prompts) => {
         throw new Error('simulated non-fatal failure');
       };
       const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
-      const warnSpy = spy(logger, 'warn');
+      const errorSpy = spy(logger, 'error');
       const cacheSpy = spy(cache, 'write');
       try {
         await phaseFrontmatter(
@@ -277,36 +278,36 @@ describe('_phaseFrontmatter', () => {
         );
         // Both entries fail (throw → catch in phase), no cache write happens
         assertEquals(cacheSpy.calls.length, 0);
-        // logger.warn was called at least once (for each failing entry)
-        assertEquals(warnSpy.calls.length >= 1, true);
+        // logger.error was called at least once (for each failing entry)
+        assertEquals(errorSpy.calls.length >= 1, true);
       } finally {
-        warnSpy.restore();
+        errorSpy.restore();
         cacheSpy.restore();
       }
     });
 
-    it('[Error] T-02-04-02: generateProvider が AiError/ExitFailure を throw → 握りつぶさず再 throw（abort）', async () => {
+    it('[Error] T-02-04-02: generateProvider が AiError/ExitFailure を throw → 再 throw せず継続・error ログが出る', async () => {
       const cache = await _makeCache();
       const _throwingStub: _GenerateProvider = (_entry, _maxLen, _dics, _prompts) => {
         throw new ChatlogError('AiError', 'ExitFailure', 'simulated exit failure');
       };
       const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
-
-      const error = await assertRejects(
-        () =>
-          phaseFrontmatter(
-            entries,
-            cache,
-            1000,
-            _FAKE_DICS,
-            _FAKE_PROMPTS,
-            { concurrency: 1, dryRun: false },
-            _throwingStub,
-          ),
-        ChatlogError,
-      );
-      assertEquals(error.kind, 'AiError');
-      assertEquals(error.subindex, 'ExitFailure');
+      const errorSpy = spy(logger, 'error');
+      try {
+        // ExitFailure は再 throw せず resolve する
+        await phaseFrontmatter(
+          entries,
+          cache,
+          1000,
+          _FAKE_DICS,
+          _FAKE_PROMPTS,
+          { concurrency: 1, dryRun: false },
+          _throwingStub,
+        );
+        assertEquals(errorSpy.calls.some((c) => String(c.args[0]).includes('生成失敗')), true);
+      } finally {
+        errorSpy.restore();
+      }
     });
   });
 

--- a/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/phases/__tests__/unit/phase-review.unit.spec.ts
@@ -192,41 +192,43 @@ describe('phaseReview', () => {
   });
 
   /**
-   * reviewProvider が非 fatal エラー（AiError 以外）を throw したとき phase が継続するケース。
+   * reviewProvider が RateLimit 以外のエラー（非 AiError / AiError/ExitFailure）を throw したとき
+   * phase が abort せず継続し `logger.error` にログを出すケース。
    *
-   * fatal な AiError はバッチを abort する（別ケース T-04-05-01 / T-04-04-02 で検証）。
-   * 非 fatal なエラーは握りつぶして他エントリの処理を継続する。
+   * RateLimit のみバッチを abort する（別ケース T-04-05-01 で検証）。
+   * 非 RateLimit のエラーは握りつぶして他エントリの処理を継続する。
    */
-  describe('When: reviewProvider がエラーを throw する', () => {
-    it('[Normal] T-04-04-01: reviewProvider が非 fatal エラーを throw → abort せず他エントリ継続', async () => {
+  describe('When: reviewProvider が非 RateLimit エラーを throw する', () => {
+    it('[Normal] T-04-04-01: reviewProvider が非 AiError を throw → abort せず他エントリ継続・error ログが出る', async () => {
       const cache = await _makeCache();
       const _throwingStub: _ReviewProvider = (_entry, _dics, _prompts) => {
         throw new Error('simulated non-fatal failure');
       };
       const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
-      const warnSpy = spy(logger, 'warn');
+      const errorSpy = spy(logger, 'error');
       try {
         // Should resolve without throwing (catch inside phase)
         await phaseReview(entries, cache, _dics, _prompts, { concurrency: 2, dryRun: false }, _throwingStub);
-        assertEquals(warnSpy.calls.length >= 1, true);
+        assertEquals(errorSpy.calls.length >= 1, true);
       } finally {
-        warnSpy.restore();
+        errorSpy.restore();
       }
     });
 
-    it('[Error] T-04-04-02: reviewProvider が AiError/ExitFailure を throw → 握りつぶさず再 throw（abort）', async () => {
+    it('[Error] T-04-04-02: reviewProvider が AiError/ExitFailure を throw → 再 throw せず継続・error ログが出る', async () => {
       const cache = await _makeCache();
       const _throwingStub: _ReviewProvider = (_entry, _dics, _prompts) => {
         throw new ChatlogError('AiError', 'ExitFailure', 'simulated exit failure');
       };
       const entries = [_makeEntry('/path/to/a.md'), _makeEntry('/path/to/b.md')];
-
-      const error = await assertRejects(
-        () => phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: false }, _throwingStub),
-        ChatlogError,
-      );
-      assertEquals(error.kind, 'AiError');
-      assertEquals(error.subindex, 'ExitFailure');
+      const errorSpy = spy(logger, 'error');
+      try {
+        // ExitFailure は再 throw せず resolve する
+        await phaseReview(entries, cache, _dics, _prompts, { concurrency: 1, dryRun: false }, _throwingStub);
+        assertEquals(errorSpy.calls.some((c) => String(c.args[0]).includes('review 失敗')), true);
+      } finally {
+        errorSpy.restore();
+      }
     });
   });
 

--- a/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-frontmatter.ts
@@ -13,7 +13,7 @@
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
-import { isFatalAiError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -131,10 +131,10 @@ export const phaseFrontmatter = async (
         try {
           _ok = await _generate(entry, maxContentLength, dics, prompts, config.maxRetry ?? 0, config.model, ctl.signal);
         } catch (e) {
-          if (isFatalAiError(e) || ctl.signal.aborted) {
+          if (isRateLimitError(e) || ctl.signal.aborted) {
             throw e;
           }
-          logger.warn(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
+          logger.error(`${LOGGER_TEXT.INDENT}FAIL (生成失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
         }
         if (_ok) {

--- a/skills/set-frontmatter/scripts/phases/phase-review.ts
+++ b/skills/set-frontmatter/scripts/phases/phase-review.ts
@@ -13,7 +13,7 @@
 import { ChatlogCache } from '../../../_scripts/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_scripts/classes/ChatlogEntry.class.ts';
 import { LOGGER_TEXT } from '../../../_scripts/constants/logger.constants.ts';
-import { isFatalAiError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
+import { isRateLimitError } from '../../../_scripts/libs/ai/rate-limit-utils.ts';
 import { logger } from '../../../_scripts/libs/io/logger.ts';
 import { runConcurrent } from '../../../_scripts/libs/parallel/concurrency.ts';
 import { getFilename } from '../../../_scripts/libs/path-utils/path-utils.ts';
@@ -78,10 +78,10 @@ export const phaseReview = async (
         try {
           r = await _review(entry, dics, prompts, config.maxRetry ?? 0, config.model, ctl.signal);
         } catch (e) {
-          if (isFatalAiError(e) || ctl.signal.aborted) {
+          if (isRateLimitError(e) || ctl.signal.aborted) {
             throw e;
           }
-          logger.warn(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
+          logger.error(`${LOGGER_TEXT.INDENT}FAIL (review 失敗): ${getFilename(entry.filePath!)} — ${e}`);
           return;
         }
         if (r.validity === 'pass') {


### PR DESCRIPTION
## Overview

**Summary**
Judge claude AI success/failure from JSON `is_error` instead of exit code.

**Background / Motivation**
Issue #373. PR #372 treated the sandbox banner (`⚠ Sandbox disabled: ...`) as a RateLimit signal. But this banner also appears on auth errors, invalid models, and config errors, so those failures were misclassified as RateLimit and aborted downstream processing. This PR bases the claude backend decision on the JSON body, and lets non-RateLimit errors skip the entry and continue instead of aborting.

## Changes

### Core Changes

- `skills/_scripts/libs/ai/run-ai.ts`:
  - Pass `--output-format json` to the claude call.
  - For the claude backend, ignore the exit code and parse stdout JSON, judging success by `is_error`.
  - Add helpers: `_parseClaudeJson` (parse from the first `{`, tolerating a leading banner; returns `null` on failure), `_formatClaudeError` (format only `api_error_status` / `terminal_reason` / `result`), `_interpretClaudeOutput` (return `.result` on success; on `is_error:true` log raw stdout and throw `ChatlogError`, classifying `429` as `RateLimit` and the rest as `ExitFailure`).
  - Fall back to the old exit-code + regex path only when the JSON cannot be parsed.
- Continue on non-RateLimit errors (log and skip instead of abort):
  - `skills/set-frontmatter/scripts/phases/phase-review.ts`: use `isRateLimitError` instead of `isFatalAiError`.
  - `skills/set-frontmatter/scripts/phases/phase-frontmatter.ts`: switch the abort check to `isRateLimitError`.
  - `skills/set-frontmatter/scripts/modules/setfm-type-category.ts`: rethrow on RateLimit/abort, skip on non-RateLimit AI errors, keep the fallback value on non-AiError.

### Test Updates

- `skills/_scripts/__tests__/helpers/deno-command-mock.ts`: add `wrapClaudeJson` and `makeClaudeJsonMock`.
- `skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts`: wrap success output as claude JSON; add `EXIT_FAILURE_JSON` and success-then-exit-failure helpers.
- Migrate classify / filter / normalize / set-frontmatter unit / functional / e2e tests to claude JSON mocks.

### Removed

N/A

## Change Type

- [x] Refactor
- [x] Bug fix
- [x] Test

## Related Issues

Closes #373

## Checklist

- [ ] Formatting and lint checks pass (`dprint fmt --check`)
- [ ] Tests pass (`deno task test`)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows Conventional Commits
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

Not a formal breaking change, but downstream behavior changes: non-RateLimit AI errors now skip and continue (with a `logger.error`) instead of aborting.

## Additional Notes

- Scope: 35 files, +1061 / -296 (4 fix commits + 14 test commits).
- The claude backend now treats JSON `is_error` as the source of truth and no longer depends on the exit code.
