### PR TITLE
docs(blume): add bilingual homepage and Pages deploy pipeline

### DIFF
--- a/.github/workflows/cd-deploy-pages.yml
+++ b/.github/workflows/cd-deploy-pages.yml
@@ -1,0 +1,83 @@
+# src: ./.github/workflows/cd-deploy-pages.yml
+# @(#) : Build blume docs site and deploy to GitHub Pages via official Pages actions
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+name: "CD Deploy Pages"
+
+# Minimal permissions at top level; jobs narrow/extend as needed
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+# Serialize Pages deployments; never cancel an in-flight deploy (official recommendation)
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # ----- Build job: produce the static site artifact -----
+  build:
+    name: Build blume site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: aglabo.github.io
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: aglabo.github.io/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # NOTE: actions/configure-pages is intentionally omitted. blume hardcodes
+      # `base: '/chatlog-exporter'` in blume.config.ts, so its base_path output is
+      # unused — dropping it keeps the build job at `contents: read` only.
+      - name: Build docs site
+        run: pnpm docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: aglabo.github.io/dist
+
+  # ----- Deploy job: publish the artifact to GitHub Pages -----
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/aglabo.github.io/.gitignore
+++ b/aglabo.github.io/.gitignore
@@ -8,7 +8,10 @@
 
 ## blume
 .blume/
-dist/
 
 # ignore node modules
 node_modules/
+
+# created page dir
+dist/
+.blume-verify/

--- a/aglabo.github.io/blume.config.ts
+++ b/aglabo.github.io/blume.config.ts
@@ -15,4 +15,11 @@ export default defineConfig({
     site: 'https://aglabo.github.io/chatlog-exporter',
     base: '/chatlog-exporter',
   },
+  i18n: {
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', label: 'English' },
+      { code: 'ja', label: '日本語' },
+    ],
+  },
 });

--- a/aglabo.github.io/docs/index.mdx
+++ b/aglabo.github.io/docs/index.mdx
@@ -1,10 +1,139 @@
 ---
-title: Introduction
-description: Welcome to your new Blume docs.
+title: chatlog-exporter
+description: A set of tools that exports, classifies, and organizes AI agent session logs into Markdown ready to import into Obsidian. Runs as Claude Code skills.
 ---
 
-## Introduction
+**chatlog-exporter** is a set of tools that exports, classifies, filters, and reshapes session logs from AI agents such as Claude and ChatGPT into Markdown you can import into Obsidian. It is implemented as Claude Code skills, invoked from slash commands like `/export-chatlogs`. It is written in TypeScript (Deno runtime) and distributed as JSR packages.
 
-Welcome to **Blume** — markdown-first docs powered by Astro and Vite.
+<CardGroup cols={2}>
+  <Card title="export-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/export-chatlogs/SKILL.md" icon="rocket">
+    Exports AI agent session logs to Markdown with noise removed. It strips system logs, short affirmative replies, and tool-use records, writing out only the substantive conversation. Supported agents: claude (default), codex, chatgpt.
+  </Card>
+  <Card title="classify-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/classify-chatlogs/SKILL.md" icon="folder-tree">
+    Classifies chat logs into per-project subdirectories. It analyzes metadata with the Claude CLI to infer the project name and adds a `project` field to the frontmatter.
+  </Card>
+  <Card title="filter-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/filter-chatlogs/SKILL.md" icon="filter">
+    Batch-judges exported Markdown with the claude CLI and deletes low-value files (DISCARD).
+  </Card>
+  <Card title="normalize-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/normalize-chatlogs/SKILL.md" icon="wand-sparkles">
+    Splits chat logs into topic-based segments with AI and outputs them as Markdown with frontmatter.
+  </Card>
+  <Card title="set-frontmatter" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/set-frontmatter/SKILL.md" icon="tags">
+    Adds or overwrites frontmatter across ChatLog Markdown in bulk. AI generates title / summary / category / topics / tags.
+  </Card>
+</CardGroup>
 
-Edit `docs/index.mdx` to get started, then run `blume dev`.
+## Workflow
+
+Applying the five skills in the following order progressively refines raw session logs into Markdown ready for Obsidian.
+
+<Steps>
+  <Step title="export">
+    `/export-chatlogs` writes session logs to Markdown with noise removed.
+  </Step>
+  <Step title="classify">
+    `/classify-chatlogs` sorts them into per-project subdirectories.
+  </Step>
+  <Step title="filter">
+    `/filter-chatlogs` deletes low-value files.
+  </Step>
+  <Step title="normalize">
+    `/normalize-chatlogs` splits them into topic-based segments.
+  </Step>
+  <Step title="set-frontmatter">
+    `/set-frontmatter` adds title / summary / category / topics / tags.
+  </Step>
+</Steps>
+
+:::tip
+Each skill can run independently. Start with just `/export-chatlogs`, then combine the later skills as needed.
+:::
+
+## Project structure
+
+Each skill lives under `skills/`, with its specification described in `SKILL.md`.
+
+<FileTree>
+
+- skills/
+  - export-chatlogs/
+    - SKILL.md
+  - classify-chatlogs/
+    - SKILL.md
+  - filter-chatlogs/
+    - SKILL.md
+  - normalize-chatlogs/
+    - SKILL.md
+  - set-frontmatter/
+    - SKILL.md
+- scripts/
+  - setup-dev-env.sh
+
+</FileTree>
+
+## Getting started
+
+<Steps>
+  <Step title="Check prerequisites">
+    Make sure the `claude` command (Claude Code CLI) and `deno` are on your PATH.
+  </Step>
+  <Step title="Set up the environment">
+    Run the development environment setup script from the repository root.
+
+    ```bash
+    bash scripts/setup-dev-env.sh
+    ```
+  </Step>
+  <Step title="Invoke a skill">
+    Run a slash command from within Claude Code.
+
+    ```bash
+    /export-chatlogs
+    ```
+  </Step>
+</Steps>
+
+:::warning[Prerequisites]
+If the `claude` command and `deno` are not installed, the skills will not work. Install both first and add them to your PATH.
+:::
+
+## Invoking the skills
+
+Depending on your goal, run the corresponding slash command within Claude Code.
+
+<Tabs>
+  <Tab title="export">
+    ```bash
+    /export-chatlogs
+    ```
+    Exports session logs to Markdown with noise removed.
+  </Tab>
+  <Tab title="classify">
+    ```bash
+    /classify-chatlogs
+    ```
+    Classifies chat logs by project.
+  </Tab>
+  <Tab title="filter">
+    ```bash
+    /filter-chatlogs
+    ```
+    Deletes low-value files.
+  </Tab>
+  <Tab title="normalize">
+    ```bash
+    /normalize-chatlogs
+    ```
+    Splits logs into topic-based segments.
+  </Tab>
+  <Tab title="set-frontmatter">
+    ```bash
+    /set-frontmatter
+    ```
+    Adds or overwrites frontmatter in bulk.
+  </Tab>
+</Tabs>
+
+:::note
+This tool set is implemented in TypeScript (Deno runtime) and distributed as JSR packages. For the detailed specification of each skill, refer to its `SKILL.md`.
+:::

--- a/aglabo.github.io/docs/ja/index.mdx
+++ b/aglabo.github.io/docs/ja/index.mdx
@@ -1,0 +1,139 @@
+---
+title: chatlog-exporter
+description: AIエージェントのセッション履歴をエクスポート・分類・整理し、Obsidian へのインポート用に整えるツール群。Claude Code スキルとして動作します。
+---
+
+**chatlog-exporter** は、Claude や ChatGPT などの AIエージェントとのセッション履歴を、エクスポート・分類・フィルタ・整形し、Obsidian にインポートできる Markdown へと整備するツール群です。Claude Code のスキルとして実装されており、`/export-chatlogs` などのスラッシュコマンドから呼び出せます。TypeScript（Deno ランタイム）で書かれ、JSR パッケージとして提供されます。
+
+<CardGroup cols={2}>
+  <Card title="export-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/export-chatlogs/SKILL.md" icon="rocket">
+    AIエージェントのセッション履歴をノイズ除外して Markdown にエクスポートします。システムログ・短文の肯定応答・ツール使用記録を除外し、実質的な会話だけを書き出します。対応エージェント: claude（デフォルト）, codex, chatgpt。
+  </Card>
+  <Card title="classify-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/classify-chatlogs/SKILL.md" icon="folder-tree">
+    チャットログをプロジェクト別のサブディレクトリに分類します。Claude CLI でメタデータを解析してプロジェクト名を推定し、frontmatter に `project` フィールドを付加します。
+  </Card>
+  <Card title="filter-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/filter-chatlogs/SKILL.md" icon="filter">
+    エクスポート済みの Markdown を claude CLI で一括バッチ判定し、再利用価値の低いファイル（DISCARD）を削除します。
+  </Card>
+  <Card title="normalize-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/normalize-chatlogs/SKILL.md" icon="wand-sparkles">
+    チャットログを AI でトピック別のセグメントに分割し、frontmatter 付きの Markdown として出力します。
+  </Card>
+  <Card title="set-frontmatter" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/set-frontmatter/SKILL.md" icon="tags">
+    ChatLog Markdown に frontmatter を一括で付加・上書きします。AI が title / summary / category / topics / tags を生成します。
+  </Card>
+</CardGroup>
+
+## ワークフロー
+
+5つのスキルを次の順に適用すると、生のセッション履歴を Obsidian 用に整った Markdown へと段階的に整備できます。
+
+<Steps>
+  <Step title="export — エクスポート">
+    `/export-chatlogs` でセッション履歴をノイズ除外して Markdown に書き出します。
+  </Step>
+  <Step title="classify — 分類">
+    `/classify-chatlogs` でプロジェクト別のサブディレクトリに振り分けます。
+  </Step>
+  <Step title="filter — 選別">
+    `/filter-chatlogs` で再利用価値の低いファイルを削除します。
+  </Step>
+  <Step title="normalize — 正規化">
+    `/normalize-chatlogs` でトピック別セグメントに分割します。
+  </Step>
+  <Step title="set-frontmatter — メタデータ付与">
+    `/set-frontmatter` で title / summary / category / topics / tags を付加します。
+  </Step>
+</Steps>
+
+:::tip
+各スキルは独立して実行できます。まずは `/export-chatlogs` だけを試し、必要に応じて後続のスキルを組み合わせてください。
+:::
+
+## プロジェクト構造
+
+各スキルは `skills/` 以下に配置され、`SKILL.md` に仕様が記述されています。
+
+<FileTree>
+
+- skills/
+  - export-chatlogs/
+    - SKILL.md
+  - classify-chatlogs/
+    - SKILL.md
+  - filter-chatlogs/
+    - SKILL.md
+  - normalize-chatlogs/
+    - SKILL.md
+  - set-frontmatter/
+    - SKILL.md
+- scripts/
+  - setup-dev-env.sh
+
+</FileTree>
+
+## 導入手順
+
+<Steps>
+  <Step title="前提を確認する">
+    `claude` コマンド（Claude Code CLI）と `deno` が PATH 上にあることを確認します。
+  </Step>
+  <Step title="環境をセットアップする">
+    リポジトリのルートで開発環境セットアップスクリプトを実行します。
+
+    ```bash
+    bash scripts/setup-dev-env.sh
+    ```
+  </Step>
+  <Step title="スキルを呼び出す">
+    Claude Code 上でスラッシュコマンドを実行します。
+
+    ```bash
+    /export-chatlogs
+    ```
+  </Step>
+</Steps>
+
+:::warning[前提条件]
+`claude` コマンドと `deno` が未インストールの場合、スキルは動作しません。先にどちらもインストールし、PATH を通してください。
+:::
+
+## スキルの呼び出し
+
+目的に応じて、対応するスラッシュコマンドを Claude Code 上で実行します。
+
+<Tabs>
+  <Tab title="export">
+    ```bash
+    /export-chatlogs
+    ```
+    セッション履歴をノイズ除外して Markdown にエクスポートします。
+  </Tab>
+  <Tab title="classify">
+    ```bash
+    /classify-chatlogs
+    ```
+    チャットログをプロジェクト別に分類します。
+  </Tab>
+  <Tab title="filter">
+    ```bash
+    /filter-chatlogs
+    ```
+    再利用価値の低いファイルを削除します。
+  </Tab>
+  <Tab title="normalize">
+    ```bash
+    /normalize-chatlogs
+    ```
+    トピック別セグメントに分割します。
+  </Tab>
+  <Tab title="set-frontmatter">
+    ```bash
+    /set-frontmatter
+    ```
+    frontmatter を一括付加・上書きします。
+  </Tab>
+</Tabs>
+
+:::note
+本ツール群は TypeScript（Deno ランタイム）で実装され、JSR パッケージとして提供されます。各スキルの詳細な仕様は、それぞれの `SKILL.md` を参照してください。
+:::


### PR DESCRIPTION
## Overview

**Summary**
Add a bilingual (English/Japanese) homepage and an automated GitHub Pages deploy pipeline for the Blume-based `aglabo.github.io` site.

**Background / Motivation**
The site needs a discoverable landing page for chatlog-exporter and an automated way to publish it. This PR rewrites the homepage, adds a Japanese translation with i18n config, and sets up a Pages deploy workflow that runs on every push to `main`.

## Changes

### Core Changes

- `aglabo.github.io/docs/index.mdx`: Rewrite the English homepage with overview, workflow, skills, structure, installation, and slash command reference.
- `aglabo.github.io/docs/ja/index.mdx`: Add the Japanese homepage.
- `aglabo.github.io/blume.config.ts`: Add i18n config (`defaultLocale: en`, locales `en` and `ja`).
- `aglabo.github.io/public/.nojekyll`: Add a `.nojekyll` marker so Pages serves the site without Jekyll.
- `aglabo.github.io/.gitignore`: Move `dist/` to the generated-page section and ignore `.blume-verify/`.
- `.github/workflows/cd-deploy-pages.yml`: Add a Pages deploy workflow (push to `main` / `workflow_dispatch`) that builds `docs:build` and deploys `dist`.

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

Publishing requires GitHub Pages to be enabled with the "GitHub Actions" source. The workflow deploys `aglabo.github.io/dist`, produced by `docs:build`.
