### PR TITLE
config: migrate repo URLs to aglabo org and add runtime constraints

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -25,7 +25,7 @@ json: false
 # actor: ""
 actor: "atsushifx"
 sync:
-  remote: "git+https://github.com/atsushifx/chatlog-exporter.git"
+  remote: "git+https://github.com/aglabo/chatlog-exporter.git"
 
 # Export events (audit trail) to .beads/events.jsonl on each flush/sync
 # When enabled, new events are appended incrementally using a high-water mark.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -16,7 +16,7 @@ If you discover a security vulnerability, please **do not open a public issue**.
 Instead, contact the maintainers directly via one of the following methods:
 
 - Private report via GitHub Security Advisories
-  [Create a security advisory](https://github.com/atsushifx/chatlog-exporter/security/advisories/new)
+  [Create a security advisory](https://github.com/aglabo/chatlog-exporter/security/advisories/new)
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 

--- a/package.json
+++ b/package.json
@@ -11,11 +11,16 @@
     "claude",
     "obsidian"
   ],
+  "packageManager": "pnpm@11.17.0",
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=11"
+  },
   "author": "atsushifx",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/atsushifx/chatlog-exporter.git"
+    "url": "https://github.com/aglabo/chatlog-exporter.git"
   },
   "scripts": {
     "prepare": "bash ./scripts/setup-dev-env.sh"


### PR DESCRIPTION
## Overview

**Summary**
Migrate repository URLs to the `aglabo` org and pin the runtime toolchain.

**Background / Motivation**
The repository moved from the `atsushifx` account to the `aglabo` organization. Update every hard-coded repository URL to the new location, and pin Node/pnpm versions so local and CI environments stay consistent. Implements #375.

## Changes

### Core Changes

- `package.json`: update `repository.url` to `aglabo`; add `packageManager` and `engines` (node >=22, pnpm >=11).
- `.beads/config.yaml`: update `sync.remote` to `aglabo`.
- `.github/SECURITY.md`: update the security advisory link to `aglabo`.

### Test Updates

N/A — config and documentation only.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> Closes #375

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Only repository URLs and runtime version constraints changed.

## Additional Notes

The `engines` constraints (node >=22, pnpm >=11) may cause install warnings on older toolchains. Confirm CI runners meet these versions.
