### PR TITLE
config(hooks): sync skill assets on pre-commit and diff by content

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,7 +23,38 @@ pre-commit:
       skip:
         - empty
 
+    # regenerate the distributable skill assets and stage them alongside the
+    # sources they came from, so the sync cannot be forgotten. the glob limits
+    # this to commits that touch a sync source (see SYNC_ENTRIES in the script);
+    # every other commit skips it.
+    #
+    # the explicit git add is required: the regenerated files are not among the
+    # staged files handed to the command, so stage_fixed would not pick them up.
+    # adding the destination as a whole also stages deletions, which is what
+    # makes a file removed from a source disappear from the distribution.
+    #
+    # --check-staged runs first, and the order is the point: the sync reads the
+    # working tree, not the index, and lefthook does not stash unstaged changes.
+    # so a commit that stages one source while another source has unstaged edits
+    # would bake the unstaged edits into the distribution while leaving the source
+    # change out, and only pre-push would notice. running the check after the sync
+    # would reject the commit with the distribution already rewritten.
+    #
+    # the glob stays as it is: a commit that stages no source never syncs, so it
+    # has nothing to check either.
+    skill-assets-sync:
+      glob:
+        - ".config/chatlog-exporter/**"
+        - "deno.json"
+        - "skills/_cle-libs/**"
+      run: bash ./scripts/sync-skill-assets.sh --check-staged && bash ./scripts/sync-skill-assets.sh && git add -- skills/setup-chatlogs/assets
+
 # verify the distributable skill assets are regenerated from their sources.
+# kept as the final gate even though pre-commit now syncs automatically: that
+# hook does not fire on a rebase replay or under --no-verify, and a pathspec
+# commit builds its tree from the pathspec rather than the index, so the staged
+# distribution is left out. a stale distribution can still reach a commit
+# without passing through the sync.
 # reads the committed tree, not the working tree: regenerating the assets without
 # committing them would otherwise pass here and let the drift reach the remote.
 pre-push:

--- a/scripts/__tests__/unit/sync-skill-assets.unit.spec.sh
+++ b/scripts/__tests__/unit/sync-skill-assets.unit.spec.sh
@@ -1,7 +1,7 @@
 # src: ./scripts/__tests__/unit/sync-skill-assets.unit.spec.sh
 # @(#) : Unit tests for scripts/sync-skill-assets.sh
 #        対象: usage / parse_args / resolve_repo_root / copy_tree /
-#              run_sync / run_check / run_check_head
+#              run_sync / run_check / run_check_head / run_check_staged
 #
 # Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
 #
@@ -31,9 +31,12 @@ Describe 'sync-skill-assets.sh'
       It '[Normal] T-SSA-US-01: 全オプションを表示する'
         # --force は削除済み。ヘルプに載っていると、実装が受理しないオプションを
         # 利用者に案内することになるため、載らないことも併せて確かめる。
+        # --check は書式行の [--check] で確かめる。素の '--check' だと
+        # --check-head / --check-staged の前方一致でも通ってしまい、--check 自体が
+        # ヘルプから消えても気づけない。
         When call usage
         The status should be success
-        The output should include '--check'
+        The output should include '[--check]'
         The output should include '--help'
         The output should not include '--force'
       End
@@ -50,6 +53,15 @@ Describe 'sync-skill-assets.sh'
         When call usage
         The status should be success
         The output should include 'scripts/sync-skill-assets.sh'
+      End
+
+      It '[Normal] T-SSA-US-04: --check-staged を案内する'
+        # 実装が受理するオプションはヘルプに載っていなければ利用者から見えない。
+        # 書式行にも載っていなければ、起動方法として読み取れない。
+        When call usage
+        The status should be success
+        The output should include '--check-staged'
+        The output should include '[--check-staged]'
       End
     End
   End
@@ -77,6 +89,12 @@ Describe 'sync-skill-assets.sh'
       It '[Normal] T-SSA-PA-10: --check-head → check-head'
         When call parse_args --check-head
         The output should equal 'check-head'
+        The status should be success
+      End
+
+      It '[Normal] T-SSA-PA-15: --check-staged → check-staged'
+        When call parse_args --check-staged
+        The output should equal 'check-staged'
         The status should be success
       End
     End
@@ -136,6 +154,38 @@ Describe 'sync-skill-assets.sh'
         The output should equal 'check-head'
         The status should be success
       End
+
+      It '[Edge] T-SSA-PA-16: --check は --check-staged より優先される（check-staged が後）'
+        # 併記されたときは検査範囲の広いほうを採る。--check-staged はソースの git 状態だけを
+        # 見る最も狭い検査であり、配布物を一切見ないため最下位。
+        When call parse_args --check --check-staged
+        The output should equal 'check'
+        The status should be success
+      End
+
+      It '[Edge] T-SSA-PA-17: --check は --check-staged より優先される（check-staged が先）'
+        # 隣接する境界（check 対 check-staged）だけは両方の順序で確かめる。
+        # 全オプションを読んでから判定するため、指定順に依存しない。
+        When call parse_args --check-staged --check
+        The output should equal 'check'
+        The status should be success
+      End
+
+      It '[Edge] T-SSA-PA-18: --check-head は --check-staged より優先される'
+        # check-head 対 check-staged は check 経由で推移的に定まる組であり、
+        # 既存 T-SSA-PA-09 と同様に片方の順序で足りる。
+        When call parse_args --check-staged --check-head
+        The output should equal 'check-head'
+        The status should be success
+      End
+
+      It '[Edge] T-SSA-PA-19: --help は --check-staged より優先される'
+        # help 対 check-staged も推移的に定まる組。help は何も検査せず案内するだけなので、
+        # 併記されたら常に help が勝つ。
+        When call parse_args --check-staged --help
+        The output should equal 'help'
+        The status should be success
+      End
     End
   End
 
@@ -179,17 +229,155 @@ Describe 'sync-skill-assets.sh'
         The path "${repo}/out/libs/file-io/path-utils.ts" should be exist
         The output should equal ''
       End
+
+      It '[Normal] T-SSA-CT-03: 内容が同じファイルは書き換えない'
+        # 宛先を作り直すのではなくファイル単位で更新する根拠。同一内容のファイルに
+        # 触らないので、同期が生む変更は実際に差分のあるファイルだけに限られる。
+        # 判定は mtime ではなく内容で行う: git は mtime を記録せず clone や rebase が
+        # 操作時刻で上書きするため、宛先の方が新しく見える状態は普通に起こりうる。
+        keep_unchanged_mtime() {
+          copy_tree "${repo}/skills/_cle-libs" "${repo}/out" || return 1
+          touch -t 202001010000 "${repo}/out/libs/file-io/path-utils.ts"
+          local before after
+          before="$(stat -c %Y "${repo}/out/libs/file-io/path-utils.ts")"
+          copy_tree "${repo}/skills/_cle-libs" "${repo}/out" || return 1
+          after="$(stat -c %Y "${repo}/out/libs/file-io/path-utils.ts")"
+          [[ "$before" == "$after" ]] || return 1
+          echo 'untouched'
+        }
+        When call keep_unchanged_mtime
+        The status should be success
+        The output should equal 'untouched'
+      End
+
+      It '[Normal] T-SSA-CT-04: 内容が異なるファイルは書き換える'
+        # ファイル単位の更新に切り替えても、差分のあるファイルは必ず直る。
+        # mtime 判定ならここで取りこぼす（宛先の方が新しいため）。
+        BeforeCall 'copy_tree "${repo}/skills/_cle-libs" "${repo}/out"; echo drift >"${repo}/out/libs/file-io/path-utils.ts"; touch -t 203001010000 "${repo}/out/libs/file-io/path-utils.ts"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The contents of file "${repo}/out/libs/file-io/path-utils.ts" should equal 'export const noop = 0;'
+      End
     End
 
     Describe 'When: エッジケース'
       It '[Edge] T-SSA-CT-02: 宛先に残っていた古いファイルを消す'
-        # tar の展開は上書きするだけで消さないため、事前削除が無いと
+        # ファイル単位の更新は上書きするだけで消さないため、明示的な削除が無いと
         # 削除済みソースの残骸が配布物に残り続ける。
         BeforeCall 'mkdir -p "${repo}/out"; echo stale >"${repo}/out/stale.ts"'
         When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
         The status should be success
         The path "${repo}/out/stale.ts" should not be exist
         The path "${repo}/out/libs/file-io/path-utils.ts" should be exist
+      End
+
+      It '[Edge] T-SSA-CT-05: ソースに無いディレクトリを消す'
+        # ファイルだけ消すと空ディレクトリが残り、diff -r が片側だけの
+        # ディレクトリを差分として報告して検査が永久に失敗する。
+        BeforeCall 'mkdir -p "${repo}/out/gone/deep"; echo stale >"${repo}/out/gone/deep/stale.ts"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out/gone" should not be exist
+        The path "${repo}/out/libs/file-io/path-utils.ts" should be exist
+      End
+
+      It '[Edge] T-SSA-CT-06: ソース側の空ディレクトリを複製する'
+        # ファイルを頼りにディレクトリを作ると、ソースの空ディレクトリが宛先に
+        # 現れず diff -r が差分として報告する。git は空ディレクトリを追跡しないが
+        # 作業ツリーには存在しうる。
+        BeforeCall 'mkdir -p "${repo}/skills/_cle-libs/empty-dir"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out/empty-dir" should be directory
+      End
+
+      It '[Edge] T-SSA-CT-07: 宛先がディレクトリでもファイル同期元を置ける'
+        # run_check は 3 つの同期元を同じ一時パスに順に複製する。2 番目が
+        # deno.json（ファイル）なので、1 番目のディレクトリが残った宛先に
+        # ファイルを置く場面が必ず通る。ファイル単位更新は種類の違う宛先を
+        # 上書きできないため、この差し替えが検査の成立条件になる。
+        BeforeCall 'mkdir -p "${repo}/out/leftover"'
+        When call copy_tree "${repo}/deno.json" "${repo}/out"
+        The status should be success
+        The path "${repo}/out" should be file
+        The contents of file "${repo}/out" should equal '{"tasks":{}}'
+      End
+
+      It '[Edge] T-SSA-CT-08: 宛先がファイルでもディレクトリ同期元を置ける'
+        # T-SSA-CT-07 の逆順。run_check の 3 番目は _cle-libs（ディレクトリ）で、
+        # 2 番目が残したファイルが宛先に居る。
+        BeforeCall 'echo leftover >"${repo}/out"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out" should be directory
+        The path "${repo}/out/libs/file-io/path-utils.ts" should be exist
+      End
+
+      It '[Edge] T-SSA-CT-09: 宛先にディレクトリが残っていてもネストしたファイルを置ける'
+        # T-SSA-CT-07 は $dest 自身の種別違いだが、こちらはツリー内部のネストした
+        # 相対パス（libs/file-io/path-utils.ts）で種別が食い違う場面。前回の同期時に
+        # ディレクトリだった名前が今はファイルなので、宛先には残骸のディレクトリが
+        # 居る。ファイル単位更新は種類の違う宛先を上書きできないため、コピー前に
+        # 取り除かないと 1 回目の同期は成功を報告したままファイルを置き損ねる。
+        BeforeCall 'mkdir -p "${repo}/out/libs/file-io/path-utils.ts"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out/libs/file-io/path-utils.ts" should be file
+        The contents of file "${repo}/out/libs/file-io/path-utils.ts" should equal 'export const noop = 0;'
+        The stderr should equal ''
+      End
+
+      It '[Edge] T-SSA-CT-10: 宛先にファイルが残っていてもネストしたディレクトリを置ける'
+        # T-SSA-CT-09 の逆向き。T-SSA-CT-08 は $dest 自身の種別違いだが、こちらは
+        # ツリー内部のネストした相対パス（libs/file-io）で種別が食い違う場面。前回の
+        # 同期時にファイルだった名前が今はディレクトリなので、宛先には残骸のファイルが
+        # 居る。ディレクトリは種類の違う宛先の上に作れないため、作る前に取り除かないと
+        # 同期はツリーの複製を最後まで終えられない。
+        BeforeCall 'mkdir -p "${repo}/out/libs"; echo leftover >"${repo}/out/libs/file-io"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out/libs/file-io" should be directory
+        The path "${repo}/out/libs/file-io/path-utils.ts" should be file
+        The contents of file "${repo}/out/libs/file-io/path-utils.ts" should equal 'export const noop = 0;'
+      End
+
+      It '[Edge] T-SSA-CT-11: 祖先パスに残骸ファイルがあってもその配下のツリー全体を作れる'
+        # T-SSA-CT-10 の残骸ファイルはソース側で末端のディレクトリ（libs/file-io）に
+        # あたるため、取り除いた後にその配下へ作るものが無い。こちらは残骸ファイルが
+        # これから作る相対パスの祖先（libs）に居る場面で、これを取り除けて初めて配下の
+        # libs/file-io とその中のファイルまで作れる。ディレクトリ一覧は整列済みなので
+        # 祖先が子孫より先に処理される、という実装コメントの根拠を確かめるケース。
+        BeforeCall 'mkdir -p "${repo}/out"; echo leftover >"${repo}/out/libs"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out/libs" should be directory
+        The path "${repo}/out/libs/file-io" should be directory
+        The path "${repo}/out/libs/file-io/path-utils.ts" should be file
+        The contents of file "${repo}/out/libs/file-io/path-utils.ts" should equal 'export const noop = 0;'
+      End
+
+      It '[Edge] T-SSA-CT-12: 両方向の種別衝突を 1 回の実行で解消する'
+        # T-SSA-CT-09 〜 T-SSA-CT-11 は 1 回の実行で片方向の衝突しか通らない。
+        # 2 つのガードはディレクトリ側ループとファイル側ループという別の場所に
+        # 居て順番も固定なので、「両方が 1 回のパスで噛み合う」ことはどちらの
+        # 単独ケースからも導けない。それを唯一証明するケース。
+        # ソースに types/x.types.ts を足すのは、既存パスだけでは逆向きを作れない
+        # ため（ソースのディレクトリ libs・libs/file-io は唯一のソースファイルの
+        # 祖先で、そこをファイルにすると順向きの衝突が作れなくなる）。
+        # 宛先ファイル↔ソースディレクトリ: out/types
+        # 宛先ディレクトリ↔ソースファイル: out/libs/file-io/path-utils.ts
+        # 併せて、両ガードが動いた後も残骸の刈り取りが走ることを out/other で確かめる。
+        BeforeCall 'mkdir -p "${repo}/skills/_cle-libs/types"; echo "export {};" >"${repo}/skills/_cle-libs/types/x.types.ts"; mkdir -p "${repo}/out/libs/file-io/path-utils.ts"; echo leftover >"${repo}/out/types"; mkdir -p "${repo}/out/other"; echo leftover >"${repo}/out/other/stale-dir"'
+        When call copy_tree "${repo}/skills/_cle-libs" "${repo}/out"
+        The status should be success
+        The path "${repo}/out/libs/file-io" should be directory
+        The path "${repo}/out/libs/file-io/path-utils.ts" should be file
+        The contents of file "${repo}/out/libs/file-io/path-utils.ts" should equal 'export const noop = 0;'
+        The path "${repo}/out/types" should be directory
+        The path "${repo}/out/types/x.types.ts" should be file
+        The contents of file "${repo}/out/types/x.types.ts" should equal 'export {};'
+        The path "${repo}/out/other" should not be exist
+        The stderr should equal ''
       End
     End
   End
@@ -408,6 +596,160 @@ Describe 'sync-skill-assets.sh'
         When call head_check_preserves_worktree
         The status should be success
         The output should equal 'drift'
+      End
+    End
+  End
+
+  Describe 'run_check_staged'
+    # 同期は作業ツリーから配布物を生成するが、lefthook は未ステージ変更を stash しない。
+    # そのため「ソース A をステージし、ソース B に未ステージ編集がある」コミットは、
+    # ステージしていない B 由来の配布物だけが入り、B のソース変更は入らない状態になる。
+    # コミット単体で整合しないため、後から pre-push の --check-head が原因から遠い形で
+    # push を拒否する。それをコミット時点で弾く検査。
+
+    Describe 'When: 正常系'
+      It '[Normal] T-SSA-RCS-01: 全ソースがコミット済みでクリーンなら成功する'
+        # 検査の基準点。index と作業ツリーが一致しているなら通さなければならない。
+        # stderr の空は主張しない: BeforeCall の git add -A が環境次第で
+        # 改行変換の warning を出しうるため、検査と無関係な理由で落ちる形は採らない。
+        BeforeCall 'commit_fixture_repo "$repo"'
+        When call run_check_staged "$repo"
+        The status should be success
+        The output should include 'no unstaged changes'
+        The stderr should not include 'unstaged changes'
+      End
+
+      It '[Normal] T-SSA-RCS-02: ソースがステージ済みのみなら成功する'
+        # pre-commit における通常のケース。T-SSA-RCS-01 とはクリーンかステージ済みかで
+        # 主張が別であり、こちらで失敗する実装は全てのコミットを止めてしまう。
+        # porcelain は "M " で、2 文字目ではなく 1 文字目を見る実装がここで落ちる。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "agent: codex" >"${repo}/.config/chatlog-exporter/config.yaml"; git -C "$repo" add -- .config/chatlog-exporter'
+        When call run_check_staged "$repo"
+        The status should be success
+        The output should include 'no unstaged changes'
+      End
+    End
+
+    Describe 'When: 異常系'
+      It '[Error] T-SSA-RCS-03: 1 つのソースに未ステージ編集があれば失敗しそのパスを報告する'
+        # porcelain " M"。報告はエントリ名ではなくパス単位でなければ、どのファイルを
+        # ステージすればよいのか利用者に伝わらない。対処方法も併せて出す。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "agent: codex" >"${repo}/.config/chatlog-exporter/config.yaml"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include '.config/chatlog-exporter/config.yaml'
+        The stderr should include 'unstaged changes'
+        # 'stage' だけでは "unstaged changes" の部分一致で満たされてしまい、対処方法の行を
+        # 消しても気づけない。Hint: 行にしか現れない語で固定する。
+        The stderr should include 'Hint:'
+        The stderr should include 'git stash push'
+      End
+
+      It '[Error] T-SSA-RCS-04: A をステージし B が未ステージなら失敗する'
+        # 本件の存在理由そのもの（PR #413 の再現）。deno.json は "M " なので報告に
+        # 出してはならない。出るなら、ステージ済みの変更まで巻き込んでいる。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "{\"tasks\":{\"x\":\"y\"}}" >"${repo}/deno.json"; git -C "$repo" add -- deno.json; echo "agent: codex" >"${repo}/.config/chatlog-exporter/config.yaml"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include '.config/chatlog-exporter/config.yaml'
+        The stderr should not include 'deno.json'
+      End
+
+      It '[Error] T-SSA-RCS-05: 未ステージの削除があれば失敗する'
+        # porcelain " D"。同期は削除を反映して配布物からもファイルを消すが、ソースの
+        # 削除はステージされていないためコミットに入らない。配布物だけが消えた
+        # コミットになる。
+        BeforeCall 'commit_fixture_repo "$repo"; rm "${repo}/skills/_cle-libs/libs/file-io/path-utils.ts"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include 'path-utils.ts'
+      End
+
+      It '[Error] T-SSA-RCS-06: ソース配下の追跡外の新規ファイルがあれば失敗する'
+        # porcelain "??"。git diff 単独では追跡外ファイルが見えないため、
+        # git status --porcelain を選んだ根拠になるケース。copy_tree は作業ツリーを
+        # 読むので、このファイルは配布物に入るがソース側はコミットに入らない。
+        # 新規ファイルは既に追跡されている dics/ の下に置く: ディレクトリ全体が
+        # 追跡外だと porcelain が "?? <dir>/" に畳み、ファイルパスの主張が成立しない。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "extra" >"${repo}/.config/chatlog-exporter/dics/extra.dic"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include 'dics/extra.dic'
+      End
+
+      It '[Error] T-SSA-RCS-07: ステージ済みの上にさらに未ステージ編集があれば失敗する'
+        # porcelain "MM"。「そのソースがステージされているか」だけを見る実装はここを
+        # 取り落とす。"M "（T-SSA-RCS-02）とは別の同値クラスである。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "{\"tasks\":{\"v\":\"1\"}}" >"${repo}/deno.json"; git -C "$repo" add -- deno.json; echo "{\"tasks\":{\"v\":\"2\"}}" >"${repo}/deno.json"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include 'deno.json'
+      End
+
+      It '[Error] T-SSA-RCS-08: 2 つのソースが未ステージなら両方を報告する'
+        # 最初の 1 件で return 1 する実装を排除する。1 回の実行で全て直せなければ、
+        # 利用者はコミットのたびに残りを 1 件ずつ知らされることになる。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "agent: codex" >"${repo}/.config/chatlog-exporter/config.yaml"; echo "{\"tasks\":{\"x\":\"y\"}}" >"${repo}/deno.json"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include '.config/chatlog-exporter/config.yaml'
+        The stderr should include 'deno.json'
+      End
+    End
+
+    Describe 'When: エッジケース'
+      It '[Edge] T-SSA-RCS-09: ソース外の未ステージ変更では失敗しない'
+        # 同期ソースと無関係なコミットまで止める実装を排除する。追跡済みの変更（" M"）と
+        # 追跡外の新規（"??"）を両方置くのは、pathspec を渡さずリポジトリ全体の
+        # git status を見ている実装をどちらの形でも捕まえるため。
+        BeforeCall 'echo "# readme" >"${repo}/README.md"; commit_fixture_repo "$repo"; echo "# edited" >"${repo}/README.md"; mkdir -p "${repo}/docs"; echo "note" >"${repo}/docs/note.md"'
+        When call run_check_staged "$repo"
+        The status should be success
+        The output should include 'no unstaged changes'
+        The stderr should not include 'unstaged changes'
+      End
+
+      It '[Edge] T-SSA-RCS-10: 検査は作業ツリーを書き換えない'
+        # 却下した「index をスナップショットする」案の混入を防ぐ。git stash を使う実装は
+        # ここで未ステージ編集を巻き上げてしまい落ちる。
+        # git status は stat キャッシュを更新しうるので、index のバイト列ではなく
+        # git status --porcelain の出力の一致をもって読み取り専用を示す（T-SSA-RCH-07 と同じ形）。
+        staged_check_preserves_worktree() {
+          local before after
+          commit_fixture_repo "$repo" || return 1
+          echo 'agent: codex' >"${repo}/.config/chatlog-exporter/config.yaml"
+          before="$(git -C "$repo" status --porcelain)"
+          run_check_staged "$repo" >/dev/null 2>&1 || true
+          after="$(git -C "$repo" status --porcelain)"
+          [[ "$before" == "$after" ]] || return 1
+          cat "${repo}/.config/chatlog-exporter/config.yaml"
+        }
+        When call staged_check_preserves_worktree
+        The status should be success
+        The output should equal 'agent: codex'
+      End
+
+      It '[Edge] T-SSA-RCS-11: コミットが無く全てステージ済みなら成功する'
+        # 検査が HEAD 基準ではなく index 基準であることの主張。git diff HEAD で
+        # 実装すると HEAD が無いここで落ちる。commit_fixture_repo は呼ばない
+        # （git add は identity 設定を必要としない）。porcelain は全て "A "。
+        # HEAD 無しで失敗する run_check_head（T-SSA-RCH-04）と対照的である。
+        BeforeCall 'git -C "$repo" add -A'
+        When call run_check_staged "$repo"
+        The status should be success
+        The output should include 'no unstaged changes'
+      End
+
+      It '[Edge] T-SSA-RCS-12: __tests__ 配下の未ステージ編集でも失敗する'
+        # 意図的な過剰検出。__tests__ は配布物に入らないのでこの編集は配布物を
+        # 変化させないが、それでも失敗させる。除外規則を git のパスに対して
+        # 再実装すると EXCLUDE_NAME / find -prune と二重定義になり、同ファイルの
+        # コメントが繰り返し禁じている事態そのものになる。過剰検出は安全側にしか
+        # 外れず、対処方法は検査が既に出しているメッセージそのものである。
+        BeforeCall 'commit_fixture_repo "$repo"; echo "export const edited = 1;" >"${repo}/skills/_cle-libs/__tests__/unit/noop.unit.spec.ts"'
+        When call run_check_staged "$repo"
+        The status should be failure
+        The stderr should include 'noop.unit.spec.ts'
       End
     End
   End

--- a/scripts/sync-skill-assets.sh
+++ b/scripts/sync-skill-assets.sh
@@ -33,7 +33,7 @@ readonly EXCLUDE_NAME="__tests__"
 # @description Print usage to stdout
 usage() {
   cat <<'EOF'
-Usage: bash scripts/sync-skill-assets.sh [--check] [--check-head] [--help]
+Usage: bash scripts/sync-skill-assets.sh [--check] [--check-head] [--check-staged] [--help]
 
 Regenerates the distributable copies under skills/setup-chatlogs/ from their
 sources:
@@ -48,6 +48,7 @@ as a whole, so files deleted from a source disappear from the distribution too.
 Options:
   --check       Report whether the distribution is out of date; write nothing
   --check-head  Same as --check, but against the committed HEAD tree
+  --check-staged  Report whether a sync source has changes that are not staged; write nothing
   --help        Show this help
 EOF
 }
@@ -57,22 +58,27 @@ EOF
 #
 # Kept free of side effects so the option rules can be verified on their own.
 # Every option is read before a mode is chosen, so the priority is
-# help > check-head > check no matter what order the options are written in.
+# help > check-head > check > check-staged no matter what order the options are
+# written in.
 # check-head outranks check because it verifies the wider surface: the tree that
 # would actually reach the remote rather than the working tree.
+# check-staged ranks last by the same measure, being the narrowest surface: it
+# reads only the git state of the sources and never looks at the distribution
+# at all.
 #
-# @arg $@ string Command line options (--check, --check-head, --help)
-# @stdout One of: help, check-head, check, "" (empty, plain sync)
+# @arg $@ string Command line options (--check, --check-head, --check-staged, --help)
+# @stdout One of: help, check-head, check, check-staged, "" (empty, plain sync)
 # @return 0 If the options are valid
 # @return 1 If an option is unknown
 parse_args() {
-  local help=false check=false check_head=false
+  local help=false check=false check_head=false check_staged=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
     --help) help=true ;;
     --check) check=true ;;
     --check-head) check_head=true ;;
+    --check-staged) check_staged=true ;;
     *)
       echo "Error: unknown option: $1" >&2
       return 1
@@ -87,6 +93,8 @@ parse_args() {
     echo "check-head"
   elif [[ "$check" == "true" ]]; then
     echo "check"
+  elif [[ "$check_staged" == "true" ]]; then
+    echo "check-staged"
   else
     echo ""
   fi
@@ -100,34 +108,98 @@ resolve_repo_root() {
 }
 
 ##
+# @description List paths of one type under a tree, relative to its root
+#
+# The listing every other step is built on, so the exclusion rule lives in one
+# place. Sources are listed pruned (a matching directory drops along with
+# everything below it); destinations are listed whole, because a __tests__
+# directory that leaked into a destination is exactly what has to be found and
+# removed rather than skipped.
+#
+# @arg $1 string Tree root
+# @arg $2 string find type letter: f for files, d for directories
+# @arg $3 string pruned to drop __tests__ branches, whole to keep everything
+# @stdout One relative path per line, without the leading ./ and without .
+list_tree_paths() {
+  local base="$1" type="$2" scope="$3"
+
+  if [[ "$scope" == "pruned" ]]; then
+    (cd "$base" && find . -name "$EXCLUDE_NAME" -prune -o -type "$type" -print)
+  else
+    (cd "$base" && find . -type "$type" -print)
+  fi | sed -e 's|^\./||' -e '/^\.$/d' | sort
+}
+
+##
 # @description Copy a source into a destination, dropping every __tests__ directory
 #
 # The single definition of "what the distribution should contain": both the sync
 # and the check go through here, so the two can never disagree about the
 # exclusion rule.
 #
-# The destination is removed first because tar only overlays; without this a file
-# deleted from the source would linger in the distribution forever.
+# Updates file by file rather than replacing the destination wholesale, so a sync
+# only ever touches the files that actually differ. rsync is not available in
+# this environment, so the three steps it would do are spelled out: mirror the
+# directories, refresh the files that differ, then remove what the source no
+# longer has.
 #
-# rsync is not available in this environment, so the exclusion rides on tar,
-# which prunes a matching directory along with everything below it.
+# The difference is decided by content (cmp), not by timestamp. git does not
+# record mtimes and clone, checkout and rebase stamp them with the time of the
+# operation, so a stale distribution file routinely looks newer than the source
+# it came from -- an mtime test would report success and leave the drift in
+# place, which is the exact failure this script exists to catch.
+#
+# Empty directories are mirrored too: the check compares whole trees, so a
+# directory present on one side only counts as drift.
+#
+# A node whose kind changed is resolved at any depth, not just at $dest itself:
+# a nested relative path can also be left over from an earlier sync as the other
+# kind of node, and file-by-file updating cannot overwrite across kinds.
 #
 # @arg $1 string Source file or directory
 # @arg $2 string Destination path
 # @return 0 If the copy succeeds
 copy_tree() {
-  local src="$1" dest="$2"
+  local src="$1" dest="$2" path
 
-  rm -rf -- "$dest"
-  mkdir -p -- "$(dirname "$dest")"
-
+  # A destination left over as the other kind of node cannot be updated in place.
   if [[ -f "$src" ]]; then
-    cp -f -- "$src" "$dest"
+    [[ -d "$dest" ]] && rm -rf -- "$dest"
+    mkdir -p -- "$(dirname "$dest")"
+    cmp -s -- "$src" "$dest" || cp -f -- "$src" "$dest"
     return 0
   fi
 
+  [[ -f "$dest" ]] && rm -f -- "$dest"
   mkdir -p -- "$dest"
-  tar --exclude="$EXCLUDE_NAME" -cf - -C "$src" . | tar -xf - -C "$dest"
+
+  while IFS= read -r path; do
+    # Leftover file under a path the source now has as a directory: drop it
+    # before mkdir, which cannot create a directory over an existing file. The
+    # listing is sorted, so an ancestor is cleared before its descendants are
+    # created and this one guard covers a file standing in for a whole subtree.
+    [[ -f "${dest}/${path}" ]] && rm -f -- "${dest:?}/${path}"
+    mkdir -p -- "${dest}/${path}"
+  done < <(list_tree_paths "$src" d pruned)
+
+  while IFS= read -r path; do
+    # Leftover directory under a path the source now has as a file: drop it
+    # before cmp, or cp lands the file inside it and the later pruning of stale
+    # nodes takes the whole thing away while the sync still reports success.
+    [[ -d "${dest}/${path}" ]] && rm -rf -- "${dest:?}/${path}"
+    cmp -s -- "${src}/${path}" "${dest}/${path}" || cp -f -- "${src}/${path}" "${dest}/${path}"
+  done < <(list_tree_paths "$src" f pruned)
+
+  while IFS= read -r path; do
+    rm -f -- "${dest:?}/${path}"
+  done < <(comm -13 <(list_tree_paths "$src" f pruned) <(list_tree_paths "$dest" f whole))
+
+  # Reverse lexicographic order is enough to reach the deepest directory first: a
+  # nested path shares its parent's prefix and is longer, so it always sorts after
+  # the parent and therefore comes first once reversed.
+  while IFS= read -r path; do
+    rm -rf -- "${dest:?}/${path}"
+  done < <(comm -13 <(list_tree_paths "$src" d pruned) <(list_tree_paths "$dest" d whole) | sort -r)
 }
 
 ##
@@ -256,8 +328,66 @@ run_check_head() {
 }
 
 ##
+# @description Report whether a sync source has changes that are not staged
+#
+# The pre-commit counterpart to run_check_head. The sync regenerates the
+# distribution from the working tree, and the hook does not stash unstaged
+# changes, so committing with source A staged and source B edited but unstaged
+# produces a commit carrying a distribution built from B's unstaged edit while
+# B's source change itself stays out. The commit does not agree with itself, and
+# the failure only surfaces later as a pre-push --check-head rejection far from
+# its cause. Rejecting it here turns that into an immediate, actionable message.
+#
+# Judged on git status --porcelain output rather than its exit status: git
+# returns 0 even for a pathspec that matches nothing, so the exit status carries
+# no verdict. The second column is the working-tree side, so a blank there means
+# the index already holds what the working tree has: "M " (staged only) is let
+# through, while " M", "MM", " D" and "??" are reported.
+#
+# Reports per path and accumulates instead of returning at the first offender,
+# so one run lists everything that has to be dealt with -- the same reason
+# run_check accumulates drift.
+#
+# @arg $1 string Repository root directory
+# @stdout A "no unstaged changes" report line when every source is staged
+# @return 0 If no sync source has unstaged changes
+# @return 1 If git status cannot be read or a source has unstaged changes
+run_check_staged() {
+  local base="$1"
+  local entry src line status_out dirty=0
+
+  for entry in "${SYNC_ENTRIES[@]}"; do
+    src="${entry%%|*}"
+
+    # git 自体の失敗を成功として通さない。読めなかったことは検査できなかったことである。
+    if ! status_out="$(git -C "$base" status --porcelain -- "$src")"; then
+      echo "Error: cannot read the git status of: ${src}" >&2
+      return 1
+    fi
+
+    # 空文字列に対して <<< は 1 行として回ってしまうため、ここで打ち切る。
+    [[ -n "$status_out" ]] || continue
+
+    while IFS= read -r line; do
+      # 2 文字目は作業ツリー側の列。空白なら index と作業ツリーは一致しているため見送る。
+      if [[ "${line:1:1}" != " " ]]; then
+        echo "Error: sync source has unstaged changes: ${line:3}" >&2
+        dirty=1
+      fi
+    done <<<"$status_out"
+  done
+
+  if [[ "$dirty" -ne 0 ]]; then
+    echo "Hint: stage them or set them aside (git stash push) before committing" >&2
+    return 1
+  fi
+
+  echo "Sync sources have no unstaged changes"
+}
+
+##
 # @description Main entry point
-# @arg $@ string Command line options (--check, --check-head, --help)
+# @arg $@ string Command line options (--check, --check-head, --check-staged, --help)
 # @return 0 If the distribution is synced or verified
 # @return 1 If the options are invalid, a source is missing, or the check fails
 main() {
@@ -282,6 +412,11 @@ main() {
 
   if [[ "$mode" == "check" ]]; then
     run_check "$repo_root"
+    return
+  fi
+
+  if [[ "$mode" == "check-staged" ]]; then
+    run_check_staged "$repo_root"
     return
   fi
 


### PR DESCRIPTION
## Overview

**Summary**
Sync the distributable skill assets on `pre-commit`, guard that sync with a staged-source check,
and make `copy_tree` update files by content instead of rebuilding the whole destination.

**Background / Motivation**
`skills/setup-chatlogs/assets` is generated from three sources: `.config/chatlog-exporter/**`,
`deno.json`, and `skills/_cle-libs/**` (see `SYNC_ENTRIES`). Until now the only check was the
`pre-push --check-head` gate. It can fail a push, but it cannot fix anything, so a contributor
who edited a source had to remember to run the sync by hand. Moving the sync to `pre-commit`
prevents the drift instead of just reporting it.

That move needed the second change. The old `copy_tree` deleted the destination and
re-expanded it with `tar`, so every sync rewrote every file. A hook that runs on each commit
should only touch files that really differ, so `copy_tree` now compares first.

The comparison uses file content, not timestamps. git does not record mtimes, and clone,
checkout and rebase set them to the time of the operation. A stale file in the distribution
often looks newer than its source, so an mtime check would pass and leave the drift in place.
`cmp -s` compares bytes instead.

The third change closes the gap that `pre-commit` syncing opens. The sync reads the working
tree, and lefthook does not stash unstaged changes, so staging one source while another source
holds unstaged edits would bake those unstaged edits into the distribution while leaving the
source change itself out of the commit. `--check-staged` rejects that combination before
anything is written.

## Changes

### Core Changes

**`scripts/sync-skill-assets.sh`** (+151 / -16)

- Add `list_tree_paths <base> <f|d> <pruned|whole>`, so the `__tests__` exclusion lives in one
  place. Sources are listed `pruned` (a matching directory drops with everything under it).
  Destinations are listed `whole`, because a `__tests__` directory that leaked into a
  destination has to be found and removed, not skipped.
- Rewrite `copy_tree` as four steps: mirror the source directories, copy only files whose
  content differs (`cmp -s`), delete files the source no longer has (`comm -13`), and delete
  directories the source no longer has (`comm -13` with `sort -r`, so the deepest path goes
  first).
- Mirror empty directories too. The check compares whole trees with `diff -r`, so a directory
  on one side only counts as drift.
- Resolve a destination node whose kind changed, **at any depth** — not only at `$dest` itself.
  A leftover file where the source now has a directory is removed before `mkdir` (which cannot
  create a directory over a file); a leftover directory where the source now has a file is
  removed before `cmp` (otherwise `cp` lands the file *inside* it, and the later stale-node
  pruning deletes the whole thing while the sync still reports success). Both listings are
  sorted, so an ancestor is cleared before its descendants are created, and a single file
  standing in for a whole subtree is handled by the same guard.
- Add `run_check_staged` and the `--check-staged` mode: report whether any sync source has
  changes that are not staged. It judges on `git status --porcelain` *output*, not its exit
  status — git returns 0 even for a pathspec matching nothing, so the status carries no
  verdict. The second column is the working-tree side, so `M ` (staged only) passes while
  ` M`, `MM`, ` D` and `??` are reported. Offenders are accumulated and reported per path
  rather than returning at the first one, the same way `run_check` accumulates drift.
- `parse_args` gains `--check-staged`. The priority is `help > check-head > check >
  check-staged`, independent of the order the options are written in: `check-staged` ranks last
  because it is the narrowest surface — it reads only the git state of the sources and never
  looks at the distribution at all.

**`lefthook.yml`** (+31)

- Add a `skill-assets-sync` command to `pre-commit`:
  `bash ./scripts/sync-skill-assets.sh --check-staged && bash ./scripts/sync-skill-assets.sh &&
  git add -- skills/setup-chatlogs/assets`. Its `glob` limits it to the three sync sources, so
  other commits skip it.
- The order matters and is the point: `--check-staged` runs **before** the sync. Running the
  check afterwards would reject the commit with the distribution already rewritten.
- Use an explicit `git add` instead of `stage_fixed`. The regenerated files are not among the
  staged files passed to the command, so `stage_fixed` would miss them. Adding the destination
  directory also stages deletions, which is how a file removed from a source disappears from
  the distribution.
- The `glob` stays as it is: a commit that stages no source never syncs, so it has nothing to
  check either.
- Keep the `pre-push --check-head` gate, with a comment explaining why (see Additional Notes).

### Test Updates

`scripts/__tests__/unit/sync-skill-assets.unit.spec.sh` (+345 / -3). One existing comment was
updated: the reason `T-SSA-CT-02` holds changed from "tar only overlays" to "per-file update
only overwrites". The assertion is unchanged.

`copy_tree`:

| ID | Kind | What it checks |
| -- | ---- | -------------- |
| `T-SSA-CT-03` | Normal | A file with the same content is not rewritten (mtime unchanged after a second sync) |
| `T-SSA-CT-04` | Normal | A file with different content is rewritten even when the destination mtime is set to 2030 |
| `T-SSA-CT-05` | Edge | A directory missing from the source is removed, so `diff -r` does not report an empty leftover |
| `T-SSA-CT-06` | Edge | An empty directory in the source is mirrored |
| `T-SSA-CT-07` | Edge | A file source replaces a directory destination (top level) |
| `T-SSA-CT-08` | Edge | A directory source replaces a file destination (top level) |
| `T-SSA-CT-09` | Edge | A nested file is placed even though a directory is left at that path |
| `T-SSA-CT-10` | Edge | A nested directory is placed even though a file is left at that path |
| `T-SSA-CT-11` | Edge | A leftover file on an *ancestor* path does not block creating the whole subtree under it |
| `T-SSA-CT-12` | Edge | Both kind-conflict directions are resolved in a single run |

`--check-staged`:

| ID | Kind | What it checks |
| -- | ---- | -------------- |
| `T-SSA-US-04` | Normal | Usage documents `--check-staged` |
| `T-SSA-PA-15` | Normal | `--check-staged` → `check-staged` |
| `T-SSA-PA-16` … `T-SSA-PA-19` | Edge | `check`, `check-head` and `help` each outrank `check-staged`, in both option orders |
| `T-SSA-RCS-01` / `-02` | Normal | A clean tree passes; sources that are staged only pass |
| `T-SSA-RCS-03` … `-08` | Error | One unstaged source, staged-A-with-unstaged-B, an unstaged deletion, an untracked file under a source, an unstaged edit on top of a staged one, and two unstaged sources reported together |
| `T-SSA-RCS-09` … `-12` | Edge | Unstaged changes *outside* the sources do not fail; the check writes nothing; a repository with no commits passes when everything is staged; an unstaged edit under `__tests__` still fails |

## Change Type (optional)

Select all that apply:

- [x] Feature
- [x] Bug fix
- [x] Test
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

Feature is checked for the new `--check-staged` mode. CI/CD is unchecked because lefthook runs
local git hooks and no workflow changed.

## Related Issues

> N/A

This PR does not close or relate to any issue. The `2rf` in the branch name
`task-2rf/hooks/update-pre-hooks` is reused from `cle-2rf` (the filter strip feature, already
closed) and is unrelated to this change. All 12 open issues are filter/strip or docs work.

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass — `dprint check` (exit 0), `pnpm run check:sh` (shfmt),
  `pnpm run lint:sh scripts/` (shellcheck). markdownlint, textlint and cspell were not run:
  no `.md` file is in this diff.
- [x] Tests pass — `pnpm run test:sh:all`: 147 examples, 0 failures. The
  `sync-skill-assets.unit.spec.sh` file alone: 64 examples, 0 failures. `pnpm run
  check:skill-assets` reports the distribution is up to date.
- [x] Documentation updated (for user-facing changes) — N/A, no user-facing change.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in
  implementation files — N/A (shell and YAML only). `list_tree_paths` was extracted so the
  `__tests__` rule exists in one place.

## Breaking Change

No runtime, CLI or API change. Two developer-facing changes, both limited to commits that stage
at least one of the three sync sources — commits touching none of them are unaffected.

1. **A commit can now be rejected.** Whenever the hook fires, `--check-staged` refuses the
   commit if *any* of the three sources has unstaged changes. Staging `deno.json` while holding
   an unrelated work-in-progress edit under `skills/_cle-libs/` blocks the commit, with a hint
   to stage the edit or set it aside with `git stash push`. This is the deliberate cost of
   rejecting rather than generating from an index snapshot (see Additional Notes).
2. **The commit is larger than what was staged by hand**, because it also carries the
   regenerated `skills/setup-chatlogs/assets`.

## Additional Notes

**Responses to the Codex review.** Both comments on `555d878432` are addressed by later commits
on this branch:

| Comment | Addressed by |
| ------- | ------------ |
| Build generated assets from the staged sources (`lefthook.yml`) | `ef621a4` (`run_check_staged`) + `67f5371` (run it before the sync). Of the two options suggested, rejecting the relevant unstaged changes was taken over generating from an index snapshot. `T-SSA-RCS-04` covers the staged-A / unstaged-B case directly. |
| Replace nested nodes whose type changed (`scripts/sync-skill-assets.sh`) | `4e05b4d` resolves both directions at any depth, covered by `T-SSA-CT-09` … `T-SSA-CT-12` (`1241a78`). |

**Why reject instead of snapshotting the index.** Generating from an index snapshot would need
a scratch checkout of the staged tree on every commit and would still leave the working tree
and the commit disagreeing about what the sources say. Rejecting keeps the commit
self-consistent and turns what would otherwise surface much later as a `pre-push --check-head`
rejection into an immediate, actionable message.

**Why `pre-push --check-head` stays.** `pre-commit` does not run on a rebase replay or under
`--no-verify`, and `git commit -- <path>` builds its tree from the pathspec instead of the
index, so the staged distribution is left out. A stale distribution can still reach a commit
without passing through the sync. `--check-head` reads the committed tree, not the working
tree, which is what makes it a real gate.

**Why not `rsync`.** It is not available in this environment, so the three things it would do
are written out by hand.

**Suggested review focus.**

- The `comm -13` deletion steps and the `sort -r` ordering in `copy_tree`. A nested path shares
  its parent's prefix and is longer, so it sorts after the parent and comes first once reversed.
  `T-SSA-CT-05` covers the nested case.
- The kind-conflict guards in `copy_tree`, and whether the sorted-listing argument really makes
  the ancestor case safe (`T-SSA-CT-11`).
- The column `run_check_staged` reads in `git status --porcelain`, and its decision to judge on
  output rather than exit status.
