### PR TITLE
config(textlint): require spaces around inline markup in Japanese text

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -19,3 +19,6 @@
 
 ## Releases
 releases/**
+
+## Chatlogs
+chatlogs/**

--- a/configs/textlintrc.yaml
+++ b/configs/textlintrc.yaml
@@ -38,8 +38,18 @@ rules:
       space:
         - alphabets
         - numbers
-    ja-space-around-code: true
-    ja-space-around-strong: true
+    ja-space-around-code:
+      before: true
+      after: true
+    ja-space-around-link:
+      before: true
+      after: true
+    ja-space-around-strong:
+      before: true
+      after: true
+    ja-space-around-emphasis:
+      before: true
+      after: true
   "@textlint-ja/no-synonyms": true
   common-misspellings: true
   no-mixed-zenkaku-and-hankaku-alphabet: true


### PR DESCRIPTION
## Overview

**Summary**
Change four `preset-ja-spacing` rules to the `before` / `after` object form, and add
`ja-space-around-link` and `ja-space-around-emphasis`.

**Background / Motivation**
This branch continues the textlint work from #407, which fixed two rule names but left the rules on
their preset defaults.

Note for reviewers: this change reverses the spacing policy. It does not just make it explicit.
The bare `true` form and the `before: true` / `after: true` form mean opposite things for these
rules. `true` forbids spaces around the markup; the object form requires them.

The repository's Japanese Markdown is written without those spaces, so 19 lines that passed before
now fail. See Additional Notes.

## Changes

### Core Changes

- `configs/textlintrc.yaml`, inside `preset-ja-spacing`:
  - `ja-space-around-code`: `true` → `before: true` / `after: true`
  - `ja-space-around-strong`: `true` → `before: true` / `after: true`
  - `ja-space-around-link`: added, `before: true` / `after: true`
  - `ja-space-around-emphasis`: added, `before: true` / `after: true`

The two added keys were already active at their preset default of `true`. Adding them explicitly
reverses them in the same way as the two existing keys.

### Test Updates

None. This branch touches no test files.

### Removed

Nothing.

## Change Type (optional)

- [x] Configuration

## Related Issues

> N/A

No commit on this branch references a GitHub issue. As noted in #407, the branch prefix `task-374`
does not refer to issue #374, which is an unrelated merged PR about `run-ai` JSON output.

## Checklist

- [x] Formatting passes — `dprint check`
- [ ] Lint checks pass — `pnpm run lint:text` reports 19 new `ja-space-around-strong` errors under
      `skills/`. See Additional Notes.
- [x] Tests pass — not run; this branch changes no application code
- [x] Documentation updated — not applicable
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined

## Breaking Change

None at runtime. This is a lint-policy change only. No application code or output is affected.

## Additional Notes

### 1. Why the object form reverses the rule

From `textlint-rule-ja-space-around-strong@3.0.2`:

```js
const defaultOptions = { before: false, after: false };
const allowBeforeSpace = options.before || defaultOptions.before;
```

`true` is not an object, so `options.before` is `undefined` and the rule falls back to `false`,
which is the "no space" policy. The object form sets it to `true`, which is the "space required"
policy.

Tested with a fixture holding both styles, using a config containing only the preset:

| Config                                      | Line flagged                     |
| ------------------------------------------- | -------------------------------- |
| `ja-space-around-strong: true`              | `これは **強調** のテストです。` |
| `ja-space-around-strong: before/after true` | `これは**強調**のテストです。`   |

The two configs flag opposite lines.

### 2. 19 existing lines now fail

`README.md`, `CLAUDE.md`, and `docs/` stay clean. The only error there is a pre-existing
`sentence-length` one in `README.md`, unchanged by this branch.

All 19 new errors are `ja-space-around-strong`:

| File                                       | Errors |
| ------------------------------------------ | ------ |
| `skills/export-chatlogs/SKILL.md`          | 5      |
| `skills/filter-chatlogs/SKILL.md`          | 4      |
| `skills/classify-chatlogs/SKILL.md`        | 2      |
| `skills/set-frontmatter/SKILL.md`          | 2      |
| `skills/setup-chatlogs/SKILL.md`           | 2      |
| `skills/normalize-chatlogs/SKILL.md`       | 1      |
| `skills/normalize-chatlogs/**/fixtures/**` | 3      |

Example, `skills/classify-chatlogs/SKILL.md:24`:

```markdown
  - AI に渡されるのは**キー（プロジェクト名）のみ**
```

Three questions for reviewers:

1. Is the reversal intended? The commit message describes setting `before` and `after`
   "separately", which reads as a clarification rather than a policy change. If the goal was to
   keep the current no-space style and only make it explicit, the correct form is `before: false` /
   `after: false`, and this branch does the opposite.
2. If it is intended, fix the 19 lines here or in a follow-up? All 19 are fixable with
   `textlint --fix`.
3. Should test fixtures be linted at all? Three of the 19 are fixture data. Editing them to satisfy
   a prose linter may change what the tests assert.

### 3. Currently latent, since `lint:text` is not in CI

`pnpm run lint:text` takes explicit file arguments and no workflow in `.github/workflows/` calls it,
so these errors will not fail CI. They appear only when the script is run manually on matching
paths.

Two pre-existing gaps, not introduced here:

- `pnpm run lint:text README.md "docs/**/*.md"` skips `docs/.deckrd/README.md`, the only file under
  `docs/`, because the glob does not match dotted directories. That command effectively lints
  `README.md` alone.
- With the `lint:markdown` no-op described in #407, repository Markdown has no enforced lint
  coverage in CI from either script.
