### PR TITLE
config(lint): centralize cspell config and shared doc toolchain

### DIFF
--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -45,6 +45,16 @@ is_shellspec_installed() {
 }
 
 ##
+# @description Check if agla-doc-tools is already installed in specified directory
+# @arg $1 string Directory path where agla-doc-tools should be installed
+# @return 0 If agla-doc-tools is installed
+# @return 1 If agla-doc-tools is not installed
+is_agla_doc_tools_installed() {
+  local install_dir="$1"
+  [[ -f "${install_dir}/bin/textlint" ]]
+}
+
+##
 # @description Install and configure lefthook
 # @return 0 If installation succeeds
 # @return 1 If installation fails
@@ -80,8 +90,51 @@ setup_shellspec() {
 }
 
 ##
+# @description Install agla-doc-tools to specified directory
+#
+# Provides the remark / textlint / cspell executables used by the lint:* scripts.
+# These are not local devDependencies: the toolchain is centralized in
+# aglabo/agla-doc-tools, which exposes bin/ wrappers that run each CLI against
+# its own node_modules. The lint:* scripts are local-only, so this install is
+# skipped in CI along with the rest of main().
+#
+# @arg $1 string Directory path where agla-doc-tools will be installed
+#               (default: ${HOME}/.local/tools/agla-doc-tools, shared across repositories)
+# @return 0 If installation succeeds
+# @return 1 If installation fails
+setup_agla_doc_tools() {
+  local install_dir="${1:-${HOME}/.local/tools/agla-doc-tools}"
+
+  if is_agla_doc_tools_installed "$install_dir"; then
+    echo "agla-doc-tools is already installed in $install_dir"
+    return 0
+  fi
+
+  echo "Installing agla-doc-tools to $install_dir..."
+
+  if ! git clone --depth 1 https://github.com/aglabo/agla-doc-tools.git "$install_dir" >/dev/null 2>&1; then
+    echo "Error: agla-doc-tools clone failed" >&2
+    return 1
+  fi
+
+  # bin/ wrappers resolve the CLIs from the tool repository's own node_modules
+  # On failure, discard the clone made just above: bin/textlint is tracked in the
+  # repository, so leaving it behind would make the next run skip this install and
+  # treat the unusable wrappers as a completed setup.
+  if ! (cd "$install_dir" && pnpm install --frozen-lockfile >/dev/null 2>&1); then
+    rm -rf "$install_dir"
+    echo "Error: agla-doc-tools dependency install failed" >&2
+    return 1
+  fi
+
+  echo "agla-doc-tools installed successfully to $install_dir"
+  echo "Add to PATH: export PATH=\"$install_dir/bin:\$PATH\""
+}
+
+##
 # @description Main entry point
 # @arg $1 string Optional shellspec installation directory (default: .tools/shellspec)
+# @arg $2 string Optional agla-doc-tools installation directory (default: ${HOME}/.local/tools/agla-doc-tools)
 # @return 0 If installation succeeds or is skipped
 # @return 1 If installation fails
 main() {
@@ -101,6 +154,9 @@ main() {
   # Install shellspec
   local shellspec_dir="${1:-.tools/shellspec}"
   setup_shellspec "$shellspec_dir"
+
+  # Install agla-doc-tools (provides remark / textlint / cspell)
+  setup_agla_doc_tools "${2:-${HOME}/.local/tools/agla-doc-tools}"
 }
 
 main "$@"


### PR DESCRIPTION
## Overview

**Summary**
Add a shared cspell config under `configs/` and install `agla-doc-tools` in the dev setup.

**Background / Motivation**
Documentation lint configs are being collected under `configs/`. `textlintrc.yaml` and `remark.config.mjs` already live there, but cspell did not. The remark, textlint, and cspell binaries are not local devDependencies. They come from `aglabo/agla-doc-tools`, which ships `bin/` wrappers that run each CLI against its own `node_modules`. Without that repository installed, the `lint:*` scripts cannot run in a fresh checkout. This PR adds both the config and the toolchain that runs it.

## Changes

### Core Changes

- `configs/cspell.json`: add a shared cspell workspace config. It sets language and compound-word options, enables `useGitignore`, defines `project-dic` pointing at `.vscode/cspell/dicts/project.dic`, and enables the built-in language dictionaries plus `user-dic`, `textlint-dic`, and `project-dic`.
- `package.json`: change `lint:spells` to read `./configs/cspell.json` instead of `.vscode/cspell.json`. This matches `lint:text` and `lint:mdx`, which already read from `configs/`.
- `scripts/setup-dev-env.sh`: install `agla-doc-tools` during dev setup. `is_agla_doc_tools_installed()` detects an existing install by checking for `bin/textlint`. `setup_agla_doc_tools()` shallow-clones the repository, runs `pnpm install --frozen-lockfile` in it, and prints the `PATH` line for the `bin/` wrappers. `main()` takes an optional second argument for the install directory, defaulting to `${HOME}/.local/tools/agla-doc-tools`. That is a user-wide location shared across repositories, so one install serves every project. Both install steps fail on error, and an existing install is a no-op.

### Test Updates

None. This PR changes configuration and tooling only.

### Removed

None. `.vscode/cspell.json` is unchanged, and the new config still uses `.vscode/cspell/dicts/`.

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #375

## Checklist

- [ ] Formatting and lint checks pass
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. `lint:spells` reads a different config file, but `.vscode/cspell.json` still exists.

## Additional Notes

N/A
