### PR TITLE
docs(path-utils): align project root docs with cached cwd behavior

### DIFF
--- a/skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/dir-utils.unit.spec.ts
@@ -32,7 +32,7 @@ import { getProjectRoot, resetProjectRoot } from '../../dir-utils.ts';
 describe('getProjectRoot / resetProjectRoot', () => {
   beforeEach(() => resetProjectRoot());
 
-  /** seed 設定後に getProjectRoot() が git を実行せず即時返るテスト。 */
+  /** seed 設定後に getProjectRoot() がシードした値をそのまま返すテスト。 */
   describe('When: resetProjectRoot でパスをシードした場合', () => {
     it('[Normal] T-LIB-U-60-01: resetProjectRoot("/home/user/project") 後に getProjectRoot() → "/home/user/project" が返る', () => {
       resetProjectRoot('/home/user/project');

--- a/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
+++ b/skills/_scripts/libs/path-utils/__tests__/unit/path-utils.unit.spec.ts
@@ -168,7 +168,7 @@ describe('normalizePath', () => {
     it('[Edge] T-LIB-U-80-03: プレースホルダーなしパスは従来通り正規化される', () => {
       assertEquals(normalizePath('/plain/path'), '/plain/path');
     });
-    it('[Edge] T-LIB-U-80-04: ${ProjectRoot}/x → /mock/root/x（git 実行なし）', () => {
+    it('[Edge] T-LIB-U-80-04: ${ProjectRoot}/x → /mock/root/x（シード値が展開される）', () => {
       assertEquals(normalizePath('${ProjectRoot}/x'), '/mock/root/x');
     });
   });

--- a/skills/_scripts/libs/path-utils/dir-utils.ts
+++ b/skills/_scripts/libs/path-utils/dir-utils.ts
@@ -20,9 +20,14 @@ const _fetchProjectRoot = (): string => normalizePath(Deno.cwd());
 let _cachedRoot: string | null = null;
 
 /**
- * プロジェクトルートの絶対パスを返す。初回は git を実行し、以降はキャッシュを返す。
+ * プロジェクトルートの絶対パスを返す。
+ *
+ * 初回呼び出し時に `Deno.cwd()` を正規化して取得し、以降はモジュールレベルにキャッシュした値を返す。
+ * そのため値はプロセス中の最初の呼び出し時点のカレントディレクトリに固定される。
+ * 値を差し替えるには `resetProjectRoot()` を使う。
  *
  * @returns プロジェクトルートの絶対パス（正規化済み）
+ * @see resetProjectRoot
  */
 export const getProjectRoot = (): string => (_cachedRoot ??= _fetchProjectRoot());
 


### PR DESCRIPTION
## Overview

**Summary**
Update the `getProjectRoot()` JSDoc and two test labels to describe the current
`Deno.cwd()` behavior.

**Background / Motivation**
`getProjectRoot()` used to run git to find the project root. PR #248 replaced
that with `normalizePath(Deno.cwd())`, but the comments around it were left
alone. The JSDoc still said the function runs git on the first call, and two
test labels still claimed git semantics: `git を実行せず即時返る` and
`（git 実行なし）`. All three describe a git call the code no longer makes.

This PR changes comments only. `dir-utils.ts` shows `+6 -1`, but every added
line is JSDoc. No executable line changed.

## Changes

### Core Changes

- `skills/_scripts/libs/path-utils/dir-utils.ts`: rewrite the `getProjectRoot()`
  JSDoc. It now says the root comes from `Deno.cwd()`, is normalized, and is
  cached at module level, so the value is fixed to the working directory at the
  first call in the process. Adds `@see resetProjectRoot`, which is the only
  supported way to replace the cached value.

### Test Updates

No assertions changed. Two labels were reworded to drop the git claim:

- `__tests__/unit/dir-utils.unit.spec.ts`: the seeded-case `describe` comment
  now reads `シードした値をそのまま返す`.
- `__tests__/unit/path-utils.unit.spec.ts`: `T-LIB-U-80-04` now reads
  `（シード値が展開される）`.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Comments only, so `getProjectRoot()` and `resetProjectRoot()` behave
exactly as they do on `main`.

## Additional Notes

The stale wording dates back to #248 (`af910118`), which switched
`_fetchProjectRoot` from git to `Deno.cwd()` without updating the comments. This
PR closes that gap. It does not revisit how the root is resolved.
