### PR TITLE
fix(filter-chatlogs): exclude Codex preamble turns from prefilter

### DIFF
--- a/skills/filter-chatlogs/scripts/constants/patterns/assistant.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/patterns/assistant.constants.ts
@@ -20,10 +20,12 @@ import type { NoiseConversationPattern } from '../../types/patterns.types.ts';
 /**
  * システムタグのみと判断するプレフィックス正規表現。
  *
- * `INSTRUCTIONS` は Codex が常に大文字で出力するため、`i` フラグは付けずリテラルで列挙する。
+ * 前方一致のため、先頭に現れればターン全体がシステム入力とみなせるタグに限る。
+ * Codex 注入タグ（`recommended_plugins` 等）は本題が後続しうるため、
+ * ここではなくターン全体を見る `isPreambleTurn` で判定する。
  */
 export const SYSTEM_TAG_REGEX =
-  /^<(system-reminder|command-name|command-message|local-command-stdout|ide_opened_file|ide_selection|recommended_plugins|INSTRUCTIONS|environment_context)\b/;
+  /^<(system-reminder|command-name|command-message|local-command-stdout|ide_opened_file|ide_selection)\b/;
 
 /** Assistantの応答内容によるノイズパターン。checkAssistantContent() で使用。 */
 export const NOISE_ASSISTANT_PATTERNS: NoiseConversationPattern[] = [

--- a/skills/filter-chatlogs/scripts/constants/patterns/assistant.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/patterns/assistant.constants.ts
@@ -17,9 +17,13 @@ import { ENTRY_CONTROL } from '../../types/patterns.types.ts';
 // types
 import type { NoiseConversationPattern } from '../../types/patterns.types.ts';
 
-/** システムタグのみと判断するプレフィックス正規表現。 */
+/**
+ * システムタグのみと判断するプレフィックス正規表現。
+ *
+ * `INSTRUCTIONS` は Codex が常に大文字で出力するため、`i` フラグは付けずリテラルで列挙する。
+ */
 export const SYSTEM_TAG_REGEX =
-  /^<(system-reminder|command-name|command-message|local-command-stdout|ide_opened_file|ide_selection)\b/;
+  /^<(system-reminder|command-name|command-message|local-command-stdout|ide_opened_file|ide_selection|recommended_plugins|INSTRUCTIONS|environment_context)\b/;
 
 /** Assistantの応答内容によるノイズパターン。checkAssistantContent() で使用。 */
 export const NOISE_ASSISTANT_PATTERNS: NoiseConversationPattern[] = [

--- a/skills/filter-chatlogs/scripts/constants/patterns/filename.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/patterns/filename.constants.ts
@@ -6,7 +6,13 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/** システム/コマンドタグとして認識するプレフィックス一覧（`startsWith` 判定用）。 */
+/**
+ * システム/コマンドタグとして認識するプレフィックス一覧（`startsWith` 判定用）。
+ *
+ * ここに列挙するタグは「先頭に現れればターン全体がシステム入力」とみなせるものに限る。
+ * Codex が会話冒頭に注入する `recommended_plugins` 等は本題が後続しうるため、
+ * 前方一致ではなくターン全体を見る `isPreambleTurn` で判定する。
+ */
 export const SYSTEM_TAG_PREFIXES: string[] = [
   '<system-reminder',
   '<command-name',
@@ -14,10 +20,6 @@ export const SYSTEM_TAG_PREFIXES: string[] = [
   '<local-command-stdout',
   '<ide_opened_file',
   '<ide_selection',
-  // Codex が会話冒頭に自動注入するタグ
-  '<recommended_plugins',
-  '<INSTRUCTIONS',
-  '<environment_context',
   '---\n',
 ] as const;
 
@@ -30,12 +32,28 @@ const _BASE_FILENAME_PATTERNS: string[] = [
   'command-message-deckrd-coder',
   'pr-temp-idd-pr',
   'temp-idd-pr-pr-current-draft',
-  // Codex プリアンブル断片がタイトル化したログ（前後ハイフンで日付・ハッシュ付き形式に限定）
-  '-recommended-plugins-',
+];
+
+/**
+ * ファイル名ノイズ判定の正規表現専用パターン一覧（非公開）。
+ *
+ * 文字列部分一致では正当なログを誤除外するため、アンカー付き正規表現で表現する必要があるものを置く。
+ * `EXCLUDE_FILENAME_PATTERNS_STR`（`includes` 判定用）には含めない。
+ */
+const _REGEXP_ONLY_FILENAME_PATTERNS: RegExp[] = [
+  // Codex プリアンブル断片がそのままタイトル化したログ。
+  // session-writer の `<date>-<slug>-<hash>.md` 形式でスラッグ全体が
+  // `recommended-plugins` である場合のみ一致させる（判定前に小文字化済み）。
+  // 例: 2026-07-30-recommended-plugins-cfa0110de248.md → 一致
+  //     2026-08-11-which-recommended-plugins-should-i-install-abc123.md → 不一致
+  /^\d{4}-\d{2}-\d{2}-recommended-plugins-[0-9a-f]+\.md$/,
 ];
 
 /** 除外対象ファイル名パターン（文字列部分一致、`includes` 判定用）。 */
 export const EXCLUDE_FILENAME_PATTERNS_STR: string[] = [..._BASE_FILENAME_PATTERNS];
 
 /** noise-filter-chatlogs のファイル名除外正規表現パターン一覧。 */
-export const NOISE_FILENAME_PATTERNS: RegExp[] = _BASE_FILENAME_PATTERNS.map((p) => new RegExp(p));
+export const NOISE_FILENAME_PATTERNS: RegExp[] = [
+  ..._BASE_FILENAME_PATTERNS.map((p) => new RegExp(p)),
+  ..._REGEXP_ONLY_FILENAME_PATTERNS,
+];

--- a/skills/filter-chatlogs/scripts/constants/patterns/filename.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/patterns/filename.constants.ts
@@ -14,6 +14,10 @@ export const SYSTEM_TAG_PREFIXES: string[] = [
   '<local-command-stdout',
   '<ide_opened_file',
   '<ide_selection',
+  // Codex が会話冒頭に自動注入するタグ
+  '<recommended_plugins',
+  '<INSTRUCTIONS',
+  '<environment_context',
   '---\n',
 ] as const;
 
@@ -26,6 +30,8 @@ const _BASE_FILENAME_PATTERNS: string[] = [
   'command-message-deckrd-coder',
   'pr-temp-idd-pr',
   'temp-idd-pr-pr-current-draft',
+  // Codex プリアンブル断片がタイトル化したログ（前後ハイフンで日付・ハッシュ付き形式に限定）
+  '-recommended-plugins-',
 ];
 
 /** 除外対象ファイル名パターン（文字列部分一致、`includes` 判定用）。 */

--- a/skills/filter-chatlogs/scripts/constants/patterns/user.constants.ts
+++ b/skills/filter-chatlogs/scripts/constants/patterns/user.constants.ts
@@ -14,6 +14,32 @@ import { ConversationRole } from '../../../../_cle-libs/types/conversation-role.
 // types
 import type { NoiseConversationPattern } from '../../types/patterns.types.ts';
 
+/**
+ * プリアンブル判定で開閉ペアごと除去するタグ名一覧（非公開）。派生定数の共通ソース。
+ *
+ * Codex が会話冒頭に自動注入するタグ。内部に任意の Markdown を含むため、
+ * 行単位ではなく `<tag>` 〜 `</tag>` の領域ごと除去する。
+ */
+const _PREAMBLE_TAG_NAMES: string[] = [
+  'recommended_plugins',
+  'INSTRUCTIONS',
+  'environment_context',
+];
+
+/** プリアンブルタグブロックを開閉ペアごと除去する正規表現一覧。 */
+export const PREAMBLE_BLOCK_PATTERNS: RegExp[] = _PREAMBLE_TAG_NAMES.map(
+  (tag) => new RegExp(`<${tag}>[\\s\\S]*?</${tag}>`, 'g'),
+);
+
+/**
+ * タグブロック除去後に残る定型行のパターン一覧。
+ *
+ * Codex がプリアンブルに含める裸の見出し。これらのみが残る場合もプリアンブルとみなす。
+ */
+export const PREAMBLE_RESIDUE_PATTERNS: RegExp[] = [
+  /^#\s+AGENTS\.md\s+instructions\s+for\s+\S.*$/,
+];
+
 /** chatlog-exporter スラッシュコマンドパターン。checkUserContent() で使用。 */
 export const NOISE_USER_PATTERNS_CHATLOG: NoiseConversationPattern[] = [
   {

--- a/skills/filter-chatlogs/scripts/libs/__tests__/unit/classify-file.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/libs/__tests__/unit/classify-file.unit.spec.ts
@@ -8,7 +8,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── BDD modules
-import { assert, assertEquals } from '@std/assert';
+import { assert, assertEquals, assertFalse } from '@std/assert';
 import { describe, it } from '@std/testing/bdd';
 import { assertNotNull, assertNull } from '../../../../../_cle-libs/__tests__/helpers/assert.ts';
 
@@ -20,7 +20,9 @@ import {
   checkPromptContent,
   checkUserContent,
   classifyConversation,
+  isPreambleTurn,
   readConversation,
+  stripPreamble,
 } from '../../../libs/classify-file.ts';
 
 // ─── Helpers
@@ -40,7 +42,7 @@ import type { Turn } from '../../../../../_cle-libs/types/conversation.types.ts'
  *
  * ファイル名パターン一致・不一致・大文字小文字無視・reason 文字列を検証する。
  *
- * テスト ID 範囲: T-PF-CF-01 〜 T-PF-CF-04
+ * テスト ID 範囲: T-PF-CF-01 〜 T-PF-CF-06
  *
  * @see checkFilename
  */
@@ -94,6 +96,18 @@ describe('checkFilename', () => {
 
       assertNull(result);
     });
+
+    it('[Normal] T-PF-CF-05-01: 日付+ハッシュ付き recommended-plugins ログ → null でない', () => {
+      const result = checkFilename('2026-07-30-recommended-plugins-cfa0110de248.md');
+
+      assertNotNull(result);
+    });
+
+    it('[Normal] T-PF-CF-05-02: 別ハッシュの recommended-plugins ログ → null でない', () => {
+      const result = checkFilename('2026-07-30-recommended-plugins-49f4148fa064.md');
+
+      assertNotNull(result);
+    });
   });
 
   /** 大文字小文字を区別しない検証ケース。 */
@@ -115,6 +129,24 @@ describe('checkFilename', () => {
 
       assert(result!.includes('ファイル名パターン:'));
     });
+
+    it('[Edge] T-PF-CF-06-01: 前ハイフンなし "recommended-plugins.md" → null（誤除外しない）', () => {
+      const result = checkFilename('recommended-plugins.md');
+
+      assertNull(result);
+    });
+
+    it('[Edge] T-PF-CF-06-02: 後続語のみ "recommended-plugins-for-vscode.md" → null（誤除外しない）', () => {
+      const result = checkFilename('recommended-plugins-for-vscode.md');
+
+      assertNull(result);
+    });
+
+    it('[Edge] T-PF-CF-06-03: 大文字混在 "2026-07-30-Recommended-Plugins-abc123.md" → null でない', () => {
+      const result = checkFilename('2026-07-30-Recommended-Plugins-abc123.md');
+
+      assertNotNull(result);
+    });
   });
 });
 
@@ -127,7 +159,7 @@ describe('checkFilename', () => {
  *
  * User ターンなし・システムタグのみ・コマンドのみ・NOISE_USER_PATTERNS（スラッシュ/パス）・1ターン限定ルールを検証する。
  *
- * テスト ID 範囲: T-PF-UC-01 〜 T-PF-UC-08
+ * テスト ID 範囲: T-PF-UC-01 〜 T-PF-UC-09
  *
  * @see checkUserContent
  */
@@ -212,6 +244,36 @@ describe('checkUserContent', () => {
     it('[Error] T-PF-UC-06-02: "docs/readme.md" → reason を返す', () => {
       const turns = _makeTurns([
         { role: 'user', content: 'docs/readme.md' },
+        { role: 'assistant', content: '回答' },
+      ]);
+      const result = checkUserContent(turns);
+
+      assertNotNull(result);
+    });
+
+    it('[Error] T-PF-UC-09-01: 単一 User ターンが <recommended_plugins> のみ → reason を返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+        { role: 'assistant', content: '回答' },
+      ]);
+      const result = checkUserContent(turns);
+
+      assertNotNull(result);
+    });
+
+    it('[Error] T-PF-UC-09-02: 単一 User ターンが <INSTRUCTIONS> のみ → reason を返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<INSTRUCTIONS>\nPlease answer in Japanese\n</INSTRUCTIONS>' },
+        { role: 'assistant', content: '回答' },
+      ]);
+      const result = checkUserContent(turns);
+
+      assertNotNull(result);
+    });
+
+    it('[Error] T-PF-UC-09-03: 単一 User ターンが <environment_context> のみ → reason を返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>' },
         { role: 'assistant', content: '回答' },
       ]);
       const result = checkUserContent(turns);
@@ -955,3 +1017,274 @@ describe('classifyConversation', () => {
 
 // NOTE: NOISE_USER_PATTERNS_* の定数直接参照テスト（T-PF-NP-01〜04）は削除済み。
 // checkUserContent 経由で同等ロジックを検証しているため再追加しないこと。
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isPreambleTurn
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `isPreambleTurn` のユニットテストスイート。
+ *
+ * Codex が会話冒頭に自動注入するプリアンブルターンの識別を検証する。
+ * タグブロック・定型見出しのみで構成される場合に true、本題が混在する場合に false を返す。
+ *
+ * テスト ID 範囲: T-PF-PR-01 〜 T-PF-PR-03
+ *
+ * @see isPreambleTurn
+ */
+describe('isPreambleTurn', () => {
+  /** タグブロック・定型見出しのみで構成されるプリアンブルを識別するケース。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-PF-PR-01-01: <recommended_plugins> ブロックのみ → true', () => {
+      const text = '<recommended_plugins>\n- Slack (slack@openai-curated-remote)\n</recommended_plugins>';
+
+      assert(isPreambleTurn(text));
+    });
+
+    it('[Normal] T-PF-PR-01-02: <INSTRUCTIONS> ブロックのみ → true', () => {
+      const text = '<INSTRUCTIONS>\nPlease provide all answers in Japanese\n</INSTRUCTIONS>';
+
+      assert(isPreambleTurn(text));
+    });
+
+    it('[Normal] T-PF-PR-01-03: <environment_context> ブロックのみ → true', () => {
+      const text = '<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>';
+
+      assert(isPreambleTurn(text));
+    });
+
+    it('[Normal] T-PF-PR-01-04: 実ログのプリアンブル全体（3ブロック + AGENTS.md 見出し）→ true', () => {
+      const text = [
+        '<recommended_plugins>',
+        'Here is a list of plugins that are available but not installed.',
+        '',
+        '- Slack (slack@openai-curated-remote)',
+        '</recommended_plugins>',
+        '# AGENTS.md instructions for C:\\Users\\atsushifx\\workspaces\\develop\\chatlog-exporter',
+        '',
+        '<INSTRUCTIONS>',
+        'Please provide all answers in Japanese',
+        '',
+        '## Quick Reference',
+        '',
+        '```bash',
+        'bd ready',
+        '```',
+        '</INSTRUCTIONS>',
+        '<environment_context>',
+        '  <cwd>C:\\Users\\atsushifx\\workspaces\\develop\\chatlog-exporter</cwd>',
+        '  <shell>powershell</shell>',
+        '</environment_context>',
+      ].join('\n');
+
+      assert(isPreambleTurn(text));
+    });
+  });
+
+  /** 本題が混在するターン・通常の会話を誤ってプリアンブル扱いしないケース。 */
+  describe('When: 異常系', () => {
+    it('[Error] T-PF-PR-02-01: タグブロックの後に本題が続く → false（誤除外しない）', () => {
+      const text = '<recommended_plugins>\n- Slack\n</recommended_plugins>\nこの設計についてどう思いますか？';
+
+      assertFalse(isPreambleTurn(text));
+    });
+
+    it('[Error] T-PF-PR-02-02: タグブロックの前に本題がある → false', () => {
+      const text = 'まず質問です。\n<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>';
+
+      assertFalse(isPreambleTurn(text));
+    });
+
+    it('[Error] T-PF-PR-02-03: 通常の会話テキスト → false', () => {
+      assertFalse(isPreambleTurn('この機能の設計についてどう思いますか？'));
+    });
+
+    it('[Error] T-PF-PR-02-04: 未知のタグブロックのみ → false', () => {
+      assertFalse(isPreambleTurn('<unknown_tag>\ncontent\n</unknown_tag>'));
+    });
+  });
+
+  /** 空文字列・空白のみ・閉じタグ欠落など境界値のケース。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-PF-PR-03-01: 空文字列 → false', () => {
+      assertFalse(isPreambleTurn(''));
+    });
+
+    it('[Edge] T-PF-PR-03-02: 空白のみ → false', () => {
+      assertFalse(isPreambleTurn('   \n  '));
+    });
+
+    it('[Edge] T-PF-PR-03-03: 閉じタグ欠落 → false（ブロックとして除去できない）', () => {
+      assertFalse(isPreambleTurn('<recommended_plugins>\n- Slack'));
+    });
+
+    it('[Edge] T-PF-PR-03-04: AGENTS.md 定型見出しのみ → true', () => {
+      assert(isPreambleTurn('# AGENTS.md instructions for C:\\Users\\foo\\bar'));
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stripPreamble
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `stripPreamble` のユニットテストスイート。
+ *
+ * 会話先頭から連続するプリアンブル User ターンを除去し、実質的な会話のみを返すことを検証する。
+ *
+ * テスト ID 範囲: T-PF-SP-01 〜 T-PF-SP-03
+ *
+ * @see stripPreamble
+ */
+describe('stripPreamble', () => {
+  /** @param turns - ロール・テキストペアから Turn[] を生成するヘルパー。 */
+  function _makeTurns(turns: Array<{ role: 'user' | 'assistant'; content: string }>): Turn[] {
+    return turns;
+  }
+
+  /** 先頭のプリアンブルターンが除去されるケース。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-PF-SP-01-01: 先頭プリアンブル 1 ターンを除去し残りを返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+        { role: 'user', content: '---\nname: commit-message-generator\n---\n本文' },
+        { role: 'assistant', content: 'コミットメッセージです' },
+      ]);
+
+      const result = stripPreamble(turns);
+
+      assertEquals(result.length, 2);
+      assertEquals(result[0].content, '---\nname: commit-message-generator\n---\n本文');
+    });
+
+    it('[Normal] T-PF-SP-01-02: 連続する複数プリアンブルターンをすべて除去する', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+        { role: 'user', content: '<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>' },
+        { role: 'user', content: '本題の質問' },
+        { role: 'assistant', content: '回答' },
+      ]);
+
+      const result = stripPreamble(turns);
+
+      assertEquals(result.length, 2);
+      assertEquals(result[0].content, '本題の質問');
+    });
+
+    it('[Normal] T-PF-SP-01-03: プリアンブルがない会話は変更せず返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '設計について質問です' },
+        { role: 'assistant', content: '回答' },
+      ]);
+
+      const result = stripPreamble(turns);
+
+      assertEquals(result.length, 2);
+      assertEquals(result[0].content, '設計について質問です');
+    });
+  });
+
+  /** 除去対象が先頭に限られることを検証するケース。 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-PF-SP-02-01: 途中のプリアンブル相当ターンは除去しない', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '本題の質問' },
+        { role: 'assistant', content: '回答' },
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+      ]);
+
+      const result = stripPreamble(turns);
+
+      assertEquals(result.length, 3);
+    });
+
+    it('[Edge] T-PF-SP-02-02: 空の会話 → 空配列を返す', () => {
+      const result = stripPreamble([]);
+
+      assertEquals(result.length, 0);
+    });
+
+    it('[Edge] T-PF-SP-02-03: 全ターンがプリアンブル → 空配列を返す', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+        { role: 'user', content: '<INSTRUCTIONS>\nrules\n</INSTRUCTIONS>' },
+      ]);
+
+      const result = stripPreamble(turns);
+
+      assertEquals(result.length, 0);
+    });
+
+    it('[Edge] T-PF-SP-02-04: 先頭が Assistant ターンなら除去しない', () => {
+      const turns = _makeTurns([
+        { role: 'assistant', content: '先制発話' },
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+      ]);
+
+      const result = stripPreamble(turns);
+
+      assertEquals(result.length, 2);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classifyConversation（プリアンブル除去の統合）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `classifyConversation` のプリアンブル除去統合テストスイート。
+ *
+ * Codex ログ（プリアンブル + エージェント定義 + 応答）が除外判定されること、
+ * プリアンブル直後に実質的な会話が続くログは保持されることを検証する。
+ *
+ * テスト ID 範囲: T-PF-CP-01 〜 T-PF-CP-02
+ *
+ * @see classifyConversation
+ */
+describe('classifyConversation（プリアンブル除去）', () => {
+  /** @param turns - ロール・テキストペアから Turn[] を生成するヘルパー。 */
+  function _makeTurns(turns: Array<{ role: 'user' | 'assistant'; content: string }>): Turn[] {
+    return turns;
+  }
+
+  /** プリアンブル除去により既存ノイズパターンが適用されるケース。 */
+  describe('When: 正常系', () => {
+    it('[Normal] T-PF-CP-01-01: プリアンブル + スキル定義YAML → reason を返す（除外対象）', () => {
+      const turns = _makeTurns([
+        {
+          role: 'user',
+          content: '<recommended_plugins>\n- Slack\n</recommended_plugins>\n'
+            + '# AGENTS.md instructions for C:\\work\n'
+            + '<INSTRUCTIONS>\nrules\n</INSTRUCTIONS>\n'
+            + '<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>',
+        },
+        { role: 'user', content: '---\nname: commit-message-generator\ndescription: Generates messages.\n---\n本文' },
+        { role: 'assistant', content: '=== commit header ===\nfix(x): y\n=== commit footer ===' },
+      ]);
+
+      const result = classifyConversation(turns);
+
+      assertNotNull(result);
+    });
+  });
+
+  /** プリアンブル直後に実質的な会話が続くログを誤除外しないケース。 */
+  describe('When: 異常系', () => {
+    it('[Error] T-PF-CP-02-01: プリアンブル + 通常の質問 → null（保持する）', () => {
+      const turns = _makeTurns([
+        { role: 'user', content: '<recommended_plugins>\n- Slack\n</recommended_plugins>' },
+        { role: 'user', content: 'この設計のトレードオフを教えてください。アーキテクチャ上の懸念はありますか？' },
+        {
+          role: 'assistant',
+          content: '主なトレードオフは結合度と拡張性です。'.repeat(20),
+        },
+      ]);
+
+      const result = classifyConversation(turns);
+
+      assertNull(result);
+    });
+  });
+});

--- a/skills/filter-chatlogs/scripts/libs/__tests__/unit/classify-file.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/libs/__tests__/unit/classify-file.unit.spec.ts
@@ -42,7 +42,7 @@ import type { Turn } from '../../../../../_cle-libs/types/conversation.types.ts'
  *
  * ファイル名パターン一致・不一致・大文字小文字無視・reason 文字列を検証する。
  *
- * テスト ID 範囲: T-PF-CF-01 〜 T-PF-CF-06
+ * テスト ID 範囲: T-PF-CF-01 〜 T-PF-CF-07
  *
  * @see checkFilename
  */
@@ -147,6 +147,18 @@ describe('checkFilename', () => {
 
       assertNotNull(result);
     });
+
+    it('[Edge] T-PF-CF-07-01: スラッグ内に語を含む正当なログ → null（誤除外しない）', () => {
+      const result = checkFilename('2026-08-11-which-recommended-plugins-should-i-install-abc123.md');
+
+      assertNull(result);
+    });
+
+    it('[Edge] T-PF-CF-07-02: 日付なしで前後にハイフンがある名前 → null（誤除外しない）', () => {
+      const result = checkFilename('notes-recommended-plugins-list.md');
+
+      assertNull(result);
+    });
   });
 });
 
@@ -159,7 +171,7 @@ describe('checkFilename', () => {
  *
  * User ターンなし・システムタグのみ・コマンドのみ・NOISE_USER_PATTERNS（スラッシュ/パス）・1ターン限定ルールを検証する。
  *
- * テスト ID 範囲: T-PF-UC-01 〜 T-PF-UC-09
+ * テスト ID 範囲: T-PF-UC-01 〜 T-PF-UC-10
  *
  * @see checkUserContent
  */
@@ -284,6 +296,19 @@ describe('checkUserContent', () => {
 
   /** 通常テキストや複数ターンで 1ターン限定ルールが適用されないケース。 */
   describe('When: 正常系', () => {
+    it('[Normal] T-PF-UC-10-01: 単一 User ターンがプリアンブル + 本題 → null を返す（誤除外しない）', () => {
+      const turns = _makeTurns([
+        {
+          role: 'user',
+          content: '<recommended_plugins>\n- Slack\n</recommended_plugins>\nこの設計についてどう思いますか？',
+        },
+        { role: 'assistant', content: '回答' },
+      ]);
+      const result = checkUserContent(turns);
+
+      assertNull(result);
+    });
+
     it('[Normal] T-PF-UC-08-01: 通常テキストの単一 User ターン → null を返す', () => {
       const turns = _makeTurns([
         { role: 'user', content: 'この機能の設計についてどう思いますか？' },

--- a/skills/filter-chatlogs/scripts/libs/classify-file.ts
+++ b/skills/filter-chatlogs/scripts/libs/classify-file.ts
@@ -158,8 +158,8 @@ export const checkUserContent = (conversation: Conversation): string | null => {
 
   const _userTurns = getUserTurns(conversation);
 
-  // 全Userターンがシステムタグのみ
-  if (_userTurns.every((t) => SYSTEM_TAG_REGEX.test(t.content))) {
+  // 全Userターンがシステムタグのみ、または Codex プリアンブルのみ
+  if (_userTurns.every((t) => SYSTEM_TAG_REGEX.test(t.content) || isPreambleTurn(t.content))) {
     return '全UserターンがシステムTagのみ';
   }
 
@@ -175,8 +175,8 @@ export const checkUserContent = (conversation: Conversation): string | null => {
     const _patternReason = _matchUserPattern(text, NOISE_USER_PATTERNS);
     if (_patternReason) { return _patternReason; }
 
-    // システムタグのみ
-    if (SYSTEM_TAG_REGEX.test(text)) { return 'UserがシステムTagのみ'; }
+    // システムタグのみ、または Codex プリアンブルのみ
+    if (SYSTEM_TAG_REGEX.test(text) || isPreambleTurn(text)) { return 'UserがシステムTagのみ'; }
   }
 
   return null;

--- a/skills/filter-chatlogs/scripts/libs/classify-file.ts
+++ b/skills/filter-chatlogs/scripts/libs/classify-file.ts
@@ -32,6 +32,8 @@ import {
   NOISE_FILENAME_PATTERNS,
   NOISE_PROMPT_PATTERNS,
   NOISE_USER_PATTERNS,
+  PREAMBLE_BLOCK_PATTERNS,
+  PREAMBLE_RESIDUE_PATTERNS,
   SYSTEM_TAG_REGEX,
 } from '../constants/patterns.constants.ts';
 // types
@@ -102,6 +104,45 @@ const _matchConversationPattern = (
     }
   }
   return null;
+};
+
+/**
+ * テキストが Codex 自動注入のプリアンブルのみで構成されているかどうかを判定する。
+ *
+ * `PREAMBLE_TAG_NAMES` のタグを開閉ペアごと除去し、続いて `PREAMBLE_RESIDUE_PATTERNS`
+ * に一致する定型行を除去したうえで、残余が空であればプリアンブルとみなす。
+ * 本題が混在する場合は残余が空にならないため `false` を返す。
+ *
+ * @param text - 判定対象の User ターン本文
+ * @returns プリアンブルのみなら `true`
+ */
+export const isPreambleTurn = (text: string): boolean => {
+  if (!text.trim()) { return false; }
+
+  const _stripped = PREAMBLE_BLOCK_PATTERNS
+    .reduce((acc, pat) => acc.replaceAll(pat, ''), text)
+    .split('\n')
+    .filter((line) => line.trim() && !PREAMBLE_RESIDUE_PATTERNS.some((pat) => pat.test(line.trim())))
+    .join('\n');
+
+  return _stripped.trim() === '';
+};
+
+/**
+ * 会話先頭から連続するプリアンブル User ターンを除去する。
+ *
+ * Codex ログは User ターン 1 がプリアンブル、User ターン 2 以降が実質的な会話という構造を取る。
+ * 判定関数群がプリアンブルを実質ターンと誤認しないよう、判定の手前で正規化する。
+ * 除去対象は先頭からの連続分のみで、途中に現れる同形のターンは残す。
+ *
+ * @param conversation - 解析済みの会話ターン配列
+ * @returns プリアンブルを除去した会話ターン配列
+ */
+export const stripPreamble = (conversation: Conversation): Conversation => {
+  const _firstReal = conversation.findIndex(
+    (turn) => !(turn.role === ConversationRole.user && isPreambleTurn(turn.content)),
+  );
+  return _firstReal === -1 ? [] : conversation.slice(_firstReal);
 };
 
 export const checkFilename = (filename: string): string | null => {
@@ -194,14 +235,19 @@ export const readConversation = (text: string): Conversation => {
 /**
  * 会話に対して User本文・会話パターン・プロンプトパターン・Assistant応答長のチェックを順に適用する。
  *
+ * 各チェックは「User ターンが 1 件」または「先頭 User ターン」を前提とするため、
+ * 判定の前に `stripPreamble` で Codex 注入のプリアンブルを取り除いて正規化する。
+ *
  * @param conversation - 解析済みの会話ターン配列
  * @returns 最初に一致したチェックの reason。いずれも一致しない場合は `null`
  */
-export const classifyConversation = (conversation: Conversation): string | null =>
-  checkUserContent(conversation)
-    ?? checkConversationPattern(conversation)
-    ?? checkPromptContent(conversation)
-    ?? checkAssistantContent(conversation);
+export const classifyConversation = (conversation: Conversation): string | null => {
+  const _conv = stripPreamble(conversation);
+  return checkUserContent(_conv)
+    ?? checkConversationPattern(_conv)
+    ?? checkPromptContent(_conv)
+    ?? checkAssistantContent(_conv);
+};
 
 /**
  * ファイル名パターンのみでノイズ判定を行い、一致した場合は `NoiseDiscardFile` を返す。

--- a/skills/filter-chatlogs/scripts/modules/__tests__/unit/prefilter.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/__tests__/unit/prefilter.unit.spec.ts
@@ -35,7 +35,7 @@ function _makeBody(options: { userText?: string; assistantText?: string; extraPa
  * SYSTEM_TAG_PREFIXES に含まれるプレフィックスで始まるテキストを検出することを検証する。
  * trim後のマッチ・不一致ケース・境界値を網羅する。
  *
- * テスト ID 範囲: T-PF-IS-01 〜 T-PF-IS-05
+ * テスト ID 範囲: T-PF-IS-01 〜 T-PF-IS-06
  *
  * @see isSystemOnlyMessage
  */
@@ -80,6 +80,27 @@ describe('isSystemOnlyMessage', () => {
 
     it('[Normal] T-PF-IS-05-03: `<environment_context>`（Codex 注入タグ）→ true', () => {
       assert(isSystemOnlyMessage('<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>'));
+    });
+  });
+
+  /** Codex プリアンブルの後に本題が続くターンを誤ってシステム扱いしないケース。 */
+  describe('When: 異常系（プリアンブル + 本題）', () => {
+    it('[Error] T-PF-IS-06-01: `<recommended_plugins>` の後に本題が続く → false（誤除外しない）', () => {
+      const text = '<recommended_plugins>\n- Slack\n</recommended_plugins>\nこの設計についてどう思いますか？';
+
+      assertFalse(isSystemOnlyMessage(text));
+    });
+
+    it('[Error] T-PF-IS-06-02: `<INSTRUCTIONS>` の後に本題が続く → false（誤除外しない）', () => {
+      const text = '<INSTRUCTIONS>\nPlease answer in Japanese\n</INSTRUCTIONS>\nこの関数の責務を教えてください。';
+
+      assertFalse(isSystemOnlyMessage(text));
+    });
+
+    it('[Error] T-PF-IS-06-03: `<environment_context>` の後に本題が続く → false（誤除外しない）', () => {
+      const text = '<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>\nビルドが失敗する原因は？';
+
+      assertFalse(isSystemOnlyMessage(text));
     });
   });
 
@@ -376,6 +397,38 @@ describe('isExcludedByContent', () => {
           const { excluded } = isExcludedByContent(body, minCharCount);
 
           assertFalse(excluded);
+        });
+      });
+    });
+  });
+
+  // ─── T-FL-IC-08: Codex プリアンブル + 本題 → excluded=false ──────────────────
+
+  describe('Given: Codex プリアンブルの後に実質的な質問が続く単一 User ターン', () => {
+    describe('When: isExcludedByContent(body) を呼び出す', () => {
+      describe('Then: T-FL-IC-08 - プリアンブルだけを理由に除外されず excluded=false が返される', () => {
+        /** プリアンブル + 本題の User ターンと、十分な長さの Assistant 応答を持つ本文。 */
+        const _preambleWithQuestionBody = [
+          '### User',
+          '<recommended_plugins>',
+          '- Slack (slack@openai-curated-remote)',
+          '</recommended_plugins>',
+          `この設計についてどう思いますか？${'詳しく説明してください。'.repeat(40)}`,
+          '',
+          '### Assistant',
+          'a'.repeat(500),
+        ].join('\n');
+
+        it('[Normal] T-FL-IC-08-01: プリアンブル + 本題 → excluded=false', () => {
+          const { excluded } = isExcludedByContent(_preambleWithQuestionBody);
+
+          assertFalse(excluded);
+        });
+
+        it('[Normal] T-FL-IC-08-02: reason が空文字列（除外理由が付かない）', () => {
+          const { reason } = isExcludedByContent(_preambleWithQuestionBody);
+
+          assertEquals(reason, '');
         });
       });
     });

--- a/skills/filter-chatlogs/scripts/modules/__tests__/unit/prefilter.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/modules/__tests__/unit/prefilter.unit.spec.ts
@@ -35,7 +35,7 @@ function _makeBody(options: { userText?: string; assistantText?: string; extraPa
  * SYSTEM_TAG_PREFIXES に含まれるプレフィックスで始まるテキストを検出することを検証する。
  * trim後のマッチ・不一致ケース・境界値を網羅する。
  *
- * テスト ID 範囲: T-PF-IS-01 〜 T-PF-IS-04
+ * テスト ID 範囲: T-PF-IS-01 〜 T-PF-IS-05
  *
  * @see isSystemOnlyMessage
  */
@@ -68,6 +68,18 @@ describe('isSystemOnlyMessage', () => {
 
     it('[Normal] T-PF-IS-01-07: `---\\ntitle: test\\n---\\n` → true', () => {
       assert(isSystemOnlyMessage('---\ntitle: test\n---\n'));
+    });
+
+    it('[Normal] T-PF-IS-05-01: `<recommended_plugins>`（Codex 注入タグ）→ true', () => {
+      assert(isSystemOnlyMessage('<recommended_plugins>\nHere is a list of plugins.\n</recommended_plugins>'));
+    });
+
+    it('[Normal] T-PF-IS-05-02: `<INSTRUCTIONS>`（Codex 注入タグ）→ true', () => {
+      assert(isSystemOnlyMessage('<INSTRUCTIONS>\nPlease provide all answers in Japanese\n</INSTRUCTIONS>'));
+    });
+
+    it('[Normal] T-PF-IS-05-03: `<environment_context>`（Codex 注入タグ）→ true', () => {
+      assert(isSystemOnlyMessage('<environment_context>\n  <cwd>C:\\work</cwd>\n</environment_context>'));
     });
   });
 

--- a/skills/filter-chatlogs/scripts/modules/prefilter.ts
+++ b/skills/filter-chatlogs/scripts/modules/prefilter.ts
@@ -29,7 +29,7 @@ import { LOGGER_TEXT } from '../../../_cle-libs/constants/logger.constants.ts';
 // classes
 import { ChatlogEntry } from '../../../_cle-libs/classes/ChatlogEntry.class.ts';
 // functions
-import { checkFilename } from '../libs/classify-file.ts';
+import { checkFilename, isPreambleTurn } from '../libs/classify-file.ts';
 import { extractConversation } from '../libs/common-utils.ts';
 // constants
 import { SYSTEM_TAG_PREFIXES } from '../constants/patterns.constants.ts';
@@ -45,14 +45,19 @@ import type { BaseStats } from '../types/stats.types.ts';
 /**
  * テキストがシステム/コマンドタグのみで構成されているかどうかを判定する。
  *
- * `SYSTEM_TAG_PREFIXES` に登録されたプレフィックスで始まる場合に `true` を返す。
+ * 次のいずれかに該当する場合に `true` を返す。
+ * 1. `SYSTEM_TAG_PREFIXES` に登録されたプレフィックスで始まる
+ * 2. ターン全体が Codex 注入のプリアンブルである（`isPreambleTurn`）
+ *
+ * Codex 注入タグは本題が後続しうるため前方一致では判定できない。
+ * 「プリアンブル + 実質的な質問」のターンを誤除外しないよう、ターン全体で判定する。
  *
  * @param text - 判定対象のテキスト
  * @returns システム/コマンドタグのみなら `true`
  */
 export const isSystemOnlyMessage = (text: string): boolean => {
   const stripped = text.trim();
-  return SYSTEM_TAG_PREFIXES.some((prefix) => stripped.startsWith(prefix));
+  return SYSTEM_TAG_PREFIXES.some((prefix) => stripped.startsWith(prefix)) || isPreambleTurn(stripped);
 };
 
 /**


### PR DESCRIPTION
## Overview

**Summary**
Strip Codex-injected preamble turns in the prefilter so commit-message-generator logs are discarded before AI classification.

**Background / Motivation**
Of 1063 codex logs from 2026-07, 1021 were commit-message-generator runs. All of them were titled `recommended-plugins`, and their only real content was a trailing commit message. They had no reuse value, but they all passed the prefilter and were sent to AI classification.

Four causes let them through:

1. The Codex tags `recommended_plugins`, `INSTRUCTIONS`, and `environment_context` were missing from `SYSTEM_TAG_PREFIXES` and `SYSTEM_TAG_REGEX`.
2. `checkConversationPattern` handles only one user turn. These logs have two (preamble + agent definition), so it returned `null` right away.
3. `checkPromptContent` reads only `_userTurns[0]`, the preamble. The YAML header in user turn 2 never matched the skill-invocation pattern.
4. The preamble and the SKILL definition padded the text past the `minCharCount=1000` filter.

There was also a downstream effect. Once these logs reached the AI, their filenames were nearly identical, so haiku mixed up the hashes. That broke the exact-match lookup in `process-chunk.ts` and left many files unclassified.

## Changes

### Core Changes

**Pattern constants (`ae676ec0`)**

- `constants/patterns/assistant.constants.ts`: added `recommended_plugins|INSTRUCTIONS|environment_context` to `SYSTEM_TAG_REGEX`. The tags are listed literally and the `i` flag is not used, because Codex always writes `INSTRUCTIONS` in uppercase.
- `constants/patterns/filename.constants.ts`: added the same three tags to `SYSTEM_TAG_PREFIXES`, and added `-recommended-plugins-` to `_BASE_FILENAME_PATTERNS`. The leading and trailing hyphens keep it from matching anything but the dated, hashed filename form.
- `constants/patterns/user.constants.ts`: added `PREAMBLE_BLOCK_PATTERNS` and `PREAMBLE_RESIDUE_PATTERNS`. The first removes each `<tag>…</tag>` pair as a whole, because the blocks hold arbitrary Markdown. The second matches the bare heading `# AGENTS.md instructions for …` that is left behind. Both are built from one private `_PREAMBLE_TAG_NAMES` array, so the tag list has a single source.

**Preamble stripping (`e60afd92`)**

- `libs/classify-file.ts`: added `isPreambleTurn(text)` and `stripPreamble(conversation)`. `classifyConversation()` now calls `stripPreamble()` first, then runs the existing four checks (`checkUserContent` → `checkConversationPattern` → `checkPromptContent` → `checkAssistantContent`) on the result.
- `stripPreamble` removes only the leading run of preamble user turns. Similar turns later in the conversation are kept.
- `isPreambleTurn` returns `false` if anything real is left after stripping, so a log with a genuine question after the preamble is not discarded.

### Test Updates

- `libs/__tests__/unit/classify-file.unit.spec.ts` (+339): added `describe` blocks for `isPreambleTurn`, `stripPreamble`, and `classifyConversation（プリアンブル除去）`, each covering 正常系 / 異常系 / エッジケース. New IDs include `T-PF-PR-01..03` and `T-PF-SP-01..03`, plus cases under `T-PF-CF-*` and `T-PF-UC-*`.
- `modules/__tests__/unit/prefilter.unit.spec.ts` (`5eb44346`): extended the `isSystemOnlyMessage` ID range to `T-PF-IS-05` and added `T-PF-IS-05-01/02/03`, which check that `<recommended_plugins>`, `<INSTRUCTIONS>`, and `<environment_context>` each return `true`.

### Removed

None. Every change is an addition or an in-place edit.

## Change Type (optional)

Select all that apply:

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

No GitHub issue. Tracked in beads as `cle-cs4` (bug, P2).

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists) — unit suite only, see Additional Notes
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files — the new patterns live in `constants/patterns/*.constants.ts` and are used by `libs/classify-file.ts`

## Breaking Change

None. The signature of `classifyConversation` is unchanged, and `isPreambleTurn` and `stripPreamble` are new exports. Only Codex logs that start with pure preamble turns behave differently.

## Additional Notes

Verified:

- `deno task test:unit` — `ok | 202 passed (4080 steps) | 0 failed`
- `dprint check` — no diff

Not yet verified:

- The full `deno task test` suite has not been run. Only the unit suite was executed.
- `/filter-chatlogs` has not been run against the real 1021-file corpus. The acceptance criterion "1021 files are discarded at prefilter" is backed by unit tests only.
