### PR TITLE
fix(runners): resolve project root from script repository

### DIFF
--- a/runners/libs/init-vars.lib.sh
+++ b/runners/libs/init-vars.lib.sh
@@ -16,4 +16,6 @@ readonly _INIT_VARS_LIB_SH=1
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
 
 # PROJECT_ROOT: git repository root, or parent of SCRIPT_ROOT as fallback
-PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || dirname "${SCRIPT_ROOT}")}"
+# git runs with -C SCRIPT_ROOT so the runner's own repository is resolved,
+# not the repository the caller happened to be in when invoking the runner
+PROJECT_ROOT="${PROJECT_ROOT:-$(git -C "${SCRIPT_ROOT}" rev-parse --show-toplevel 2>/dev/null || dirname "${SCRIPT_ROOT}")}"

--- a/scripts/__tests__/spec_helper.sh
+++ b/scripts/__tests__/spec_helper.sh
@@ -29,6 +29,52 @@ make_fixture_repo() {
 }
 
 ##
+# @description Create a throwaway setup-chatlogs skill directory holding the assets to deploy
+#
+# Mirrors the layout the real skill ships with, so the copy examples can run
+# against a fixture instead of the checkout.
+#
+# @stdout Absolute path to the new skill directory
+make_fixture_skill_dir() {
+  local skill_dir
+  skill_dir="$(mktemp -d)"
+  mkdir -p "${skill_dir}/assets/.config/chatlog-exporter/dics" "${skill_dir}/_scripts/libs"
+  echo 'agent: claude' >"${skill_dir}/assets/.config/chatlog-exporter/config.yaml"
+  echo 'category' >"${skill_dir}/assets/.config/chatlog-exporter/dics/category.dic"
+  echo '{"tasks":{}}' >"${skill_dir}/assets/deno.json"
+  echo 'export const noop = () => {};' >"${skill_dir}/_scripts/libs/noop.ts"
+  echo "$skill_dir"
+}
+
+##
+# @description Create a throwaway git repository holding a runner that sources the real library
+#
+# The wrapper lives in `<repo>/runners/` and sources the checkout's actual
+# `init-vars.lib.sh` by absolute path, so `BASH_SOURCE[1]` resolves SCRIPT_ROOT
+# to the fixture repository rather than to the spec file. The library under test
+# is never copied: the real file is exercised so a regression cannot pass.
+#
+# The wrapper prints `SCRIPT_ROOT` and `PROJECT_ROOT` one per line.
+#
+# @arg $1 string Absolute path to the checkout root holding runners/libs/init-vars.lib.sh
+# @stdout Absolute path to the new repository root
+make_fixture_runner_repo() {
+  local checkout_root="$1"
+  local repo
+  repo="$(mktemp -d)"
+  mkdir -p "${repo}/runners"
+  cat >"${repo}/runners/wrapper.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+. "${checkout_root}/runners/libs/init-vars.lib.sh"
+echo "SCRIPT_ROOT=\${SCRIPT_ROOT}"
+echo "PROJECT_ROOT=\${PROJECT_ROOT}"
+EOF
+  git -C "$repo" init -q
+  echo "$repo"
+}
+
+##
 # @description Report whether the shell cannot create real symbolic links
 #
 # Phrased negatively because `Skip if` takes a plain condition and cannot

--- a/scripts/__tests__/unit/init-vars.unit.spec.sh
+++ b/scripts/__tests__/unit/init-vars.unit.spec.sh
@@ -1,0 +1,56 @@
+# src: ./scripts/__tests__/unit/init-vars.unit.spec.sh
+# @(#) : unit spec for init-vars library variable initialization
+#        対象: SCRIPT_ROOT / PROJECT_ROOT
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+#
+
+# shellcheck shell=bash disable=SC2016
+
+Describe 'init-vars.lib.sh'
+  # The library guards against double sourcing and reads BASH_SOURCE[1], so each
+  # example runs a fresh bash process through a wrapper script instead of Include.
+  setup() {
+    runner_repo="$(make_fixture_runner_repo "$SHELLSPEC_PROJECT_ROOT")"
+    other_repo="$(make_fixture_repo)"
+    wrapper="${runner_repo}/runners/wrapper.sh"
+    runner_repo_toplevel="$(git -C "$runner_repo" rev-parse --show-toplevel)"
+  }
+
+  cleanup() {
+    rm -rf "$runner_repo" "$other_repo"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe 'PROJECT_ROOT'
+    Describe 'When: 正常系'
+      It '[Normal] T-LIB-IV-01: runner を含むリポジトリ内から起動するとそのリポジトリのルートを指す'
+        cd "$runner_repo" || return 1
+        When run env -u PROJECT_ROOT bash "$wrapper"
+        The status should be success
+        The line 2 should equal "PROJECT_ROOT=${runner_repo_toplevel}"
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-LIB-IV-02: 無関係な git リポジトリを cwd に絶対パス起動しても runner 側のリポジトリを指す'
+        cd "$other_repo" || return 1
+        When run env -u PROJECT_ROOT bash "$wrapper"
+        The status should be success
+        The line 2 should equal "PROJECT_ROOT=${runner_repo_toplevel}"
+      End
+
+      It '[Edge] T-LIB-IV-03: 環境変数 PROJECT_ROOT が与えられた場合はそれを優先する'
+        cd "$other_repo" || return 1
+        When run env PROJECT_ROOT=/preset/project/root bash "$wrapper"
+        The status should be success
+        The line 2 should equal 'PROJECT_ROOT=/preset/project/root'
+      End
+    End
+  End
+End


### PR DESCRIPTION
## Overview

**Summary**
Resolve `PROJECT_ROOT` from the runner script's own repository instead of the current directory.

**Background / Motivation**
`runners/libs/init-vars.lib.sh` ran `git rev-parse --show-toplevel` in the current
working directory. When a runner was started by absolute path from inside an unrelated
git repository, `PROJECT_ROOT` pointed at the caller's repository instead of the
runner's own. Every path derived from it then resolved against the wrong checkout.

## Changes

### Core Changes

- `runners/libs/init-vars.lib.sh`: run git as `git -C "${SCRIPT_ROOT}" rev-parse --show-toplevel`,
  so the lookup is anchored to the runner script's location. A comment records why.
- The diff adds only the `-C "${SCRIPT_ROOT}"` argument. The `dirname "${SCRIPT_ROOT}"`
  fallback for non-git checkouts and the `${PROJECT_ROOT:-...}` environment variable
  precedence are unchanged.

### Test Updates

- `scripts/__tests__/spec_helper.sh`: add two fixture helpers.
  - `make_fixture_runner_repo` builds a throwaway git repository with a wrapper script
    under `runners/` that sources the real `init-vars.lib.sh` by absolute path. The
    library is never copied, so a regression in the real file cannot pass silently.
  - `make_fixture_skill_dir` builds a throwaway setup-chatlogs skill directory that
    mirrors the layout the real skill ships with.
- `scripts/__tests__/unit/init-vars.unit.spec.sh`: new unit spec for `PROJECT_ROOT`.
  Each example runs a fresh bash process through the wrapper instead of ShellSpec's
  `Include`, because the library guards against double sourcing and reads
  `BASH_SOURCE[1]` to derive `SCRIPT_ROOT`.
  - `T-LIB-IV-01` (normal): started inside the runner's own repository, `PROJECT_ROOT`
    points at that repository root.
  - `T-LIB-IV-02` (edge): started by absolute path while the current directory is an
    unrelated git repository, `PROJECT_ROOT` still points at the runner's repository.
    This is the case that failed before the fix.
  - `T-LIB-IV-03` (edge): an explicit `PROJECT_ROOT` environment variable wins over
    git resolution.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists) — run `pnpm run test:sh`
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. `PROJECT_ROOT` changes only in the previously broken case where a runner was
started from an unrelated git repository. Runs started inside the runner's own
repository, non-git checkouts, and explicit `PROJECT_ROOT` overrides are unaffected.

## Additional Notes

N/A
