### PR TITLE
fix(filter-chatlogs): bound backup sweep deletion concurrency

### DIFF
--- a/skills/filter-chatlogs/scripts/__tests__/unit/strip/sweep-backups.unit.spec.ts
+++ b/skills/filter-chatlogs/scripts/__tests__/unit/strip/sweep-backups.unit.spec.ts
@@ -32,6 +32,9 @@ import { LOGGER_TEXT } from '../../../../../_cle-libs/constants/logger.constants
 /** テスト対象ディレクトリ。`normalizePath` 済みの形（ドライブレター大文字・スラッシュ区切り）で与える。 */
 const _DIR = 'W:/temp/strip';
 
+/** 並列度そのものを検証しないケースで渡す既定の並列度。ゲート・包含検査・報告の結果は並列度に依存しない。 */
+const _CONCURRENCY = 4;
+
 // types
 
 /** `_makeRemoveProvider` が返す削除プロバイダと、その呼び出し履歴。 */
@@ -40,6 +43,14 @@ interface _RemoveSpy {
   provider: RemoveProvider;
   /** 削除を試行したパスを呼び出し順に記録した配列。 */
   calls: string[];
+}
+
+/** `_makeLatchedRemoveProvider` が返す削除プロバイダと、同時実行数の観測手段。 */
+interface _LatchedRemoveSpy extends _RemoveSpy {
+  /** 観測された同時実行数の最大値を返す。 */
+  maxInFlight: () => number;
+  /** 保留中の削除を解放し続け、`total` 件が解放されるか打ち切り回数に達するまで待つ。 */
+  releaseAll: (total: number) => Promise<void>;
 }
 
 // functions
@@ -90,23 +101,69 @@ const _makeDirGlob = (entries: string[]): GlobProvider => (pattern: string) => {
 /**
  * 削除試行を記録し、指定パスだけを失敗させる `RemoveProvider` を生成する。
  *
- * 失敗は `Deno.errors.PermissionDenied` で表す。`removeFile` は `isFileIoError` に
- * 該当しない例外を `throwFileIoError: false` でも再 throw するため（remove-utils.ts:63）、
- * 素の `Error` では「1 件失敗しても中断しない」挙動を再現できない。
+ * 既定の失敗は `Deno.errors.PermissionDenied`（ファイル I/O エラー）で表す。
+ * `removeFile` は `isFileIoError` に該当しない例外を `throwFileIoError: false` でも
+ * 再 throw するため（remove-utils.ts:63-64）、file-I/O エラーだけでは
+ * 「例外が `sweepBackups` の外へ漏れない」という DD-03 の no-throw 契約を検証できない。
+ * 非 file-I/O エラーを注入するには `errorFactory` を渡す。
  *
  * @param failPaths - 削除に失敗させるパスの集合
+ * @param errorFactory - 失敗時に reject する例外を生成する関数（省略時は `PermissionDenied`）
  * @returns 削除プロバイダと呼び出し履歴
  */
-const _makeRemoveProvider = (failPaths: string[] = []): _RemoveSpy => {
+const _makeRemoveProvider = (
+  failPaths: string[] = [],
+  errorFactory: (path: string) => Error = (path) => new Deno.errors.PermissionDenied(`permission denied: ${path}`),
+): _RemoveSpy => {
   const calls: string[] = [];
   const _failSet = new Set(failPaths);
   const provider: RemoveProvider = (path: string) => {
     calls.push(path);
-    return _failSet.has(path)
-      ? Promise.reject(new Deno.errors.PermissionDenied(`permission denied: ${path}`))
-      : Promise.resolve();
+    return _failSet.has(path) ? Promise.reject(errorFactory(path)) : Promise.resolve();
   };
   return { provider, calls };
+};
+
+/**
+ * 削除を保留したまま同時実行数を観測する `RemoveProvider` を生成する。
+ *
+ * `Promise.resolve()` で即時解決するプロバイダでは、次の呼び出しの前に必ず 1 件目が
+ * 完了してしまうため同時実行数が観測できず、逐次実装と並列実装を区別できない。
+ * ここでは呼び出しごとに未解決の `Promise` を返して in-flight を積み上げ、
+ * `releaseAll` が解放するまで保留する。
+ *
+ * @returns 削除プロバイダ・呼び出し履歴・同時実行数の最大値・保留の解放関数
+ */
+const _makeLatchedRemoveProvider = (): _LatchedRemoveSpy => {
+  const calls: string[] = [];
+  const _pending: (() => void)[] = [];
+  let _inFlight = 0;
+  let _maxInFlight = 0;
+  let _released = 0;
+
+  const provider: RemoveProvider = (path: string) => {
+    calls.push(path);
+    _inFlight++;
+    _maxInFlight = Math.max(_maxInFlight, _inFlight);
+    return new Promise<void>((resolve) => {
+      _pending.push(() => {
+        _inFlight--;
+        _released++;
+        resolve();
+      });
+    });
+  };
+
+  const releaseAll = async (total: number): Promise<void> => {
+    // 解放は「保留の発生を待つ → 解放する」を繰り返す逐次処理であり高階関数へ置き換えられない。
+    // 打ち切りが無いと、呼び出しが total 件へ届かない実装でテストが失敗せずハングする
+    for (let i = 0; _released < total && i <= total; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      _pending.splice(0).forEach((release) => release());
+    }
+  };
+
+  return { provider, calls, maxInFlight: () => _maxInFlight, releaseAll };
 };
 
 /** 戻り値が `ChatlogError` であることを表明し、型を絞り込む。 */
@@ -139,7 +196,8 @@ const _parameterNames = (): string[] => {
  * R-011（error 時は全保持）→ R-013（包含検査）→ R-010（一括削除）→ R-012（削除失敗の報告）
  * の順序でゲートが働くことを、`glob` / `removeProvider` の注入により実 I/O なしで確認する。
  *
- * テスト ID 範囲: T-FL-SBS-01-01 〜 T-FL-SBS-04-05 / T-FL-SBS-05-01 / T-FL-SBS-06-01 〜 T-FL-SBS-06-03
+ * テスト ID 範囲: T-FL-SBS-01-01 〜 T-FL-SBS-04-05 / T-FL-SBS-05-01 / T-FL-SBS-06-01 〜 T-FL-SBS-06-03 /
+ * T-FL-SBS-07-01 〜 T-FL-SBS-07-04 / T-FL-SBS-08-01 〜 T-FL-SBS-08-03
  *
  * @see sweepBackups
  */
@@ -159,7 +217,7 @@ describe('sweepBackups', () => {
         const { provider, calls } = _makeRemoveProvider();
         const { glob, patterns } = _makeGlobSpy(_backups);
 
-        const error = await sweepBackups(_DIR, _stripped, 0, { glob, removeProvider: provider });
+        const error = await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, { glob, removeProvider: provider });
 
         assertEquals(error, undefined);
         assertEquals(calls.sort(), _backups.toSorted());
@@ -173,7 +231,10 @@ describe('sweepBackups', () => {
         const _backups = [`${_DIR}/a.md.bak`, `${_DIR}/zombie.md.bak`];
         const { provider, calls } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, _stripped, 0, { glob: _makeGlob(_backups), removeProvider: provider });
+        const error = await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, {
+          glob: _makeGlob(_backups),
+          removeProvider: provider,
+        });
 
         assertEquals(error, undefined);
         assert(calls.includes(`${_DIR}/zombie.md.bak`));
@@ -185,7 +246,10 @@ describe('sweepBackups', () => {
         const _backups = [`${_DIR}/leftover.md.bak`];
         const { provider, calls } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, [], 0, { glob: _makeGlob(_backups), removeProvider: provider });
+        const error = await sweepBackups(_DIR, [], 0, _CONCURRENCY, {
+          glob: _makeGlob(_backups),
+          removeProvider: provider,
+        });
 
         assertEquals(error, undefined);
         assertEquals(calls, _backups);
@@ -206,7 +270,7 @@ describe('sweepBackups', () => {
         const _stripped = [`${_DIR}/a.md`];
         const { provider, calls } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, _stripped, 1, {
+        const error = await sweepBackups(_DIR, _stripped, 1, _CONCURRENCY, {
           glob: _makeGlob([`${_DIR}/a.md.bak`]),
           removeProvider: provider,
         });
@@ -221,7 +285,10 @@ describe('sweepBackups', () => {
         const _failed = [`${_DIR}/a.md.bak`, `${_DIR}/c.md.bak`];
         const { provider } = _makeRemoveProvider(_failed);
 
-        const error = await sweepBackups(_DIR, [], 0, { glob: _makeGlob(_backups), removeProvider: provider });
+        const error = await sweepBackups(_DIR, [], 0, _CONCURRENCY, {
+          glob: _makeGlob(_backups),
+          removeProvider: provider,
+        });
 
         const _error = _assertChatlogError(error);
         assertEquals(_error.subindex, 'BackupSweepFailed');
@@ -234,7 +301,7 @@ describe('sweepBackups', () => {
         // 終了コードは main 側の責務のため、ChatlogError を返すことを観測可能な代理として検証する
         const { provider } = _makeRemoveProvider([`${_DIR}/a.md.bak`]);
 
-        const error = await sweepBackups(_DIR, [], 0, {
+        const error = await sweepBackups(_DIR, [], 0, _CONCURRENCY, {
           glob: _makeGlob([`${_DIR}/a.md.bak`]),
           removeProvider: provider,
         });
@@ -246,7 +313,7 @@ describe('sweepBackups', () => {
         const _backups = [1, 2, 3, 4, 5].map((n) => `${_DIR}/f${n}.md.bak`);
         const { provider, calls } = _makeRemoveProvider([`${_DIR}/f2.md.bak`]);
 
-        await sweepBackups(_DIR, [], 0, { glob: _makeGlob(_backups), removeProvider: provider });
+        await sweepBackups(_DIR, [], 0, _CONCURRENCY, { glob: _makeGlob(_backups), removeProvider: provider });
 
         // 失敗で中断しないため、全 5 件が試行される
         assertEquals(calls.toSorted(), _backups.toSorted());
@@ -274,7 +341,7 @@ describe('sweepBackups', () => {
         const _stripped = [`${_DIR}/a.md`, `${_DIR}/b.md`];
         const { provider, calls } = _makeRemoveProvider();
 
-        await sweepBackups(_DIR, _stripped, 0, {
+        await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, {
           glob: _makeGlob([`${_DIR}/a.md.bak`]),
           removeProvider: provider,
         });
@@ -286,7 +353,7 @@ describe('sweepBackups', () => {
         const _stripped = [`${_DIR}/a.md`, `${_DIR}/b.md`];
         const { provider } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, _stripped, 0, {
+        const error = await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, {
           glob: _makeGlob([`${_DIR}/a.md.bak`]),
           removeProvider: provider,
         });
@@ -299,7 +366,7 @@ describe('sweepBackups', () => {
       it('[Error] T-FL-SBS-03-03: 包含不成立なら戻り値が ChatlogError になる', async () => {
         const { provider } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, [`${_DIR}/b.md`], 0, {
+        const error = await sweepBackups(_DIR, [`${_DIR}/b.md`], 0, _CONCURRENCY, {
           glob: _makeGlob([]),
           removeProvider: provider,
         });
@@ -324,7 +391,10 @@ describe('sweepBackups', () => {
         const _stripped = [1, 2, 3].map((n) => `${_DIR}/f${n}.md`);
         const { provider, calls } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, _stripped, 0, { glob: _makeGlob(_backups), removeProvider: provider });
+        const error = await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, {
+          glob: _makeGlob(_backups),
+          removeProvider: provider,
+        });
 
         assertEquals(error, undefined);
         assertEquals(calls.toSorted(), _backups.toSorted());
@@ -334,7 +404,7 @@ describe('sweepBackups', () => {
         // 大小文字を畳んで照合すると誤って成立してしまうケース
         const { provider, calls } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, [`${_DIR}/Foo.md`], 0, {
+        const error = await sweepBackups(_DIR, [`${_DIR}/Foo.md`], 0, _CONCURRENCY, {
           glob: _makeGlob([`${_DIR}/foo.md.bak`]),
           removeProvider: provider,
         });
@@ -346,7 +416,7 @@ describe('sweepBackups', () => {
       it('[Edge] T-FL-SBS-04-03: 不足報告のパスが大小文字を変換しない原形である', async () => {
         const { provider } = _makeRemoveProvider();
 
-        const error = await sweepBackups(_DIR, [`${_DIR}/Foo.md`], 0, {
+        const error = await sweepBackups(_DIR, [`${_DIR}/Foo.md`], 0, _CONCURRENCY, {
           glob: _makeGlob([`${_DIR}/foo.md.bak`]),
           removeProvider: provider,
         });
@@ -369,7 +439,7 @@ describe('sweepBackups', () => {
       it('[Edge] T-FL-SBS-04-04: sweepBackups のシグネチャが dryRun を持たない', () => {
         // Phase 3〜6 は dry-run 時に main がスキップする設計のため、
         // フェーズ内部に dryRun 分岐を置かない（呼ばれた以上は必ず削除を試行する）
-        assertEquals(_parameterNames(), ['targetDir', 'strippedPaths', 'errorCount', 'options']);
+        assertEquals(_parameterNames(), ['targetDir', 'strippedPaths', 'errorCount', 'concurrency', 'options']);
       });
     });
   });
@@ -389,7 +459,7 @@ describe('sweepBackups', () => {
         const { provider, calls } = _makeRemoveProvider();
         const glob = _makeDirGlob([`${_DIR}/a.md`, `${_DIR}/a.md.bak`, `${_DIR}/notes.bak`]);
 
-        const error = await sweepBackups(_DIR, [`${_DIR}/a.md`], 0, { glob, removeProvider: provider });
+        const error = await sweepBackups(_DIR, [`${_DIR}/a.md`], 0, _CONCURRENCY, { glob, removeProvider: provider });
 
         assertEquals(error, undefined);
         assertEquals(calls, [`${_DIR}/a.md.bak`]);
@@ -415,7 +485,10 @@ describe('sweepBackups', () => {
 
         let error: ChatlogError | undefined;
         try {
-          error = await sweepBackups(_DIR, _stripped, 0, { glob: _makeGlob(_backups), removeProvider: provider });
+          error = await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, {
+            glob: _makeGlob(_backups),
+            removeProvider: provider,
+          });
         } finally {
           loggerStub.restore();
         }
@@ -438,7 +511,10 @@ describe('sweepBackups', () => {
 
         let error: ChatlogError | undefined;
         try {
-          error = await sweepBackups(_DIR, _stripped, 0, { glob: _makeGlob(_backups), removeProvider: provider });
+          error = await sweepBackups(_DIR, _stripped, 0, _CONCURRENCY, {
+            glob: _makeGlob(_backups),
+            removeProvider: provider,
+          });
         } finally {
           loggerStub.restore();
         }
@@ -461,7 +537,10 @@ describe('sweepBackups', () => {
 
         let error: ChatlogError | undefined;
         try {
-          error = await sweepBackups(_DIR, [], 0, { glob: _makeGlob(_backups), removeProvider: provider });
+          error = await sweepBackups(_DIR, [], 0, _CONCURRENCY, {
+            glob: _makeGlob(_backups),
+            removeProvider: provider,
+          });
         } finally {
           loggerStub.restore();
         }
@@ -473,6 +552,151 @@ describe('sweepBackups', () => {
         // 報告は削除をゲートしない（警告のうえで削除は実行される）
         assertEquals(error, undefined);
         assertEquals(calls, _backups);
+      });
+    });
+  });
+
+  /**
+   * DD-03 の no-throw 契約の検証。
+   *
+   * `removeFile` は `isFileIoError` に該当しない例外を `throwFileIoError: false` でも
+   * 再 throw するため（remove-utils.ts:63-64）、削除ループが例外を捕捉しないと
+   * 非 file-I/O エラーが `sweepBackups` の外へ漏れる。漏れると呼び出し側（`_processFiles`）が
+   * `ChatlogError` を受け取れず、報告順序と終了コードの決定（`main` の責務）が成立しない。
+   *
+   * 併せて R-012（1 件の失敗で中断せず全件試行）が維持されることを確認する。
+   */
+  describe('no-throw 契約の担保', () => {
+    /** 削除が非 file-I/O エラーで失敗するケース。 */
+    describe('When: 異常系', () => {
+      it('[Error] T-FL-SBS-07-01: 非 file-I/O 例外でも throw せず BackupSweepFailed を返す', async () => {
+        const { provider } = _makeRemoveProvider([`${_DIR}/a.md.bak`], () => new TypeError('boom'));
+
+        const error = await sweepBackups(_DIR, [], 0, 1, {
+          glob: _makeGlob([`${_DIR}/a.md.bak`]),
+          removeProvider: provider,
+        });
+
+        const _error = _assertChatlogError(error);
+        assertEquals(_error.kind, 'FailFast');
+        assertEquals(_error.subindex, 'BackupSweepFailed');
+      });
+
+      it('[Error] T-FL-SBS-07-02: 非 file-I/O 失敗でも中断せず全件試行し detail は失敗分のみ', async () => {
+        const _backups = [1, 2, 3, 4, 5].map((n) => `${_DIR}/f${n}.md.bak`);
+        const _failed = [`${_DIR}/f2.md.bak`, `${_DIR}/f4.md.bak`];
+        const { provider, calls } = _makeRemoveProvider(_failed, () => new TypeError('boom'));
+
+        const error = await sweepBackups(_DIR, [], 0, 2, {
+          glob: _makeGlob(_backups),
+          removeProvider: provider,
+        });
+
+        // R-012: 1 件の失敗で残タスクを中断しない（best-effort を維持する）
+        assertEquals(calls.toSorted(), _backups.toSorted());
+        const _message = _assertChatlogError(error).message;
+        assertStringIncludes(_message, '(2)');
+        _failed.forEach((path) => assertStringIncludes(_message, path));
+        // 成功した退避は失敗として報告しない
+        [1, 3, 5].forEach((n) => assert(!_message.includes(`${_DIR}/f${n}.md.bak`), `成功分が報告された: f${n}`));
+      });
+
+      it('[Error] T-FL-SBS-07-04: 捕捉した例外が該当パスとメッセージ付きで error 報告される', async () => {
+        const { provider } = _makeRemoveProvider([`${_DIR}/a.md.bak`], () => new TypeError('boom'));
+        const loggerStub = makeLoggerStub();
+
+        try {
+          await sweepBackups(_DIR, [], 0, 1, {
+            glob: _makeGlob([`${_DIR}/a.md.bak`]),
+            removeProvider: provider,
+          });
+        } finally {
+          loggerStub.restore();
+        }
+
+        // 完全一致で照合する。部分一致では per-item 報告を欠き集約行しか出さない実装も通ってしまう
+        assertEquals(loggerStub.errorLogs, [
+          `${LOGGER_TEXT.INDENT}削除失敗 (boom): ${_DIR}/a.md.bak`,
+          '退避の削除に失敗しました（1 件）',
+          `${LOGGER_TEXT.INDENT}failed: ${_DIR}/a.md.bak`,
+        ]);
+      });
+    });
+
+    /** file-I/O エラーと非 file-I/O エラーが同一実行に混在するケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-FL-SBS-07-03: file-I/O と非 file-I/O の失敗が同一経路で合流する', async () => {
+        // a は removeFile が false を返す経路、b は removeFile が再 throw する経路を通る
+        const _backups = [`${_DIR}/a.md.bak`, `${_DIR}/b.md.bak`, `${_DIR}/c.md.bak`];
+        const { provider, calls } = _makeRemoveProvider(
+          [`${_DIR}/a.md.bak`, `${_DIR}/b.md.bak`],
+          (path) =>
+            path === `${_DIR}/b.md.bak` ? new TypeError('boom') : new Deno.errors.PermissionDenied(`denied: ${path}`),
+        );
+
+        const error = await sweepBackups(_DIR, [], 0, _CONCURRENCY, {
+          glob: _makeGlob(_backups),
+          removeProvider: provider,
+        });
+
+        const _message = _assertChatlogError(error).message;
+        assertStringIncludes(_message, '(2)');
+        assertStringIncludes(_message, `${_DIR}/a.md.bak`);
+        assertStringIncludes(_message, `${_DIR}/b.md.bak`);
+        assert(!_message.includes(`${_DIR}/c.md.bak`), `成功分が報告された: c.md.bak`);
+        assertEquals(calls.toSorted(), _backups.toSorted());
+      });
+    });
+  });
+
+  /**
+   * `concurrency` の尊重の検証。
+   *
+   * 退避の一括削除は対象ディレクトリ配下の全件に及ぶため、無制限に並列化すると
+   * 6000 件規模の実行でファイルハンドルを使い切る。`concurrency` は同時実行数の
+   * **上限**であり、件数がそれを下回る場合は件数で頭打ちになる。
+   */
+  describe('並列度の尊重', () => {
+    /** 退避件数が `concurrency` を上回るケース。 */
+    describe('When: 正常系', () => {
+      it('[Normal] T-FL-SBS-08-01: concurrency=2 で 5 件を削除しても同時実行は 2 を超えない', async () => {
+        const _backups = [1, 2, 3, 4, 5].map((n) => `${_DIR}/f${n}.md.bak`);
+        const { provider, calls, maxInFlight, releaseAll } = _makeLatchedRemoveProvider();
+
+        const _sweep = sweepBackups(_DIR, [], 0, 2, { glob: _makeGlob(_backups), removeProvider: provider });
+        await releaseAll(_backups.length);
+        const error = await _sweep;
+
+        // 上限に「達する」ことも併せて表明する。`<= 2` では逐次実装（最大 1）も通ってしまう
+        assertEquals(maxInFlight(), 2);
+        assertEquals(error, undefined);
+        assertEquals(calls.toSorted(), _backups.toSorted());
+      });
+    });
+
+    /** 退避件数が `concurrency` を下回るケース。 */
+    describe('When: エッジケース', () => {
+      it('[Edge] T-FL-SBS-08-02: concurrency=8 で 2 件なら同時実行が件数で頭打ちになる', async () => {
+        const _backups = [`${_DIR}/a.md.bak`, `${_DIR}/b.md.bak`];
+        const { provider, calls, maxInFlight, releaseAll } = _makeLatchedRemoveProvider();
+
+        const _sweep = sweepBackups(_DIR, [], 0, 8, { glob: _makeGlob(_backups), removeProvider: provider });
+        await releaseAll(_backups.length);
+        const error = await _sweep;
+
+        // `concurrency` は上限であって下限ではない
+        assertEquals(maxInFlight(), 2);
+        assertEquals(error, undefined);
+        assertEquals(calls.toSorted(), _backups.toSorted());
+      });
+
+      it('[Edge] T-FL-SBS-08-03: 退避 0 件でも例外を出さず正常終了する', async () => {
+        const { provider, calls } = _makeRemoveProvider();
+
+        const error = await sweepBackups(_DIR, [], 0, _CONCURRENCY, { glob: _makeGlob([]), removeProvider: provider });
+
+        assertEquals(error, undefined);
+        assertEquals(calls, []);
       });
     });
   });

--- a/skills/filter-chatlogs/scripts/modules/strip/sweep-backups.ts
+++ b/skills/filter-chatlogs/scripts/modules/strip/sweep-backups.ts
@@ -12,6 +12,7 @@
 import { findFilesFlat } from '../../../../_cle-libs/libs/file-ops/find-files.ts';
 import { removeFile } from '../../../../_cle-libs/libs/file-ops/remove-utils.ts';
 import { logger } from '../../../../_cle-libs/libs/io/logger.ts';
+import { runConcurrent } from '../../../../_cle-libs/libs/parallel/concurrency.ts';
 // classes
 import { ChatlogError } from '../../../../_cle-libs/classes/ChatlogError.class.ts';
 // constants
@@ -53,7 +54,9 @@ const _BAK_GLOB_EXT = '.md.bak';
  * こうした当該実行に由来しない退避も削除対象に含む（DR-08 決定 2）。削除の前に件数とパスを
  * 警告として報告する（DR-34）。報告は削除範囲・戻り値・終了コードのいずれも変えない。
  *
- * DD-03 に従い throw せず `ChatlogError` を返す。終了コードは呼び出し側（main）の責務であり、
+ * DD-03 に従い throw せず `ChatlogError` を返す。削除の例外捕捉は 1 件ごとに閉じる必要がある。
+ * 削除全体を一括で捕捉すると、DD-03 の no-throw は満たしても残りの退避が中断され R-012 が破れる。
+ * 終了コードは呼び出し側（main）の責務であり、
  * R-012 と R-013 の区別は `subindex` が担う。削除失敗は分類（stripped/done/passthrough/error）に
  * 加えないため `stats` を受け取らない。dry-run 時は呼び出し側がこの関数を呼ばない設計のため
  * `dryRun` 引数を持たない。
@@ -64,6 +67,7 @@ const _BAK_GLOB_EXT = '.md.bak';
  *   期待退避パスの構成は `` `${path}${BAK_SUFFIX}` `` で行うため、
  *   `findFilesFlat` が返す正規化済みパスと基準がずれると包含検査全体が成立しない。
  * @param errorCount - 当該実行で error として計上された件数
+ * @param concurrency - 同時実行する退避削除処理の最大並列数。
  * @param options - `glob`（退避一覧の取得）、`removeProvider`（削除）のテスト用注入
  * @returns 不足退避または削除失敗があれば `ChatlogError`、それ以外は `undefined`
  */
@@ -71,6 +75,7 @@ export const sweepBackups = async (
   targetDir: string,
   strippedPaths: string[],
   errorCount: number,
+  concurrency: number,
   options?: { glob?: GlobProvider; removeProvider?: RemoveProvider },
 ): Promise<ChatlogError | undefined> => {
   // R-011: error があれば復旧手段を残すため退避を全保持する
@@ -107,12 +112,21 @@ export const sweepBackups = async (
   }
 
   // R-010: 1 件の失敗で中断せず全件の削除を試行する
-  const _results = await Promise.all(
-    _backups.map(async (bakPath) => ({
-      bakPath,
-      removed: await removeFile(bakPath, { removeProvider: options?.removeProvider, throwFileIoError: false }),
-    })),
-  );
+  const _results = await runConcurrent(_backups, async (bakPath) => {
+    // DD-03: `removeFile` は file-I/O でないエラーを `throwFileIoError: false` でも再 throw する
+    // （remove-utils.ts:63-64）。ここで捕捉しないと例外が関数外へ漏れ、no-throw 契約が破れる。
+    // 捕捉は 1 件ごとに閉じる。`runConcurrent` 全体を包むと reject が `AbortController` で
+    // 残タスクを止めてしまい、全件試行を求める R-012 が破れる
+    try {
+      return {
+        bakPath,
+        removed: await removeFile(bakPath, { removeProvider: options?.removeProvider, throwFileIoError: false }),
+      };
+    } catch (e) {
+      logger.error(`${LOGGER_TEXT.INDENT}削除失敗 (${(e as Error).message}): ${bakPath}`);
+      return { bakPath, removed: false };
+    }
+  }, concurrency);
   const _failed = _results.filter(({ removed }) => !removed).map(({ bakPath }) => bakPath);
 
   // R-012: 削除に失敗した退避があれば件数とパスを報告する

--- a/skills/filter-chatlogs/scripts/strip-chatlogs.ts
+++ b/skills/filter-chatlogs/scripts/strip-chatlogs.ts
@@ -453,7 +453,7 @@ const _applyFileBytes = (outcome: StripOutcome, decision: StripDecision, stats: 
  * @param cache - 処理済み記録を参照・書き込むキャッシュ
  * @param deps - `main` に注入された依存
  * @param dryRun - 真なら書き込みも退避の一括削除も行わず、明細出力と計上のみ行う
- * @param concurrency - 同時実行する判定・書き込み処理の最大並列数（1 以上）
+ * @param concurrency - 同時実行する判定・書き込み処理および退避の一括削除の最大並列数（1 以上）
  * @returns ファイルパスと判定結果のペアの一覧（入力と同順・同数）と、
  *   退避不足または削除失敗があれば `ChatlogError`
  */
@@ -494,6 +494,7 @@ const _processFiles = async (
     // `_result.outcome` へ「単純化」しても全テストが通ってしまう。
     _decisions.filter(({ decision }) => decision.outcome === 'stripped').map(({ filePath }) => filePath),
     stats.error,
+    concurrency,
     { glob: deps.glob, removeProvider: deps.removeProvider },
   );
   return { decisions: _decisions, sweepError: _sweepError };


### PR DESCRIPTION
## Overview

**Summary**
Bound the backup sweep to the pipeline concurrency limit and keep it from throwing.

**Background / Motivation**
`sweepBackups` deleted every `.md.bak` file under the target directory with a single unbounded
`Promise.all`. On a large strip run, all deletions start at once and exhaust the available file
handles. The rest of the strip pipeline already has a `concurrency` limit, so the sweep should use
it too.

The sweep also had a second problem. `removeFile` re-throws errors that are not file I/O errors,
even when it is called with `throwFileIoError: false`. Such an error escaped `sweepBackups` and
broke the DD-03 no-throw contract: the caller expects a returned `ChatlogError` and decides its
report and exit code from it, not from a thrown exception.

## Changes

### Core Changes

- `skills/filter-chatlogs/scripts/modules/strip/sweep-backups.ts`
  - Add a required `concurrency` parameter and replace the unbounded `Promise.all` with
    `runConcurrent` from `_cle-libs/libs/parallel/concurrency.ts`.
  - Wrap each deletion in its own `try`/`catch`. A caught error is logged with its path and message
    and counted as a failed deletion instead of escaping the function.
  - The `catch` is per item on purpose. One `try`/`catch` around the whole `runConcurrent` call
    would satisfy the no-throw contract, but its `AbortController` would cancel the remaining
    deletions on the first rejection, which breaks R-012 (attempt every backup, report every
    failure).
- `skills/filter-chatlogs/scripts/strip-chatlogs.ts`
  - `_processFiles` passes its `concurrency` value to `sweepBackups`.

### Test Updates

- `skills/filter-chatlogs/scripts/__tests__/unit/strip/sweep-backups.unit.spec.ts`
  - Update every existing `sweepBackups` call for the new parameter.
  - Add T-FL-SBS-07-01..04 for the no-throw contract:
    a non file-I/O error does not escape and returns `BackupSweepFailed`; the batch is not aborted
    and only failures are reported; file-I/O and non file-I/O failures share one report path;
    a caught error is reported with its path and message.
  - Add T-FL-SBS-08-01..03 for the concurrency limit, using a latched `RemoveProvider` that records
    the maximum number of deletions in flight: `concurrency=2` over 5 backups never exceeds 2;
    `concurrency=8` over 2 backups caps at the item count; 0 backups finish without throwing.

### Removed

None.

## Change Type

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

Tracked as bd-982 in the local beads issue tracker. There is no matching GitHub issue.

## Checklist

- [x] Formatting and lint checks pass (`dprint check`)
- [x] Tests pass (`deno task test:module unit filter` — 39 passed, 654 steps, 0 failed)
- [ ] Documentation updated (for user-facing changes) — no user-facing change
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation
      files (`runConcurrent` comes from `_cle-libs`)

## Breaking Change

None for users. `sweepBackups` gains a required `concurrency` parameter, but the function is
internal to `skills/filter-chatlogs` and its only caller, `_processFiles` in `strip-chatlogs.ts`,
is updated in the same change.

## Additional Notes

Behavior is otherwise unchanged. R-011 (keep all backups when an error occurred), R-012 and R-013
still hold, and dry-run still skips the sweep at the call site.
