### PR TITLE
docs(user-guide): add basic workflow guide and update install docs

### DIFF
--- a/aglabo.github.io/docs/index.mdx
+++ b/aglabo.github.io/docs/index.mdx
@@ -9,21 +9,26 @@ Claude Code skills, invoked from slash commands like `/export-chatlogs`. It is w
 (Deno runtime) and distributed as JSR packages.
 
 <CardGroup cols={2}>
-  <Card title="export-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/export-chatlogs/SKILL.md" icon="rocket">
+  <Card title="export-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/export-chatlogs/SKILL.md" icon="rocket">
     Exports AI agent session logs to Markdown with noise removed. It strips system logs, short affirmative replies,
     and tool-use records, writing out only the substantive conversation. Supported agents: claude (default), codex, chatgpt.
   </Card>
-  <Card title="classify-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/classify-chatlogs/SKILL.md" icon="folder-tree">
+  <Card title="classify-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/classify-chatlogs/SKILL.md" icon="folder-tree">
     Classifies chat logs into per-project subdirectories. It analyzes metadata with the Claude CLI to infer
     the project name and adds a `project` field to the frontmatter.
   </Card>
-  <Card title="filter-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/filter-chatlogs/SKILL.md" icon="filter">
+  <Card title="filter-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/filter-chatlogs/SKILL.md" icon="filter">
     Batch-judges exported Markdown with the claude CLI and deletes low-value files (DISCARD).
   </Card>
-  <Card title="normalize-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/normalize-chatlogs/SKILL.md" icon="wand-sparkles">
+  <Card title="normalize-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/normalize-chatlogs/SKILL.md" icon="wand-sparkles">
     Splits chat logs into topic-based segments with AI and outputs them as Markdown with frontmatter.
   </Card>
-  <Card title="set-frontmatter" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/set-frontmatter/SKILL.md" icon="tags">
+  <Card title="set-frontmatter"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/set-frontmatter/SKILL.md" icon="tags">
     Adds or overwrites frontmatter across ChatLog Markdown in bulk. AI generates title / summary / category / topics / tags.
   </Card>
 </CardGroup>
@@ -84,6 +89,8 @@ chatlog-exporter is distributed as agent skills. Install them with `gh skill` or
 - [Quickstart](./user-guide/quickstart) — from nothing installed to running `/export-chatlogs` once.
 - [Installation](./user-guide/install) — full setup, including the installer options and where the
   configuration lives.
+- [Basic workflow](./user-guide/basic-workflow) — applying the skills in order to finish with Markdown
+  for Obsidian.
 
 :::warning
 **Prerequisites**

--- a/aglabo.github.io/docs/ja/index.mdx
+++ b/aglabo.github.io/docs/ja/index.mdx
@@ -8,43 +8,48 @@ description: AIエージェントのセッション履歴をエクスポート�
 Claude Code のスキルとして実装されており、`/export-chatlogs` などのスラッシュコマンドから呼び出せます。TypeScript（Deno ランタイム）で書かれ、JSR パッケージとして提供されます。
 
 <CardGroup cols={2}>
-  <Card title="export-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/export-chatlogs/SKILL.md" icon="rocket">
+  <Card title="export-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/export-chatlogs/SKILL.md" icon="rocket">
     AIエージェントのセッション履歴をノイズ除外して Markdown にエクスポートします。
     システムログ・短文の肯定応答・ツール使用記録を除外し、実質的な会話だけを書き出します。対応エージェント: claude（デフォルト）, codex, chatgpt。
   </Card>
-  <Card title="classify-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/classify-chatlogs/SKILL.md" icon="folder-tree">
+  <Card title="classify-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/classify-chatlogs/SKILL.md" icon="folder-tree">
     チャットログをプロジェクト別のサブディレクトリに分類します。Claude CLI でメタデータを解析してプロジェクト名を推定し、frontmatter に `project` フィールドを付加します。
   </Card>
-  <Card title="filter-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/filter-chatlogs/SKILL.md" icon="filter">
+  <Card title="filter-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/filter-chatlogs/SKILL.md" icon="filter">
     エクスポート済みの Markdown を claude CLI で一括バッチ判定し、再利用価値の低いファイル（DISCARD）を削除します。
   </Card>
-  <Card title="normalize-chatlogs" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/normalize-chatlogs/SKILL.md" icon="wand-sparkles">
+  <Card title="normalize-chatlogs"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/normalize-chatlogs/SKILL.md" icon="wand-sparkles">
     チャットログを AI でトピック別のセグメントに分割し、frontmatter 付きの Markdown として出力します。
   </Card>
-  <Card title="set-frontmatter" href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/set-frontmatter/SKILL.md" icon="tags">
+  <Card title="set-frontmatter"
+    href="https://github.com/aglabo/chatlog-exporter/blob/main/skills/set-frontmatter/SKILL.md" icon="tags">
     ChatLog Markdown に frontmatter を一括で付加・上書きします。AI が title / summary / category / topics / tags を生成します。
   </Card>
 </CardGroup>
 
 ## ワークフロー
 
-5つのスキルを次の順に適用すると、生のセッション履歴を Obsidian 用に整った Markdown へと段階的に整備できます。
+スキルを次の順に適用すると、生のセッション履歴を Obsidian 用に整った Markdown へと段階的に整備できます。
 
 <Steps>
   <Step title="export — エクスポート">
     `/export-chatlogs` でセッション履歴をノイズ除外して Markdown に書き出します。
   </Step>
-  <Step title="classify — 分類">
-    `/classify-chatlogs` でプロジェクト別のサブディレクトリに振り分けます。
-  </Step>
   <Step title="filter — 選別">
     `/filter-chatlogs` で再利用価値の低いファイルを削除します。
+  </Step>
+  <Step title="classify — 分類">
+    `/classify-chatlogs` でプロジェクト別のサブディレクトリに振り分けます。
   </Step>
   <Step title="normalize — 正規化">
     `/normalize-chatlogs` でトピック別セグメントに分割します。
   </Step>
-  <Step title="set-frontmatter — メタデータ付与">
-    `/set-frontmatter` で title / summary / category / topics / tags を付加します。
+  <Step title="set-frontmatter — Frontmatter付与">
+    `/set-frontmatter` で title / category / topics などの frontmatter を付加します。
   </Step>
 </Steps>
 
@@ -81,6 +86,7 @@ chatlog-exporter はエージェントスキルとして配布しています。
 
 - [クイックスタート](./user-guide/quickstart) — 何もインストールしていない状態から `/export-chatlogs` を1回実行するまで。
 - [インストール](./user-guide/install) — インストーラのオプションや設定の配置を含む、詳しいセットアップ手順。
+- [基本ワークフロー](./user-guide/basic-workflow) — 5つのスキルを順に適用して Obsidian 用 Markdown に仕上げる手順。
 
 :::warning
 **前提条件**

--- a/aglabo.github.io/docs/ja/user-guide/01-quickstart.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/01-quickstart.mdx
@@ -9,10 +9,12 @@ description: Chatlog Exporter をインストールし、スラッシュコマ�
 :::warning
 **必要ツール**
 以下のツールが実行できる必要があります。
+
 - `Deno`: 各スキルの実行環境
 - `claude` (Claude Code CLI): AI 処理を行うスキルが使用
 - `bash` (Windowsの場合、Git Bash): 初期設定用
 - スキルマネージャー (`gh` または `npx`): インストール時のみ使用
+
 :::
 
 <Steps>
@@ -27,11 +29,12 @@ description: Chatlog Exporter をインストールし、スラッシュコマ�
       </Tab>
       <Tab title="npx skills">
         ```bash
-        npx skills add aglabo/chatlog-exporter --all --agent claude-code
+        npx skills add aglabo/chatlog-exporter --skill '*' --agent claude-code
         ```
       </Tab>
     </Tabs>
-  </Step>
+
+</Step>
   <Step title="スクリプト、設定ファイルのセットアップ">
     `Chatlog Exporter`の各スキルを実行するためには、共通スクリプトおよび設定ファイルをセットアップし、所定の位置に配置しておく必要があります。
     スキル`/setup-chatlogs`を実行することで、スクリプト・設定ファイルを配置します。
@@ -45,7 +48,8 @@ description: Chatlog Exporter をインストールし、スラッシュコマ�
     - `.config/chatlog-exporter/`: Chatlog Exporter用各種設定ファイル (カレントディレクトリ基準)
     - `deno.json`: Denoスクリプト実行用設定 (カレントディレクトリ基準)
     - `_cle-libs/`: 各スキルが共有するライブラリ (スキルの隣に配置)
-  </Step>
+
+</Step>
   <Step title="Chatlogの抽出">
     スキルをインストールしたディレクトリ上で、次のコマンドを実行します。
 
@@ -55,9 +59,11 @@ description: Chatlog Exporter をインストールし、スラッシュコマ�
     ```
 
     上記の例では、Claude Code の 2026 年 6 月分のログを抽出します。
-  </Step>
+
+</Step>
 </Steps>
 
 :::tip
 各スキルは独立して実行できます。まずは `/export-chatlogs` だけを試し、必要に応じて後続のスキルを組み合わせてください。
+5つのスキルを順に適用する手順は [基本ワークフロー](./basic-workflow) を参照してください。
 :::

--- a/aglabo.github.io/docs/ja/user-guide/02-install.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/02-install.mdx
@@ -11,10 +11,12 @@ Chatlog Exporter は **エージェントスキル**として配布していま�
 :::warning
 **使用ツール**
 以下のツールが使用可能である必要があります。
+
 - `GitHub CLI` / `npm`: スキルのインストール用 (インストール時のみ)
 - `Deno`: 各スキルの TypeScript 実行環境
 - `claude` (Claude Code CLI): AI 処理を行うスキルが使用
 - `bash`: Chatlog Exporter 初期設定用。Windowsの場合はGit Bashを使用してください
+
 :::
 
 <Steps>
@@ -53,20 +55,25 @@ Chatlog Exporter は **エージェントスキル**として配布していま�
         スキルを追加する場合は、次の形式で `npx skills` を実行します。
 
         ```bash
-        npx skills add <package> --all --agent <agent>
+        npx skills add <package> --skill '*' --agent <agent>
         ```
-        `<package>`: スキルのリポジトリ URL。GitHub リポジトリの場合は、`https://github.com/` を省略できる。
-                     Chatlog Exporter の場合、`aglabo/chatlog-exporter`となる。
-        `--all`:     指定されたリポジトリに全てのスキルをインストールするオプション。
-                     指定しない場合、自分でインストールするスキルを選ぶ。
-        `<agent>`:   スキルをインストールするAIコーディングエージェント。
-                     Claude Code にインストールする場合、`claude-code`となる。
-                     省略時は、インタラクティブに選択する。
+        `<package>`:   スキルのリポジトリ URL。GitHub リポジトリの場合は、`https://github.com/` を省略できる。
+                       Chatlog Exporter の場合、`aglabo/chatlog-exporter`となる。
+        `--skill '*'`: 指定されたリポジトリの全てのスキルをインストールするオプション。
+                       指定しない場合、自分でインストールするスキルを選ぶ。
+        `<agent>`:     スキルをインストールするAIコーディングエージェント。
+                       Claude Code にインストールする場合、`claude-code`となる。
+                       省略時は、インタラクティブに選択する。
+
+        :::warning
+        `npx skills` の `--all` は `--skill '*' --agent '*' -y` のショートハンドであり、`--agent` の指定を打ち消します。
+        インストール先を Claude Code だけに限定するには、`--all` ではなく `--skill '*'` を使用してください。
+        :::
 
         Chatlog Exporter をインストールするときは、次のようになります。
 
         ```bash
-        npx skills add aglabo/chatlog-exporter --all --agent claude-code
+        npx skills add aglabo/chatlog-exporter --skill '*' --agent claude-code
         ```
 
       </Tab>
@@ -75,7 +82,8 @@ Chatlog Exporter は **エージェントスキル**として配布していま�
     :::note
     GitHub CLI のエージェントスキル対応はプレビュー段階であり、インターフェースが変更される可能性があります。
     :::
-  </Step>
+
+</Step>
   <Step title="Chatlog Exporterの初期設定">
     Chatlog Exporter を使用する場合、最初に `/setup-chatlogs` を実行して、設定ファイルや辞書を初期設定します。
 
@@ -101,14 +109,16 @@ Chatlog Exporter は **エージェントスキル**として配布していま�
     リポジトリルート以外のサブディレクトリで実行してもエラーにはならず、サブディレクトリを基準に展開されます。
     実行前にカレントディレクトリを確認してください。
     :::
-  </Step>
+
+</Step>
   <Step title="スキルを実行する">
     セットアップを実行したディレクトリで、スラッシュコマンドを実行します。
 
     ```bash
     /export-chatlogs
     ```
-  </Step>
+
+</Step>
 </Steps>
 
 最小構成での最初の実行は [クイックスタート](./quickstart) を参照してください。

--- a/aglabo.github.io/docs/ja/user-guide/03-basic-workflow.mdx
+++ b/aglabo.github.io/docs/ja/user-guide/03-basic-workflow.mdx
@@ -1,0 +1,168 @@
+---
+title: 基本ワークフロー
+description: スキルを順に適用し、生のセッション履歴を Obsidian にインポートできる Markdown へ変換します。
+---
+
+## 基本ワークフロー
+
+このガイドでは、`Chatlog Exporter` の スキルを順に適用し、生のセッション履歴を Obsidian 用の Markdown へ整える流れを案内します。
+各スキルは独立して実行できるので、途中まで実行して結果を確認しながら進められます。
+スキルの実行には、`/setup-chatlogs` で初期設定を済ませておく必要があります。
+詳しくは、[インストール](02-install.mdx) を参照してください。
+
+:::warning
+**前提条件**
+
+以下を満たしている必要があります。
+
+- `/setup-chatlogs` を実行済みであること (設定ファイル・辞書・共有ライブラリが配置されている)
+- `Deno`: 各スキルの実行環境
+- `claude` (Claude Code CLI): AI 処理を行うスキルが使用
+- セットアップを実行したディレクトリで、各スラッシュコマンドを実行すること
+
+:::
+
+:::tip
+`--dry-run` オプションを付けると、スキルを実行せず、処理対象になるファイルを確認できます。 (`/export-chatlog` を除く)
+AIの呼び出しを行わないためトークンを消費しませんが、その分、確認できるのは処理対象であってAIの判定結果ではありません。
+:::
+
+<Steps>
+<Step title="export - ログの抽出">
+
+### 1. ログの抽出
+
+`/export-chatlogs` で、AI エージェントのセッション履歴を Markdown ファイルとして出力します。
+このとき、システムが使用しているセッションなど、ノイズとなる履歴は除外します。
+エージェント名と期間を指定します。エージェントを省略した場合は `claude` を対象とします。
+
+```bash
+/export-chatlogs claude 2026-06
+```
+
+抽出したファイルは `chatlogs/originalLogs/claude/2026/2026-06/` 以下に出力されます。
+
+:::note
+再実行すると同じ会話が別名で二重に出力される場合があります。
+やり直すときは、対象期間のディレクトリ (例: `chatlogs/originalLogs/claude/2026/2026-06/`) を削除してから実行してください。
+:::
+</Step>
+<Step title="filter — 不要ログの削除">
+
+### 2. 不要ログの削除
+
+`/filter-chatlogs` で、再利用価値の低いログを削除します。
+パターンマッチによる機械的な判定と、AIによる判定の2種類があります。
+それぞれ、ログを KEEP / DISCARD に分類し、DISCARD のログを削除します。
+
+- パターンマッチフィルター
+  パターンマッチによる機械的な削除は、フィルター名に `noise-filter` を指定します。
+
+  ```bash
+  /filter-chatlogs noise-filter claude 2026-06
+  ```
+
+- AIフィルター:
+  AIによるフィルターは、フィルター名に `filter` を指定します。
+
+  ```bash
+  /filter-chatlogs filter claude 2026-06
+  ```
+
+:::warning
+
+- このスキルは**ファイルを削除します**。まず `--dry-run` を付けて、削除対象になる
+  ファイルを確認してから、フラグなしで実行してください。
+- AIフィルターの `--dry-run` は claude CLI を呼び出さないため、KEEP/DISCARD の判定は
+  行われません (`judged=0`)。確認できるのは判定対象になるファイルの一覧だけで、
+  削除判定そのものの妥当性は事前に検証できません。
+- AI判定の場合は、それぞれのログを読んで判定するため、トークンを消費します。
+  まず、パターンマッチフィルターで不要なファイルを削除してから、AIフィルターで内容を判定すべきです。
+
+:::
+</Step>
+
+<Step title="classify — プロジェクトの分類">
+
+### 3. プロジェクト別の分類
+
+`/classify-chatlogs` で、抽出したログをプロジェクト別のサブディレクトリへ振り分けます。
+`.config/chatlog-exporter/dics/projects.dic` の辞書をもとに、AI がプロジェクト名を推定します。
+
+```bash
+/classify-chatlogs claude 2026-06
+```
+
+ログの内容からプロジェクト名が判別できなかった場合、プロジェクト名は `misc` となります。
+その後、ファイルを `chatlogs/originalLogs/claude/2026/2026-06/<プロジェクト名>/` 下に移動します。
+frontmatter に `project` フィールドが付きます。
+
+:::tip
+
+- `projects.dic` を編集することで、自身のプロジェクトを追加できます。
+
+:::
+</Step>
+<Step title="normalize — トピックス別にログを分割">
+
+### 4. トピックス別にログを分割
+
+`/normalize-chatlogs` では、1 つのログを AI がトピックス別に複数のセグメントへ分割します (内容によっては、1つのみ)。
+このスキルは引数を省略できません。エージェント名と期間、またはパスを指定してください。
+
+```bash
+/normalize-chatlogs claude 2026-06
+```
+
+分割したファイルは `chatlogs/normalizeLogs/claude/2026/2026-06/<プロジェクト名>/` へ出力します。
+ここから出力先が `originalLogs` ではなく `normalizeLogs` に変わる点に注意してください。
+</Step>
+<Step title="filter (2) — トピックスの整理">
+
+### 5. トピックスの整理
+
+トピックス別に分割したログファイルの中には、短すぎるログや、内容のないログなどが存在します。
+再度、`/filter-chatlogs` を実行して、上記の不要なログを削除します。
+
+```bash
+/filter-chatlogs noise-filter "chatlogs/normalizeLogs/claude/2026/2026-06"
+/filter-chatlogs filter "chatlogs/normalizeLogs/claude/2026/2026-06"
+```
+
+トピックスログのパスを指定すると、トピックスに分割後のログを判定します。
+
+:::warning
+`claude 2026-06`の形式のばあい、旧来の `chatlogs/originalLogs/claude/2026/2026-06/` を指定したことになります。
+`"chatlogs/normalizeLogs/claude/2026/2026-06"` とトピックスログのあるディレクトリを指定します。
+:::
+</Step>
+<Step title="set-frontmatter — Frontmatter の付与">
+
+### 6. Frontmatter の付与
+
+ログを解析し、種別、カテゴリーなどのログ分類用の Frontmatter を付与します。
+タグは `#<namespace>/<tag>` 形式で付与し、Obsidian 上での検索をしやすくしています。
+
+```bash
+/set-frontmatter claude 2026-06
+```
+
+完成したファイルは `chatlogs/outputLogs/claude/2026/2026-06/<プロジェクト名>/` 下に出力します。
+このディレクトリの内容を、そのまま Obsidian の Vault へ取り込めます。
+
+:::tip
+
+- ログの種別、カテゴリー判定、トピックス判定、レビューによるメタ情報チェックをAIを何回も呼び出します。
+  エージェントAIに余裕があるときに実行すると良いでしょう。
+- AI によるレビュー処理を省いて短時間で処理したい場合は `--no-review` を指定します。
+
+:::
+</Step>
+</Steps>
+
+以上で、`chatlogs/outputLogs/` に Obsidian へインポートできる Markdown が揃います。
+
+:::tip
+各スキルは独立して実行できます。
+まずは `/export-chatlogs` だけを試し、出力を確認しながら後続のスキルを 1 つずつ追加していくとよいでしょう。
+:::

--- a/aglabo.github.io/docs/user-guide/01-quickstart.mdx
+++ b/aglabo.github.io/docs/user-guide/01-quickstart.mdx
@@ -9,10 +9,12 @@ For the options and the full setup details, see [Installation](./install).
 :::warning
 **Prerequisites**
 The following tools must be available.
+
 - `Deno`: the runtime every skill runs on
 - `claude` (Claude Code CLI): used by the skills that run AI processing
 - `bash` (Git Bash on Windows): used for the initial setup
 - A skill manager (`gh` or `npx`): used only at install time
+
 :::
 
 <Steps>
@@ -27,11 +29,12 @@ The following tools must be available.
       </Tab>
       <Tab title="npx skills">
         ```bash
-        npx skills add aglabo/chatlog-exporter --all --agent claude-code
+        npx skills add aglabo/chatlog-exporter --skill '*' --agent claude-code
         ```
       </Tab>
     </Tabs>
-  </Step>
+
+</Step>
   <Step title="Set up the scripts and configuration">
     To run the chatlog-exporter skills, the shared scripts and configuration files must be set up
     and placed where the skills expect them.
@@ -46,7 +49,8 @@ The following tools must be available.
     - `.config/chatlog-exporter/`: the configuration files chatlog-exporter uses (relative to the current directory)
     - `deno.json`: the settings for running the Deno scripts (relative to the current directory)
     - `_cle-libs/`: the libraries every skill shares (placed beside the skills)
-  </Step>
+
+</Step>
   <Step title="Export a chatlog">
     From the directory you installed the skills in, run the following command.
 
@@ -56,7 +60,8 @@ The following tools must be available.
     ```
 
     This example exports the Claude Code logs for June 2026.
-  </Step>
+
+</Step>
 </Steps>
 
 :::tip

--- a/aglabo.github.io/docs/user-guide/02-install.mdx
+++ b/aglabo.github.io/docs/user-guide/02-install.mdx
@@ -13,10 +13,12 @@ The setup step with `/setup-chatlogs` cannot be skipped.
 :::warning
 **Tools used**
 The following tools must be available.
+
 - `GitHub CLI` / `npm`: for installing the skills (install time only)
 - `Deno`: the TypeScript runtime every skill runs on
 - `claude` (Claude Code CLI): used by the skills that run AI processing
 - `bash`: for the chatlog-exporter initial setup. On Windows, use Git Bash
+
 :::
 
 <Steps>
@@ -55,20 +57,25 @@ The following tools must be available.
         To add skills, run `npx skills` in the following form.
 
         ```bash
-        npx skills add <package> --all --agent <agent>
+        npx skills add <package> --skill '*' --agent <agent>
         ```
-        `<package>`: the skill repository URL. For a GitHub repository, `https://github.com/` can be omitted.
-                     For chatlog-exporter this is `aglabo/chatlog-exporter`.
-        `--all`:     the option to install every skill in the given repository.
-                     Without it, you choose which skills to install yourself.
-        `<agent>`:   the AI coding agent to install the skills into.
-                     To install into Claude Code, this is `claude-code`.
-                     If omitted, you select it interactively.
+        `<package>`:   the skill repository URL. For a GitHub repository, `https://github.com/` can be omitted.
+                       For chatlog-exporter this is `aglabo/chatlog-exporter`.
+        `--skill '*'`: the option to install every skill in the given repository.
+                       Without it, you choose which skills to install yourself.
+        `<agent>`:     the AI coding agent to install the skills into.
+                       To install into Claude Code, this is `claude-code`.
+                       If omitted, you select it interactively.
+
+        :::warning
+        For `npx skills`, `--all` is shorthand for `--skill '*' --agent '*' -y`, so it overrides `--agent`.
+        To install into Claude Code only, use `--skill '*'` rather than `--all`.
+        :::
 
         To install chatlog-exporter, the command is as follows.
 
         ```bash
-        npx skills add aglabo/chatlog-exporter --all --agent claude-code
+        npx skills add aglabo/chatlog-exporter --skill '*' --agent claude-code
         ```
 
       </Tab>
@@ -77,7 +84,8 @@ The following tools must be available.
     :::note
     Agent skills support in the GitHub CLI is in preview and its interface may change.
     :::
-  </Step>
+
+</Step>
   <Step title="Set up chatlog-exporter">
     To use chatlog-exporter, first run `/setup-chatlogs` to set up the configuration files and dictionaries.
 
@@ -103,14 +111,16 @@ The following tools must be available.
     Running it in a subdirectory other than the repository root does not raise an error; it deploys relative to that subdirectory instead.
     Check the current directory before running it.
     :::
-  </Step>
+
+</Step>
   <Step title="Run a skill">
     From the directory you ran the setup in, run a slash command.
 
     ```bash
     /export-chatlogs
     ```
-  </Step>
+
+</Step>
 </Steps>
 
 For a minimal first run, see [Quickstart](./quickstart).

--- a/aglabo.github.io/docs/user-guide/03-basic-workflow.mdx
+++ b/aglabo.github.io/docs/user-guide/03-basic-workflow.mdx
@@ -1,0 +1,178 @@
+---
+title: Basic workflow
+description: Apply the skills in order to turn raw session logs into Markdown ready to import into Obsidian.
+---
+
+## Basic workflow
+
+This guide walks you through applying the `chatlog-exporter` skills in order to reshape raw session
+history into Markdown for Obsidian.
+Each skill runs independently, so you can stop partway and check the results as you go.
+Running the skills requires that you have finished the initial setup with `/setup-chatlogs`.
+For details, see [Installation](./install).
+
+:::warning
+**Prerequisites**
+
+The following must be in place.
+
+- `/setup-chatlogs` has been run (the configuration files, dictionaries, and shared libraries are deployed)
+- `Deno`: the runtime every skill runs on
+- `claude` (Claude Code CLI): used by the skills that run AI processing
+- Run each slash command from the directory you ran the setup in
+
+:::
+
+:::tip
+Adding the `--dry-run` option lets you check which files a skill would act on without running it (except for `/export-chatlog`).
+It skips the AI call, so it consumes no tokens — but for the same reason it shows the targets, not the AI's results.
+:::
+
+<Steps>
+  <Step title="export — Export the logs">
+
+    ### 1. Export the logs
+
+    `/export-chatlogs` writes the session history of an AI agent out as Markdown files.
+    As it does so, it excludes noise such as the sessions the system itself uses.
+    Specify the agent name and the period. If you omit the agent, `claude` is used.
+
+    ```bash
+    /export-chatlogs claude 2026-06
+    ```
+
+    The exported files are written under `chatlogs/originalLogs/claude/2026/2026-06/`.
+
+    :::note
+    Running it again can write the same conversation out a second time under a different name.
+    To start over, delete the directory for that period (for example
+    `chatlogs/originalLogs/claude/2026/2026-06/`) before running it.
+    :::
+
+</Step>
+  <Step title="filter — Delete unneeded logs">
+
+    ### 2. Delete unneeded logs
+
+    `/filter-chatlogs` deletes logs that are of little value to keep.
+    There are two kinds of judgment: mechanical pattern matching, and judgment by AI.
+    Each classifies the logs as KEEP or DISCARD, and deletes the DISCARD ones.
+
+    - Pattern-matching filter
+      For mechanical deletion by pattern matching, give `noise-filter` as the filter name.
+
+      ```bash
+      /filter-chatlogs noise-filter claude 2026-06
+      ```
+
+    - AI filter:
+      For filtering by AI, give `filter` as the filter name.
+
+      ```bash
+      /filter-chatlogs filter claude 2026-06
+      ```
+
+    :::warning
+
+    - This skill *deletes files*. Add `--dry-run` first to review which files are
+      targeted, and only once you have confirmed them, run it without the flag.
+    - The AI filter's `--dry-run` does not call the claude CLI, so it makes no
+      KEEP/DISCARD judgments (`judged=0`). It only lists the files that would be
+      judged; it cannot validate the deletion decisions in advance.
+    - The AI judgment reads each log to judge it, so it consumes tokens.
+      Delete the unneeded files with the pattern-matching filter first, then judge the
+      contents with the AI filter.
+
+    :::
+
+</Step>
+
+<Step title="classify — Classify by project">
+
+    ### 3. Classify by project
+
+    `/classify-chatlogs` sorts the exported logs into per-project subdirectories.
+    Based on the dictionary at `.config/chatlog-exporter/dics/projects.dic`, the AI infers the project name.
+
+    ```bash
+    /classify-chatlogs claude 2026-06
+    ```
+
+    If the project name cannot be determined from the contents of a log, the project name becomes `misc`.
+    The files are then moved under `chatlogs/originalLogs/claude/2026/2026-06/<project>/`.
+    A `project` field is added to the frontmatter.
+
+    :::tip
+
+    - Editing `projects.dic` lets you add your own projects.
+
+    :::
+
+</Step>
+  <Step title="normalize — Split logs by topic">
+
+    ### 4. Split logs by topic
+
+    With `/normalize-chatlogs`, the AI splits a single log into several topic-based segments
+    (depending on the contents, there may be only one).
+    This skill does not allow its arguments to be omitted. Specify the agent name and the period, or a path.
+
+    ```bash
+    /normalize-chatlogs claude 2026-06
+    ```
+
+    The split files are written to `chatlogs/normalizeLogs/claude/2026/2026-06/<project>/`.
+    Note that from here on the output location changes from `originalLogs` to `normalizeLogs`.
+
+</Step>
+  <Step title="filter (2) — Tidy up the topics">
+
+    ### 5. Tidy up the topics
+
+    Among the log files split by topic, some are too short and some have no substance.
+    Run `/filter-chatlogs` again to delete those unneeded logs.
+
+    ```bash
+    /filter-chatlogs noise-filter "chatlogs/normalizeLogs/claude/2026/2026-06"
+    /filter-chatlogs filter "chatlogs/normalizeLogs/claude/2026/2026-06"
+    ```
+
+    Specifying the path to the topic logs judges the logs after they have been split into topics.
+
+    :::warning
+    The `claude 2026-06` form refers to the earlier `chatlogs/originalLogs/claude/2026/2026-06/`.
+    Specify `"chatlogs/normalizeLogs/claude/2026/2026-06"`, the directory holding the topic logs.
+    :::
+
+</Step>
+  <Step title="set-frontmatter — Add frontmatter">
+
+    ### 6. Add frontmatter
+
+    This analyzes the logs and adds the frontmatter used to classify them, such as type and category.
+    Tags are added in the `#<namespace>/<tag>` form, which makes them easier to search within Obsidian.
+
+    ```bash
+    /set-frontmatter claude 2026-06
+    ```
+
+    The finished files are written under `chatlogs/outputLogs/claude/2026/2026-06/<project>/`.
+    The contents of this directory can be imported into an Obsidian vault as they are.
+
+    :::tip
+
+    - Judging the log type, the category, and the topics, and reviewing the metadata, calls the AI many times.
+      It is best run when your agent AI has capacity to spare.
+    - To skip the AI review and finish faster, specify `--no-review`.
+
+    :::
+
+</Step>
+</Steps>
+
+With that, `chatlogs/outputLogs/` holds Markdown ready to import into Obsidian.
+
+:::tip
+Each skill can run independently.
+Start by trying just `/export-chatlogs`, then add the later skills one at a time while checking the output.
+:::


### PR DESCRIPTION
## Overview

**Summary**
Add a "Basic workflow" page to the user guide in English and Japanese, and replace the deprecated `--all` flag with `--skill '*'` in the install and quickstart examples.

**Background / Motivation**
The user guide covered installation and a quickstart. It did not explain what to do next. A reader who finished `02-install` had no page describing the export → filter → normalize → frontmatter sequence. The new `03-basic-workflow` page fills that gap. The docs index links to it.

The install and quickstart pages also used a stale flag. `npx skills add` no longer uses `--all` to select every skill. Worse, `--all` silently overrides `--agent`, so the examples did not match the surrounding prose. The examples now use `--skill '*'` and a warning documents the override.

Finally, a prerequisites admonition on the two English pages closed with an indented `:::`. The indentation pulled the fence into the preceding list item, so the block never closed. The Japanese pages were already correct.

## Changes

### Core Changes

- `aglabo.github.io/docs/user-guide/03-basic-workflow.mdx` (new): add the Basic workflow guide in English.
- `aglabo.github.io/docs/ja/user-guide/03-basic-workflow.mdx` (new): add the same guide in Japanese.
- `aglabo.github.io/docs/user-guide/01-quickstart.mdx`, `02-install.mdx`, and their `ja/` counterparts: replace `--all` with `--skill '*'` in the `npx skills add` examples, add a warning that `--all` overrides `--agent`, and apply MDX formatting.
- `aglabo.github.io/docs/user-guide/01-quickstart.mdx`, `02-install.mdx`: unindent the closing `:::` of the prerequisites warning and add a blank line before it, so the admonition closes correctly.
- `aglabo.github.io/docs/index.mdx`, `aglabo.github.io/docs/ja/index.mdx`: link the new Basic workflow page and adjust card formatting.

Config parity restored after merge `8c508595` (see Additional Notes):

- `.vscode/settings.json`: change `"markdown"` back to `"[markdown]"`. `"markdown"` is not a valid language-scoped key, so the dprint default formatter was not applied.
- `configs/markdownlint.yaml`: nest `siblings_only: true` under `no-duplicate-heading` again. At the top level it is not a valid rule name.

### Test Updates

N/A. This PR changes documentation only. No test code was touched.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Implements beads issue `cle-4bj.2` (「基本ワークフロー…の解説ページを追加」), part of epic `cle-4bj`. There is no matching GitHub issue.

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files (N/A: no implementation files changed)

## Breaking Change

None.

## Additional Notes

This branch started before #403 (`config(lint): add markdownlint config and enable mdx formatting`) merged. Merge commit `8c508595` brought its own copy of those settings, which reverted two fixes from #403. The two config bullets above restore them.

That merge is also why `configs/markdownlint.yaml`, `configs/textlintrc.yaml`, and `.vscode/settings.json` appear in the diff against the merge base. All three now match `origin/main`: `git diff origin/main -- configs/ .vscode/` is empty. This PR introduces no other configuration change.

`dprint check` passes on the current working tree.
