### PR TITLE
config(ci): update action pins and patch mermaid advisories

### DIFF
--- a/.github/workflows/cd-deploy-pages.yml
+++ b/.github/workflows/cd-deploy-pages.yml
@@ -37,15 +37,15 @@ jobs:
         working-directory: aglabo.github.io
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -61,7 +61,7 @@ jobs:
         run: pnpm docs:build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: aglabo.github.io/dist
 
@@ -80,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -1,7 +1,7 @@
 # src: ./.github/workflows/ci-scan-secrets.yml
 # @(#) : Caller workflow for secret scanning in .github repository
 #
-# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+# Copyright (c) 2025- atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
@@ -28,4 +28,4 @@ jobs:
     name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ru-scan-betterleaks.yml@3b3ba7602e8588aefbd08babedb8364da5b73c27 # v0.3.2
+    uses: aglabo/ci-platform/.github/workflows/ru-scan-betterleaks.yml@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -1,7 +1,7 @@
 # src: ./.github/workflows/ci-workflows-qa.yml
 # @(#) : Caller workflow for GitHub Actions workflow QA in .github repository
 #
-# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+# Copyright (c) 2025- atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ru-qa-actionlint.yml@3b3ba7602e8588aefbd08babedb8364da5b73c27 # v0.3.2
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-actionlint.yml@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ru-qa-ghalint.yml@3b3ba7602e8588aefbd08babedb8364da5b73c27 # v0.3.2
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-ghalint.yml@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4

--- a/aglabo.github.io/pnpm-lock.yaml
+++ b/aglabo.github.io/pnpm-lock.yaml
@@ -957,48 +957,24 @@ packages:
     resolution: {integrity: sha512-Sc1TkcwGV6aVCO51AyKeaGiP8gpwAHxEtO5d3tZzPV+KsnlC/YokQxFxwBrbIXw73k9hmcExnJyGu3k5i6n6VA==}
     engines: {node: '>=20'}
 
-  '@shikijs/core@4.3.1':
-    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
-    engines: {node: '>=20'}
-
   '@shikijs/core@4.4.1':
     resolution: {integrity: sha512-VeR2CY6Nn9/WbisoYLOQZ7HZOnwTrpBuOw4wExjqLnBCi62BNWynBUO6K2uPIASPFJwAv7cX1fUu+LrPlSstcw==}
-    engines: {node: '>=20'}
-
-  '@shikijs/engine-javascript@4.3.1':
-    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
     engines: {node: '>=20'}
 
   '@shikijs/engine-javascript@4.4.1':
     resolution: {integrity: sha512-6U4lJBh8LTvIkEVqRHv/rr3ruwtO6IweFQt1ME1ntHJMGHS+6N86vfYGO1o8c/DtOCTia2lfhdQBtBrps1sDfQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
-    engines: {node: '>=20'}
-
   '@shikijs/engine-oniguruma@4.4.1':
     resolution: {integrity: sha512-p23RugMKss0r5DAtRJW1yAXUDl60JvhQYV20yuxei//26JyDSJefV3umyWzzwep2weblMnJGDYahuti6XkcMgA==}
-    engines: {node: '>=20'}
-
-  '@shikijs/langs@4.3.1':
-    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
     engines: {node: '>=20'}
 
   '@shikijs/langs@4.4.1':
     resolution: {integrity: sha512-xb2kCMloBCIraIy2fS5MW0t/BxVY3q2nDyQKBoeSeq6KNrQbShHetCFlw2n35fGIJ6t3+hXDLQogP5ir9O9bvA==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.3.1':
-    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
-    engines: {node: '>=20'}
-
   '@shikijs/primitive@4.4.1':
     resolution: {integrity: sha512-ko2OfDoG89YuQ7xL5LtcQiWKb7NIv1Ephb7g48TVU198OzAMLC8lXVEwaJGHK4sUMYrfAGJDqYmNLOLiW/Kz8w==}
-    engines: {node: '>=20'}
-
-  '@shikijs/themes@4.3.1':
-    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
     engines: {node: '>=20'}
 
   '@shikijs/themes@4.4.1':
@@ -1014,10 +990,6 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       typescript: '>=5.5.0'
-
-  '@shikijs/types@4.3.1':
-    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
-    engines: {node: '>=20'}
 
   '@shikijs/types@4.4.1':
     resolution: {integrity: sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw==}
@@ -2569,10 +2541,6 @@ packages:
     resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
@@ -2910,8 +2878,8 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3486,10 +3454,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shiki@4.3.1:
-    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
-    engines: {node: '>=20'}
 
   shiki@4.4.1:
     resolution: {integrity: sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==}
@@ -4154,10 +4118,10 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
-      shiki: 4.3.1
+      shiki: 4.4.1
       smol-toml: 1.7.1
       unified: 11.0.5
 
@@ -4968,14 +4932,6 @@ snapshots:
 
   '@scalar/validation@0.6.2': {}
 
-  '@shikijs/core@4.3.1':
-    dependencies:
-      '@shikijs/primitive': 4.3.1
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-      hast-util-to-html: 9.0.5
-
   '@shikijs/core@4.4.1':
     dependencies:
       '@shikijs/primitive': 4.4.1
@@ -4984,51 +4940,26 @@ snapshots:
       '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
-
   '@shikijs/engine-javascript@4.4.1':
     dependencies:
       '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/engine-oniguruma@4.4.1':
     dependencies:
       '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-
   '@shikijs/langs@4.4.1':
     dependencies:
       '@shikijs/types': 4.4.1
-
-  '@shikijs/primitive@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
 
   '@shikijs/primitive@4.4.1':
     dependencies:
       '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
-
-  '@shikijs/themes@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
 
   '@shikijs/themes@4.4.1':
     dependencies:
@@ -5047,11 +4978,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@shikijs/types@4.3.1':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
 
   '@shikijs/types@4.4.1':
     dependencies:
@@ -5743,7 +5669,7 @@ snapshots:
       js-yaml: 4.3.1
       katex: 0.18.1
       marked: 18.0.7
-      mermaid: 11.16.0
+      mermaid: 11.16.1
       node-html-parser: 9.0.1
       pagefind: 1.5.2
       pathe: 2.0.3
@@ -6838,10 +6764,6 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
@@ -7211,7 +7133,7 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -8055,17 +7977,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shiki@4.3.1:
-    dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/engine-javascript': 4.3.1
-      '@shikijs/engine-oniguruma': 4.3.1
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
 
   shiki@4.4.1:
     dependencies:

--- a/runners/run-shellcheck.sh
+++ b/runners/run-shellcheck.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=runners/libs/init-vars.lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
 cd "${SCRIPT_ROOT}/.."
 

--- a/runners/run-shellspec.sh
+++ b/runners/run-shellspec.sh
@@ -18,8 +18,8 @@ SHELLSPEC="${SHELLSPEC:-${PROJECT_ROOT}/.tools/shellspec/shellspec}"
 
 readonly TEST_TYPES=("all" "unit" "functional" "integration" "system" "e2e")
 
-# Spec root directory, relative to PROJECT_ROOT. Must match --default-path in .shellspec
-readonly SPEC_ROOT_DIR="scripts/__tests__"
+# Directory name holding spec files, relative to each source tree
+readonly TEST_DIR_NAME="__tests__"
 
 SKIP_INTEGRATION_TESTS="${SKIP_INTEGRATION_TESTS:-1}"
 SPEC_SEARCH_ROOT="${SPEC_SEARCH_ROOT:-${PROJECT_ROOT}}"
@@ -61,8 +61,8 @@ expand_spec_glob() {
   )
 
   if [[ ${#matches[@]} -eq 0 ]]; then
-    echo "Warning: No spec files found matching glob '${pattern}'" >&2
-    return 0
+    echo "Error: No spec files found matching glob '${pattern}'" >&2
+    return 1
   fi
 
   local file
@@ -94,11 +94,24 @@ get_spec_files() {
   local test_type="$1"
   shift
 
+  # get_filelist applies these filters as unanchored regexes, so they have to be
+  # delimited as whole path components: the trailing separator keeps "unit" from
+  # matching "__tests__/unitary", and the leading one keeps "all" from matching
+  # "not__tests__". Both filters contain a separator, so each takes get_filelist's
+  # path-filter branch and is used as-is.
+  #
+  # Separators are written as [/] rather than a bare /: on Windows/Git Bash the
+  # MSYS argument path conversion rewrites a pattern shaped like /c/ before rg
+  # ever receives it (confirmed via MSYS_NO_PATHCONV), which silently matches
+  # nothing. A pattern starting with [ is left alone. This is not an rg defect.
+  #
+  # TEST_DIR_NAME and TEST_TYPES hold no regex metacharacters, so interpolating
+  # them directly is safe.
   local type_filter
   if [[ "$test_type" == "all" ]]; then
-    type_filter="${SPEC_ROOT_DIR}/"
+    type_filter="(^|[/])${TEST_DIR_NAME}[/]"
   else
-    type_filter="${SPEC_ROOT_DIR}/${test_type}/"
+    type_filter="(^|[/])${TEST_DIR_NAME}[/]${test_type}[/]"
   fi
 
   local -a spec_files
@@ -134,6 +147,13 @@ resolve_spec_files() {
     local -a expanded_specs
     mapfile -t expanded_specs < <(expand_spec_glob "$first_arg")
     mapfile -t RESOLVED_SPEC_FILES < <(filter_runnable_specs "${expanded_specs[@]}")
+    # mapfile masks expand_spec_glob's exit status, so the emptiness has to be
+    # re-checked here. mapfile yields either a zero-length array or a single
+    # empty element for empty input, hence both conditions.
+    if [[ ${#RESOLVED_SPEC_FILES[@]} -eq 0 || -z "${RESOLVED_SPEC_FILES[0]}" ]]; then
+      echo "Error: No runnable spec files found matching glob '${first_arg}'" >&2
+      return 1
+    fi
     shift
     SHELLSPEC_ARGS=("$@")
     printf '%s\n' "${RESOLVED_SPEC_FILES[@]}"
@@ -155,10 +175,11 @@ resolve_spec_files() {
 
   local test_type="$1"
   shift
-  # 統合テストのゲートを開く種別。integration は指定されれば毎回実行する。
-  # system は integration ゲートも通す必要があるため従来どおり開く。
-  # all は「すべて」の要求であり、閉じたままだと integration/system 単独指定の
-  # 和集合より弱いスイートになってしまうため同様に開く。
+  # Test types that open the integration test gate.
+  # "integration" always runs the integration tests when requested.
+  # "system" needs the integration gate open as well.
+  # "all" means everything, so keeping the gate closed would make it a weaker
+  # suite than running "integration" and "system" separately.
   case "$test_type" in
   integration | system | all) SKIP_INTEGRATION_TESTS=0 ;;
   esac
@@ -178,8 +199,8 @@ resolve_spec_files() {
   local -a spec_files
   mapfile -t spec_files < <(get_spec_files "$test_type" "${file_filters[@]}")
   if [[ ${#spec_files[@]} -eq 0 || -z "${spec_files[0]}" ]]; then
-    echo "Warning: No spec files found for test type '${test_type}'" >&2
-    return 0
+    echo "Error: No spec files found for test type '${test_type}'" >&2
+    return 1
   fi
 
   RESOLVED_SPEC_FILES=("${spec_files[@]}")
@@ -196,13 +217,44 @@ run_shellspec() {
   (cd "$PROJECT_ROOT" && export SKIP_INTEGRATION_TESTS && bash "$SHELLSPEC" "${normalized_args[@]}")
 }
 
+usage() {
+  cat <<'USAGE'
+Usage: run-shellspec.sh <test-type|spec-file|spec-glob> [--integration] [shellspec-options]
+
+Test types:
+  all           Run every spec
+  unit          Run unit specs
+  functional    Run functional specs
+  integration   Run integration specs
+  system        Run system specs
+  e2e           Run e2e specs
+
+Options:
+  --integration Run integration tests that are skipped by default
+
+Examples:
+  run-shellspec.sh all
+  run-shellspec.sh unit
+  run-shellspec.sh path/to/foo.spec.sh
+  run-shellspec.sh 'path/to/__tests__/unit/*.spec.sh'
+USAGE
+}
+
 main() {
   if [[ $# -eq 0 ]]; then
-    run_shellspec
-    exit $?
+    usage >&2
+    exit 1
   fi
 
   parse_options "$@" >/dev/null
+
+  # Options-only invocation (e.g. "--integration") selects no specs. Running
+  # shellspec's default path here would report success without checking the
+  # specs the caller meant to run, so ask for an explicit selection instead.
+  if [[ ${#PARSED_ARGS[@]} -eq 0 ]]; then
+    usage >&2
+    exit 1
+  fi
 
   local resolved resolved_file
   resolved_file=$(mktemp)
@@ -212,10 +264,7 @@ main() {
     echo "$resolved" >&2
     exit 1
   fi
-  resolved=$(cat "$resolved_file")
   rm -f "$resolved_file"
-
-  [[ -z "$resolved" ]] && exit 0
 
   run_shellspec "${RESOLVED_SPEC_FILES[@]}" "${SHELLSPEC_ARGS[@]}"
 }


### PR DESCRIPTION
## Overview

**Summary**
Update pinned GitHub Actions, bump mermaid to clear all Dependabot alerts, and make the ShellSpec runner require an explicit target.

**Background / Motivation**
The Pages deploy workflow pinned `pnpm/action-setup` at v4.1.0, which cannot handle the `packageManager: pnpm@11.17.0` declared by `aglabo.github.io/package.json`. Support for pnpm 11 only landed in action-setup v6.0.0. The other action pins were refreshed in the same pass.

Separately, every open Dependabot alert on `aglabo.github.io` came from one transitive dependency, `mermaid < 11.16.1`, so a single lockfile bump resolves all of them.

## Changes

### Core Changes

**GitHub Actions pins (`3f0e360d`)**

- `cd-deploy-pages.yml`: bumped 5 pinned actions, keeping the SHA-pin + `# vX.Y.Z` comment convention.
  - `actions/checkout` v4.2.2 → v7.0.1
  - `pnpm/action-setup` v4.1.0 → v6.0.10
  - `actions/setup-node` v4.4.0 → v7.0.0
  - `actions/upload-pages-artifact` v3.0.1 → v5.0.0
  - `actions/deploy-pages` v4.0.5 → v5.0.0
- The `pnpm/action-setup` bump is required, not cosmetic. The workflow passes no explicit `version:` input, so the action resolves pnpm from `packageManager`.
- `ci-scan-secrets.yml` / `ci-workflows-qa.yml`: `aglabo/ci-platform` refs updated v0.3.2 → v0.3.4, copyright year corrected 2026 → 2025.

**Security: lockfile (`d4bdcba5`)**

- `mermaid` 11.16.0 → 11.16.1, lockfile only. `mermaid` is a transitive dependency of `blume@1.3.1`, whose range `^11.15.0` already permits 11.16.1, so `package.json` is unchanged.
- Clears all 5 open Dependabot alerts, all caused by `mermaid < 11.16.1`:
  - CVE-2026-71437 — Architecture diagram prototype pollution (medium)
  - CVE-2026-71439 — radar diagram denial of service (medium)
  - CVE-2026-50159 — CSS injection into sibling elements (medium)
  - CVE-2026-71436 — XY Charts infinite-loop denial of service (medium)
  - CVE-2026-71438 — config API prototype pollution (low)

**ShellSpec / ShellCheck runners (`f5a0462e`)**

Unrelated to the security work above; grouped here as a separate item.

- `runners/run-shellspec.sh`: spec discovery switched from `SPEC_ROOT_DIR` to `TEST_DIR_NAME` (`__tests__`) so specs are found across source trees. The runner now exits with usage and an error when no specs match or no argument is given; previously it warned and returned success.
- `runners/run-shellcheck.sh`: replaced a `shellcheck disable` comment with an explicit `source` directive for `init-vars.lib.sh`.

### Test Updates

None. No test files changed in this PR.

### Removed

- Unreferenced duplicate lockfile entries: the `@shikijs/*` 4.3.1 family, `js-yaml` 4.3.0, and `shiki` 4.3.1. This is deduplication, not a downgrade — `mermaid` is the only package whose resolved version changed.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. Breaking changes in the new action majors were reviewed and do not affect this configuration:

- explicit `cache: pnpm` takes precedence over setup-node v5+ automatic caching;
- checkout v7's fork-PR restriction does not apply (triggers are `push` / `workflow_dispatch` only);
- the Node 24 runtime requirement is satisfied by `ubuntu-latest`.

## Additional Notes

Verification performed:

- `dprint check` — pass
- `actionlint .github/workflows/cd-deploy-pages.yml` — pass
- `pnpm audit --prod` (in `aglabo.github.io`) — "No known vulnerabilities found"
- `pnpm install --frozen-lockfile` — succeeded
- `pnpm docs:build` — succeeded, 9 pages built

Still pending:

- The Pages deploy workflow has not been run. It triggers only on push to `main` or `workflow_dispatch`, so end-to-end deploy verification with the new pins is outstanding.
- `pnpm run test:sh` was not run, although `run-shellspec.sh` changed. Worth running before merge.
- Reviewer note: `upload-pages-artifact` v4+ excludes dotfiles, and `dist/.nojekyll` is generated. This is harmless because artifact-based `deploy-pages` does not run Jekyll; `include-hidden-files: true` is available if it ever matters.
