### PR TITLE
feat(runners): add shell developer tooling with ShellSpec, ShellCheck, and shfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,7 @@ tab_width = 2
 # ─────────────────────────────
 # Exclude directories/files
 # ─────────────────────────────
-[node_modules/*]
+[**/node_modules/*]
 ignore = true
 
 [.tools/*]

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,53 @@
+# .shellspec - ShellSpec project configuration
+# @(#) : ShellSpec configuration - unified testing options
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+## ShellSpec Configuration
+## Project-wide settings for shell script testing
+
+# Set shell to bash
+--shell bash
+
+# Specify spec directory
+--default-path "scripts/__tests__"
+
+# Spec file pattern (match .spec.sh instead of _spec.sh)
+--pattern "*.spec.sh"
+
+# Load path for shared helpers
+--load-path "scripts/__tests__"
+
+# Load spec_helper before each spec file
+--require spec_helper
+
+# Enable colored output
+--color
+
+# Show execution times
+# --profile
+--profile-limit=10
+
+# Show failure messages in detail
+--fail-fast=1
+
+# Set formatter (default: progress, options: documentation, tap, junit)
+--format documentation
+
+# Coverage settings (requires kcov)
+# --kcov
+# --kcov-options "--exclude-pattern=/usr"
+
+# Execution options
+--jobs 16
+
+# --random none
+
+# Output directory for reports
+--reportdir "temp/shellspec-reports"
+
+# Warning settings
+--warning-as-failure

--- a/configs/shellcheckrc
+++ b/configs/shellcheckrc
@@ -1,0 +1,18 @@
+# src: configs/shellcheckrc
+# @(#) : shellcheck configuration for aplys shell scripts
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# Shell dialect: bash (#!/usr/bin/env bash, bash 4.0+ features used)
+shell=bash
+
+# Minimum severity to report (style = all categories: error/warning/info/style)
+severity=style
+
+# SC2317 - unreachable code after return/exit
+#   shellspec test framework patterns; also present in .tools/shellspec/.shellcheckrc
+disable=SC2317,SC1091
+

--- a/package.json
+++ b/package.json
@@ -26,9 +26,16 @@
     "prepare": "bash ./scripts/setup-dev-env.sh",
     "docs:dev": "pnpm --dir aglabo.github.io run docs:dev",
     "docs:build": "pnpm --dir aglabo.github.io run docs:build",
+    "check:sh": "bash runners/run-shfmt.sh --list .",
+    "format:sh": "bash runners/run-shfmt.sh --format .",
+    "check:dprint": "dprint check",
+    "format:dprint": "dprint fmt",
     "lint:spells": "cspell --config .vscode/cspell.json --cache --cache-location .cache/cspell/cSpellCache ",
     "lint:text": "textlint --config ./configs/textlintrc.yaml ",
-    "lint:mdx": "remark --rc-path ./configs/remark.config.mjs \"aglabo.github.io/docs/**/*.mdx\""
+    "lint:mdx": "remark --rc-path ./configs/remark.config.mjs \"aglabo.github.io/docs/**/*.mdx\"",
+    "lint:sh": "bash runners/run-shellcheck.sh ",
+    "test:sh": "bash runners/run-shellspec.sh ",
+    "test:sh:all": "bash runners/run-shellspec.sh all"
   },
   "devDependencies": {
     "remark-lint-emphasis-marker": "^4.0.1",

--- a/runners/libs/get-filelist.lib.sh
+++ b/runners/libs/get-filelist.lib.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# get-filelist.sh — file list and argument normalization library
+# Provides path normalization, glob-to-regex conversion, and file list retrieval
+
+# Guard against double sourcing
+[[ -n "${_GET_FILELIST_SH:-}" ]] && return 0
+readonly _GET_FILELIST_SH=1
+
+#
+# @description Convert shell glob pattern to rg-compatible regex filter
+# @arg $1 string Pattern to convert (optional; reads from stdin if omitted)
+# @stdout Converted pattern
+# @exitcode 0 always
+#
+args_to_filter() {
+  local __pattern
+  if [[ $# -gt 0 ]]; then
+    __pattern="$1"
+  else
+    IFS= read -r __pattern
+  fi
+  __pattern="${__pattern//\*/.*}"
+  __pattern="${__pattern//\?/.}"
+  printf '%s\n' "${__pattern}"
+}
+
+#
+# @description Convert Windows backslash path separators to forward slashes
+# @arg $1 string Path to normalize (optional; reads from stdin if omitted)
+# @stdout Normalized path string
+# @exitcode 0 always
+#
+normalize_path() {
+  local __path
+  if [[ $# -gt 0 ]]; then
+    __path="$1"
+  else
+    IFS= read -r __path
+  fi
+  printf '%s\n' "${__path//\\/\/}"
+}
+
+#
+# @description Test whether a string contains shell glob characters (* or ?)
+# @arg $1 string Pattern to test
+# @stdout nothing
+# @exitcode 0 if pattern contains * or ?, 1 otherwise
+#
+is_glob_pattern() {
+  local __pattern="$1"
+  [[ "$__pattern" == *'*'* || "$__pattern" == *'?'* ]]
+}
+
+#
+# @description Get list of files matching a pattern with optional filters
+# @arg $1 string Search root directory
+# @arg $2 string File glob pattern (e.g. "*.spec.sh")
+# @arg $@ Additional filters: slash-containing args are dir_filters, others are str_filters
+# @stdout Newline-separated list of matching file paths (./-prefixed, forward slashes); empty output when no files match
+# @exitcode 0 always
+#
+get_filelist() {
+  local __root="$1"
+  local __pattern="$2"
+  shift 2
+
+  # Collect all filters as rg patterns (dir: as-is, str: glob-converted)
+  local -a __filters=()
+  local __f __norm
+  for __f in "$@"; do
+    __norm=$(normalize_path "$__f")
+    if [[ "$__norm" == */* ]]; then
+      __filters+=("$__norm")
+    else
+      __filters+=("$(args_to_filter "$__f")")
+    fi
+  done
+
+  # Enumerate files; normalize separators and prepend ./
+  local __result
+  __result=$(cd "$__root" && rg --files -g "$__pattern" 2>/dev/null | sed 's|\\|/|g; s|^[^./]|./&|' || true)
+
+  # Apply each filter (AND: narrow results; short-circuit on empty)
+  local __pat
+  for __pat in "${__filters[@]}"; do
+    [[ -z "$__result" ]] && break
+    __result=$(printf '%s\n' "$__result" | rg "$__pat" 2>/dev/null || true)
+  done
+
+  [[ -z "$__result" ]] && return 0
+  printf '%s\n' "$__result"
+}

--- a/runners/libs/init-vars.lib.sh
+++ b/runners/libs/init-vars.lib.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# init-vars.lib.sh — common runner variable initialization library
+# Provides SCRIPT_ROOT and PROJECT_ROOT for all runner scripts
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# Guard against double sourcing
+[[ -n "${_INIT_VARS_LIB_SH:-}" ]] && return 0
+readonly _INIT_VARS_LIB_SH=1
+
+# SCRIPT_ROOT: directory of the runner script that sourced this file
+# BASH_SOURCE[1] refers to the caller's script path when this file is sourced
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+
+# PROJECT_ROOT: git repository root, or parent of SCRIPT_ROOT as fallback
+PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || dirname "${SCRIPT_ROOT}")}"

--- a/runners/run-shellcheck.sh
+++ b/runners/run-shellcheck.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# src: ./scripts/run-shellcheck.sh
+# @(#) : shellcheck runner
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+set -euo pipefail
+
+# shellcheck source=runners/libs/init-vars.lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
+cd "${SCRIPT_ROOT}/.."
+
+SHELLCHECKRC="${SHELLCHECKRC:-${SCRIPT_ROOT}/../configs/shellcheckrc}"
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --rcfile | -r)
+      SHELLCHECKRC="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      return 1
+      ;;
+    *) break ;;
+    esac
+  done
+  local -a targets=("$@")
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    targets=(".")
+  fi
+  targets=("${targets[@]//\\//}")
+  local -a files=()
+  for target in "${targets[@]}"; do
+    if [[ -d $target ]]; then
+      while IFS= read -r -d '' f; do
+        files+=("$f")
+      done < <(find "$target" \
+        -path "*/.tools/*" -prune -o \
+        -path "*/node_modules/*" -prune -o \
+        -name "*.sh" -print0)
+    else
+      files+=("$target")
+    fi
+  done
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No .sh files found." >&2
+    return 0
+  fi
+  (shellcheck --rcfile="$SHELLCHECKRC" "${files[@]}")
+}
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/runners/run-shellspec.sh
+++ b/runners/run-shellspec.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# src: ./runners/run-shellspec.sh
+# @(#) : shellspec runner
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# shellcheck disable=SC1091
+
+set -euo pipefail
+
+# shellcheck source=runners/libs/init-vars.lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
+
+SHELLSPEC="${SHELLSPEC:-${PROJECT_ROOT}/.tools/shellspec/shellspec}"
+
+readonly TEST_TYPES=("all" "unit" "functional" "integration" "system" "e2e")
+
+# Spec root directory, relative to PROJECT_ROOT. Must match --default-path in .shellspec
+readonly SPEC_ROOT_DIR="scripts/__tests__"
+
+SKIP_INTEGRATION_TESTS="${SKIP_INTEGRATION_TESTS:-1}"
+SPEC_SEARCH_ROOT="${SPEC_SEARCH_ROOT:-${PROJECT_ROOT}}"
+
+PARSED_ARGS=()
+RESOLVED_SPEC_FILES=()
+SHELLSPEC_ARGS=()
+
+# shellcheck source=runners/libs/get-filelist.sh
+. "${SCRIPT_ROOT}/libs/get-filelist.lib.sh"
+
+is_test_type() {
+  local arg="$1"
+  local type
+  for type in "${TEST_TYPES[@]}"; do
+    [[ "$arg" == "$type" ]] && return 0
+  done
+  return 1
+}
+
+is_spec_file() {
+  local arg="$1"
+  [[ "$arg" == *.spec.sh ]]
+}
+
+is_spec_glob() {
+  local arg="$1"
+  is_glob_pattern "$arg" && [[ "$arg" == *".spec.sh"* ]]
+}
+
+expand_spec_glob() {
+  local pattern="$1"
+  local norm_pattern
+  norm_pattern=$(normalize_path "$pattern")
+
+  local -a matches
+  mapfile -t matches < <(
+    cd "$SPEC_SEARCH_ROOT" && compgen -G "$norm_pattern" 2>/dev/null || true
+  )
+
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    echo "Warning: No spec files found matching glob '${pattern}'" >&2
+    return 0
+  fi
+
+  local file
+  for file in "${matches[@]}"; do
+    normalize_path "$file"
+  done
+}
+
+is_skip_shellspec_file() {
+  local file="$1"
+  local file_path="$file"
+  if [[ "$file_path" != /* ]]; then
+    file_path="${SPEC_SEARCH_ROOT}/${file_path#./}"
+  fi
+
+  [[ -f "$file_path" ]] && head -n 5 "$file_path" 2>/dev/null | grep -q '^# skip shellspec'
+}
+
+filter_runnable_specs() {
+  local file
+  for file in "$@"; do
+    if ! is_skip_shellspec_file "$file"; then
+      printf '%s\n' "$file"
+    fi
+  done
+}
+
+get_spec_files() {
+  local test_type="$1"
+  shift
+
+  local type_filter
+  if [[ "$test_type" == "all" ]]; then
+    type_filter="${SPEC_ROOT_DIR}/"
+  else
+    type_filter="${SPEC_ROOT_DIR}/${test_type}/"
+  fi
+
+  local -a spec_files
+  mapfile -t spec_files < <(get_filelist "$SPEC_SEARCH_ROOT" "*.spec.sh" "$type_filter" "$@")
+  filter_runnable_specs "${spec_files[@]}"
+}
+
+parse_options() {
+  PARSED_ARGS=()
+
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "--integration" ]]; then
+      SKIP_INTEGRATION_TESTS=0
+    elif [[ "$arg" == "--" ]]; then
+      continue
+    else
+      PARSED_ARGS+=("$arg")
+      printf '%s\n' "$arg"
+    fi
+  done
+}
+
+resolve_spec_files() {
+  RESOLVED_SPEC_FILES=()
+  SHELLSPEC_ARGS=()
+
+  [[ $# -eq 0 ]] && return 0
+
+  local first_arg="$1"
+
+  if is_spec_glob "$first_arg"; then
+    local -a expanded_specs
+    mapfile -t expanded_specs < <(expand_spec_glob "$first_arg")
+    mapfile -t RESOLVED_SPEC_FILES < <(filter_runnable_specs "${expanded_specs[@]}")
+    shift
+    SHELLSPEC_ARGS=("$@")
+    printf '%s\n' "${RESOLVED_SPEC_FILES[@]}"
+    return 0
+  fi
+
+  if is_spec_file "$first_arg"; then
+    RESOLVED_SPEC_FILES=("$first_arg")
+    shift
+    SHELLSPEC_ARGS=("$@")
+    printf '%s\n' "${RESOLVED_SPEC_FILES[@]}"
+    return 0
+  fi
+
+  if ! is_test_type "$first_arg"; then
+    printf "Error: Unknown argument '%s'. Expected a test type, spec file, or glob pattern.\n" "$first_arg"
+    return 1
+  fi
+
+  local test_type="$1"
+  shift
+  [[ "$test_type" == "system" ]] && SKIP_INTEGRATION_TESTS=0
+
+  local -a file_filters=()
+  local parsing_shellspec_args=0
+  local arg
+  for arg in "$@"; do
+    if [[ $parsing_shellspec_args -eq 1 || "$arg" == -* ]]; then
+      parsing_shellspec_args=1
+      SHELLSPEC_ARGS+=("$arg")
+    else
+      file_filters+=("$arg")
+    fi
+  done
+
+  local -a spec_files
+  mapfile -t spec_files < <(get_spec_files "$test_type" "${file_filters[@]}")
+  if [[ ${#spec_files[@]} -eq 0 || -z "${spec_files[0]}" ]]; then
+    echo "Warning: No spec files found for test type '${test_type}'" >&2
+    return 0
+  fi
+
+  RESOLVED_SPEC_FILES=("${spec_files[@]}")
+  printf '%s\n' "${RESOLVED_SPEC_FILES[@]}"
+}
+
+run_shellspec() {
+  local -a normalized_args=()
+  local arg
+  for arg in "$@"; do
+    normalized_args+=("$(normalize_path "$arg")")
+  done
+
+  (cd "$PROJECT_ROOT" && export SKIP_INTEGRATION_TESTS && bash "$SHELLSPEC" "${normalized_args[@]}")
+}
+
+main() {
+  if [[ $# -eq 0 ]]; then
+    run_shellspec
+    exit $?
+  fi
+
+  parse_options "$@" >/dev/null
+
+  local resolved resolved_file
+  resolved_file=$(mktemp)
+  if ! resolve_spec_files "${PARSED_ARGS[@]}" >"$resolved_file"; then
+    resolved=$(cat "$resolved_file")
+    rm -f "$resolved_file"
+    echo "$resolved" >&2
+    exit 1
+  fi
+  resolved=$(cat "$resolved_file")
+  rm -f "$resolved_file"
+
+  [[ -z "$resolved" ]] && exit 0
+
+  run_shellspec "${RESOLVED_SPEC_FILES[@]}" "${SHELLSPEC_ARGS[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/runners/run-shfmt.sh
+++ b/runners/run-shfmt.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# src: ./runners/run-shfmt.sh
+# @(#) : shfmt runner
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+set -euo pipefail
+
+# shellcheck source=runners/libs/init-vars.lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
+
+main() {
+  local mode="list"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --list | -l)
+      mode="list"
+      shift
+      ;;
+    --format)
+      mode="format"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      return 1
+      ;;
+    *) break ;;
+    esac
+  done
+  local -a targets=("$@")
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    targets=(".")
+  fi
+  targets=("${targets[@]//\\//}")
+  case "$mode" in
+  list) (cd "$PROJECT_ROOT" && shfmt -ln bash -i 2 -l -- "${targets[@]}") ;;
+  format) (cd "$PROJECT_ROOT" && shfmt -ln bash -i 2 -w -- "${targets[@]}") ;;
+  esac
+}
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/__tests__/spec_helper.sh
+++ b/scripts/__tests__/spec_helper.sh
@@ -1,0 +1,63 @@
+# src: ./scripts/__tests__/spec_helper.sh
+# @(#) : ShellSpec shared setup
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+#
+
+# shellcheck shell=bash
+
+set -eu
+
+##
+# @description Create a throwaway repository holding a minimal skills tree
+#
+# The spec files exercise functions that create and delete directories, so each
+# example works inside its own git repository rather than the real checkout.
+#
+# @stdout Absolute path to the new repository root
+make_fixture_repo() {
+  local repo
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/skills/export-chatlogs" "${repo}/skills/filter-chatlogs" "${repo}/.claude"
+  echo '# export' >"${repo}/skills/export-chatlogs/SKILL.md"
+  echo '# filter' >"${repo}/skills/filter-chatlogs/SKILL.md"
+  git -C "$repo" init -q
+  echo "$repo"
+}
+
+##
+# @description Report whether the shell cannot create real symbolic links
+#
+# Phrased negatively because `Skip if` takes a plain condition and cannot
+# negate one itself.
+#
+# @return 0 If symbolic links are unavailable
+# @return 1 If symbolic links work
+no_symlink_support() {
+  ! supports_symlinks
+}
+
+##
+# @description Report whether the shell can create real symbolic links
+#
+# On Windows Git Bash without Developer Mode `ln -s` silently copies, so the
+# symlink examples are skipped instead of failing.
+#
+# @return 0 If a real symbolic link can be created
+# @return 1 Otherwise
+supports_symlinks() {
+  local probe link
+  probe="$(mktemp -d)"
+  mkdir "${probe}/target"
+  link="${probe}/link"
+  MSYS=winsymlinks:nativestrict ln -s ./target "$link" 2>/dev/null || true
+  if [[ -L "$link" ]]; then
+    rm -rf "$probe"
+    return 0
+  fi
+  rm -rf "$probe"
+  return 1
+}

--- a/scripts/__tests__/unit/get-filelist.unit.spec.sh
+++ b/scripts/__tests__/unit/get-filelist.unit.spec.sh
@@ -1,0 +1,88 @@
+# src: ./scripts/__tests__/unit/get-filelist.unit.spec.sh
+# @(#) : unit spec for get-filelist library pure functions
+#        対象: normalize_path / is_glob_pattern / args_to_filter
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+#
+
+# shellcheck shell=bash
+
+Describe 'get-filelist.lib.sh'
+  Include runners/libs/get-filelist.lib.sh
+
+  Describe 'normalize_path'
+    Describe 'When: 正常系'
+      It '[Normal] T-LIB-GFL-01: バックスラッシュ区切りをスラッシュ区切りに変換する'
+        When call normalize_path 'a\b\c'
+        The output should equal 'a/b/c'
+      End
+
+      It '[Normal] T-LIB-GFL-02: テストディレクトリパスを正規化する'
+        When call normalize_path 'scripts\__tests__\unit'
+        The output should equal 'scripts/__tests__/unit'
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-LIB-GFL-03: 既にスラッシュ区切りのパスはそのまま返す'
+        When call normalize_path 'a/b/c'
+        The output should equal 'a/b/c'
+      End
+
+      It '[Edge] T-LIB-GFL-04: 空文字列は空文字列を返す'
+        When call normalize_path ''
+        The output should equal ''
+      End
+    End
+  End
+
+  Describe 'is_glob_pattern'
+    Describe 'When: 正常系'
+      It '[Normal] T-LIB-GFL-05: アスタリスクを含むパターンは成功を返す'
+        When call is_glob_pattern '*.sh'
+        The status should be success
+      End
+
+      It '[Normal] T-LIB-GFL-06: クエスチョンマークを含むパターンは成功を返す'
+        When call is_glob_pattern 'a?.sh'
+        The status should be success
+      End
+
+      It '[Normal] T-LIB-GFL-07: メタ文字を含まない文字列は失敗を返す'
+        When call is_glob_pattern 'a.sh'
+        The status should be failure
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-LIB-GFL-08: 空文字列は失敗を返す'
+        When call is_glob_pattern ''
+        The status should be failure
+      End
+    End
+  End
+
+  Describe 'args_to_filter'
+    Describe 'When: 正常系'
+      It '[Normal] T-LIB-GFL-09: アスタリスクを任意文字列の正規表現に変換する'
+        When call args_to_filter '*.spec.sh'
+        The output should equal '.*.spec.sh'
+      End
+
+      It '[Normal] T-LIB-GFL-10: クエスチョンマークを任意1文字の正規表現に変換する'
+        When call args_to_filter 'a?.sh'
+        The output should equal 'a..sh'
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-LIB-GFL-11: メタ文字を含まない文字列はそのまま返す'
+        When call args_to_filter 'a.sh'
+        The output should equal 'a.sh'
+      End
+    End
+  End
+End


### PR DESCRIPTION
## Overview

**Summary**
Add a shell script toolchain with ShellSpec, ShellCheck, and shfmt.

**Background / Motivation**
The shell scripts under `scripts/` and `runners/` had no test or lint setup. Broken shell code could only be found by hand. This PR adds runners for the three tools, the shared libraries they use, their config files, and a first unit spec.

## Changes

### Core Changes

Runners:

- `runners/run-shellspec.sh` (+219) — ShellSpec runner. Selects test type, file pattern, and integration mode.
- `runners/run-shellcheck.sh` (+61) — ShellCheck runner. Takes a custom rcfile and target paths. Skips `.tools` and `node_modules`.
- `runners/run-shfmt.sh` (+50) — shfmt runner. Has list and format modes.

Libraries:

- `runners/libs/get-filelist.lib.sh` (+92) — Adds `args_to_filter`, `normalize_path`, `is_glob_pattern`, and `get_filelist`.
- `runners/libs/init-vars.lib.sh` (+19) — Sets `SCRIPT_ROOT` and `PROJECT_ROOT`. Guards against double sourcing.

Configuration:

- `.shellspec` (+53) — ShellSpec config. Uses bash, sets `scripts/__tests__` as spec dir and load path, and matches `*.spec.sh`.
- `configs/shellcheckrc` (+18) — ShellCheck config. Targets Bash, sets severity to `style`, and disables SC1091 and SC2317.
- `package.json` (+8 -1) — Adds `check:sh`, `format:sh`, `lint:sh`, `test:sh`, `test:sh:all`, `check:dprint`, and `format:dprint`.
- `.editorconfig` (+1 -1) — Changes `node_modules/*` to `**/node_modules/*` to ignore nested `node_modules`.

### Test Updates

- `scripts/__tests__/spec_helper.sh` (+63) — Adds `make_fixture_repo` to build a fixture git repo, plus `no_symlink_support` and `supports_symlinks`.
- `scripts/__tests__/unit/get-filelist.unit.spec.sh` (+88) — Unit spec for `normalize_path`, `is_glob_pattern`, and `args_to_filter`.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

Test results on this branch:

- `pnpm run test:sh` — 11 examples, 0 failures. Covers `normalize_path`, `is_glob_pattern`, and `args_to_filter`.
- `pnpm run lint:sh` — passed, no findings.
- `pnpm run check:sh` — passed, no files needed reformatting.

Notes for reviewers:

- `get_filelist` itself and the three runner scripts have no tests yet.
- The branch is named `fix-lhs/...`, but every commit adds new tooling instead of fixing a bug. The title uses `feat` to match the actual change.
