### PR TITLE
fix(run-ai): stop treating sandbox disabled banner as rate limit

### DIFF
--- a/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
+++ b/skills/_scripts/libs/ai/__tests__/unit/run-ai.unit.spec.ts
@@ -70,7 +70,7 @@ const _makeRejectingCommandStub = () => {
 };
 
 // constants
-/** レートリミット検出のテーブル駆動ケース (RA-13〜15, RA-21, RA-22, RA-24)。stdout / stderr の両ストリームを検査対象とする。 */
+/** レートリミット検出のテーブル駆動ケース (RA-13〜15, RA-21, RA-22)。stdout / stderr の両ストリームを検査対象とする。 */
 const _rateLimitCases = [
   {
     id: 'T-LIB-AI-RA-13',
@@ -95,14 +95,6 @@ const _rateLimitCases = [
     desc: 'stdout に "Claude usage limit reached" (stderr 空)',
   },
   { id: 'T-LIB-AI-RA-22', label: 'Error', stdout: '', stderr: 'usage limit exceeded', desc: 'stderr に "usage limit"' },
-  {
-    id: 'T-LIB-AI-RA-24',
-    label: 'Error',
-    stdout: '',
-    stderr:
-      '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)',
-    desc: 'stderr に sandbox disabled バナー (rate limit 文字列なし)',
-  },
 ] as const;
 
 const _cases: Array<{ model: string; expected: CommandSpec }> = [
@@ -304,6 +296,29 @@ describe('runAI', () => {
           assertEquals(_err.kind, 'AiError');
           assertEquals(_err.subindex, 'ExitFailure');
           assertStringIncludes(_err.message, 'model not found');
+        } finally {
+          Deno.Command = _origCommand;
+        }
+      });
+
+      it('[Error] T-LIB-AI-RA-24: runAI — stderr に sandbox disabled バナー (rate limit 文字列なし) → RateLimit にならず AiError/ExitFailure', async () => {
+        const _origCommand = Deno.Command;
+        Deno.Command = _makeCommandStub({
+          success: false,
+          code: 1,
+          stdout: new Uint8Array(),
+          stderr: new TextEncoder().encode(
+            '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)',
+          ),
+          signal: null,
+        }) as unknown as typeof Deno.Command;
+        try {
+          const _err = await assertRejects(
+            () => runAI('sys', 'user', { model: 'sonnet' }),
+            ChatlogError,
+          ) as ChatlogError;
+          assertEquals(_err.kind, 'AiError');
+          assertEquals(_err.subindex, 'ExitFailure');
         } finally {
           Deno.Command = _origCommand;
         }
@@ -714,12 +729,15 @@ describe('runAI', () => {
     /**
      * レートリミット判定の誤検出防止に関するエッジケース。
      *
+     * フォールバック分岐のレートリミット判定は `_RATE_LIMIT_PATTERN`
+     * (`rate.?limit|429|usage limit|spend limit`) のみで行う。sandbox バナー系の文字列は
+     * レートリミットの代理シグナルとして扱わないため、いずれも ExitFailure に分類される。
+     *
      * - 正常終了(exit 0)の stdout はレートリミット検査対象外である（RA-23）。
-     * - sandbox バナー衝突: "disabled" を含まない "sandbox is enabled but not active" は
-     *   RateLimit に誤分類されず ExitFailure のままである（RA-25）。
-     * - 大文字小文字の区別: 小文字 "sandbox disabled" はマッチせず ExitFailure のままである（RA-26）。
-     * - バナー本文全体判定: "Sandbox disabled:" で始まっても後続がバナー本文と異なればマッチせず
-     *   ExitFailure のままである（RA-27）。
+     * - sandbox バナー本文 "sandbox is enabled but not active" は RateLimit にならず
+     *   ExitFailure である（RA-25）。
+     * - 小文字 "sandbox disabled" も RateLimit にならず ExitFailure である（RA-26）。
+     * - "Sandbox disabled:" で始まる任意の文字列も RateLimit にならず ExitFailure である（RA-27）。
      */
     describe('When: エッジケース', () => {
       it('[Edge] T-LIB-AI-RA-23: runAI — 正常終了 かつ .result に "usage limit" を含む → RateLimit 判定されず .result を返す', async () => {
@@ -777,7 +795,7 @@ describe('runAI', () => {
         }
       });
 
-      it('[Edge] T-LIB-AI-RA-26: runAI — stderr が小文字 "sandbox disabled" のみ（先頭 s 小文字）→ 大文字小文字を区別しマッチせず AiError/ExitFailure', async () => {
+      it('[Edge] T-LIB-AI-RA-26: runAI — stderr が小文字 "sandbox disabled" のみ（先頭 s 小文字）→ RateLimit にならず AiError/ExitFailure', async () => {
         const _origCommand = Deno.Command;
         Deno.Command = _makeCommandStub({
           success: false,
@@ -798,7 +816,7 @@ describe('runAI', () => {
         }
       });
 
-      it('[Edge] T-LIB-AI-RA-27: runAI — stderr が "Sandbox disabled: something else entirely"（前方一致するがバナー本文と異なる）→ 本文全体で判定しマッチせず AiError/ExitFailure', async () => {
+      it('[Edge] T-LIB-AI-RA-27: runAI — stderr が "Sandbox disabled: something else entirely" → RateLimit にならず AiError/ExitFailure', async () => {
         const _origCommand = Deno.Command;
         Deno.Command = _makeCommandStub({
           success: false,

--- a/skills/_scripts/libs/ai/run-ai.ts
+++ b/skills/_scripts/libs/ai/run-ai.ts
@@ -33,10 +33,6 @@ type _CommandSpec = { command: AiBackendCommand; args: string[]; hasSystemPrompt
 /** レートリミット検出パターン。CLI は文言を stdout / stderr のいずれにも出しうる。`i` フラグのみ（`g` を付けると `.test()` がステートフルになる）。 */
 const _RATE_LIMIT_PATTERN = /rate.?limit|429|usage limit|spend limit/i;
 
-/** rate limit で落ちた Claude CLI の起動バナー "⚠ Sandbox disabled: ..." を検出する。
- *  非ASCII の警告記号(⚠)は含めず、バナー本文(ASCII)で詳細にマッチする。大文字・小文字は厳密に区別する。 */
-const _SANDBOX_DISABLED_PATTERN = /Sandbox disabled: sandbox is enabled but the Windows sandbox is not active/;
-
 // ─── Functions
 
 /**
@@ -256,8 +252,7 @@ export const runAI = async (
     if (!_output.success) {
       if (_stderr) { logger.error(`${_spec.command} exited with code ${_output.code} (stderr): ${_stderr}`); }
       if (_stdout) { logger.error(`${_spec.command} exited with code ${_output.code} (stdout): ${_stdout}`); }
-      const _isRateLimit = _RATE_LIMIT_PATTERN.test(_stderr) || _RATE_LIMIT_PATTERN.test(_stdout)
-        || _SANDBOX_DISABLED_PATTERN.test(_stderr) || _SANDBOX_DISABLED_PATTERN.test(_stdout);
+      const _isRateLimit = _RATE_LIMIT_PATTERN.test(_stderr) || _RATE_LIMIT_PATTERN.test(_stdout);
       throw new ChatlogError(
         'AiError',
         _isRateLimit ? 'RateLimit' : 'ExitFailure',

--- a/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
+++ b/skills/classify-chatlogs/scripts/phases/__tests__/functional/phase-classify-ai.functional.spec.ts
@@ -9,7 +9,7 @@
 // cspell:words MoveByAI
 
 // ─── BDD modules
-import { assertEquals } from '@std/assert';
+import { assertEquals, assertRejects } from '@std/assert';
 import { afterEach, beforeEach, describe, it } from '@std/testing/bdd';
 
 // ─── Test target
@@ -17,6 +17,8 @@ import { classifyByAI } from '../../phase-classify-ai.ts';
 
 // ─── Helpers
 import { makeLoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
+// classes
+import { ChatlogError } from '../../../../../_scripts/classes/ChatlogError.class.ts';
 // types
 import type { ChatlogCache } from '../../../../../_scripts/classes/ChatlogCache.class.ts';
 import type { ChatlogEntry } from '../../../../../_scripts/classes/ChatlogEntry.class.ts';
@@ -27,6 +29,7 @@ import { CLASSIFY_ACTIONS } from '../../../types/classify.types.ts';
 
 // ─── Internal Helpers
 import {
+  BaseMockCommand,
   installCommandMock,
   makeClaudeJsonMock,
   makeCountingMock,
@@ -37,12 +40,42 @@ import {
   _makeEmptyClassifyCache,
 } from '../../../__tests__/_helpers/classify-test-helpers.ts';
 // types
-import type { CommandMockHandle } from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
+import type {
+  CommandMockHandle,
+  DenoCommandLike,
+} from '../../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import type { LoggerStub } from '../../../../../_scripts/__tests__/helpers/logger-stub.ts';
 
 // constants
 /** テスト共通の空プロジェクト辞書。分類対象プロジェクトを問わないテストで使用する。 */
 const _PROJECTS: ProjectDicEntry = { app1: {}, misc: {} };
+
+/**
+ * 非ゼロ exit かつ stderr に rate limit 文言を含む出力を模倣するモッククラス。
+ *
+ * `runAI` の rate limit 判定（stderr に対する `/rate.?limit|429/i`）を発火させ、
+ * `processChunk` に `ChatlogError('AiError', 'RateLimit', ...)` を re-throw させるために使用する。
+ * `BaseMockCommand.spawn()` は `output()` のみを呼ぶため、stderr を持つ `makeOutput()` を独自実装する。
+ */
+class _RateLimitMockCommand extends BaseMockCommand {
+  /** コマンドとオプションを受け取るが実行はしない（インターフェース互換用）。 */
+  constructor(_cmd: string, _opts: unknown) {
+    super();
+  }
+
+  /** 常に `success: false`・`code: 1`・stderr に `'rate limit exceeded'` を返す。 */
+  protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
+    return Promise.resolve({
+      success: false,
+      code: 1,
+      stdout: new Uint8Array(),
+      stderr: new TextEncoder().encode('rate limit exceeded'),
+    });
+  }
+}
+
+/** `_RateLimitMockCommand` を `DenoCommandLike` として返すファクトリヘルパー。 */
+const _makeRateLimitMock = (): DenoCommandLike => _RateLimitMockCommand as unknown as DenoCommandLike;
 
 /** テスト共通の分類設定。chunkSize/concurrency/model のみを指定する。 */
 const _makeConfig = (
@@ -61,7 +94,7 @@ const _makeConfig = (
  *
  * 渡された `ChatlogEntry[]` のチャンク分割並列実行・cache への書き込み・0件時の早期 return を検証する。
  *
- * テスト ID 範囲: T-CL-CBA-01 〜 T-CL-CBA-04
+ * テスト ID 範囲: T-CL-CBA-01 〜 T-CL-CBA-07
  *
  * @see classifyByAI
  */
@@ -231,6 +264,48 @@ describe('classifyByAI', () => {
 
       assertEquals(result, undefined);
       assertEquals(counter.calls, 0);
+    });
+  });
+
+  /**
+   * 異常系: rate limit エラー発生時、スキル入口の `classifyByAI` が例外を握りつぶさず上流へ re-throw するケース。
+   *
+   * `processChunk` の re-throw が `runChunked`（`withConcurrency` → `_wrapParallelError`）を通過しても
+   * `ChatlogError('AiError', 'RateLimit')` のまま伝播し、cache に分類結果が残らないことを保証する回帰テスト。
+   */
+  describe('When: 異常系', () => {
+    let mockHandle: CommandMockHandle;
+    let cache: ChatlogCache<ClassifyCache>;
+
+    beforeEach(async () => {
+      cache = await _makeEmptyClassifyCache();
+      mockHandle = installCommandMock(_makeRateLimitMock());
+    });
+
+    afterEach(() => {
+      mockHandle.restore();
+    });
+
+    it('[Error] T-CL-CBA-07-01: rate limit エラー → ChatlogError(AiError/RateLimit) が上流へ re-throw される', async () => {
+      const targets: ChatlogEntry[] = [_makeClassifyChatlogEntry('a.md')];
+
+      const error = await assertRejects(
+        () => classifyByAI(targets, _PROJECTS, _makeConfig(), cache, false),
+        ChatlogError,
+      );
+      assertEquals(error.kind, 'AiError');
+      assertEquals(error.subindex, 'RateLimit');
+    });
+
+    it('[Error] T-CL-CBA-07-02: rate limit エラーで中断 → cache に分類結果（MOVEBYAI）が書き込まれない', async () => {
+      const targets: ChatlogEntry[] = [_makeClassifyChatlogEntry('a.md')];
+
+      await assertRejects(
+        () => classifyByAI(targets, _PROJECTS, _makeConfig(), cache, false),
+        ChatlogError,
+      );
+
+      assertEquals(cache.read('/tmp/input/a.md'), {});
     });
   });
 });

--- a/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/error-handling.e2e.spec.ts
@@ -19,11 +19,11 @@ import { ChatlogError } from '../../../../_scripts/classes/ChatlogError.class.ts
 import { installCommandMock, makeClaudeJsonMock } from '../../../../_scripts/__tests__/helpers/deno-command-mock.ts';
 import { makeLoggerStub } from '../../../../_scripts/__tests__/helpers/logger-stub.ts';
 import {
-  makeBannerFailOnNthMock,
   makeDicsDir,
+  makeRateLimitFailOnNthMock,
   makeRateLimitMock,
-  makeSuccessThenBannerFailMock,
   makeSuccessThenExitFailMock,
+  makeSuccessThenRateLimitFailMock,
   makeTargetDir,
 } from '../helpers/setfm-e2e-helpers.ts';
 // types
@@ -147,18 +147,18 @@ describe('main - rate limit 貫通 (T-SF-E2E-13)', () => {
   });
 });
 
-// ─── T-SF-E2E-16: rate limit(sandbox バナー) が Phase 2.1 で main を reject（バグの発生箇所） ─
+// ─── T-SF-E2E-16: rate limit が Phase 2.1 で main を reject（バグの発生箇所） ─
 
 /**
- * バグ再現テスト。Phase 2.1（type/category）の最初の runAI が exit 1 + sandbox バナー
- * （バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定）で落ちたとき、以前はデフォルト type/category を黙って書き込んでいた。
+ * バグ再現テスト。Phase 2.1（type/category）の最初の runAI が exit 1 + rate limit
+ * （`_RATE_LIMIT_PATTERN` にヒットし RateLimit 判定）で落ちたとき、以前はデフォルト type/category を黙って書き込んでいた。
  * 修正後は `RateLimit` が judgeTypeAndCategory(即throw) → phaseTypeAndCategory(try/catchなし・素通し)
  * → withConcurrency abort → main と貫通し、`main()` が `ChatlogError(AiError/RateLimit)` で reject する。
  *
  * テスト ID 範囲: T-SF-E2E-16-01
  */
-describe('main - rate limit(sandbox バナー) 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-16)', () => {
-  describe('Given: Phase2.1 最初の runAI が sandbox バナー rate limit を返すモック', () => {
+describe('main - rate limit 貫通 (Phase 2.1 / バグ発生箇所) (T-SF-E2E-16)', () => {
+  describe('Given: Phase2.1 最初の runAI が rate limit を返すモック', () => {
     describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--cache-dir", ..., "--no-review", "--dics", ...]) を呼び出す', () => {
       describe('Then: T-SF-E2E-16 - main が ChatlogError(AiError/RateLimit) で reject する', () => {
         let inputDir: string;
@@ -173,11 +173,11 @@ describe('main - rate limit(sandbox バナー) 貫通 (Phase 2.1 / バグ発生�
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          // 1回目(type/category)のみ banner rate limit。以降(frontmatter)は success。
+          // 1回目(type/category)のみ rate limit。以降(frontmatter)は success。
           // Phase 2.1 が握りつぶすと後続が成功し main は resolve するため、Phase 2.1 の
           // abort ゲート単体を分離検証できる（gate 未修正なら resolve = RED）。
           commandHandle = installCommandMock(
-            makeBannerFailOnNthMock(
+            makeRateLimitFailOnNthMock(
               1,
               'type: research\ncategory: development\ntitle: "t"\ntopics:\n  - ai\ntags:\n  - test\n',
             ),
@@ -194,7 +194,7 @@ describe('main - rate limit(sandbox バナー) 貫通 (Phase 2.1 / バグ発生�
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Error] T-SF-E2E-16-01: Phase 2.1 の rate limit(sandbox バナー) が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
+        it('[Error] T-SF-E2E-16-01: Phase 2.1 の rate limit が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
           const _err = await assertRejects(
             () =>
               main([
@@ -218,18 +218,18 @@ describe('main - rate limit(sandbox バナー) 貫通 (Phase 2.1 / バグ発生�
   });
 });
 
-// ─── T-SF-E2E-14: rate limit(sandbox バナー) が frontmatter フェーズを貫通して main を reject ─
+// ─── T-SF-E2E-14: rate limit が frontmatter フェーズを貫通して main を reject ─
 
 /**
  * Phase 2.1（type/category）は成功し、Phase 2.2（frontmatter 生成）の runAI が
- * exit 1 + sandbox バナー（バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定）で落ちたとき、`RateLimit` が
+ * exit 1 + rate limit（`_RATE_LIMIT_PATTERN` にヒットし RateLimit 判定）で落ちたとき、`RateLimit` が
  * generateFrontmatter(即throw) → phaseFrontmatter の abort ゲート → withConcurrency abort → main
  * と貫通し、`main()` が `ChatlogError(AiError/RateLimit)` で reject することを検証する。
  *
  * テスト ID 範囲: T-SF-E2E-14-01
  */
-describe('main - rate limit(sandbox バナー) 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', () => {
-  describe('Given: Phase2.1 成功・Phase2.2 で sandbox バナー rate limit を返すモック', () => {
+describe('main - rate limit 貫通 (frontmatter フェーズ) (T-SF-E2E-14)', () => {
+  describe('Given: Phase2.1 成功・Phase2.2 で rate limit を返すモック', () => {
     describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--no-review", "--dics", ...]) を呼び出す', () => {
       describe('Then: T-SF-E2E-14 - main が ChatlogError(AiError/RateLimit) で reject する', () => {
         let inputDir: string;
@@ -244,9 +244,9 @@ describe('main - rate limit(sandbox バナー) 貫通 (frontmatter フェーズ)
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          // 1回目(type/category)成功、2回目以降(frontmatter)を banner rate limit にする
+          // 1回目(type/category)成功、2回目以降(frontmatter)を rate limit にする
           commandHandle = installCommandMock(
-            makeSuccessThenBannerFailMock(1, 'type: research\ncategory: development'),
+            makeSuccessThenRateLimitFailMock(1, 'type: research\ncategory: development'),
           );
           loggerStub = makeLoggerStub();
         });
@@ -260,7 +260,7 @@ describe('main - rate limit(sandbox バナー) 貫通 (frontmatter フェーズ)
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Error] T-SF-E2E-14-01: frontmatter フェーズの rate limit(sandbox バナー) が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
+        it('[Error] T-SF-E2E-14-01: frontmatter フェーズの rate limit が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
           const _err = await assertRejects(
             () =>
               main([
@@ -284,11 +284,11 @@ describe('main - rate limit(sandbox バナー) 貫通 (frontmatter フェーズ)
   });
 });
 
-// ─── T-SF-E2E-15: rate limit(sandbox バナー) が review フェーズを貫通して main を reject ─
+// ─── T-SF-E2E-15: rate limit が review フェーズを貫通して main を reject ─
 
 /**
  * Phase 2.1（type/category）と Phase 2.2（frontmatter）は成功し、Phase 3.1（review）の
- * runAI が exit 1 + sandbox バナー（バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定）で落ちたとき、`RateLimit` が
+ * runAI が exit 1 + rate limit（`_RATE_LIMIT_PATTERN` にヒットし RateLimit 判定）で落ちたとき、`RateLimit` が
  * reviewFrontmatter(即throw) → phaseReview の abort ゲート → withConcurrency abort → main
  * と貫通し、`main()` が `ChatlogError(AiError/RateLimit)` で reject することを検証する。
  *
@@ -296,8 +296,8 @@ describe('main - rate limit(sandbox バナー) 貫通 (frontmatter フェーズ)
  *
  * テスト ID 範囲: T-SF-E2E-15-01
  */
-describe('main - rate limit(sandbox バナー) 貫通 (review フェーズ) (T-SF-E2E-15)', () => {
-  describe('Given: Phase2.1/2.2 成功・Phase3.1(review) で sandbox バナー rate limit を返すモック', () => {
+describe('main - rate limit 貫通 (review フェーズ) (T-SF-E2E-15)', () => {
+  describe('Given: Phase2.1/2.2 成功・Phase3.1(review) で rate limit を返すモック', () => {
     describe('When: main(["--input-dir", dir, "--output-dir", outDir, "--dics", ...]) を呼び出す', () => {
       describe('Then: T-SF-E2E-15 - main が ChatlogError(AiError/RateLimit) で reject する', () => {
         let inputDir: string;
@@ -312,10 +312,10 @@ describe('main - rate limit(sandbox バナー) 貫通 (review フェーズ) (T-S
           outputDir = await Deno.makeTempDir();
           cacheDir = await Deno.makeTempDir();
           dicsDir = await makeDicsDir();
-          // 1回目(type/category)+2回目(frontmatter)成功、3回目以降(review)を banner rate limit にする。
+          // 1回目(type/category)+2回目(frontmatter)成功、3回目以降(review)を rate limit にする。
           // frontmatter フェーズが必須フィールドを生成できるよう title/topics/tags を返す。
           commandHandle = installCommandMock(
-            makeSuccessThenBannerFailMock(
+            makeSuccessThenRateLimitFailMock(
               2,
               'type: research\ncategory: development\ntitle: "t"\ntopics:\n  - ai\ntags:\n  - test\n',
             ),
@@ -332,7 +332,7 @@ describe('main - rate limit(sandbox バナー) 貫通 (review フェーズ) (T-S
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Error] T-SF-E2E-15-01: review フェーズの rate limit(sandbox バナー) が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
+        it('[Error] T-SF-E2E-15-01: review フェーズの rate limit が貫通し ChatlogError(AiError/RateLimit) で reject する', async () => {
           const _err = await assertRejects(
             () =>
               main([

--- a/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
+++ b/skills/set-frontmatter/scripts/__tests__/helpers/setfm-e2e-helpers.ts
@@ -135,22 +135,21 @@ export const makeRateLimitMock = (stdout = 'Claude usage limit reached'): DenoCo
   } as unknown as DenoCommandLike;
 };
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
-export const SANDBOX_BANNER =
-  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+/** claude CLI が rate limit で落ちたときの stderr。`runAI` の `_RATE_LIMIT_PATTERN` (`usage limit`) にヒットし RateLimit 判定される。 */
+export const RATE_LIMIT_STDERR = 'Claude usage limit reached';
 
 /**
- * 最初の `okCount` 回は指定 stdout で成功し、それ以降は exit 1 + sandbox バナー（stderr）で失敗するモック。
+ * 最初の `okCount` 回は指定 stdout で成功し、それ以降は exit 1 + rate limit stderr で失敗するモック。
  *
- * バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットするため `RateLimit` に分類される。
+ * 失敗時 stderr が `runAI` の `_RATE_LIMIT_PATTERN` にヒットするため `RateLimit` に分類される。
  * Phase 2.1（type/category）を成功させてから後続フェーズ（frontmatter / review）で
- * rate limit(sandbox バナー) を発生させ、fatal 伝播でバッチが abort することを検証するために使用する。
+ * rate limit を発生させ、fatal 伝播でバッチが abort することを検証するために使用する。
  *
  * @param okCount - 成功させる先頭呼び出し回数
  * @param okStdout - 成功時に返す stdout 文字列
  * @returns `DenoCommandLike` モッククラス
  */
-export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string): DenoCommandLike => {
+export const makeSuccessThenRateLimitFailMock = (okCount: number, okStdout: string): DenoCommandLike => {
   let callCount = 0;
   const _okBytes = enc.encode(wrapClaudeJson(okStdout));
   return class extends BaseMockCommand {
@@ -166,7 +165,7 @@ export const makeSuccessThenBannerFailMock = (okCount: number, okStdout: string)
           success: false,
           code: 1,
           stdout: new Uint8Array(),
-          stderr: enc.encode(SANDBOX_BANNER),
+          stderr: enc.encode(RATE_LIMIT_STDERR),
         });
       }
       return Promise.resolve({ success: true, code: 0, stdout: _okBytes, stderr: new Uint8Array() });
@@ -213,16 +212,16 @@ export const makeSuccessThenExitFailMock = (okCount: number, okStdout: string): 
 };
 
 /**
- * `failOn`（1始まり）番目の呼び出しだけ exit 1 + sandbox バナーで失敗し、他は success を返すモック。
+ * `failOn`（1始まり）番目の呼び出しだけ exit 1 + rate limit stderr で失敗し、他は success を返すモック。
  *
- * 特定フェーズ 1 箇所だけを rate limit(sandbox バナー) にして、そのフェーズの abort ゲート単体が
+ * 特定フェーズ 1 箇所だけを rate limit にして、そのフェーズの abort ゲート単体が
  * バッチを止めることを分離検証するために使用する（後続フェーズが救済しない構成）。
  *
  * @param failOn - 失敗させる呼び出し番号（1始まり）
  * @param okStdout - success 時に返す stdout 文字列
  * @returns `DenoCommandLike` モッククラス
  */
-export const makeBannerFailOnNthMock = (failOn: number, okStdout: string): DenoCommandLike => {
+export const makeRateLimitFailOnNthMock = (failOn: number, okStdout: string): DenoCommandLike => {
   let callCount = 0;
   const _okBytes = enc.encode(wrapClaudeJson(okStdout));
   return class extends BaseMockCommand {
@@ -238,7 +237,7 @@ export const makeBannerFailOnNthMock = (failOn: number, okStdout: string): DenoC
           success: false,
           code: 1,
           stdout: new Uint8Array(),
-          stderr: enc.encode(SANDBOX_BANNER),
+          stderr: enc.encode(RATE_LIMIT_STDERR),
         });
       }
       return Promise.resolve({ success: true, code: 0, stdout: _okBytes, stderr: new Uint8Array() });

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/judge-type-category.unit.spec.ts
@@ -87,24 +87,23 @@ class _RateLimitMockCommand extends BaseMockCommand {
   }
 }
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
-const _SANDBOX_BANNER =
-  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+/** claude CLI が rate limit で落ちたときの stderr。`runAI` の `_RATE_LIMIT_PATTERN` (`usage limit`) にヒットし RateLimit 判定される。 */
+const _RATE_LIMIT_STDERR = 'Claude usage limit reached';
 
 /**
- * claude CLI が exit 1 で落ち、stderr に sandbox バナーのみを返すモック。
+ * claude CLI が exit 1 で落ち、stderr に rate limit 文字列のみを返すモック。
  *
- * sandbox バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
- * 分類される。実際に観測された rate limit 落ち（バナーのみ）を再現し、fatal 伝播を検証する。
+ * stderr が `runAI` の `_RATE_LIMIT_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
+ * 分類される。実際に観測される rate limit 落ちを再現し、fatal 伝播を検証する。
  */
-class _SandboxBannerFailMock extends BaseMockCommand {
-  /** 常に exit 1 + stderr に sandbox バナーのみを返す。 */
+class _RateLimitFailMock extends BaseMockCommand {
+  /** 常に exit 1 + stderr に rate limit 文字列のみを返す。 */
   protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
     return Promise.resolve({
       success: false,
       code: 1,
       stdout: new Uint8Array(),
-      stderr: _enc.encode(_SANDBOX_BANNER),
+      stderr: _enc.encode(_RATE_LIMIT_STDERR),
     });
   }
 }
@@ -480,9 +479,9 @@ describe('judgeTypeAndCategory', () => {
     );
 
     it(
-      '[Error] T-SF-TC-23: CLI が exit 1 + sandbox バナーのみ（rate limit 文字列なし） → ChatlogError(AiError/RateLimit) を throw',
+      '[Error] T-SF-TC-23: CLI が exit 1 + rate limit 文字列のみ → ChatlogError(AiError/RateLimit) を throw',
       async () => {
-        commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
+        commandHandle = installCommandMock(_RateLimitFailMock as unknown as DenoCommandLike);
 
         const _entry = _makeChatlogEntry('# テスト\n本文');
         const _err = await assertRejects(

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-frontmatter.unit.spec.ts
@@ -110,23 +110,22 @@ class _CountingRateLimitMock extends BaseMockCommand {
   }
 }
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
-const _SANDBOX_BANNER =
-  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+/** claude CLI が rate limit で落ちたときの stderr。`runAI` の `_RATE_LIMIT_PATTERN` (`usage limit`) にヒットし RateLimit 判定される。 */
+const _RATE_LIMIT_STDERR = 'Claude usage limit reached';
 
 /**
- * claude CLI が exit 1 で落ち、stderr に sandbox バナーのみを返すモック。
+ * claude CLI が exit 1 で落ち、stderr に rate limit 文字列のみを返すモック。
  *
- * sandbox バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
+ * stderr が `runAI` の `_RATE_LIMIT_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
  * 分類される。fatal 伝播（リトライで成功に化けないこと）を検証する。
  */
-class _SandboxBannerFailMock extends BaseMockCommand {
+class _RateLimitFailMock extends BaseMockCommand {
   protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
     return Promise.resolve({
       success: false,
       code: 1,
       stdout: new Uint8Array(),
-      stderr: _enc.encode(_SANDBOX_BANNER),
+      stderr: _enc.encode(_RATE_LIMIT_STDERR),
     });
   }
 }
@@ -264,8 +263,8 @@ describe('generateFrontmatter', () => {
       assertEquals(_entry.frontmatter.get('title'), undefined);
     });
 
-    it('[Error] T-SF-FM-04-03: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/RateLimit) を throw', async () => {
-      commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
+    it('[Error] T-SF-FM-04-03: CLI が exit 1 + rate limit 文字列のみ → ChatlogError(AiError/RateLimit) を throw', async () => {
+      commandHandle = installCommandMock(_RateLimitFailMock as unknown as DenoCommandLike);
 
       const _entry = _makeChatlogEntry();
       const _err = await assertRejects(

--- a/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/unit/setfm-review.unit.spec.ts
@@ -103,23 +103,22 @@ class _CountingRateLimitMock extends BaseMockCommand {
   }
 }
 
-/** Windows で claude CLI が rate limit で落ちたとき実際に観測される起動バナー。バナー本文が `_SANDBOX_DISABLED_PATTERN` にヒットし RateLimit 判定される。 */
-const _SANDBOX_BANNER =
-  '⚠ Sandbox disabled: sandbox is enabled but the Windows sandbox is not active on this session (feature gate off)';
+/** claude CLI が rate limit で落ちたときの stderr。`runAI` の `_RATE_LIMIT_PATTERN` (`usage limit`) にヒットし RateLimit 判定される。 */
+const _RATE_LIMIT_STDERR = 'Claude usage limit reached';
 
 /**
- * claude CLI が exit 1 で落ち、stderr に sandbox バナーのみを返すモック。
+ * claude CLI が exit 1 で落ち、stderr に rate limit 文字列のみを返すモック。
  *
- * sandbox バナー本文が `runAI` の `_SANDBOX_DISABLED_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
+ * stderr が `runAI` の `_RATE_LIMIT_PATTERN` にヒットし `ChatlogError('AiError', 'RateLimit', ...)` に
  * 分類される。fatal 伝播（`{ validity: 'error' }` に握りつぶさず即 throw すること）を検証する。
  */
-class _SandboxBannerFailMock extends BaseMockCommand {
+class _RateLimitFailMock extends BaseMockCommand {
   protected makeOutput(): Promise<{ success: boolean; code: number; stdout: Uint8Array; stderr: Uint8Array }> {
     return Promise.resolve({
       success: false,
       code: 1,
       stdout: new Uint8Array(),
-      stderr: _enc.encode(_SANDBOX_BANNER),
+      stderr: _enc.encode(_RATE_LIMIT_STDERR),
     });
   }
 }
@@ -238,8 +237,8 @@ describe('reviewFrontmatter', () => {
       assertEquals(_err.kind, 'AiError');
     });
 
-    it('[Error] T-SF-RV-11-02: CLI が exit 1 + sandbox バナーのみ → ChatlogError(AiError/RateLimit) を throw', async () => {
-      commandHandle = installCommandMock(_SandboxBannerFailMock as unknown as DenoCommandLike);
+    it('[Error] T-SF-RV-11-02: CLI が exit 1 + rate limit 文字列のみ → ChatlogError(AiError/RateLimit) を throw', async () => {
+      commandHandle = installCommandMock(_RateLimitFailMock as unknown as DenoCommandLike);
 
       const _entry = _makeChatlogEntry();
       const _err = await assertRejects(


### PR DESCRIPTION
## Overview

**Summary**
Stop classifying the Claude CLI sandbox disabled banner as a rate limit error.

**Background / Motivation**
`runAI` matched the Claude CLI startup banner `"⚠ Sandbox disabled: ..."` as a
rate limit. Real sandbox-configuration failures were reported as spurious
`RateLimit` errors, hiding the true cause. This PR narrows rate-limit detection
so a sandbox disabled banner falls through to `AiError/ExitFailure` instead.

## Changes

### Core Changes

- `skills/_scripts/libs/ai/run-ai.ts`
  - Remove `_SANDBOX_DISABLED_PATTERN`.
  - Restrict the `RateLimit` decision to `_RATE_LIMIT_PATTERN` only.

### Test Updates

- `run-ai.unit.spec.ts`: assert the sandbox banner yields `AiError/ExitFailure`.
- `phase-classify-ai.functional.spec.ts`: add a rate-limit regression test.
- `error-handling.e2e.spec.ts`, `setfm-e2e-helpers.ts`,
  `judge-type-category.unit.spec.ts`, `setfm-frontmatter.unit.spec.ts`,
  `setfm-review.unit.spec.ts`: replace sandbox banner mocks with rate/usage
  limit stderr mocks.

### Removed

- `_SANDBOX_DISABLED_PATTERN` from `run-ai.ts`.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #373

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

N/A

## Additional Notes

N/A
