### PR TITLE
feat(_cle-libs): add backup-aware file write and frontmatter equality

### DIFF
--- a/skills/_cle-libs/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_cle-libs/classes/ChatlogFrontmatter.class.ts
@@ -39,6 +39,25 @@ const _addTagHashes = (entries: FrontmatterFields): FrontmatterFields => {
   return { ...entries, tags: _prefixed };
 };
 
+/**
+ * frontmatter の 2 つの値が同一かを判定する。
+ *
+ * 文字列同士は `===`、配列同士は長さと各要素を順序どおり比較する。
+ * 型が異なる場合（`string` と `string[]`）は非同一とする。
+ *
+ * 型不一致の早期 return は意図の明示が目的であり、振る舞い上は冗長である。
+ * この行を削除しても後段の `a === b` が同じく `false` を返すため、
+ * 差異を観測できるテストは書けない（削除しても全テストが PASS する）。
+ * 判定順序を「型 → 配列 → スカラー」と読める形に保つために残している。
+ */
+const _valuesEqual = (a: string | string[] | undefined, b: string | string[] | undefined): boolean => {
+  if (Array.isArray(a) !== Array.isArray(b)) { return false; }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => item === b[index]);
+  }
+  return a === b;
+};
+
 export class ChatlogFrontmatter {
   private _entries: FrontmatterFields;
 
@@ -119,6 +138,13 @@ export class ChatlogFrontmatter {
   /** type / category / title の3フィールドがすべて充足しているか判定する。 */
   hasBaseFields(): boolean {
     return hasFrontmatterFields(this._entries, ['type', 'category', 'title']);
+  }
+
+  /** 他の `ChatlogFrontmatter` とキー集合・各値が同一かを判定する。キー順序は比較対象に含めない。 */
+  equals(other: ChatlogFrontmatter): boolean {
+    const _keys = Object.keys(this._entries);
+    if (_keys.length !== Object.keys(other._entries).length) { return false; }
+    return _keys.every((key) => _valuesEqual(this._entries[key], other._entries[key]));
   }
 
   toFrontmatter(fieldOrder: string[] = DEFAULT_ORDERED_FIELDS, opts?: { addTagHashes?: boolean }): string {

--- a/skills/_cle-libs/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
+++ b/skills/_cle-libs/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts
@@ -19,7 +19,7 @@ import { ChatlogError } from '../../ChatlogError.class.ts';
 // ─────────────────────────────────────────────
 /**
  * @description ChatlogFrontmatter クラスのユニットテストスイート。
- * get / set / remove / toFrontmatter および各コンストラクタ入力形式を網羅的に検証する。
+ * get / set / remove / equals / toFrontmatter および各コンストラクタ入力形式を網羅的に検証する。
  */
 describe('ChatlogFrontmatter', () => {
   /**
@@ -273,6 +273,129 @@ describe('ChatlogFrontmatter', () => {
         assertEquals(err.kind, tc.kind);
       });
     }
+  });
+
+  /**
+   * @description equals() メソッドのユニットテスト。
+   * キー集合・各値の一致判定、キー順序非依存、配列の順序依存比較を検証する。
+   */
+  describe('equals()', () => {
+    /** 同一と判定されることを期待する frontmatter 文字列のペア。 */
+    const _equalCases: { id: string; label: string; inputA: string; inputB: string }[] = [
+      {
+        id: 'T-CLS-CF-51',
+        label: '同じキー集合と値を持つ 2 つ',
+        inputA: '---\ntype: note\ntitle: Hello\n---\n',
+        inputB: '---\ntype: note\ntitle: Hello\n---\n',
+      },
+      {
+        id: 'T-CLS-CF-52',
+        label: '同じキー集合・値でキーの並び順のみが異なる 2 つ',
+        inputA: '---\ntype: note\ntitle: Hello\n---\n',
+        inputB: '---\ntitle: Hello\ntype: note\n---\n',
+      },
+      {
+        id: 'T-CLS-CF-53',
+        label: 'tags 配列を持ち値が等しい 2 つ',
+        inputA: '---\ntags:\n  - a\n  - b\n---\n',
+        inputB: '---\ntags:\n  - a\n  - b\n---\n',
+      },
+    ];
+
+    /** 非同一と判定されることを期待する frontmatter 文字列のペア。 */
+    const _notEqualErrorCases: { id: string; label: string; inputA: string; inputB: string }[] = [
+      {
+        id: 'T-CLS-CF-54',
+        label: '一方のみ category を持つ（キー欠落）',
+        inputA: '---\ntitle: Hello\ncategory: dev\n---\n',
+        inputB: '---\ntitle: Hello\n---\n',
+      },
+      {
+        id: 'T-CLS-CF-55',
+        label: '一方に未知フィールドが 1 つ多い（キー増加）',
+        inputA: '---\ntitle: Hello\n---\n',
+        inputB: '---\ntitle: Hello\nunknown: extra\n---\n',
+      },
+      {
+        id: 'T-CLS-CF-56',
+        label: 'title の値のみ異なる',
+        inputA: '---\ntitle: Hello\n---\n',
+        inputB: '---\ntitle: World\n---\n',
+      },
+      {
+        id: 'T-CLS-CF-57',
+        label: 'tags の配列長が異なる',
+        inputA: '---\ntags:\n  - a\n---\n',
+        inputB: '---\ntags:\n  - a\n  - b\n---\n',
+      },
+    ];
+
+    /** @description キー集合・各値がともに一致し同一と判定されるケース。 */
+    describe('When: 正常系', () => {
+      for (const tc of _equalCases) {
+        it(`${tc.id}: [Normal] ${tc.label} → 同一と判定される`, () => {
+          // arrange
+          const fmA = new ChatlogFrontmatter(tc.inputA);
+          const fmB = new ChatlogFrontmatter(tc.inputB);
+
+          // act
+          const result = fmA.equals(fmB);
+
+          // assert
+          assertEquals(result, true);
+        });
+      }
+    });
+
+    /** @description キー集合または値が食い違い非同一と判定されるケース。対称性もあわせて検証する。 */
+    describe('When: 異常系', () => {
+      for (const tc of _notEqualErrorCases) {
+        it(`${tc.id}: [Error] ${tc.label} → 非同一と判定される`, () => {
+          // arrange
+          const fmA = new ChatlogFrontmatter(tc.inputA);
+          const fmB = new ChatlogFrontmatter(tc.inputB);
+
+          // act & assert（equals は対称であるため両方向を検証する）
+          assertEquals(fmA.equals(fmB), false);
+          assertEquals(fmB.equals(fmA), false);
+        });
+      }
+    });
+
+    /** @description 空 frontmatter・配列要素順など境界的なケース。 */
+    describe('When: エッジケース', () => {
+      it('T-CLS-CF-58: [Edge] キーを 1 つも持たない 2 つ（空 frontmatter） → 同一と判定される', () => {
+        // arrange
+        const fmA = new ChatlogFrontmatter('---\n---\n');
+        const fmB = new ChatlogFrontmatter('---\n---\n');
+
+        // act
+        const result = fmA.equals(fmB);
+
+        // assert
+        assertEquals(result, true);
+      });
+
+      it('T-CLS-CF-59: [Edge] tags の要素順のみが異なる 2 つ → 非同一と判定される', () => {
+        // arrange
+        const fmA = new ChatlogFrontmatter('---\ntags:\n  - a\n  - b\n---\n');
+        const fmB = new ChatlogFrontmatter('---\ntags:\n  - b\n  - a\n---\n');
+
+        // act & assert（equals は対称であるため両方向を検証する）
+        assertEquals(fmA.equals(fmB), false);
+        assertEquals(fmB.equals(fmA), false);
+      });
+
+      it('T-CLS-CF-60: [Edge] 同じキーが string と string[] の 2 つ → 非同一と判定される', () => {
+        // arrange（YAML のスカラーと 1 要素リストは別の値として扱う）
+        const fmA = new ChatlogFrontmatter('---\ntags: a\n---\n');
+        const fmB = new ChatlogFrontmatter('---\ntags:\n  - a\n---\n');
+
+        // act & assert（equals は対称であるため両方向を検証する）
+        assertEquals(fmA.equals(fmB), false);
+        assertEquals(fmB.equals(fmA), false);
+      });
+    });
   });
 
   /**

--- a/skills/_cle-libs/libs/file-io/__tests__/unit/write-utils.unit.spec.ts
+++ b/skills/_cle-libs/libs/file-io/__tests__/unit/write-utils.unit.spec.ts
@@ -17,7 +17,44 @@ import { stub } from '@std/testing/mock';
 import { writeTextFile } from '../../write-utils.ts';
 
 // ─── Helpers
+import { fileExists } from '../../../file-ops/exists-utils.ts';
 import { readTextFile } from '../../read-utils.ts';
+// types
+import type { BackupProvider } from '../../../../types/providers.types.ts';
+
+// ─── Internal Helpers
+
+// types
+
+/** `_makeBackupSpy` が返す、呼び出し履歴付き `BackupProvider` の組。 */
+type _BackupSpy = {
+  /** `provider` が呼ばれたときの引数パスを呼び出し順に記録する配列。 */
+  calls: string[];
+  /** テスト対象に注入する `BackupProvider`。 */
+  provider: BackupProvider;
+};
+
+// functions
+
+/**
+ * 呼び出し履歴を記録する `BackupProvider` のスパイを生成する。
+ *
+ * 実際の退避は行わず、`result` をそのまま解決値として返す。
+ * 退避の呼び出し有無・回数・引数を検証する用途に使う。
+ *
+ * @param result - `provider` が解決する退避先パス（退避しない場合は `null`）
+ * @returns 呼び出し履歴 `calls` と `provider` を持つオブジェクト
+ */
+const _makeBackupSpy = (result: string | null): _BackupSpy => {
+  const calls: string[] = [];
+  return {
+    calls,
+    provider: (path: string) => {
+      calls.push(path);
+      return Promise.resolve(result);
+    },
+  };
+};
 
 // ─── Tests
 
@@ -26,7 +63,8 @@ import { readTextFile } from '../../read-utils.ts';
  *
  * Deno.makeTempDir を使ってテンポラリディレクトリにファイルを書き込む実際のファイル操作テスト。
  *
- * テスト ID 範囲: T-WO-01-01 〜 T-WO-01-02
+ * テスト ID 範囲: T-WO-01-01 〜 T-WO-03-03, T-LIB-WTF-01-01 〜 T-LIB-WTF-04-01
+ * （T-LIB-WTF-03-03 / 03-04 は失敗経路での `.tmp` 残置がないことを検証する）
  *
  * @see writeTextFile
  */
@@ -101,6 +139,91 @@ describe('writeTextFile', () => {
       assertEquals(written, newContent);
       await assertRejects(() => Deno.stat(`${outputPath}.tmp`), Deno.errors.NotFound);
     });
+
+    it('[Normal] T-LIB-WTF-01-01: BackupProvider が null を返す → 退避時点で tmp が実在し、原本が新内容に置換され tmp が残らない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const newContent = 'new content';
+      await Deno.writeTextFile(outputPath, 'old content');
+      const tmpExistsAtBackup: boolean[] = [];
+      const backup: BackupProvider = async (path) => {
+        tmpExistsAtBackup.push(await fileExists(`${path}.tmp`));
+        return null;
+      };
+
+      // act
+      await writeTextFile(outputPath, newContent, backup);
+
+      // assert
+      assertEquals(tmpExistsAtBackup, [true]);
+      assertEquals(await readTextFile(outputPath), newContent);
+      assertEquals(await fileExists(`${outputPath}.tmp`), false);
+    });
+
+    it('[Normal] T-LIB-WTF-01-03: BackupProvider が退避パスを返す → 戻り値がその退避パスと一致する', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const backupPath = `${tmpDir}/output.bak`;
+      const spy = _makeBackupSpy(backupPath);
+
+      // act
+      const result = await writeTextFile(outputPath, 'new content', spy.provider);
+
+      // assert
+      assertEquals(result, backupPath);
+      assertEquals(spy.calls, [outputPath]);
+    });
+
+    it('[Normal] T-LIB-WTF-01-02: 退避は最終リネームより先に呼ばれる → timeline が backup, rename の順になる', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const timeline: string[] = [];
+      const backup: BackupProvider = (_path) => {
+        timeline.push('backup');
+        return Promise.resolve(null);
+      };
+
+      const origRename = Deno.rename.bind(Deno);
+      const renameStub = stub(Deno, 'rename', (from, to) => {
+        timeline.push('rename');
+        return origRename(from, to);
+      });
+
+      try {
+        // act
+        await writeTextFile(outputPath, 'new content', backup);
+      } finally {
+        renameStub.restore();
+      }
+
+      // assert
+      assertEquals(timeline, ['backup', 'rename']);
+    });
+
+    it('[Normal] T-LIB-WTF-02-01: 第3引数を省略 → 内容が書き込まれ退避ファイルが作成されない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const newContent = 'new content';
+      await Deno.writeTextFile(outputPath, 'old content');
+
+      // act
+      await writeTextFile(outputPath, newContent);
+
+      // assert
+      assertEquals(await readTextFile(outputPath), newContent);
+      assertEquals(await fileExists(`${outputPath}.bak`), false);
+    });
+
+    it('[Normal] T-LIB-WTF-02-02: 第3引数を省略 → 戻り値が null', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+
+      // act
+      const result = await writeTextFile(outputPath, 'new content');
+
+      // assert
+      assertEquals(result, null);
+    });
   });
 
   /** 異常系: エラーをスローするケース */
@@ -132,6 +255,99 @@ describe('writeTextFile', () => {
       } finally {
         renameStub.restore();
       }
+    });
+
+    it('[Error] T-LIB-WTF-03-01: BackupProvider が例外をスロー → 例外が伝播し元ファイルの内容が変化せず tmp も残らない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const oldContent = 'old content';
+      await Deno.writeTextFile(outputPath, oldContent);
+      const backup: BackupProvider = () => Promise.reject(new Deno.errors.PermissionDenied('denied'));
+
+      // act & assert
+      await assertRejects(
+        () => writeTextFile(outputPath, 'new content', backup),
+        Deno.errors.PermissionDenied,
+      );
+      assertEquals(await readTextFile(outputPath), oldContent);
+      assertEquals(await fileExists(`${outputPath}.tmp`), false);
+    });
+
+    it('[Error] T-LIB-WTF-03-03: BackupProvider が例外をスロー → 一時ファイルが残置されない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      await Deno.writeTextFile(outputPath, 'old content');
+      const backup: BackupProvider = () => Promise.reject(new Deno.errors.PermissionDenied('denied'));
+
+      // act & assert
+      await assertRejects(
+        () => writeTextFile(outputPath, 'new content', backup),
+        Deno.errors.PermissionDenied,
+      );
+      assertEquals(await fileExists(`${outputPath}.tmp`), false);
+    });
+
+    it('[Error] T-LIB-WTF-03-04: rename が AlreadyExists 以外で失敗 → 一時ファイルが残置されない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const renameStub = stub(Deno, 'rename', () => Promise.reject(new Deno.errors.PermissionDenied('denied')));
+
+      try {
+        // act & assert
+        await assertRejects(
+          () => writeTextFile(outputPath, 'new content'),
+          Deno.errors.PermissionDenied,
+        );
+      } finally {
+        renameStub.restore();
+      }
+
+      assertEquals(await fileExists(`${outputPath}.tmp`), false);
+    });
+
+    it('[Error] T-LIB-WTF-03-02: 一時ファイル書き出しが失敗 → BackupProvider が呼ばれず元ファイルの内容が変化しない', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const oldContent = 'old content';
+      await Deno.writeTextFile(outputPath, oldContent);
+      const spy = _makeBackupSpy(`${outputPath}.bak`);
+
+      const writeStub = stub(
+        Deno,
+        'writeTextFile',
+        () => Promise.reject(new Deno.errors.PermissionDenied('denied')),
+      );
+
+      try {
+        // act & assert
+        await assertRejects(
+          () => writeTextFile(outputPath, 'new content', spy.provider),
+          Deno.errors.PermissionDenied,
+        );
+      } finally {
+        writeStub.restore();
+      }
+
+      assertEquals(spy.calls.length, 0);
+      assertEquals(await readTextFile(outputPath), oldContent);
+    });
+  });
+
+  /** エッジケース: 退避が行われなかった場合の戻り値・副作用 */
+  describe('When: エッジケース', () => {
+    it('[Edge] T-LIB-WTF-04-01: BackupProvider が null を返す → 例外を投げず書き込まれ戻り値が null', async () => {
+      // arrange
+      const outputPath = `${tmpDir}/output.md`;
+      const newContent = 'new content';
+      const spy = _makeBackupSpy(null);
+
+      // act
+      const result = await writeTextFile(outputPath, newContent, spy.provider);
+
+      // assert
+      assertEquals(result, null);
+      assertEquals(await readTextFile(outputPath), newContent);
+      assertEquals(spy.calls, [outputPath]);
     });
   });
 });

--- a/skills/_cle-libs/libs/file-io/write-utils.ts
+++ b/skills/_cle-libs/libs/file-io/write-utils.ts
@@ -9,7 +9,10 @@
 
 // ─── shared modules───────────────────────────
 // functions
+import { removeFile } from '../file-ops/remove-utils.ts';
 import { normalizeLine } from '../text/line-utils.ts';
+// types
+import type { BackupProvider } from '../../types/providers.types.ts';
 
 // ─── Functions
 
@@ -17,25 +20,46 @@ import { normalizeLine } from '../text/line-utils.ts';
  * Writes `content` to `outputPath` using a tmp-then-rename atomic pattern.
  *
  * Writes to `outputPath + ".tmp"`, then renames to `outputPath`.
- * Does not back up an existing file at `outputPath` — callers that need a backup
- * before overwrite must do so before calling this function.
+ *
+ * When `backup` is supplied, it is invoked after the tmp file has been written but
+ * before the final rename, so an existing file at `outputPath` is still intact at
+ * that point. A rejecting `backup` propagates and aborts the overwrite. When
+ * `backup` is omitted, no backup is taken and the existing file is overwritten.
+ *
+ * A `null` return from `backup` reports "no backup was made"; it does not abort
+ * the write (DR-03). If `backup` or the final rename fails, the tmp file is
+ * removed on a best-effort basis and the original error propagates unchanged.
+ *
+ * Note: in the `AlreadyExists` recovery path the existing file is removed before
+ * the retried rename. If that retry fails, neither the original nor the new
+ * content survives.
  *
  * @param outputPath - Destination file path
  * @param content    - Text content to write
+ * @param backup     - Optional provider that backs up an existing `outputPath`
+ * @returns The backup path created by `backup`, or `null` when no backup was made
  */
 export const writeTextFile = async (
   outputPath: string,
   content: string,
-): Promise<void> => {
+  backup?: BackupProvider,
+): Promise<string | null> => {
   const tmpPath = outputPath + '.tmp';
   await Deno.writeTextFile(tmpPath, normalizeLine(content));
   try {
-    await Deno.rename(tmpPath, outputPath);
-  } catch (e) {
-    if (!(e instanceof Deno.errors.AlreadyExists)) {
-      throw e;
+    const _backupPath = backup ? await backup(outputPath) : null;
+    try {
+      await Deno.rename(tmpPath, outputPath);
+    } catch (e) {
+      if (!(e instanceof Deno.errors.AlreadyExists)) {
+        throw e;
+      }
+      await Deno.remove(outputPath);
+      await Deno.rename(tmpPath, outputPath);
     }
-    await Deno.remove(outputPath);
-    await Deno.rename(tmpPath, outputPath);
+    return _backupPath;
+  } catch (e) {
+    await removeFile(tmpPath, { throwFileIoError: false });
+    throw e;
   }
 };

--- a/skills/_cle-libs/libs/file-ops/backup-to-bak.ts
+++ b/skills/_cle-libs/libs/file-ops/backup-to-bak.ts
@@ -1,0 +1,63 @@
+// src: skills/_cle-libs/libs/file-ops/backup-to-bak.ts
+// @(#): 既存ファイルを .bak 拡張子付加でバックアップするユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─────────────────────────────────────────────
+// shared modules
+// ─────────────────────────────────────────────
+
+// functions
+import { fileExists } from './exists-utils.ts';
+// types
+import type { RenameProvider, StatProvider } from '../../types/providers.types.ts';
+
+// ─────────────────────────────────────────────
+// 内部定数
+// ─────────────────────────────────────────────
+
+/** バックアップ先に付加する拡張子 */
+const _BAK_SUFFIX = '.bak';
+
+/** ファイルリネームプロバイダのデフォルト実装 */
+const _defaultRename: RenameProvider = (oldPath: string, newPath: string) => Deno.rename(oldPath, newPath);
+
+/** ファイル情報取得プロバイダのデフォルト実装 */
+const _defaultStat: StatProvider = (path: string) => Deno.stat(path);
+
+// ─────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────
+
+/**
+ * 既存ファイルを `<path>.bak` にリネームしてバックアップする。
+ *
+ * 拡張子は「付加」であり「置換」ではない（`entry.md` → `entry.md.bak`）。
+ * 連番・世代管理は持たず、退避先が既に存在する場合は何もしない。
+ *
+ * - 退避先 `<path>.bak` が存在する → リネームせず `null` を返す（例外は投げない）
+ * - 退避先が存在しない → `<path>` を `<path>.bak` にリネームし、そのパスを返す
+ *
+ * 元ファイルが存在しない場合は `rename` が `Deno.errors.NotFound` を投げ、
+ * そのまま呼び出し元へ伝播する（fail-first）。
+ *
+ * @param path         - バックアップ対象のファイルパス
+ * @param rename       - ファイルをリネームする関数（テスト用インジェクション可能、デフォルト: `Deno.rename`）
+ * @param statProvider - ファイル情報を取得する関数（テスト用インジェクション可能、デフォルト: `Deno.stat`）
+ * @returns 作成した退避先パス、または退避先が既存でバックアップしなかった場合は `null`
+ * @throws 元ファイル不在（`Deno.errors.NotFound`）などリネーム失敗時のエラー
+ */
+export const backupToBak = async (
+  path: string,
+  rename: RenameProvider = _defaultRename,
+  statProvider: StatProvider = _defaultStat,
+): Promise<string | null> => {
+  const _bakPath = `${path}${_BAK_SUFFIX}`;
+  if (await fileExists(_bakPath, statProvider)) { return null; }
+
+  await rename(path, _bakPath);
+  return _bakPath;
+};

--- a/skills/_cle-libs/libs/io/__tests__/unit/parse-args.unit.spec.ts
+++ b/skills/_cle-libs/libs/io/__tests__/unit/parse-args.unit.spec.ts
@@ -520,11 +520,11 @@ describe('parseArgsToConfig', () => {
   /**
    * `parseArgsToConfig` の `period` 型バリデーションテスト。
    *
-   * `--period` オプションに不正な形式の値を渡した場合に
+   * `--period` オプションに不正な形式・不正な月レンジの値を渡した場合に
    * `ChatlogError('InvalidArgs')` をスローすることを検証する。
    * 正常な YYYY-MM 形式は正常にセットされることも検証する。
    *
-   * テスト ID 範囲: T-PA-17-01 〜 T-PA-17-02
+   * テスト ID 範囲: T-PA-17-01 〜 T-PA-17-03
    */
   describe('Given: --period オプションに不正な形式の値', () => {
     /** period 型エントリを含むテスト用スキーマ。 */
@@ -538,6 +538,14 @@ describe('parseArgsToConfig', () => {
           () => parseArgs<TestConfig>(['--period', 'invalid-format'], _SCHEMA_WITH_PERIOD),
           ChatlogError,
           '期間形式ではありません',
+        );
+      });
+
+      it('[Error] T-PA-17-03: --period 2026-13 → ChatlogError(InvalidArgs) がスローされる（期間の月が範囲外です の詳細を含む）', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['--period', '2026-13'], _SCHEMA_WITH_PERIOD),
+          ChatlogError,
+          '期間の月が範囲外です',
         );
       });
     });
@@ -1022,7 +1030,7 @@ describe('parseArgsToConfig', () => {
    * 固定パターンのみを許可し、それ以外の型混在・順序違反は
    * `ChatlogError('InvalidArgs')` をスローすることを検証する。
    *
-   * テスト ID 範囲: T-PA-POS-01 〜 T-PA-POS-14
+   * テスト ID 範囲: T-PA-POS-01 〜 T-PA-POS-15
    */
   describe('Given: インデックスベースの位置引数パターン', () => {
     describe('When: パターンA（directory 系）', () => {
@@ -1111,6 +1119,16 @@ describe('parseArgsToConfig', () => {
           () => parseArgs<TestConfig>(['claude', '2026-03', '2026-04'], TEST_SCHEMA),
           ChatlogError,
           'Invalid Args',
+        );
+      });
+    });
+
+    describe('When: 異常系（値の検証）', () => {
+      it('[Error] T-PA-POS-15: ["claude", "2026-13"] → 位置引数経路でも月レンジ検証で ChatlogError(InvalidPeriodRange)', () => {
+        assertThrows(
+          () => parseArgs<TestConfig>(['claude', '2026-13'], TEST_SCHEMA),
+          ChatlogError,
+          '期間の月が範囲外です',
         );
       });
     });
@@ -1332,7 +1350,7 @@ describe('isArgDirectory', () => {
  * `isArgPeriod` のユニットテストスイート。
  *
  * `YYYY-MM` 形式の文字列を期間引数として認識するかを検証する。
- * 月レンジ（01〜12）は検証しない（現行の振る舞い保存）。
+ * 月レンジ（01〜12）はここでは検証しない（`_setByType` の period 型検証が担当する）。
  *
  * テスト ID 範囲: T-LIB-U-12-01 〜 T-LIB-U-12-06
  *
@@ -1357,7 +1375,7 @@ describe('isArgPeriod', () => {
     it('[Edge] T-LIB-U-12-04: "" → false が返る（空文字列）', () => {
       assertFalse(isArgPeriod(''));
     });
-    it('[Edge] T-LIB-U-12-05: "2025-13" → true が返る（月レンジ非チェック、現行と同一）', () => {
+    it('[Edge] T-LIB-U-12-05: "2025-13" → true が返る（形式判定のみ。月レンジは `_setByType` が検証する）', () => {
       assert(isArgPeriod('2025-13'));
     });
     it('[Edge] T-LIB-U-12-06: "20260" → false が返る（5桁年は不一致）', () => {

--- a/skills/_cle-libs/libs/io/__tests__/unit/set-by-type.unit.spec.ts
+++ b/skills/_cle-libs/libs/io/__tests__/unit/set-by-type.unit.spec.ts
@@ -41,7 +41,7 @@ const _entry = (type: ArgSchemaEntry['type'], field = 'result'): ArgSchemaEntry 
  * 各型（flag / string / agent / integer / number / directory）の
  * 正常系・異常系・エッジケースを検証する。
  *
- * テスト ID 範囲: T-SBT-FL-01 〜 T-SBT-PR-06
+ * テスト ID 範囲: T-SBT-FL-01 〜 T-SBT-PR-08-02
  *
  * @see _setByTypeForTest
  */
@@ -278,9 +278,9 @@ describe('_setByType', () => {
   /**
    * `period` 型の動作テスト。
    *
-   * `YYYY-MM` 形式の文字列は正常にセットされ、
-   * それ以外の形式（YYYY 単独を含む）はエラーになることを検証する。
-   * 月レンジ（01〜12）は `isArgPeriod` の仕様に合わせて検証しない。
+   * `YYYY-MM` 形式かつ月が 01〜12 の文字列は正常にセットされ、
+   * それ以外の形式（YYYY 単独を含む）は `InvalidPeriodFormat` エラーになることを検証する。
+   * 月レンジ外（`00` / `13` 以上）は `InvalidPeriodRange` エラーになる。
    */
   describe('period 型', () => {
     /** YYYY-MM 形式の正常ケース。 */
@@ -289,6 +289,20 @@ describe('_setByType', () => {
         const config = _makeConfig();
         const result = _setByTypeForTest(config, _entry('period'), '2026-03');
         assertEquals(config['result'], '2026-03');
+        assertNull(result);
+      });
+
+      it('[Normal] T-SBT-PR-08-01: rawValue "2026-01" → config[field] = "2026-01"（月レンジ下限）', () => {
+        const config = _makeConfig();
+        const result = _setByTypeForTest(config, _entry('period'), '2026-01');
+        assertEquals(config['result'], '2026-01');
+        assertNull(result);
+      });
+
+      it('[Normal] T-SBT-PR-08-02: rawValue "2026-12" → config[field] = "2026-12"（月レンジ上限）', () => {
+        const config = _makeConfig();
+        const result = _setByTypeForTest(config, _entry('period'), '2026-12');
+        assertEquals(config['result'], '2026-12');
         assertNull(result);
       });
     });
@@ -315,17 +329,26 @@ describe('_setByType', () => {
         assertNotNull(result);
         assert(result instanceof ChatlogError);
       });
-    });
 
-    /** 境界値・isArgPeriod の仕様に準じたケース。 */
-    describe('When: エッジケース', () => {
-      it('[Edge] T-SBT-PR-05: rawValue "2026-13" → config に設定される（月レンジ非チェック）', () => {
+      it('[Error] T-SBT-PR-05: rawValue "2026-13" → ChatlogError(InvalidPeriodRange)、config は未設定', () => {
         const config = _makeConfig();
         const result = _setByTypeForTest(config, _entry('period'), '2026-13');
-        assertEquals(config['result'], '2026-13');
-        assertNull(result);
+        assertNotNull(result);
+        assert(result instanceof ChatlogError);
+        assertEquals(config['result'], undefined);
       });
 
+      it('[Error] T-SBT-PR-07: rawValue "2026-00" → ChatlogError(InvalidPeriodRange)、config は未設定', () => {
+        const config = _makeConfig();
+        const result = _setByTypeForTest(config, _entry('period'), '2026-00');
+        assertNotNull(result);
+        assert(result instanceof ChatlogError);
+        assertEquals(config['result'], undefined);
+      });
+    });
+
+    /** 空文字列など、形式検証の前段で弾かれるケース。 */
+    describe('When: エッジケース', () => {
       it('[Edge] T-SBT-PR-06: rawValue "" → ChatlogError', () => {
         const config = _makeConfig();
         const result = _setByTypeForTest(config, _entry('period'), '');

--- a/skills/_cle-libs/libs/io/parse-args.ts
+++ b/skills/_cle-libs/libs/io/parse-args.ts
@@ -25,8 +25,25 @@ import type {
 
 // -- internal modules ---
 // functions
-/** `YYYY-MM` 形式の文字列の場合 `true` を返す（CLI 位置引数の期間判定）。 */
+/**
+ * `YYYY-MM` 形式の文字列の場合 `true` を返す（CLI 位置引数の期間判定）。
+ *
+ * 形式のみを判定し、月レンジ（01〜12）は検証しない。月レンジは `_setByType` の
+ * `period` 型検証（`_isPeriodMonthInRange`）が担当する。
+ */
 export const isArgPeriod = (arg: string): boolean => /^\d{4}-\d{2}$/.test(arg);
+
+/**
+ * `YYYY-MM` 形式の月部が 01〜12 の範囲内の場合 `true` を返す。
+ * `isArgPeriod` を通過済みの文字列を前提とする。
+ *
+ * @param arg - `isArgPeriod` が `true` を返した期間文字列
+ * @returns 月が 1〜12 の場合 `true`
+ */
+const _isPeriodMonthInRange = (arg: string): boolean => {
+  const _month = parseInt(arg.slice(-2), 10);
+  return _month >= 1 && _month <= 12;
+};
 
 /** バックスラッシュをスラッシュに変換後に `/` を含む場合 `true` を返す（CLI 位置引数のディレクトリパス判定）。 */
 export const isArgDirectory = (arg: string): boolean => {
@@ -140,6 +157,13 @@ const _setByType = (
           'InvalidArgs',
           'InvalidPeriodFormat',
           `期間形式ではありません（YYYY-MM）: ${rawValue}`,
+        );
+      }
+      if (!_isPeriodMonthInRange(rawValue)) {
+        return new ChatlogError(
+          'InvalidArgs',
+          'InvalidPeriodRange',
+          `期間の月が範囲外です（01〜12）: ${rawValue}`,
         );
       }
       config[entry.field] = rawValue;

--- a/skills/_cle-libs/types/providers.types.ts
+++ b/skills/_cle-libs/types/providers.types.ts
@@ -47,6 +47,16 @@ export type MkdirProvider = (path: string, options?: { recursive?: boolean }) =>
 /** ファイルをリネーム（移動）する関数の型。テスト用インジェクションに利用する。 */
 export type RenameProvider = (oldPath: string, newPath: string) => Promise<void>;
 
+/**
+ * 指定ミリ秒待機する関数の型。テスト用インジェクションに利用する。
+ *
+ * リトライの待機に用いる。テストでは即座に解決する実装を注入し、実待機を避ける。
+ */
+export type SleepProvider = (ms: number) => Promise<void>;
+
+/** ファイルを退避し、作成した退避先パス（退避しなかった場合は null）を返す関数の型。テスト用インジェクションに利用する。 */
+export type BackupProvider = (path: string) => Promise<string | null>;
+
 /** ディレクトリを結果に含めるか判定する述語関数の型。 */
 export type DirProvider = (dir: string) => Promise<boolean>;
 

--- a/skills/setup-chatlogs/assets/_cle-libs/classes/ChatlogFrontmatter.class.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/classes/ChatlogFrontmatter.class.ts
@@ -39,6 +39,25 @@ const _addTagHashes = (entries: FrontmatterFields): FrontmatterFields => {
   return { ...entries, tags: _prefixed };
 };
 
+/**
+ * frontmatter の 2 つの値が同一かを判定する。
+ *
+ * 文字列同士は `===`、配列同士は長さと各要素を順序どおり比較する。
+ * 型が異なる場合（`string` と `string[]`）は非同一とする。
+ *
+ * 型不一致の早期 return は意図の明示が目的であり、振る舞い上は冗長である。
+ * この行を削除しても後段の `a === b` が同じく `false` を返すため、
+ * 差異を観測できるテストは書けない（削除しても全テストが PASS する）。
+ * 判定順序を「型 → 配列 → スカラー」と読める形に保つために残している。
+ */
+const _valuesEqual = (a: string | string[] | undefined, b: string | string[] | undefined): boolean => {
+  if (Array.isArray(a) !== Array.isArray(b)) { return false; }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => item === b[index]);
+  }
+  return a === b;
+};
+
 export class ChatlogFrontmatter {
   private _entries: FrontmatterFields;
 
@@ -119,6 +138,13 @@ export class ChatlogFrontmatter {
   /** type / category / title の3フィールドがすべて充足しているか判定する。 */
   hasBaseFields(): boolean {
     return hasFrontmatterFields(this._entries, ['type', 'category', 'title']);
+  }
+
+  /** 他の `ChatlogFrontmatter` とキー集合・各値が同一かを判定する。キー順序は比較対象に含めない。 */
+  equals(other: ChatlogFrontmatter): boolean {
+    const _keys = Object.keys(this._entries);
+    if (_keys.length !== Object.keys(other._entries).length) { return false; }
+    return _keys.every((key) => _valuesEqual(this._entries[key], other._entries[key]));
   }
 
   toFrontmatter(fieldOrder: string[] = DEFAULT_ORDERED_FIELDS, opts?: { addTagHashes?: boolean }): string {

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/file-io/write-utils.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/file-io/write-utils.ts
@@ -9,7 +9,10 @@
 
 // ─── shared modules───────────────────────────
 // functions
+import { removeFile } from '../file-ops/remove-utils.ts';
 import { normalizeLine } from '../text/line-utils.ts';
+// types
+import type { BackupProvider } from '../../types/providers.types.ts';
 
 // ─── Functions
 
@@ -17,25 +20,46 @@ import { normalizeLine } from '../text/line-utils.ts';
  * Writes `content` to `outputPath` using a tmp-then-rename atomic pattern.
  *
  * Writes to `outputPath + ".tmp"`, then renames to `outputPath`.
- * Does not back up an existing file at `outputPath` — callers that need a backup
- * before overwrite must do so before calling this function.
+ *
+ * When `backup` is supplied, it is invoked after the tmp file has been written but
+ * before the final rename, so an existing file at `outputPath` is still intact at
+ * that point. A rejecting `backup` propagates and aborts the overwrite. When
+ * `backup` is omitted, no backup is taken and the existing file is overwritten.
+ *
+ * A `null` return from `backup` reports "no backup was made"; it does not abort
+ * the write (DR-03). If `backup` or the final rename fails, the tmp file is
+ * removed on a best-effort basis and the original error propagates unchanged.
+ *
+ * Note: in the `AlreadyExists` recovery path the existing file is removed before
+ * the retried rename. If that retry fails, neither the original nor the new
+ * content survives.
  *
  * @param outputPath - Destination file path
  * @param content    - Text content to write
+ * @param backup     - Optional provider that backs up an existing `outputPath`
+ * @returns The backup path created by `backup`, or `null` when no backup was made
  */
 export const writeTextFile = async (
   outputPath: string,
   content: string,
-): Promise<void> => {
+  backup?: BackupProvider,
+): Promise<string | null> => {
   const tmpPath = outputPath + '.tmp';
   await Deno.writeTextFile(tmpPath, normalizeLine(content));
   try {
-    await Deno.rename(tmpPath, outputPath);
-  } catch (e) {
-    if (!(e instanceof Deno.errors.AlreadyExists)) {
-      throw e;
+    const _backupPath = backup ? await backup(outputPath) : null;
+    try {
+      await Deno.rename(tmpPath, outputPath);
+    } catch (e) {
+      if (!(e instanceof Deno.errors.AlreadyExists)) {
+        throw e;
+      }
+      await Deno.remove(outputPath);
+      await Deno.rename(tmpPath, outputPath);
     }
-    await Deno.remove(outputPath);
-    await Deno.rename(tmpPath, outputPath);
+    return _backupPath;
+  } catch (e) {
+    await removeFile(tmpPath, { throwFileIoError: false });
+    throw e;
   }
 };

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/backup-to-bak.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/backup-to-bak.ts
@@ -1,0 +1,63 @@
+// src: skills/_cle-libs/libs/file-ops/backup-to-bak.ts
+// @(#): 既存ファイルを .bak 拡張子付加でバックアップするユーティリティ
+//
+// Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ─────────────────────────────────────────────
+// shared modules
+// ─────────────────────────────────────────────
+
+// functions
+import { fileExists } from './exists-utils.ts';
+// types
+import type { RenameProvider, StatProvider } from '../../types/providers.types.ts';
+
+// ─────────────────────────────────────────────
+// 内部定数
+// ─────────────────────────────────────────────
+
+/** バックアップ先に付加する拡張子 */
+const _BAK_SUFFIX = '.bak';
+
+/** ファイルリネームプロバイダのデフォルト実装 */
+const _defaultRename: RenameProvider = (oldPath: string, newPath: string) => Deno.rename(oldPath, newPath);
+
+/** ファイル情報取得プロバイダのデフォルト実装 */
+const _defaultStat: StatProvider = (path: string) => Deno.stat(path);
+
+// ─────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────
+
+/**
+ * 既存ファイルを `<path>.bak` にリネームしてバックアップする。
+ *
+ * 拡張子は「付加」であり「置換」ではない（`entry.md` → `entry.md.bak`）。
+ * 連番・世代管理は持たず、退避先が既に存在する場合は何もしない。
+ *
+ * - 退避先 `<path>.bak` が存在する → リネームせず `null` を返す（例外は投げない）
+ * - 退避先が存在しない → `<path>` を `<path>.bak` にリネームし、そのパスを返す
+ *
+ * 元ファイルが存在しない場合は `rename` が `Deno.errors.NotFound` を投げ、
+ * そのまま呼び出し元へ伝播する（fail-first）。
+ *
+ * @param path         - バックアップ対象のファイルパス
+ * @param rename       - ファイルをリネームする関数（テスト用インジェクション可能、デフォルト: `Deno.rename`）
+ * @param statProvider - ファイル情報を取得する関数（テスト用インジェクション可能、デフォルト: `Deno.stat`）
+ * @returns 作成した退避先パス、または退避先が既存でバックアップしなかった場合は `null`
+ * @throws 元ファイル不在（`Deno.errors.NotFound`）などリネーム失敗時のエラー
+ */
+export const backupToBak = async (
+  path: string,
+  rename: RenameProvider = _defaultRename,
+  statProvider: StatProvider = _defaultStat,
+): Promise<string | null> => {
+  const _bakPath = `${path}${_BAK_SUFFIX}`;
+  if (await fileExists(_bakPath, statProvider)) { return null; }
+
+  await rename(path, _bakPath);
+  return _bakPath;
+};

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/io/parse-args.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/io/parse-args.ts
@@ -25,8 +25,25 @@ import type {
 
 // -- internal modules ---
 // functions
-/** `YYYY-MM` 形式の文字列の場合 `true` を返す（CLI 位置引数の期間判定）。 */
+/**
+ * `YYYY-MM` 形式の文字列の場合 `true` を返す（CLI 位置引数の期間判定）。
+ *
+ * 形式のみを判定し、月レンジ（01〜12）は検証しない。月レンジは `_setByType` の
+ * `period` 型検証（`_isPeriodMonthInRange`）が担当する。
+ */
 export const isArgPeriod = (arg: string): boolean => /^\d{4}-\d{2}$/.test(arg);
+
+/**
+ * `YYYY-MM` 形式の月部が 01〜12 の範囲内の場合 `true` を返す。
+ * `isArgPeriod` を通過済みの文字列を前提とする。
+ *
+ * @param arg - `isArgPeriod` が `true` を返した期間文字列
+ * @returns 月が 1〜12 の場合 `true`
+ */
+const _isPeriodMonthInRange = (arg: string): boolean => {
+  const _month = parseInt(arg.slice(-2), 10);
+  return _month >= 1 && _month <= 12;
+};
 
 /** バックスラッシュをスラッシュに変換後に `/` を含む場合 `true` を返す（CLI 位置引数のディレクトリパス判定）。 */
 export const isArgDirectory = (arg: string): boolean => {
@@ -140,6 +157,13 @@ const _setByType = (
           'InvalidArgs',
           'InvalidPeriodFormat',
           `期間形式ではありません（YYYY-MM）: ${rawValue}`,
+        );
+      }
+      if (!_isPeriodMonthInRange(rawValue)) {
+        return new ChatlogError(
+          'InvalidArgs',
+          'InvalidPeriodRange',
+          `期間の月が範囲外です（01〜12）: ${rawValue}`,
         );
       }
       config[entry.field] = rawValue;

--- a/skills/setup-chatlogs/assets/_cle-libs/types/providers.types.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/types/providers.types.ts
@@ -47,6 +47,16 @@ export type MkdirProvider = (path: string, options?: { recursive?: boolean }) =>
 /** ファイルをリネーム（移動）する関数の型。テスト用インジェクションに利用する。 */
 export type RenameProvider = (oldPath: string, newPath: string) => Promise<void>;
 
+/**
+ * 指定ミリ秒待機する関数の型。テスト用インジェクションに利用する。
+ *
+ * リトライの待機に用いる。テストでは即座に解決する実装を注入し、実待機を避ける。
+ */
+export type SleepProvider = (ms: number) => Promise<void>;
+
+/** ファイルを退避し、作成した退避先パス（退避しなかった場合は null）を返す関数の型。テスト用インジェクションに利用する。 */
+export type BackupProvider = (path: string) => Promise<string | null>;
+
 /** ディレクトリを結果に含めるか判定する述語関数の型。 */
 export type DirProvider = (dir: string) => Promise<boolean>;
 


### PR DESCRIPTION
## Overview

**Summary**

Add an optional backup step to `writeTextFile`, a `.bak` backup utility, frontmatter equality, and a period month range check.

**Background / Motivation**

Callers need to overwrite existing chatlog files without losing the old content.
`writeTextFile` had no place to save the old file before the final rename.
This branch adds that hook, plus a concrete `.bak` strategy behind an injectable provider type.

Separately, `parse-args` accepted an invalid period month such as `2026-13`.
The value passed format validation and then reached the filter as-is.

All changes are additive.
The `backup` parameter is optional, so existing call sites keep working.

## Changes

### Core Changes

- **`skills/_cle-libs/libs/file-io/write-utils.ts`** — `writeTextFile` takes an optional `BackupProvider` as its third argument.
  - The provider runs after the tmp file is written and before the final rename.
  - The function returns the backup path, or `null` when no backup was made.
  - The tmp file is removed on a best-effort basis when the backup or the rename fails.
  - The return type widens from `void` to `string | null`.
- **`skills/_cle-libs/libs/file-ops/backup-to-bak.ts`** (new) — `backupToBak` renames `<path>` to `<path>.bak`.
  - The suffix is appended, not replaced (`entry.md` → `entry.md.bak`).
  - It returns `null` without throwing when the destination already exists.
  - It propagates `NotFound` when the source is missing.
  - `rename` and `statProvider` are injectable for tests.
- **`skills/_cle-libs/classes/ChatlogFrontmatter.class.ts`** — adds `equals()` and the internal `_valuesEqual` helper.
  - Key order is ignored.
  - Arrays are compared element-wise, in order.
  - A `string` vs `string[]` mismatch counts as unequal.
- **`skills/_cle-libs/libs/io/parse-args.ts`** — adds `_isPeriodMonthInRange` and applies it in the `period` branch of `_setByType`.
  - An out-of-range month returns `ChatlogError('InvalidArgs', 'InvalidPeriodRange')`.
  - `isArgPeriod` keeps format-only validation on purpose.
  - The range check lives in one place, so it also covers the positional-argument path.
- **`skills/_cle-libs/types/providers.types.ts`** — adds `BackupProvider` and `SleepProvider`.
  - `BackupProvider` is consumed by `write-utils.ts`.
  - `SleepProvider` is a type-only addition for injecting retry waits, and has no consumer yet.
- **`skills/setup-chatlogs/assets/_cle-libs/**`** (5 files) — hook-synchronized mirrors of the files above.
  - They are not independent edits, carry no separate logic, and have no tests of their own.

### Test Updates

New unit tests only (4 spec files, +397 / -17).

- **`skills/_cle-libs/libs/file-io/__tests__/unit/write-utils.unit.spec.ts`**
  - The backup runs before the rename (timeline assertion).
  - The tmp file exists at backup time.
  - The return value equals the backup path.
  - Omitting the third argument writes no backup file and returns `null`.
  - A throwing backup propagates the error, leaves the original content unchanged, and leaves no tmp file.
  - A non-`AlreadyExists` rename failure leaves no tmp file.
  - A tmp-write failure never calls the backup.
- **`skills/_cle-libs/classes/__tests__/unit/ChatlogFrontmatter.unit.spec.ts`**
  - `equals()` across key order, arrays, array order, missing keys, differing values, empty frontmatter, and value type differences.
- **`skills/_cle-libs/libs/io/__tests__/unit/parse-args.unit.spec.ts`**
  - `T-PA-17-03`: `--period 2026-13` returns a `ChatlogError`.
  - `T-PA-POS-15`: the positional form `["claude", "2026-13"]` is range-checked too.
  - Existing `isArgPeriod` edge cases are re-documented as format-only. Behavior is unchanged.
- **`skills/_cle-libs/libs/io/__tests__/unit/set-by-type.unit.spec.ts`**
  - Valid and invalid month-range cases for `period` values.

Run before merging:

```bash
deno task test:unit
dprint check
```

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (`dprint check`)
- [x] Tests pass (`deno task test:unit`)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

- A `null` return from the backup provider means "no backup was made". It does not abort the write (DR-03).
  Callers that require a backup must check the return value.
- This PR adds capability only. `backupToBak`, `ChatlogFrontmatter.equals()`, and `SleepProvider` have no
  production call site on this branch. Unit tests are their only caller, and `backupToBak` is not yet passed
  to `writeTextFile` anywhere. The `parse-args` month-range fix is the one change that takes effect right away.
- The `config(lefthook): enable skill assets sync hooks` commit on this branch is a no-op against `main`.
  The same content already landed via #413, so `git diff main..HEAD` shows no `lefthook.yml` change.
  It appears in the branch history only.
- Pre-existing behavior worth a second look: in the `AlreadyExists` recovery path, `writeTextFile` removes the
  existing file before retrying the rename. If that retry fails, neither the original nor the new content
  survives. This branch does not change that path. It only changes the surrounding tmp cleanup.
