### PR TITLE
config(repo): move owner to aglabo and add runtime constraints

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -25,7 +25,7 @@ json: false
 # actor: ""
 actor: "atsushifx"
 sync:
-  remote: "git+https://github.com/atsushifx/chatlog-exporter.git"
+  remote: "git+https://github.com/aglabo/chatlog-exporter.git"
 
 # Export events (audit trail) to .beads/events.jsonl on each flush/sync
 # When enabled, new events are appended incrementally using a high-water mark.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -16,7 +16,7 @@ If you discover a security vulnerability, please **do not open a public issue**.
 Instead, contact the maintainers directly via one of the following methods:
 
 - Private report via GitHub Security Advisories
-  [Create a security advisory](https://github.com/atsushifx/chatlog-exporter/security/advisories/new)
+  [Create a security advisory](https://github.com/aglabo/chatlog-exporter/security/advisories/new)
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 

--- a/package.json
+++ b/package.json
@@ -11,11 +11,16 @@
     "claude",
     "obsidian"
   ],
+  "packageManager": "pnpm@11.17.0",
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=11"
+  },
   "author": "atsushifx",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/atsushifx/chatlog-exporter.git"
+    "url": "https://github.com/aglabo/chatlog-exporter.git"
   },
   "scripts": {
     "prepare": "bash ./scripts/setup-dev-env.sh"


### PR DESCRIPTION
## Overview

**Summary**
Move the repository owner from `atsushifx` to `aglabo` and add Node.js/pnpm runtime constraints.

**Background / Motivation**
The repository is moving under the `aglabo` organization. All URLs that still point to `atsushifx/chatlog-exporter` must be updated so dependency sync, security reporting, and package metadata resolve correctly. The runtime constraints pin the supported toolchain for reproducible installs.

## Changes

### Core Changes

- `.beads/config.yaml`: Update the beads `sync.remote` URL to the `aglabo` owner.
- `package.json`: Update `repository.url` to `aglabo`, add `packageManager: "pnpm@11.17.0"`, and add an `engines` field (`node >=22`, `pnpm >=11`).
- `.github/SECURITY.md`: Update the security advisory link to the `aglabo` repository.

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. The `engines` field is advisory metadata; the remaining changes only follow the owner migration.

## Additional Notes

Configuration and documentation only — no application code changes, so the export tooling's runtime behavior is unaffected.
