### PR TITLE
config(lint): add markdownlint config and enable mdx formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,19 @@
 {
   //  chatlog dictionary files
   "files.associations": {
-    "*.dic": "yaml"
+    "*.dic": "yaml",
+    "*.mdx": "markdown"
   },
   // deno settings
   "deno.enable": true,
   "deno.config": "deno.json",
   // textlint
   "textlint.configPath": "./configs/textlintrc.yaml",
+  // markdown
+  "markdownlint.configFile": "./configs/markdownlint.yaml",
+  "[markdown]": {
+    "editor.defaultFormatter": "dprint.dprint",
+  },
   // trusted JSON schema hosts
   "json.schemaDownload.enable": true,
   "json.schemaDownload.trustedDomains": {

--- a/configs/markdownlint.yaml
+++ b/configs/markdownlint.yaml
@@ -1,0 +1,44 @@
+# src: ./configs:.markdownlint.yaml
+# @(#) : markdown lint config
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+## markdown lint rule configs
+#
+default: true
+
+## lint rule settings
+# whitespace
+whitespace: true
+
+# heading
+no-duplicate-heading:
+  siblings_only: true # allow duplicate headings if they are not siblings
+
+# line length
+line-length:
+  line_length: 120
+  code_block_line_length: 120
+
+# list item
+ol-prefix: true
+
+# html
+no-inline-html: false
+
+# styles
+emphasis-style:
+  style: asterisk
+strong-style:
+  style: asterisk
+
+# Tabs
+no-hard-tabs: true
+
+# Tables
+# Table columns
+table-column-style:
+  style: aligned

--- a/configs/textlintrc.yaml
+++ b/configs/textlintrc.yaml
@@ -36,7 +36,8 @@ rules:
       space:
         - alphabets
         - numbers
-    textlint-rule-preset-ja-spacing: false
+    ja-space-around-inline-code: true
+    ja-space-around-strong: true
   common-misspellings: true
   no-mixed-zenkaku-and-hankaku-alphabet: true
   "@proofdict/proofdict":

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -67,6 +67,9 @@
   },
   "json": {},
   "markdown": {
+    "associations": [
+      "**/*.mdx"
+    ],
     "emphasisKind": "asterisks",
   },
   "yaml": {


### PR DESCRIPTION
## Overview

**Summary**
Add a markdownlint config, format `.mdx` files with dprint, and turn the two `ja-spacing` textlint rules back on.

**Background / Motivation**
Markdown was checked inconsistently by the three tools in this repo.

markdownlint had no config file, so it used its own defaults. Those defaults do not match the rest of the project. The clearest case is `line-length`: markdownlint defaults to 80, but dprint and the other tools use 120. This reported errors on files that were already correct.

dprint and VS Code did not treat `.mdx` as markdown. dprint matches files by extension, so `dprint fmt` skipped the `.mdx` docs under `aglabo.github.io/docs/`, and VS Code had no formatter for them.

`configs/textlintrc.yaml` turned off the whole `textlint-rule-preset-ja-spacing` preset. The preset holds several rules, so disabling all of it to silence a few also dropped the spacing checks that are useful for the Japanese docs here.

This PR sets all three explicitly instead of relying on defaults or a blanket disable.

## Changes

### Core Changes

- `configs/markdownlint.yaml` (new): markdownlint rules. Starts from `default: true`, then sets `whitespace`, `no-duplicate-heading` with `siblings_only`, `line-length` 120 for prose and code blocks, `ol-prefix`, `no-inline-html: false`, `emphasis-style` and `strong-style` as asterisk, `no-hard-tabs`, and `table-column-style: aligned`.
- `configs/textlintrc.yaml`: drop `textlint-rule-preset-ja-spacing: false`, and enable `ja-space-around-inline-code` and `ja-space-around-strong` on their own.
- `dprint.jsonc`: add `associations: ["**/*.mdx"]` to the markdown plugin so dprint formats `.mdx` as markdown.
- `.vscode/settings.json`: map `*.mdx` to the `markdown` language, set `markdownlint.configFile` to `./configs/markdownlint.yaml`, and make dprint the default markdown formatter.

### Test Updates

N/A. This PR changes configuration only.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files (N/A: no implementation files changed)

## Breaking Change

None.

## Additional Notes

**`dprint check` does not pass on this branch.** Adding `**/*.mdx` puts four already-committed files under dprint for the first time, and they are not formatted the way dprint wants:

- `aglabo.github.io/docs/user-guide/01-quickstart.mdx`
- `aglabo.github.io/docs/user-guide/02-install.mdx`
- `aglabo.github.io/docs/ja/user-guide/01-quickstart.mdx`
- `aglabo.github.io/docs/ja/user-guide/02-install.mdx`

The diff is whitespace only: blank lines and indentation on closing `</Step>` and `:::` markers. This PR does not otherwise touch those files, so reformatting them here would mix a bulk whitespace change into a config-only branch. They are left as they are and should go in a separate formatting commit.

CI is not affected. No workflow in `.github/workflows/` runs `dprint check` — they cover actionlint/ghalint, secret scanning, and the Pages deploy — and lefthook only runs secretlint and commitlint. This is a local check failure only.

Verified locally: `deno task test` passes with 333 tests / 5801 steps, 0 failed, 3 ignored.

One naming note: the branch is `task-50/config/update-documents-configs`, but issue #50 covers the `ExportConfig` pipeline refactor and is unrelated to this work. Related Issues is left as N/A on purpose.
