### PR TITLE
chore(scripts): add install-skills.sh to automate skill registration

### DIFF
--- a/aglabo.github.io/docs/ja/user-guide/install.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/install.mdx
@@ -10,6 +10,8 @@ chatlog-exporter は **Claude Code のプロジェクトスキル**として動�
 **前提条件**
 
 `claude` コマンド（Claude Code CLI）と `deno` が PATH 上にある必要があります。どちらかが欠けているとスキルは動作しません。先に両方をインストールし、PATH を通してください。
+
+また、スキルは bash シェルを前提とします。Windows では Git Bash を使い、シンボリックリンクを作成できるよう開発者モードを有効にしてください。
 :::
 
 <Steps>
@@ -25,28 +27,46 @@ chatlog-exporter は **Claude Code のプロジェクトスキル**として動�
     `.claude/skills` は `.gitignore` で除外されているため、clone した直後には含まれていません。
     Claude Code は `.claude/skills` 以下からプロジェクトスキルを認識するので、自分で `skills/` ディレクトリを指すように設定する必要があります。
 
-    環境に応じて、いずれかの方法を使ってください。
+    インストールスクリプトを実行します。
 
-    <Tabs>
-      <Tab title="Git Bash / macOS / Linux">
-        ```bash
-        ln -s ../skills .claude/skills
-        ```
-        Windows のデフォルト Git Bash では、シンボリックリンクではなくディレクトリのコピーになる場合があります。その場合でもスキルの実行には支障ありませんが、`skills/` の変更は自動では反映されません。
-      </Tab>
-      <Tab title="Windows PowerShell">
-        ```powershell
-        New-Item -ItemType SymbolicLink -Path .claude\skills -Target ..\skills
-        ```
-        Windows でシンボリックリンクを作成するには、開発者モードを有効にするか、管理者権限のシェルが必要です。
-      </Tab>
-      <Tab title="コピー（代替手段）">
-        ```bash
-        cp -r skills .claude/skills
-        ```
-        シンボリックリンクが使えない場合に使用します。`skills/` を更新するたびに再実行してください。
-      </Tab>
-    </Tabs>
+    ```bash
+    bash scripts/install-skills.sh
+    ```
+
+    `.claude/skills` を `skills/` へリンクします。すでに正しくリンク済みの場合は何も変更しないので、再実行しても安全です。このスクリプトはシンボリックリンクを作成できるシェルを必要とします。Windows では、開発者モードを有効にした Git Bash が該当します。
+
+    既存のリンクを削除して張り直すには `--force` を付けます。
+
+    ```bash
+    bash scripts/install-skills.sh --force
+    ```
+
+    <Accordion>
+      <AccordionItem title="手動でスキルを登録する">
+        手作業でスキルを登録したい場合に使用します。
+
+        <Tabs>
+          <Tab title="Git Bash / macOS / Linux">
+            ```bash
+            ln -s ../skills .claude/skills
+            ```
+            Windows のデフォルト Git Bash では、シンボリックリンクではなくディレクトリのコピーになる場合があります。その場合でもスキルの実行には支障ありませんが、`skills/` の変更は自動では反映されません。
+          </Tab>
+          <Tab title="Windows PowerShell">
+            ```powershell
+            New-Item -ItemType SymbolicLink -Path .claude\skills -Target ..\skills
+            ```
+            Windows でシンボリックリンクを作成するには、開発者モードを有効にするか、管理者権限のシェルが必要です。
+          </Tab>
+          <Tab title="コピー（代替手段）">
+            ```bash
+            cp -r skills .claude/skills
+            ```
+            シンボリックリンクが使えない場合に使用します。`skills/` を更新するたびに再実行してください。
+          </Tab>
+        </Tabs>
+      </AccordionItem>
+    </Accordion>
   </Step>
   <Step title="設定を確認する">
     `.config/chatlog-exporter/` ディレクトリ（`config.yaml`・`dics/`・`prompts/`）は git 追跡済みなので、clone に含まれます。
@@ -62,5 +82,7 @@ chatlog-exporter は **Claude Code のプロジェクトスキル**として動�
 </Steps>
 
 :::note
-`bash scripts/setup-dev-env.sh` は `lefthook` と ShellSpec をインストールします。これらはリポジトリへ貢献するための**開発ツール**であり、スキルの実行には必要ありません。
+`bash scripts/setup-dev-env.sh` は `lefthook` と ShellSpec をインストールします。
+ShellSpec はシェルスクリプトのテストに使い、`pnpm test:sh` で実行します。
+これらはリポジトリへ貢献するための**開発ツール**であり、スキルの実行には必要ありません。
 :::

--- a/aglabo.github.io/docs/ja/user-guide/quickstart.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/quickstart.mdx
@@ -21,13 +21,13 @@ description: chatlog-exporter をセットアップし、スラッシュコマ�
     ```
   </Step>
   <Step title="スキルを登録する">
-    `.claude/skills` は git 追跡外のため、clone した直後には含まれていません。自分で `skills/` へのリンクを張ります。
+    `.claude/skills` は git 追跡外のため、clone した直後には含まれていません。スクリプトでスキルを登録します。
 
     ```bash
-    ln -s ../skills .claude/skills
+    bash scripts/install-skills.sh
     ```
 
-    Windows の場合、またはリンクを作成できない場合は、PowerShell やコピーによる代替手段を [インストール](./install) で確認してください。
+    `.claude/skills` を `skills/` にリンクします。既存のリンクを削除して張り直すには `--force` を付けて再実行してください。オプションと手動での代替手段は [インストール](./install) を参照してください。
   </Step>
   <Step title="スキルを実行する">
     リポジトリのルートで Claude Code を起動し、スラッシュコマンドを実行します。

--- a/aglabo.github.io/docs/user-guide/install.mdx
+++ b/aglabo.github.io/docs/user-guide/install.mdx
@@ -12,6 +12,9 @@ You then run Claude Code from the repository root so the skills and their config
 
 The `claude` command (Claude Code CLI) and `deno` must be on your PATH. If either is missing, the skills will not work.
 Install both first and add them to your PATH.
+
+The skills also assume a bash shell. On Windows, use Git Bash — and enable Developer Mode so it can
+create symbolic links.
 :::
 
 <Steps>
@@ -27,29 +30,49 @@ Install both first and add them to your PATH.
     `.claude/skills` is excluded by `.gitignore`, so a fresh clone does not contain it.
     Claude Code discovers project skills under `.claude/skills`, so you need to point it at the `skills/` directory yourself.
 
-    Use whichever method works in your environment:
+    Run the install script:
 
-    <Tabs>
-      <Tab title="Git Bash / macOS / Linux">
-        ```bash
-        ln -s ../skills .claude/skills
-        ```
-        On the default Windows Git Bash this may copy the directory instead of creating a real symbolic link.
-        That still works for running the skills, but changes to `skills/` will not be reflected automatically.
-      </Tab>
-      <Tab title="Windows PowerShell">
-        ```powershell
-        New-Item -ItemType SymbolicLink -Path .claude\skills -Target ..\skills
-        ```
-        Creating a symbolic link on Windows requires Developer Mode to be enabled or an elevated (administrator) shell.
-      </Tab>
-      <Tab title="Copy (fallback)">
-        ```bash
-        cp -r skills .claude/skills
-        ```
-        Use this when symbolic links are not available. Re-run it whenever `skills/` changes.
-      </Tab>
-    </Tabs>
+    ```bash
+    bash scripts/install-skills.sh
+    ```
+
+    This links `.claude/skills` to `skills/`. Re-running it is safe — an existing correct link is
+    left untouched. The script requires a shell that can create symbolic links; on Windows that
+    means Git Bash with Developer Mode enabled.
+
+    To remove the existing link and create it again, add `--force`:
+
+    ```bash
+    bash scripts/install-skills.sh --force
+    ```
+
+    <Accordion>
+      <AccordionItem title="Registering the skills manually">
+        Use these if you would rather register the skills by hand.
+
+        <Tabs>
+          <Tab title="Git Bash / macOS / Linux">
+            ```bash
+            ln -s ../skills .claude/skills
+            ```
+            On the default Windows Git Bash this may copy the directory instead of creating a real symbolic link.
+            That still works for running the skills, but changes to `skills/` will not be reflected automatically.
+          </Tab>
+          <Tab title="Windows PowerShell">
+            ```powershell
+            New-Item -ItemType SymbolicLink -Path .claude\skills -Target ..\skills
+            ```
+            Creating a symbolic link on Windows requires Developer Mode to be enabled or an elevated shell.
+          </Tab>
+          <Tab title="Copy (fallback)">
+            ```bash
+            cp -r skills .claude/skills
+            ```
+            Use this when symbolic links are not available. Re-run it whenever `skills/` changes.
+          </Tab>
+        </Tabs>
+      </AccordionItem>
+    </Accordion>
   </Step>
   <Step title="Confirm the configuration">
     The `.config/chatlog-exporter/` directory (`config.yaml`, `dics/`, `prompts/`) **is** tracked in git,
@@ -66,6 +89,7 @@ Install both first and add them to your PATH.
 </Steps>
 
 :::note
-`bash scripts/setup-dev-env.sh` installs `lefthook` and ShellSpec.
+`bash scripts/setup-dev-env.sh` installs `lefthook` and ShellSpec, which `pnpm test:sh` then uses to run
+the shell script tests.
 Those are **development tools** for contributing to the repository; they are not required to run the skills.
 :::

--- a/aglabo.github.io/docs/user-guide/quickstart.mdx
+++ b/aglabo.github.io/docs/user-guide/quickstart.mdx
@@ -22,13 +22,14 @@ If either is missing, the skills will not work. Install both first.
     ```
   </Step>
   <Step title="Register the skills">
-    `.claude/skills` is not tracked in git, so a fresh clone does not include it. Link it to `skills/` yourself.
+    `.claude/skills` is not tracked in git, so a fresh clone does not include it. Register the skills with the script.
 
     ```bash
-    ln -s ../skills .claude/skills
+    bash scripts/install-skills.sh
     ```
 
-    On Windows, or if the link cannot be created, see [Installation](./install) for the PowerShell and copy alternatives.
+    It links `.claude/skills` to `skills/`. To remove the existing link and create it again, re-run it with `--force`.
+    See [Installation](./install) for the options and the manual alternatives.
   </Step>
   <Step title="Run a skill">
     Start Claude Code in the repository root, then run a slash command.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "prepare": "bash ./scripts/setup-dev-env.sh",
+    "install-skills": "bash ./scripts/install-skills.sh ",
     "docs:dev": "pnpm --dir aglabo.github.io run docs:dev",
     "docs:build": "pnpm --dir aglabo.github.io run docs:build",
     "check:sh": "bash runners/run-shfmt.sh --list .",

--- a/runners/run-shellcheck.sh
+++ b/runners/run-shellcheck.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-# shellcheck source=runners/libs/init-vars.lib.sh
+# shellcheck disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
 cd "${SCRIPT_ROOT}/.."
 

--- a/scripts/__tests__/system/install-skills.system.spec.sh
+++ b/scripts/__tests__/system/install-skills.system.spec.sh
@@ -1,0 +1,79 @@
+# src: ./scripts/__tests__/system/install-skills.system.spec.sh
+# @(#) : System tests for scripts/install-skills.sh
+#        対象: install_symlink
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+#
+
+# shellcheck shell=bash disable=SC2016,SC2034
+
+Describe 'install-skills.sh'
+  Include scripts/install-skills.sh
+
+  setup() {
+    repo="$(make_fixture_repo)"
+    dest="${repo}/.claude/skills"
+    src="${repo}/skills"
+  }
+
+  cleanup() {
+    rm -rf "$repo"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe 'install_symlink'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-IL-01: 相対 symlink を作成する'
+        Skip if 'symlinks unsupported' no_symlink_support
+        When call install_symlink "$dest" ''
+        The status should be success
+        The output should include 'Linked'
+        The value "$(readlink "$dest")" should equal '../skills'
+        # 作成したリンクが実際に機能することを、リンク経由の実ファイル到達で確かめる
+        The path "${dest}/export-chatlogs/SKILL.md" should be exist
+      End
+
+      It '[Normal] T-IS-IL-02: 既にリンク済みなら作り直さない'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s ../skills "$dest"'
+        When call install_symlink "$dest" ''
+        The status should be success
+        The output should include 'already linked'
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-IS-IL-03: リンク先が違う symlink は張り直す'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s "$src" "$dest"'
+        When call install_symlink "$dest" ''
+        The status should be success
+        The output should include 'Linked'
+        The value "$(readlink "$dest")" should equal '../skills'
+      End
+
+      It '[Edge] T-IS-IL-04: 既存の通常ディレクトリを symlink に置き換える'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'mkdir -p "$dest"; echo junk >"${dest}/junk.md"'
+        When call install_symlink "$dest" ''
+        The status should be success
+        The output should include 'Linked'
+        The value "$(readlink "$dest")" should equal '../skills'
+      End
+
+      It '[Edge] T-IS-IL-06: force は既に正しいリンクでも張り直す'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s ../skills "$dest"'
+        When call install_symlink "$dest" force
+        The status should be success
+        The output should include 'Linked'
+        The value "$(readlink "$dest")" should equal '../skills'
+      End
+    End
+  End
+End

--- a/scripts/__tests__/unit/install-skills.unit.spec.sh
+++ b/scripts/__tests__/unit/install-skills.unit.spec.sh
@@ -1,0 +1,267 @@
+# src: ./scripts/__tests__/unit/install-skills.unit.spec.sh
+# @(#) : Unit tests for scripts/install-skills.sh
+#        対象: parse_args / is_correct_symlink / remove_destination /
+#              install_symlink / resolve_repo_root / run_install / usage
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+#
+
+# shellcheck shell=bash disable=SC2016,SC2329
+
+Describe 'install-skills.sh'
+  Include scripts/install-skills.sh
+
+  setup() {
+    repo="$(make_fixture_repo)"
+    dest="${repo}/.claude/skills"
+    src="${repo}/skills"
+  }
+
+  cleanup() {
+    rm -rf "$repo"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe 'parse_args'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-PA-01: 引数なし → 空文字列'
+        When call parse_args
+        The output should equal ''
+        The status should be success
+      End
+
+      It '[Normal] T-IS-PA-05: --help → help'
+        When call parse_args --help
+        The output should equal 'help'
+        The status should be success
+      End
+
+      It '[Normal] T-IS-PA-06: --force 単独 → force'
+        When call parse_args --force
+        The output should equal 'force'
+        The status should be success
+      End
+    End
+
+    Describe 'When: 異常系'
+      It '[Error] T-IS-PA-07: 未知のオプション → エラー'
+        When call parse_args --bogus
+        The status should be failure
+        The stderr should include 'unknown option: --bogus'
+      End
+
+      It '[Error] T-IS-PA-08: 位置引数 → エラー'
+        When call parse_args somearg
+        The status should be failure
+        The stderr should include 'unknown option: somearg'
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-IS-PA-10: --help は他オプションより優先される'
+        When call parse_args --force --help
+        The output should equal 'help'
+        The status should be success
+      End
+    End
+  End
+
+  Describe 'is_correct_symlink'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-CS-01: ../skills を指す symlink → true'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s ../skills "$dest"'
+        When call is_correct_symlink "$dest"
+        The status should be success
+      End
+    End
+
+    Describe 'When: 異常系'
+      It '[Error] T-IS-CS-02: 存在しないパス → false'
+        When call is_correct_symlink "${dest}/missing"
+        The status should be failure
+      End
+
+      It '[Error] T-IS-CS-03: 通常ディレクトリ → false'
+        BeforeCall 'mkdir -p "$dest"'
+        When call is_correct_symlink "$dest"
+        The status should be failure
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-IS-CS-04: リンク先が異なる symlink → false'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s "$src" "$dest"'
+        When call is_correct_symlink "$dest"
+        The status should be failure
+      End
+    End
+  End
+
+  Describe 'remove_destination'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-RD-01: ディレクトリを削除する'
+        BeforeCall 'mkdir -p "$dest"'
+        When call remove_destination "$dest"
+        The status should be success
+        The path "$dest" should not be exist
+      End
+
+      It '[Normal] T-IS-RD-02: 存在しないパスでも成功する'
+        When call remove_destination "${dest}/missing"
+        The status should be success
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-IS-RD-03: symlink を消してもリンク先は残る'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s ../skills "$dest"'
+        When call remove_destination "$dest"
+        The status should be success
+        The path "$dest" should not be exist
+        The path "${src}/export-chatlogs/SKILL.md" should be exist
+      End
+    End
+  End
+
+  Describe 'install_symlink'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-IL-07: 既に正しいリンクがあり force なしなら ln を呼ばず早期 return する'
+        # 実 symlink を作らずに「既にリンク済み」状態を再現するため判定関数ごと差し替える。
+        # ln 呼び出しの有無はフラグファイルの生成で観測する。
+        is_correct_symlink() { return 0; }
+        ln() {
+          touch "${repo}/ln_called"
+          return 0
+        }
+        When call install_symlink "$dest" ''
+        The status should be success
+        The output should include 'already linked'
+        The path "${repo}/ln_called" should not be exist
+      End
+
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-IS-IL-08: force なら既に正しいリンクでも早期 return せず ln を呼ぶ'
+        # ln をモックすると実リンクが生まれないため、実装の [[ -L ]] 検査は必ず失敗する。
+        # ここで確認したいのは force が早期 return を飛ばして ln に到達することであり、
+        # 失敗ステータスはモック環境の必然的な帰結。
+        is_correct_symlink() { return 0; }
+        ln() {
+          touch "${repo}/ln_called"
+          return 0
+        }
+        When call install_symlink "$dest" force
+        The status should be failure
+        The output should not include 'already linked'
+        The path "${repo}/ln_called" should be exist
+        The stderr should include 'could not create a symbolic link'
+      End
+    End
+
+    Describe 'When: 異常系'
+      It '[Error] T-IS-IL-05: lnがコピーになる環境では中間物を残さず失敗する'
+        # ln をコピーする偽物に差し替え、Git Bash の既定挙動を再現する
+        ln() {
+          local target="${*: -1}"
+          cp -r "$src" "$target"
+          return 0
+        }
+        When call install_symlink "$dest" ''
+        The status should be failure
+        The stderr should include 'could not create a symbolic link'
+        The stderr should include 'Developer Mode'
+        The path "$dest" should not be exist
+      End
+    End
+  End
+
+  Describe 'resolve_repo_root'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-RR-01: サブディレクトリからでもリポジトリルートを返す'
+        # cd 先に依存せず同じルートを返すことが、どこから実行しても動く根拠になる。
+        # git は Windows で W:/Temp 形式、pwd は /w/temp 形式を返すため、
+        # 文字列ではなく skills/ の実在で同一ディレクトリかを判定する。
+        resolve_from_skills() {
+          cd "${repo}/skills" || return 1
+          local root
+          root="$(resolve_repo_root)" || return 1
+          [[ -f "${root}/skills/export-chatlogs/SKILL.md" ]] || return 1
+          echo "ok"
+        }
+        When call resolve_from_skills
+        The status should be success
+        The output should equal 'ok'
+      End
+    End
+
+    Describe 'When: 異常系'
+      It '[Error] T-IS-RR-02: git 管理外では失敗する'
+        cd_into_tmp() { cd "$(mktemp -d)" || return 1; }
+        BeforeCall 'cd_into_tmp'
+        When call resolve_repo_root
+        The status should be failure
+        The stderr should be present
+      End
+    End
+  End
+
+  Describe 'run_install'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-RI-01: force なしでインストールする'
+        Skip if 'symlinks unsupported' no_symlink_support
+        When call run_install "$repo" ''
+        The status should be success
+        The output should include 'Linked'
+        The path "${dest}/export-chatlogs/SKILL.md" should be exist
+      End
+
+      It '[Normal] T-IS-RI-02: force は既存リンクを張り直す'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'MSYS=winsymlinks:nativestrict ln -s ../skills "$dest"'
+        When call run_install "$repo" force
+        The status should be success
+        The output should include 'Linked'
+        The value "$(readlink "$dest")" should equal '../skills'
+      End
+
+      It '[Normal] T-IS-RI-03: .claude が無くても親ディレクトリを作る'
+        Skip if 'symlinks unsupported' no_symlink_support
+        BeforeCall 'rm -rf "${repo}/.claude"'
+        When call run_install "$repo" ''
+        The status should be success
+        The output should include 'Linked'
+        The path "${dest}/export-chatlogs/SKILL.md" should be exist
+      End
+    End
+
+    Describe 'When: 異常系'
+      It '[Error] T-IS-RI-04: skills が存在しない → エラー'
+        # src はテストから渡せないため、fixture の skills を消して不在状態を作る。
+        BeforeCall 'rm -rf "$src"'
+        When call run_install "$repo" ''
+        The status should be failure
+        The stderr should include 'skills directory not found'
+      End
+    End
+  End
+
+  Describe 'usage'
+    Describe 'When: 正常系'
+      It '[Normal] T-IS-US-01: 全オプションを表示する'
+        When call usage
+        The status should be success
+        The output should include '--force'
+        The output should include '--help'
+      End
+    End
+  End
+End

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# src: ./scripts/install-skills.sh
+# @(#) : Install project skills into .claude/skills
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+#
+
+set -euo pipefail
+
+# Link text stored in .claude/skills. Kept relative so the link survives a repository move.
+# Its basename also names the link, so it must match the basename of the destination.
+readonly LINK_TARGET="../skills"
+
+##
+# @description Print usage to stdout
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/install-skills.sh [--force] [--help]
+
+Registers the project skills at .claude/skills so Claude Code can discover them.
+Creates a relative symbolic link; requires Git Bash with symbolic link support.
+
+Options:
+  --force  Remove the existing link and create it again
+  --help   Show this help
+EOF
+}
+
+##
+# @description Resolve the repository root directory
+# @stdout Absolute path to the repository root
+resolve_repo_root() {
+  git rev-parse --show-toplevel
+}
+
+##
+# @description Check if the destination is the expected relative symbolic link
+# @arg $1 string Destination path
+# @return 0 If the destination is a symlink pointing at LINK_TARGET
+# @return 1 Otherwise
+is_correct_symlink() {
+  local dest="$1"
+  [[ -L "$dest" ]] || return 1
+  [[ "$(readlink "$dest")" == "$LINK_TARGET" ]]
+}
+
+##
+# @description Remove the destination link or directory
+# @arg $1 string Destination path
+remove_destination() {
+  local dest="$1"
+  # No trailing slash: on a symlink that would delete the linked skills/ instead of the link.
+  rm -rf "$dest"
+}
+
+##
+# @description Install the skills as a relative symbolic link
+# @arg $1 string Destination path
+# @arg $2 string Non-empty to recreate the link even if it is already correct
+# @return 1 If the environment cannot create symbolic links
+install_symlink() {
+  local dest="$1" force="$2"
+
+  if [[ -z "$force" ]] && is_correct_symlink "$dest"; then
+    echo "Skills are already linked at $dest"
+    return 0
+  fi
+
+  remove_destination "$dest"
+  # nativestrict makes ln fail loudly instead of silently copying on Windows.
+  # Passing the parent directory lets ln name the link after LINK_TARGET's basename.
+  MSYS=winsymlinks:nativestrict ln -s "$LINK_TARGET" "$(dirname "$dest")" 2>/dev/null || true
+
+  if [[ ! -L "$dest" ]]; then
+    remove_destination "$dest"
+    echo "Error: could not create a symbolic link at $dest" >&2
+    echo "Enable Windows Developer Mode." >&2
+    return 1
+  fi
+
+  echo "Linked $dest -> $LINK_TARGET"
+}
+
+##
+# @description Parse the command line into a force keyword
+#
+# Kept free of side effects so the option rules can be verified on their own.
+#
+# @arg $@ string Command line options (--force, --help)
+# @stdout One of: force, "" (empty, no force), help
+# @return 0 If the options are valid
+# @return 1 If an option is unknown
+parse_args() {
+  local force=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --force) force=true ;;
+    --help)
+      echo "help"
+      return 0
+      ;;
+    *)
+      echo "Error: unknown option: $1" >&2
+      return 1
+      ;;
+    esac
+    shift
+  done
+
+  if [[ "$force" == "true" ]]; then
+    echo "force"
+  else
+    echo ""
+  fi
+}
+
+##
+# @description Install the skills according to the resolved force flag
+# @arg $1 string Repository root directory
+# @arg $2 string Non-empty to recreate the link even if it is already correct
+# @return 0 If the skills are installed
+# @return 1 If the source is missing or the install did not take effect
+run_install() {
+  local base="$1" force="$2"
+  local claude_dir="${base}/.claude"
+  local link_name
+  link_name="$(basename "$LINK_TARGET")"
+  local dest="${claude_dir}/${link_name}"
+  local src="${base}/${link_name}"
+
+  if [[ ! -d "$src" ]]; then
+    echo "Error: skills directory not found: $src" >&2
+    return 1
+  fi
+
+  mkdir -p "$claude_dir"
+
+  install_symlink "$dest" "$force"
+
+  if [[ ! -d "$dest" ]]; then
+    echo "Error: install finished but $dest does not resolve to a directory" >&2
+    return 1
+  fi
+}
+
+##
+# @description Main entry point
+# @arg $@ string Command line options (--force, --help)
+# @return 0 If the skills are installed or already present
+# @return 1 If the options are invalid or the install fails
+main() {
+  local force
+  if ! force="$(parse_args "$@")"; then
+    usage >&2
+    return 1
+  fi
+
+  if [[ "$force" == "help" ]]; then
+    usage
+    return 0
+  fi
+
+  local repo_root
+  repo_root="$(resolve_repo_root)"
+  run_install "$repo_root" "$force"
+}
+
+# Only run when executed directly, so tests can source this file for its functions.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Overview

**Summary**
Add an install script that links `.claude/skills` to `skills/`, and update the user guide to use it.

**Background / Motivation**
Registering the project skills required the user to pick the right command for their platform:
`ln -s`, `New-Item -ItemType SymbolicLink`, or `cp -r`. On Windows Git Bash, `ln -s` silently
copies the directory instead of creating a link, so later changes to `skills/` are not reflected
and the user gets no warning. A single script removes that choice and fails loudly when the
environment cannot create symbolic links.

## Changes

### Core Changes

- Add `scripts/install-skills.sh`.
  - Creates `.claude/skills` as a relative symbolic link to `../skills`, so the link survives a
    repository move.
  - Safe to re-run. An existing correct link is left untouched.
  - `--force` removes the existing link or directory and creates it again.
  - `--help` prints usage. An unknown option exits with code 1 and prints usage to stderr.
  - Sets `MSYS=winsymlinks:nativestrict` so `ln` fails instead of copying on Windows. On failure
    it cleans up the destination and tells the user to enable Developer Mode.
  - Fails early when `skills/` is missing, and checks after install that the destination resolves
    to a directory.
- Update `runners/run-shellcheck.sh` to use `# shellcheck disable=SC1091` instead of
  `# shellcheck source=...`, because the source path was not resolved.

### Test Updates

- Add `scripts/__tests__/unit/install-skills.unit.spec.sh`. Covers `parse_args`,
  `is_correct_symlink`, `remove_destination`, `install_symlink`, `resolve_repo_root`,
  `run_install`, and `usage`.
- Add `scripts/__tests__/system/install-skills.system.spec.sh`. Covers `install_symlink` against
  a fixture repository.

### Documentation

- Update `docs/user-guide/install.mdx` and `docs/user-guide/quickstart.mdx` (English and Japanese)
  to use `bash scripts/install-skills.sh`, document `--force`, and state the Git Bash and
  Developer Mode requirement. The manual steps are kept in a collapsed accordion as a fallback.
- Note that `pnpm test:sh` uses the ShellSpec installed by `scripts/setup-dev-env.sh`.

### Removed

N/A

## Change Type

- [x] Test
- [x] Documentation
- [x] Configuration

## Related Issues

N/A

## Checklist

- [x] Formatting and lint checks pass
- [x] Tests pass
- [x] Documentation updated
- [x] PR title follows Conventional Commits
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. The script produces the same `.claude/skills` link that the manual steps produced, and the
manual steps still work.

## Additional Notes

Two points that are easy to misread in review:

- `remove_destination` passes the destination without a trailing slash on purpose. On a symlink,
  `rm -rf dest/` deletes the contents of the linked `skills/` directory instead of the link.
- `ln -s` is given the parent directory, not the full destination path, so the link is named after
  the basename of `LINK_TARGET`. This is why that basename must match the intended link name.

Testing steps:

```bash
pnpm run test:sh
bash scripts/install-skills.sh          # creates the link
bash scripts/install-skills.sh          # reports it is already linked
bash scripts/install-skills.sh --force  # recreates the link
bash scripts/install-skills.sh --help   # prints usage
```
