### PR TITLE
docs: add bilingual user guides and project overview

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,13 @@
+<!-- markdownlint-disable first-line-heading -->
+
+|[English](./README.md)|日本語|
+
+# chatlog-exporter
+
+AI エージェントのチャットログをエクスポート、分類、整理するためのツール群です。
+
+chatlog-exporter は、AI コーディングエージェントのセッション履歴を構造化された Markdown ファイルに変換し、レビュー、フィルタリング、Obsidian などのナレッジベースへの取り込みをしやすくします。
+
+使い方、セットアップ、詳細なドキュメントは GitHub Pages を参照してください。
+
+<https://aglabo.github.io/chatlog-exporter/ja/>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable first-line-heading -->
+
+| English | [日本語](./README.ja.md) |
+
 # chatlog-exporter
 
-export AI-agents session log, and edit these for import to obsidian.
+Utilities for exporting, classifying, and organizing AI agent chat logs.
+
+chatlog-exporter helps turn session histories from AI coding agents into
+structured Markdown files that are easier to review, filter, and import into
+Obsidian or other knowledge bases.
+
+For usage, setup, and detailed documentation, see the documentation site:
+
+<https://aglabo.github.io/chatlog-exporter/>
+
+Japanese README: [README.ja.md](./README.ja.md)

--- a/aglabo.github.io/docs/index.mdx
+++ b/aglabo.github.io/docs/index.mdx
@@ -73,28 +73,13 @@ Each skill lives under `skills/`, with its specification described in `SKILL.md`
 
 ## Getting started
 
-<Steps>
-  <Step title="Check prerequisites">
-    Make sure the `claude` command (Claude Code CLI) and `deno` are on your PATH.
-  </Step>
-  <Step title="Set up the environment">
-    Run the development environment setup script from the repository root.
+chatlog-exporter runs as Claude Code project skills. Fork and clone the repository, register the skills, and run a slash command from the repository root.
 
-    ```bash
-    bash scripts/setup-dev-env.sh
-    ```
-  </Step>
-  <Step title="Invoke a skill">
-    Run a slash command from within Claude Code.
-
-    ```bash
-    /export-chatlogs
-    ```
-  </Step>
-</Steps>
+- [Quickstart](./user-guide/quickstart) — from a fresh clone to running `/export-chatlogs` once.
+- [Installation](./user-guide/install) — full setup, including how to register the skills and where the configuration lives.
 
 :::warning[Prerequisites]
-If the `claude` command and `deno` are not installed, the skills will not work. Install both first and add them to your PATH.
+The `claude` command (Claude Code CLI) and `deno` must be on your PATH. If either is missing, the skills will not work. Install both first and add them to your PATH.
 :::
 
 ## Invoking the skills

--- a/aglabo.github.io/docs/ja/index.mdx
+++ b/aglabo.github.io/docs/ja/index.mdx
@@ -73,28 +73,13 @@ description: AIエージェントのセッション履歴をエクスポート�
 
 ## 導入手順
 
-<Steps>
-  <Step title="前提を確認する">
-    `claude` コマンド（Claude Code CLI）と `deno` が PATH 上にあることを確認します。
-  </Step>
-  <Step title="環境をセットアップする">
-    リポジトリのルートで開発環境セットアップスクリプトを実行します。
+chatlog-exporter は Claude Code のプロジェクトスキルとして動作します。リポジトリを fork・clone し、スキルを登録して、リポジトリのルートからスラッシュコマンドを実行します。
 
-    ```bash
-    bash scripts/setup-dev-env.sh
-    ```
-  </Step>
-  <Step title="スキルを呼び出す">
-    Claude Code 上でスラッシュコマンドを実行します。
-
-    ```bash
-    /export-chatlogs
-    ```
-  </Step>
-</Steps>
+- [クイックスタート](./user-guide/quickstart) — clone した直後から `/export-chatlogs` を1回実行するまで。
+- [インストール](./user-guide/install) — スキルの登録方法や設定の配置を含む、詳しいセットアップ手順。
 
 :::warning[前提条件]
-`claude` コマンドと `deno` が未インストールの場合、スキルは動作しません。先にどちらもインストールし、PATH を通してください。
+`claude` コマンド（Claude Code CLI）と `deno` が PATH 上にある必要があります。どちらかが欠けているとスキルは動作しません。先にどちらもインストールし、PATH を通してください。
 :::
 
 ## スキルの呼び出し

--- a/aglabo.github.io/docs/ja/user-guide/install.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/install.mdx
@@ -1,0 +1,61 @@
+---
+title: インストール
+description: リポジトリを fork・clone し、スキルをローカルに登録して chatlog-exporter を Claude Code スキルとして導入します。
+---
+
+chatlog-exporter は **Claude Code のプロジェクトスキル**として動作します。現時点ではレジストリからインストールできるパッケージはなく、リポジトリを fork・clone し、そのローカルチェックアウトからスキルを Claude Code に登録します。スキルとその設定が正しく解決されるよう、リポジトリのルートで Claude Code を起動して使います。
+
+:::warning[前提条件]
+`claude` コマンド（Claude Code CLI）と `deno` が PATH 上にある必要があります。どちらかが欠けているとスキルは動作しません。先に両方をインストールし、PATH を通してください。
+:::
+
+<Steps>
+  <Step title="fork と clone">
+    GitHub 上でリポジトリを fork し、自分の fork を clone して移動します。
+
+    ```bash
+    git clone https://github.com/<your-account>/chatlog-exporter.git
+    cd chatlog-exporter
+    ```
+  </Step>
+  <Step title="スキルを登録する">
+    `.claude/skills` は `.gitignore` で除外されているため、clone した直後には含まれていません。Claude Code は `.claude/skills` 以下からプロジェクトスキルを認識するので、自分で `skills/` ディレクトリを指すように設定する必要があります。
+
+    環境に応じて、いずれかの方法を使ってください。
+
+    <Tabs>
+      <Tab title="Git Bash / macOS / Linux">
+        ```bash
+        ln -s ../skills .claude/skills
+        ```
+        Windows のデフォルト Git Bash では、シンボリックリンクではなくディレクトリのコピーになる場合があります。その場合でもスキルの実行には支障ありませんが、`skills/` の変更は自動では反映されません。
+      </Tab>
+      <Tab title="Windows PowerShell">
+        ```powershell
+        New-Item -ItemType SymbolicLink -Path .claude\skills -Target ..\skills
+        ```
+        Windows でシンボリックリンクを作成するには、開発者モードを有効にするか、管理者権限のシェルが必要です。
+      </Tab>
+      <Tab title="コピー（代替手段）">
+        ```bash
+        cp -r skills .claude/skills
+        ```
+        シンボリックリンクが使えない場合に使用します。`skills/` を更新するたびに再実行してください。
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step title="設定を確認する">
+    `.config/chatlog-exporter/` ディレクトリ（`config.yaml`・`dics/`・`prompts/`）は git 追跡済みなので、clone に含まれます。コピーは不要です。スキルはこの設定をカレントディレクトリから読み込むため、リポジトリのルートで Claude Code を起動してください。
+  </Step>
+  <Step title="スキルを実行する">
+    リポジトリのルートで Claude Code を起動し、スラッシュコマンドを実行します。
+
+    ```bash
+    /export-chatlogs
+    ```
+  </Step>
+</Steps>
+
+:::note
+`bash scripts/setup-dev-env.sh` は `lefthook` と ShellSpec をインストールします。これらはリポジトリへ貢献するための**開発ツール**であり、スキルの実行には必要ありません。
+:::

--- a/aglabo.github.io/docs/ja/user-guide/quickstart.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/quickstart.mdx
@@ -1,0 +1,41 @@
+---
+title: クイックスタート
+description: chatlog-exporter をセットアップし、スラッシュコマンド1つで最初のセッション履歴をエクスポートします。
+---
+
+このガイドでは、clone した直後の状態から `/export-chatlogs` を1回実行するまでを案内します。詳しいセットアップ手順は [インストール](./install) を参照してください。
+
+:::warning[前提条件]
+`claude` コマンド（Claude Code CLI）と `deno` が PATH 上にある必要があります。どちらかが欠けているとスキルは動作しません。先に両方をインストールしてください。
+:::
+
+<Steps>
+  <Step title="fork と clone">
+    GitHub 上でリポジトリを fork し、自分の fork を clone して移動します。
+
+    ```bash
+    git clone https://github.com/<your-account>/chatlog-exporter.git
+    cd chatlog-exporter
+    ```
+  </Step>
+  <Step title="スキルを登録する">
+    `.claude/skills` は git 追跡外のため、clone した直後には含まれていません。自分で `skills/` へのリンクを張ります。
+
+    ```bash
+    ln -s ../skills .claude/skills
+    ```
+
+    Windows の場合、またはリンクを作成できない場合は、PowerShell やコピーによる代替手段を [インストール](./install) で確認してください。
+  </Step>
+  <Step title="スキルを実行する">
+    リポジトリのルートで Claude Code を起動し、スラッシュコマンドを実行します。
+
+    ```bash
+    /export-chatlogs
+    ```
+  </Step>
+</Steps>
+
+:::tip
+各スキルは独立して実行できます。まずは `/export-chatlogs` だけを試し、必要に応じて後続のスキルを組み合わせてください。
+:::

--- a/aglabo.github.io/docs/user-guide/install.mdx
+++ b/aglabo.github.io/docs/user-guide/install.mdx
@@ -1,0 +1,61 @@
+---
+title: Installation
+description: Install chatlog-exporter as Claude Code project skills by forking the repository and registering the skills locally.
+---
+
+chatlog-exporter runs as **Claude Code project skills**. There is no package to install from a registry yet — you fork the repository, clone it, and register the skills into Claude Code from the local checkout. You then run Claude Code from the repository root so the skills and their configuration resolve correctly.
+
+:::warning[Prerequisites]
+The `claude` command (Claude Code CLI) and `deno` must be on your PATH. If either is missing, the skills will not work. Install both first and add them to your PATH.
+:::
+
+<Steps>
+  <Step title="Fork and clone">
+    Fork the repository on GitHub, then clone your fork and move into it.
+
+    ```bash
+    git clone https://github.com/<your-account>/chatlog-exporter.git
+    cd chatlog-exporter
+    ```
+  </Step>
+  <Step title="Register the skills">
+    `.claude/skills` is excluded by `.gitignore`, so a fresh clone does not contain it. Claude Code discovers project skills under `.claude/skills`, so you need to point it at the `skills/` directory yourself.
+
+    Use whichever method works in your environment:
+
+    <Tabs>
+      <Tab title="Git Bash / macOS / Linux">
+        ```bash
+        ln -s ../skills .claude/skills
+        ```
+        On the default Windows Git Bash this may copy the directory instead of creating a real symbolic link. That still works for running the skills, but changes to `skills/` will not be reflected automatically.
+      </Tab>
+      <Tab title="Windows PowerShell">
+        ```powershell
+        New-Item -ItemType SymbolicLink -Path .claude\skills -Target ..\skills
+        ```
+        Creating a symbolic link on Windows requires Developer Mode to be enabled or an elevated (administrator) shell.
+      </Tab>
+      <Tab title="Copy (fallback)">
+        ```bash
+        cp -r skills .claude/skills
+        ```
+        Use this when symbolic links are not available. Re-run it whenever `skills/` changes.
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step title="Confirm the configuration">
+    The `.config/chatlog-exporter/` directory (`config.yaml`, `dics/`, `prompts/`) **is** tracked in git, so it comes with the clone — no copying required. The skills read it from the current working directory, so run Claude Code from the repository root.
+  </Step>
+  <Step title="Run a skill">
+    Start Claude Code in the repository root and invoke a slash command.
+
+    ```bash
+    /export-chatlogs
+    ```
+  </Step>
+</Steps>
+
+:::note
+`bash scripts/setup-dev-env.sh` installs `lefthook` and ShellSpec. Those are **development tools** for contributing to the repository; they are not required to run the skills.
+:::

--- a/aglabo.github.io/docs/user-guide/quickstart.mdx
+++ b/aglabo.github.io/docs/user-guide/quickstart.mdx
@@ -1,0 +1,41 @@
+---
+title: Quickstart
+description: Get chatlog-exporter running and export your first session log with a single slash command.
+---
+
+This guide takes you from a fresh checkout to running `/export-chatlogs` once. For the full setup details, see [Installation](./install).
+
+:::warning[Prerequisites]
+The `claude` command (Claude Code CLI) and `deno` must be on your PATH. If either is missing, the skills will not work. Install both first.
+:::
+
+<Steps>
+  <Step title="Fork and clone">
+    Fork the repository on GitHub, then clone your fork and move into it.
+
+    ```bash
+    git clone https://github.com/<your-account>/chatlog-exporter.git
+    cd chatlog-exporter
+    ```
+  </Step>
+  <Step title="Register the skills">
+    `.claude/skills` is not tracked in git, so a fresh clone does not include it. Link it to `skills/` yourself.
+
+    ```bash
+    ln -s ../skills .claude/skills
+    ```
+
+    On Windows, or if the link cannot be created, see [Installation](./install) for the PowerShell and copy alternatives.
+  </Step>
+  <Step title="Run a skill">
+    Start Claude Code in the repository root, then run a slash command.
+
+    ```bash
+    /export-chatlogs
+    ```
+  </Step>
+</Steps>
+
+:::tip
+Each skill can run independently. Start with just `/export-chatlogs`, then combine the later skills as needed.
+:::

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -27,15 +27,21 @@
     "**/*.dic",
     // Documents
     "**/*.md",
+    "**/*.mdx",
   ],
   "excludes": [
+    // node, etc
     "**/node_modules/**",
-    "**/*lock",
     "**/lib/**",
     "**/module/**",
     "**/dist/**",
-    "aglabo.github.io/**",
-    //
+    // ignore blume files
+    "aglabo.github.io/.blume/**",
+    "aglabo.github.io/.blume-verify/**",
+    "aglabo.github.io/node_modules/**",
+    "aglabo.github.io/dist/**",
+    // package managers lock files
+    "**/*lock",
     "**lock.*",
     // Documents
     "CONTRIBUTING**.md",


### PR DESCRIPTION
## Overview

**Summary**
Add bilingual (EN/JA) Quickstart and Installation guides, and a bilingual README overview.

**Background / Motivation**
The getting-started flow lived inline on the docs-site landing page, and the README was a single line. Neither made it clear that chatlog-exporter runs as Claude Code project skills installed from a local fork, not a package registry. This PR adds dedicated guides, links the landing pages to them, and gives the README a proper overview.

## Changes

### Core Changes

- Add `install.mdx` and `quickstart.mdx` under `aglabo.github.io/docs/user-guide/` and its `ja/` counterpart. Install covers full setup as Claude Code project skills (fork, clone, register `.claude/skills`, run a slash command); Quickstart is the shortest path to running `/export-chatlogs` once.
- Update `index.mdx` (EN + JA): replace the inline getting-started `<Steps>` with links to the new guides.
- Add `README.ja.md` and expand `README.md` into a proper overview with a docs-site URL and an EN/JA language switcher.
- Update `dprint.jsonc`: add `**/*.mdx` to `includes` and scope `excludes` to `.blume`, `.blume-verify`, `node_modules`, and `dist` (was the whole `aglabo.github.io/**` tree).

### Test Updates

None. No source code changed.

### Removed

None.

## Change Type (optional)

- [x] Documentation
- [x] Configuration

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (`dprint check`)
- [x] Tests pass (no source code changed)
- [x] Documentation updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Documentation and formatter configuration only; no runtime or skill behavior changes.

## Additional Notes

The EN and JA files are kept in parity — the `ja/` files are translations, not duplicates. Running `dprint fmt --check` is the change most likely to surface a regression, since `.mdx` files are now formatted.
