### PR TITLE
refactor(_cle-libs): unify normalizeLogs directory naming

### DIFF
--- a/skills/_cle-libs/constants/defaults.constants.ts
+++ b/skills/_cle-libs/constants/defaults.constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG_FILE = 'config.yaml';
 export const DEFAULT_CHATLOGS_DIR = './chatlogs';
 
 /** normalize-chatlogs が出力するセグメントのデフォルトベースディレクトリ。 */
-export const DEFAULT_NORMALIZE_DIR = 'normalizelogs';
+export const DEFAULT_NORMALIZE_DIR = 'normalizeLogs';
 
 /** export-chatlogs が出力先に付加するサブディレクトリ名。`chatlogsDir` と `joinPath()` で組み合わせて使用する。 */
 export const DEFAULT_ORIGINAL_LOGS_DIR = 'originalLogs';

--- a/skills/_cle-libs/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
+++ b/skills/_cle-libs/libs/file-io/__tests__/unit/resolve-directory.unit.spec.ts
@@ -286,7 +286,7 @@ describe('resolveOutputBase', () => {
         chatlogsDir: '/custom/chatlogs',
         agent: 'claude',
         period: '2026-03',
-        addOnDir: 'normalizelogs',
+        addOnDir: 'normalizeLogs',
       };
       assertEquals(
         resolveOutputBase(_opts),
@@ -294,7 +294,7 @@ describe('resolveOutputBase', () => {
           chatlogsDir: '/custom/chatlogs',
           agent: 'claude',
           period: '2026-03',
-          addOnDir: 'normalizelogs',
+          addOnDir: 'normalizeLogs',
         }),
       );
     });
@@ -369,9 +369,9 @@ describe('extractChatlogPath', () => {
       assertEquals(extractChatlogPath('/chatlogs/chat.md'), '');
     });
 
-    it('[Edge] T-ECP-03-03: originalLogs 以外の addOnDir（normalizelogs）でも agent/yyyy/yyyy-mm を返す', () => {
+    it('[Edge] T-ECP-03-03: originalLogs 以外の addOnDir（normalizeLogs）でも agent/yyyy/yyyy-mm を返す', () => {
       assertEquals(
-        extractChatlogPath('chatlogs/normalizelogs/codex/2026/2026-04/proj/f.md'),
+        extractChatlogPath('chatlogs/normalizeLogs/codex/2026/2026-04/proj/f.md'),
         'codex/2026/2026-04',
       );
     });
@@ -417,24 +417,24 @@ describe('extractChatlogPath', () => {
 describe('extractChatlogBaseDir', () => {
   /** `<agent>/<yyyy>/<yyyy-mm>` を含む正常ケース。 */
   describe('When: 正常系', () => {
-    it('[Normal] T-ECB-01-01: chatlogs/normalizelogs/codex/2026/2026-04 を含むパスから chatlogs/normalizelogs を返す', () => {
+    it('[Normal] T-ECB-01-01: chatlogs/normalizeLogs/codex/2026/2026-04 を含むパスから chatlogs/normalizeLogs を返す', () => {
       assertEquals(
-        extractChatlogBaseDir('chatlogs/normalizelogs/codex/2026/2026-04/chatlog-exporter/2026-04-03-xxx.md'),
-        'chatlogs/normalizelogs',
+        extractChatlogBaseDir('chatlogs/normalizeLogs/codex/2026/2026-04/chatlog-exporter/2026-04-03-xxx.md'),
+        'chatlogs/normalizeLogs',
       );
     });
 
     it('[Normal] T-ECB-01-02: Windows ドライブレターの絶対パスでも正しく解決される', () => {
       assertEquals(
-        extractChatlogBaseDir('C:/work/chatlogs/normalizelogs/claude/2026/2026-03/proj/f.md'),
-        'C:/work/chatlogs/normalizelogs',
+        extractChatlogBaseDir('C:/work/chatlogs/normalizeLogs/claude/2026/2026-03/proj/f.md'),
+        'C:/work/chatlogs/normalizeLogs',
       );
     });
 
     it('[Normal] T-ECB-01-03: バックスラッシュ区切りパスも正規化して解決される', () => {
       assertEquals(
-        extractChatlogBaseDir('C:\\work\\chatlogs\\normalizelogs\\codex\\2026\\2026-04\\proj\\f.md'),
-        'C:/work/chatlogs/normalizelogs',
+        extractChatlogBaseDir('C:\\work\\chatlogs\\normalizeLogs\\codex\\2026\\2026-04\\proj\\f.md'),
+        'C:/work/chatlogs/normalizeLogs',
       );
     });
   });
@@ -450,7 +450,7 @@ describe('extractChatlogBaseDir', () => {
     });
 
     it('[Edge] T-ECB-02-03: <agent>/<yyyy> のみ（月なし）のときは空文字列を返す', () => {
-      assertEquals(extractChatlogBaseDir('/chatlogs/normalizelogs/claude/2026/file.md'), '');
+      assertEquals(extractChatlogBaseDir('/chatlogs/normalizeLogs/claude/2026/file.md'), '');
     });
   });
 });

--- a/skills/_cle-libs/libs/file-io/resolve-directory.ts
+++ b/skills/_cle-libs/libs/file-io/resolve-directory.ts
@@ -124,7 +124,7 @@ export const extractChatlogPath = (filePath: string): string => {
  * pattern is not found, or if it matches at the start of the path.
  *
  * @param filePath - Path to the source chatlog file
- * @returns Base directory like `'chatlogs/normalizelogs'`, or `''`
+ * @returns Base directory like `'chatlogs/normalizeLogs'`, or `''`
  */
 export const extractChatlogBaseDir = (filePath: string): string => {
   const _normalized = normalizePath(filePath);

--- a/skills/normalize-chatlogs/SKILL.md
+++ b/skills/normalize-chatlogs/SKILL.md
@@ -147,13 +147,13 @@ deno run --allow-read --allow-write --allow-env --allow-run "$SCRIPT_PATH" {変�
 
 ## 出力ディレクトリ構造
 
-出力先ベースは `--output-dir` 未指定時 `chatlogs/normalizelogs/<agent>[/<year>/<yearMonth>]` に解決される
+出力先ベースは `--output-dir` 未指定時 `chatlogs/normalizeLogs/<agent>[/<year>/<yearMonth>]` に解決される
 （`agent` / `period` から組み立てられ、`period` 省略時は `<agent>` まで）。
 
 `agent` + `YYYY-MM` を指定した場合:
 
 ```bash
-chatlogs/normalizelogs/
+chatlogs/normalizeLogs/
   └── <agent>/
        └── <year>/
             └── <yearMonth>/
@@ -164,7 +164,7 @@ chatlogs/normalizelogs/
 入力を任意パスで指定した場合（`period` が付かないため `<agent>` まで）:
 
 ```bash
-chatlogs/normalizelogs/
+chatlogs/normalizeLogs/
   └── <agent>/
        └── <project>/
             └── <baseName>-<XX>-<hash7>.md

--- a/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
+++ b/skills/normalize-chatlogs/scripts/__tests__/e2e/original-logs-dir.e2e.spec.ts
@@ -36,7 +36,7 @@ import type { LoggerStub } from '../../../../_cle-libs/__tests__/helpers/logger-
  *
  * `--input-dir` 未指定時に GlobalConfig の `chatlogsDir` を基準として
  * `originalLogs` を挟んだパスから入力ファイルを読み込むこと、および
- * `--output-dir` 未指定時に `normalizelogs` を挟んだパスへ
+ * `--output-dir` 未指定時に `normalizeLogs` を挟んだパスへ
  * `agent/yyyy/yyyy-mm` でミラーリングされることを検証する。
  *
  * テスト ID 範囲: T-NC-MAIN-01〜02
@@ -129,10 +129,10 @@ describe('main', () => {
       });
     });
 
-    /** --output-dir 未指定時、chatlogsDir/normalizelogs 配下へ agent/yyyy/yyyy-mm でミラーリングされるケース。 */
+    /** --output-dir 未指定時、chatlogsDir/normalizeLogs 配下へ agent/yyyy/yyyy-mm でミラーリングされるケース。 */
     describe('Given: chatlogsDir 配下の originalLogs/<agent>/<yyyy>/<yyyy-mm> にファイルが存在', () => {
       describe('When: --output-dir を指定せず main() を呼び出す', () => {
-        describe('Then: T-NC-MAIN-02 - outputBase が normalizelogs/<agent>/<yyyy>/<yyyy-mm> にミラーリングされる', () => {
+        describe('Then: T-NC-MAIN-02 - outputBase が normalizeLogs/<agent>/<yyyy>/<yyyy-mm> にミラーリングされる', () => {
           let chatlogsDir: string;
           let configFile: string;
           let commandHandle: CommandMockHandle;
@@ -177,7 +177,7 @@ describe('main', () => {
             await Deno.remove(chatlogsDir, { recursive: true });
           });
 
-          it('T-NC-MAIN-02-01: 出力ファイルが normalizelogs/claude/2026/2026-03/my-project/ 配下に生成される', async () => {
+          it('T-NC-MAIN-02-01: 出力ファイルが normalizeLogs/claude/2026/2026-03/my-project/ 配下に生成される', async () => {
             await main([
               '--config',
               configFile,
@@ -187,7 +187,7 @@ describe('main', () => {
               '2026-03',
             ]);
 
-            const mirroredBase = `${chatlogsDir}/normalizelogs/claude/2026/2026-03`;
+            const mirroredBase = `${chatlogsDir}/normalizeLogs/claude/2026/2026-03`;
             const files = await findFiles(mirroredBase);
             const underProject = files.filter((f) => normalizePath(f).includes(`${mirroredBase}/my-project`));
             assertEquals(underProject.length > 0, true);

--- a/skills/set-frontmatter/SKILL.md
+++ b/skills/set-frontmatter/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash, Glob
 
 # set-frontmatter スキル
 
-`chatlogs/normalizelogs/<agent>/` 配下のChatLog Markdownに、AIが生成したフロントマターを並列付加・上書きする。
+`chatlogs/normalizeLogs/<agent>/` 配下のChatLog Markdownに、AIが生成したフロントマターを並列付加・上書きする。
 `.config/chatlog-exporter/dics/` の辞書ファイルを参照して category / topics / tags を選定する。
 
 ## 前提条件
@@ -50,8 +50,8 @@ allowed-tools: Bash, Glob
 
 例:
 
-- `/set-frontmatter chatlogs/normalizelogs/claude/2026/2026-04` → input=そのパス、output=デフォルト
-- `/set-frontmatter chatlogs/normalizelogs/claude/2026/2026-04 chatlogs/outputLogs/claude/2026-04` → input=1つ目、output=2つ目
+- `/set-frontmatter chatlogs/normalizeLogs/claude/2026/2026-04` → input=そのパス、output=デフォルト
+- `/set-frontmatter chatlogs/normalizeLogs/claude/2026/2026-04 chatlogs/outputLogs/claude/2026-04` → input=1つ目、output=2つ目
 - `/set-frontmatter claude 2026-03` → claude/2026/2026-03
 - `/set-frontmatter chatgpt 2026-03` → chatgpt/2026/2026-03
 - `/set-frontmatter claude --dry-run` → claude 全年月 (dry-run)
@@ -96,7 +96,7 @@ PATH_ARGS=()
 （`chatlogsDir` は `config.yaml` の値。既定は `./chatlogs`。git は使用しない）:
 
 ```bash
-<chatlogsDir>/normalizelogs/<agent>[/<YYYY>/<YYYY-MM>]
+<chatlogsDir>/normalizeLogs/<agent>[/<YYYY>/<YYYY-MM>]
 ```
 
 プロジェクト名はパスに含まれない。`INPUT_DIR` 配下の Markdown はスクリプトが再帰走査するため、
@@ -106,9 +106,9 @@ PATH_ARGS=()
 
 `--output-dir` 未指定時の既定は `<chatlogsDir>/outputLogs` になる。
 
-> **重要**: 入力パスが `.../normalizelogs/<YYYY>/<YYYY-MM>` 形式に一致する場合、
-> 出力先は入力パスの `normalizelogs` を `outputLogs` に置換したパスに**自動的に上書きされ**、
-> `--output-dir` の指定は無視される。標準的な `chatlogs/normalizelogs/...` を入力にする限り、
+> **重要**: 入力パスが `.../normalizeLogs/<YYYY>/<YYYY-MM>` 形式に一致する場合、
+> 出力先は入力パスの `normalizeLogs` を `outputLogs` に置換したパスに**自動的に上書きされ**、
+> `--output-dir` の指定は無視される。標準的な `chatlogs/normalizeLogs/...` を入力にする限り、
 > 出力は常に対応する `chatlogs/outputLogs/...` になる。
 
 ## ステップ3: スクリプト実行
@@ -200,7 +200,7 @@ tags:
 | オプション         | 説明                                                         |
 | ------------------ | ------------------------------------------------------------ |
 | `--input-dir DIR`  | 入力ディレクトリ（agent / period を無視）                    |
-| `--output-dir DIR` | 出力先（`normalizelogs` 入力時は自動上書きされる。上記参照） |
+| `--output-dir DIR` | 出力先（`normalizeLogs` 入力時は自動上書きされる。上記参照） |
 | `--dics DIR`       | 辞書ディレクトリ                                             |
 | `--prompts DIR`    | プロンプトディレクトリ                                       |
 | `--concurrency N`  | 並列実行数（デフォルト: 4）                                  |

--- a/skills/set-frontmatter/scripts/__tests__/e2e/input-dir.e2e.spec.ts
+++ b/skills/set-frontmatter/scripts/__tests__/e2e/input-dir.e2e.spec.ts
@@ -27,15 +27,15 @@ import type { LoggerStub } from '../../../../_cle-libs/__tests__/helpers/logger-
 // ─── T-SF-E2E-12: --input-dir 未指定 → resolveChatlogsDir による agent 絞り込み ────
 
 /**
- * `--input-dir` を省略したとき、`chatlogsDir/normalizelogs/<agent>` が
+ * `--input-dir` を省略したとき、`chatlogsDir/normalizeLogs/<agent>` が
  * `resolveChatlogsDir` により算出され、そのディレクトリ配下のファイルが処理されることを検証する。
  *
  * テスト ID 範囲: T-SF-E2E-12-01
  */
 describe('main - --input-dir 未指定（デフォルト絞り込み）', () => {
-  describe('Given: chatlogsDir/normalizelogs/claude 配下に .md ファイルを配置し --input-dir を省略', () => {
+  describe('Given: chatlogsDir/normalizeLogs/claude 配下に .md ファイルを配置し --input-dir を省略', () => {
     describe('When: main(["claude", "--output-dir", outDir, ...]) を呼び出す（GlobalConfig.chatlogsDir で注入）', () => {
-      describe('Then: T-SF-E2E-12 - chatlogsDir/normalizelogs/claude 配下のファイルが処理される', () => {
+      describe('Then: T-SF-E2E-12 - chatlogsDir/normalizeLogs/claude 配下のファイルが処理される', () => {
         let chatlogsDir: string;
         let outputDir: string;
         let dicsDir: string;
@@ -44,7 +44,7 @@ describe('main - --input-dir 未指定（デフォルト絞り込み）', () => 
 
         beforeEach(async () => {
           chatlogsDir = await Deno.makeTempDir();
-          const agentDir = `${chatlogsDir}/normalizelogs/claude`;
+          const agentDir = `${chatlogsDir}/normalizeLogs/claude`;
           await Deno.mkdir(agentDir, { recursive: true });
           await Deno.writeTextFile(`${agentDir}/test.md`, '# テスト\n本文テキスト');
 
@@ -72,7 +72,7 @@ describe('main - --input-dir 未指定（デフォルト絞り込み）', () => 
           await Deno.remove(dicsDir.replace(/[/\\]dics$/, ''), { recursive: true }).catch(() => {});
         });
 
-        it('[Normal] T-SF-E2E-12-01: chatlogsDir/normalizelogs/claude/test.md がメタ読み込みされる', async () => {
+        it('[Normal] T-SF-E2E-12-01: chatlogsDir/normalizeLogs/claude/test.md がメタ読み込みされる', async () => {
           await main([
             'claude',
             '--output-dir',

--- a/skills/set-frontmatter/scripts/modules/__tests__/functional/write-frontmatter.functional.spec.ts
+++ b/skills/set-frontmatter/scripts/modules/__tests__/functional/write-frontmatter.functional.spec.ts
@@ -202,13 +202,13 @@ describe('writeFrontmatter', () => {
     });
   });
 
-  // ─── inputDir が normalizelogs ルートより深い絞り込み済みパスの場合 ─────────
+  // ─── inputDir が normalizeLogs ルートより深い絞り込み済みパスの場合 ─────────
 
-  describe('Given: inputDir が normalizelogs ルートより深い絞り込み済みパス', () => {
+  describe('Given: inputDir が normalizeLogs ルートより深い絞り込み済みパス', () => {
     describe('When: writeFrontmatter(entry, cache, outputDir, inputDir) を呼び出す', () => {
       describe('Then: T-SF-WF-05 - filePath から逆算した agent/yyyy/yyyy-mm 階層で出力される', () => {
         it('T-SF-WF-05-01: outputDir/agent/yyyy/yyyy-mm/... に出力される', async () => {
-          const inputBaseDir = `${tempDir}/chatlogs/normalizelogs`;
+          const inputBaseDir = `${tempDir}/chatlogs/normalizeLogs`;
           const outputBaseDir = `${tempDir}/chatlogs/outputLogs`;
           const narrowedInputDir = `${inputBaseDir}/codex/2026/2026-04`;
           const filePath = `${narrowedInputDir}/chatlog-exporter/2026-04-03-xxx.md`;
@@ -222,6 +222,25 @@ describe('writeFrontmatter', () => {
 
           const expectedOutputPath = `${outputBaseDir}/codex/2026/2026-04/chatlog-exporter/2026-04-03-xxx.md`;
           assertEquals(await fileOrDirExists(expectedOutputPath), true);
+        });
+
+        it('T-SF-WF-05-02: 入力が normalizeLogs 配下なら outputDir 引数を無視し outputLogs へ振り替える', async () => {
+          const inputBaseDir = `${tempDir}/chatlogs/normalizeLogs`;
+          const narrowedInputDir = `${inputBaseDir}/claude/2026/2026-05`;
+          const filePath = `${narrowedInputDir}/chatlog-exporter/2026-05-01-yyy.md`;
+          // 振り替えが働かない場合にのみ使われる、無関係な出力先
+          const unrelatedOutputDir = `${tempDir}/chatlogs/otherLogs`;
+
+          await Deno.mkdir(`${narrowedInputDir}/chatlog-exporter`, { recursive: true });
+          await Deno.writeTextFile(filePath, '# テスト\n本文');
+          const entry = _makeChatlogEntry(filePath);
+          _setAllFields(entry);
+
+          await writeFrontmatter(entry, cache, unrelatedOutputDir, narrowedInputDir);
+
+          const redirectedPath =
+            `${tempDir}/chatlogs/outputLogs/claude/2026/2026-05/chatlog-exporter/2026-05-01-yyy.md`;
+          assertEquals(await fileOrDirExists(redirectedPath), true);
         });
       });
     });

--- a/skills/set-frontmatter/scripts/modules/setfm-write.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-write.ts
@@ -19,6 +19,7 @@ import { getDirectory, getFilename } from '../../../_cle-libs/libs/path-utils/pa
 
 // ─── Local
 import { DEFAULT_ORDERED_FIELDS } from '../../../_cle-libs/constants/common.constants.ts';
+import { DEFAULT_NORMALIZE_DIR, DEFAULT_OUTPUT_DIR } from '../../../_cle-libs/constants/defaults.constants.ts';
 import { LOGGER_TEXT } from '../../../_cle-libs/constants/logger.constants.ts';
 import type { FrontmatterFields } from '../../../_cle-libs/types/frontmatter.types.ts';
 import { SETFM_CACHE_STATUSES } from '../types/cache.const.type.ts';
@@ -114,8 +115,8 @@ export const writeFrontmatter = async (
 
   const _baseDir = extractChatlogBaseDir(_inputPath);
   const _resolvedInputDir = _baseDir || inputDir;
-  const _resolvedOutputDir = _baseDir && _baseDir.endsWith('normalizelogs')
-    ? _baseDir.replace(/normalizelogs$/, 'outputLogs')
+  const _resolvedOutputDir = _baseDir && _baseDir.endsWith(DEFAULT_NORMALIZE_DIR)
+    ? _baseDir.slice(0, -DEFAULT_NORMALIZE_DIR.length) + DEFAULT_OUTPUT_DIR
     : outputDir;
 
   const _relPath = relative(_resolvedInputDir, _inputPath);

--- a/skills/set-frontmatter/scripts/set-frontmatter.ts
+++ b/skills/set-frontmatter/scripts/set-frontmatter.ts
@@ -28,6 +28,7 @@
 // ─── Shared scripts
 import { ChatlogError } from '../../_cle-libs/classes/ChatlogError.class.ts';
 import { GlobalConfig } from '../../_cle-libs/classes/GlobalConfig.class.ts';
+import { DEFAULT_NORMALIZE_DIR } from '../../_cle-libs/constants/defaults.constants.ts';
 import { LOGGER_TEXT } from '../../_cle-libs/constants/logger.constants.ts';
 import { resolveChatlogsDir } from '../../_cle-libs/libs/file-io/resolve-directory.ts';
 import { dirExists } from '../../_cle-libs/libs/file-ops/exists-utils.ts';
@@ -122,7 +123,7 @@ export const main = async (args: string[]): Promise<void> => {
     chatlogsDir: _config.chatlogsDir,
     agent: _config.agent,
     period: _config.period,
-    addOnDir: 'normalizelogs',
+    addOnDir: DEFAULT_NORMALIZE_DIR,
     override: _config.inputDir || undefined,
   });
 

--- a/skills/setup-chatlogs/assets/_cle-libs/constants/defaults.constants.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/constants/defaults.constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG_FILE = 'config.yaml';
 export const DEFAULT_CHATLOGS_DIR = './chatlogs';
 
 /** normalize-chatlogs が出力するセグメントのデフォルトベースディレクトリ。 */
-export const DEFAULT_NORMALIZE_DIR = 'normalizelogs';
+export const DEFAULT_NORMALIZE_DIR = 'normalizeLogs';
 
 /** export-chatlogs が出力先に付加するサブディレクトリ名。`chatlogsDir` と `joinPath()` で組み合わせて使用する。 */
 export const DEFAULT_ORIGINAL_LOGS_DIR = 'originalLogs';

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/file-io/resolve-directory.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/file-io/resolve-directory.ts
@@ -124,7 +124,7 @@ export const extractChatlogPath = (filePath: string): string => {
  * pattern is not found, or if it matches at the start of the path.
  *
  * @param filePath - Path to the source chatlog file
- * @returns Base directory like `'chatlogs/normalizelogs'`, or `''`
+ * @returns Base directory like `'chatlogs/normalizeLogs'`, or `''`
  */
 export const extractChatlogBaseDir = (filePath: string): string => {
   const _normalized = normalizePath(filePath);


### PR DESCRIPTION
## Overview

**Summary**
Rename the default normalize directory from `normalizelogs` to `normalizeLogs` and replace hardcoded path strings with shared constants.

**Background / Motivation**
The default normalize directory was written as `normalizelogs` in some places and referenced by hardcoded string literals in others. This was inconsistent with the neighbouring `originalLogs` and `outputLogs` directories, which already use camelCase.

The hardcoded literals were the real risk. `setfm-write.ts` decided where to write output by matching the input path against the string `'normalizelogs'`. Because that literal was duplicated instead of shared, a change to the constant would silently stop the redirect from matching, and output would fall through to the `--output-dir` value without any error.

This PR unifies the spelling on `normalizeLogs` and routes every reference through `DEFAULT_NORMALIZE_DIR` / `DEFAULT_OUTPUT_DIR`, so the constant is the single source of truth.

## Changes

### Core Changes

- `skills/_cle-libs/constants/defaults.constants.ts`: change `DEFAULT_NORMALIZE_DIR` from `'normalizelogs'` to `'normalizeLogs'`.
- `skills/set-frontmatter/scripts/modules/setfm-write.ts`: resolve the output directory using `DEFAULT_NORMALIZE_DIR` and `DEFAULT_OUTPUT_DIR` instead of a hardcoded regex replace.
- `skills/set-frontmatter/scripts/set-frontmatter.ts`: pass `DEFAULT_NORMALIZE_DIR` to `resolveChatlogsDir` instead of the literal `'normalizelogs'`.
- `assets/_cle-libs/`: sync the same two changes into the distributed copies of `defaults.constants.ts` and `resolve-directory.ts`.

### Test Updates

- `write-frontmatter.functional.spec.ts`: add `T-SF-WF-05-02`, which verifies that input under `normalizeLogs` is redirected to `outputLogs` even when an unrelated `--output-dir` is given.
- `resolve-directory.unit.spec.ts`, `input-dir.e2e.spec.ts`, `original-logs-dir.e2e.spec.ts`: update paths and labels to the new casing.

### Documentation

- `skills/normalize-chatlogs/SKILL.md`, `skills/set-frontmatter/SKILL.md`: update the documented output directory casing.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Test
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

Existing `chatlogs/normalizelogs/` directories must be renamed to `chatlogs/normalizeLogs/`.

The redirect in `setfm-write.ts` uses `endsWith(DEFAULT_NORMALIZE_DIR)`, which is case-sensitive, while the Windows filesystem is not. An existing lowercase directory therefore still opens correctly, but the `endsWith` check returns `false`, so the redirect to `outputLogs` does not fire and files are written to the `--output-dir` fallback instead. This fails silently — there is no error to indicate the redirect was skipped.

On Windows a case-only rename cannot be done in one step; rename via a temporary name:

```bash
mv chatlogs/normalizelogs chatlogs/normalizeLogs.tmp
mv chatlogs/normalizeLogs.tmp chatlogs/normalizeLogs
```

## Additional Notes

Verified locally: `dprint check` reports no issues, and `deno task test` passes with 333 tests / 5801 steps, 0 failed.
