### PR TITLE
docs(skills): update chatlog skill path resolution

### DIFF
--- a/skills/export-chatlogs/SKILL.md
+++ b/skills/export-chatlogs/SKILL.md
@@ -39,10 +39,10 @@ AIエージェントのセッション履歴をノイズ除外して Markdown �
 
 ## ステップ1: スクリプトパスの解決
 
-Glob ツールで `**/commands/export-chatlogs.md` を検索し、そのディレクトリを `SKILL_DIR` として確定する。
+Glob ツールで `**/export-chatlogs/SKILL.md` を検索し、そのディレクトリを `SKILL_DIR` として確定する。
 
 ```bash
-SKILL_DIR   = <export-chatlogs.md が存在するディレクトリの絶対パス>
+SKILL_DIR   = <SKILL.md が存在するディレクトリの絶対パス>
 SCRIPT_PATH = $SKILL_DIR/scripts/export-chatlogs.ts
 ```
 

--- a/skills/filter-chatlogs/SKILL.md
+++ b/skills/filter-chatlogs/SKILL.md
@@ -49,10 +49,10 @@ allowed-tools: Bash, Glob
 
 ## ステップ1: スクリプトパスの解決
 
-Glob ツールで `**/commands/filter-chatlogs.md` を検索し、そのディレクトリを `SKILL_DIR` として確定する。
+Glob ツールで `**/filter-chatlogs/SKILL.md` を検索し、そのディレクトリを `SKILL_DIR` として確定する。
 
 ```bash
-SKILL_DIR         = <filter-chatlogs.md が存在するディレクトリの絶対パス>
+SKILL_DIR         = <SKILL.md が存在するディレクトリの絶対パス>
 SCRIPT_PATH       = $SKILL_DIR/scripts/filter-chatlogs.ts
 NOISE_FILTER_PATH = $SKILL_DIR/scripts/noise-filter-chatlogs.ts
 ```


### PR DESCRIPTION
## Overview

**Summary**
Fix the `SKILL_DIR` Glob patterns in the export and filter chatlog skill docs.

**Background / Motivation**
Skills live at `skills/<skill>/SKILL.md`, but the docs told Glob to search a
`**/commands/<skill>.md` path that does not exist. This corrected the patterns
so `SKILL_DIR` resolves to the right directory.

## Changes

### Core Changes

- `skills/export-chatlogs/SKILL.md`: Change the `SKILL_DIR` Glob target from
  `**/commands/export-chatlogs.md` to `**/export-chatlogs/SKILL.md`, and update
  the reference file name from `export-chatlogs.md` to `SKILL.md`.
- `skills/filter-chatlogs/SKILL.md`: Change the `SKILL_DIR` Glob target from
  `**/commands/filter-chatlogs.md` to `**/filter-chatlogs/SKILL.md`, and update
  the reference file name from `filter-chatlogs.md` to `SKILL.md`.

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

Documentation-only change (`+4 -4` across 2 files). No code paths are affected,
so no automated tests are required.
