### PR TITLE
fix(skills): resolve jsr specifiers for user-scope skill execution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,9 @@
   },
   "lint": {
     "rules": {
+      // スキル実装ファイルは import map の効かない User スコープ配置でも解決できるよう
+      // inline 'jsr:' specifier を使う（#427）。このルールとは両立しない。
+      "exclude": ["no-import-prefix"]
     },
     "exclude": [".worktrees", "aglabo.github.io"]
   },

--- a/skills/_cle-libs/classes/ChatlogCache.class.ts
+++ b/skills/_cle-libs/classes/ChatlogCache.class.ts
@@ -8,8 +8,8 @@
 
 // ─── local modules
 // std
-import { expandGlob } from '@std/fs';
-import { parse as parseYaml } from '@std/yaml';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 // libs
 import { findFilesFlat } from '../libs/file-ops/find-files.ts';
 import { logger } from '../libs/io/logger.ts';

--- a/skills/_cle-libs/classes/ChatlogFrontmatter.class.ts
+++ b/skills/_cle-libs/classes/ChatlogFrontmatter.class.ts
@@ -8,7 +8,7 @@
 
 // --─ Imports
 // external
-import { parse as parseYaml } from '@std/yaml';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 
 // --- shared
 import {

--- a/skills/_cle-libs/classes/GlobalConfig.class.ts
+++ b/skills/_cle-libs/classes/GlobalConfig.class.ts
@@ -8,7 +8,7 @@
 
 // --- external modules
 // yaml
-import { parse } from '@std/yaml';
+import { parse } from 'jsr:@std/yaml@^1.0.12';
 
 // --- local modules
 // libs

--- a/skills/_cle-libs/libs/file-ops/backup-old-path.ts
+++ b/skills/_cle-libs/libs/file-ops/backup-old-path.ts
@@ -15,7 +15,7 @@
 
 // --- shared modules
 // functions
-import { expandGlob } from '@std/fs';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
 // types
 import type { GlobProvider } from '../../types/providers.types.ts';
 // classes

--- a/skills/_cle-libs/libs/file-ops/find-entries.ts
+++ b/skills/_cle-libs/libs/file-ops/find-entries.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // -- external --
-import { expandGlob } from '@std/fs';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
 
 // -- internal --
 import type { DirProvider, GlobProvider } from '../../types/providers.types.ts';

--- a/skills/_cle-libs/libs/file-ops/find-files.ts
+++ b/skills/_cle-libs/libs/file-ops/find-files.ts
@@ -6,7 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { expandGlob } from '@std/fs';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
 
 import type { GlobProvider } from '../../types/providers.types.ts';
 import { normalizePath } from '../path-utils/path-utils.ts';

--- a/skills/_cle-libs/libs/path-utils/path-utils.ts
+++ b/skills/_cle-libs/libs/path-utils/path-utils.ts
@@ -7,8 +7,8 @@
 // https://opensource.org/licenses/MIT
 
 // utils
-import { join, relative } from '@std/path';
-import { normalize as posixNormalize } from '@std/path/posix';
+import { join, relative } from 'jsr:@std/path@^1.0.0';
+import { normalize as posixNormalize } from 'jsr:@std/path@^1.0.0/posix';
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 import type { EnvProvider } from '../../types/providers.types.ts';
 import { expandEnvVars } from './path-env.ts';

--- a/skills/_cle-libs/libs/text/frontmatter-utils.ts
+++ b/skills/_cle-libs/libs/text/frontmatter-utils.ts
@@ -8,7 +8,7 @@
 
 // --- external
 // YAML パース (@std/yaml)
-import { parse as parseYaml } from '@std/yaml';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 
 // --- libs
 import { normalizeLine } from './line-utils.ts';

--- a/skills/classify-chatlogs/SKILL.md
+++ b/skills/classify-chatlogs/SKILL.md
@@ -62,8 +62,12 @@ SCRIPT_PATH = $SKILL_DIR/scripts/classify-chatlogs.ts
 解決した `SCRIPT_PATH` を使い、Bash で次のように実行する。
 
 ```bash
-deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" [agent] [YYYY-MM] [オプション]
+deno run --config ./deno.json --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" [agent] [YYYY-MM] [オプション]
 ```
+
+> `--config ./deno.json` は **Deno の設定ファイル指定**であり、下記オプション表の `--config FILE`
+> (GlobalConfig ファイル) とは別物。カレントディレクトリの `deno.json` は、その配下にない
+> モジュールの bare specifier には適用されない。User スコープに導入したスキルがこれに当たる。
 
 ### 引数からオプションを組み立てるルール
 

--- a/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
+++ b/skills/classify-chatlogs/scripts/libs/load-project-dic.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // ─── External modules
-import { parse as parseYaml } from '@std/yaml';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 
 // ─── Shared scripts
 import { ChatlogError } from '../../../_cle-libs/classes/ChatlogError.class.ts';

--- a/skills/export-chatlogs/SKILL.md
+++ b/skills/export-chatlogs/SKILL.md
@@ -57,8 +57,12 @@ SCRIPT_PATH = $SKILL_DIR/scripts/export-chatlogs.ts
 解決した `SCRIPT_PATH` を使い、Bash で次のように実行する。
 
 ```bash
-deno run --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period]
+deno run --config ./deno.json --allow-read --allow-write --allow-env "$SCRIPT_PATH" [agent] [period]
 ```
+
+> `--config ./deno.json` は **Deno の設定ファイル指定**であり、下記オプション表の `--config FILE`
+> (GlobalConfig ファイル) とは別物。カレントディレクトリの `deno.json` は、その配下にない
+> モジュールの bare specifier には適用されない。User スコープに導入したスキルがこれに当たる。
 
 `--export-dir` は明示指定しない。未指定時は `buildConfig()` が
 `<chatlogsDir ?? ./chatlogs>/originalLogs` を出力先として解決する。

--- a/skills/filter-chatlogs/SKILL.md
+++ b/skills/filter-chatlogs/SKILL.md
@@ -109,17 +109,21 @@ STRIP_PATH        = $SKILL_DIR/scripts/strip-chatlogs.ts
 先頭トークンが `noise-filter` であれば、残りの引数 `$REST_ARGS` をそのまま渡す。
 
 ```bash
-deno run --allow-read --allow-write "$NOISE_FILTER_PATH" $REST_ARGS
+deno run --config ./deno.json --allow-read --allow-write "$NOISE_FILTER_PATH" $REST_ARGS
 ```
+
+> `--config ./deno.json` は **Deno の設定ファイル指定**（Deno 自身の設定ファイル）。カレント
+> ディレクトリの `deno.json` は、その配下にないモジュールの bare specifier には適用されない。
+> User スコープに導入したスキルがこれに当たる。
 
 引数からオプションを組み立てるルール (`--input` は **追加しない**):
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 
-- 引数なし → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH"`
-- `agent` のみ → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt`
-- `agent YYYY-MM` → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt 2026-03`
-- `path` (パス区切り含む) → `deno run --allow-read --allow-write "$NOISE_FILTER_PATH" chatlogs/originalLogs/claude/2026/2026-04`
+- 引数なし → `deno run --config ./deno.json --allow-read --allow-write "$NOISE_FILTER_PATH"`
+- `agent` のみ → `deno run --config ./deno.json --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt`
+- `agent YYYY-MM` → `deno run --config ./deno.json --allow-read --allow-write "$NOISE_FILTER_PATH" chatgpt 2026-03`
+- `path` (パス区切り含む) → `deno run --config ./deno.json --allow-read --allow-write "$NOISE_FILTER_PATH" chatlogs/originalLogs/claude/2026/2026-04`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
 
 <!-- textlint-enable ja-technical-writing/sentence-length -->
@@ -145,16 +149,16 @@ deno run --allow-read --allow-write "$NOISE_FILTER_PATH" $REST_ARGS
 `ChatlogCache` の初期化で `TEMP` 環境変数を参照するため `--allow-env` が必須:
 
 ```bash
-deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" $ARGS
+deno run --config ./deno.json --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" $ARGS
 ```
 
 引数からオプションを組み立てるルール:
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 
-- 引数なし → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH"`
-- `agent` のみ → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt`
-- `agent YYYY-MM` → `deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" chatgpt 2026-03`
+- 引数なし → `deno run ... "$SCRIPT_PATH"`
+- `agent` のみ → `deno run ... "$SCRIPT_PATH" chatgpt`
+- `agent YYYY-MM` → `deno run ... "$SCRIPT_PATH" chatgpt 2026-03`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
 - `--single-file` を含む → 末尾に `--single-file` を追加
 
@@ -186,13 +190,13 @@ deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" $ARGS
 AI を呼び出さないため `--allow-run` は不要 (noise-filter と同じ):
 
 ```bash
-deno run --allow-read --allow-write --allow-env "$STRIP_PATH" $STRIP_ARGS
+deno run --config ./deno.json --allow-read --allow-write --allow-env "$STRIP_PATH" $STRIP_ARGS
 ```
 
 引数からオプションを組み立てるルール:
 
-- `agent YYYY-MM` → `deno run --allow-read --allow-write --allow-env "$STRIP_PATH" claude 2026-03`
-- `path` → `deno run --allow-read --allow-write --allow-env "$STRIP_PATH" chatlogs/normalizeLogs/claude/2026/2026-07`
+- `agent YYYY-MM` → `deno run --config ./deno.json --allow-read --allow-write --allow-env "$STRIP_PATH" claude 2026-03`
+- `path` → `deno run --config ./deno.json --allow-read --allow-write --allow-env "$STRIP_PATH" chatlogs/normalizeLogs/claude/2026/2026-07`
 - `--dry-run` を含む → 末尾に `--dry-run` を追加
 - `--recover-orphans` を含む → 末尾に `--recover-orphans` を追加
 

--- a/skills/normalize-chatlogs/SKILL.md
+++ b/skills/normalize-chatlogs/SKILL.md
@@ -72,8 +72,12 @@ SCRIPT_PATH = $SKILL_DIR/scripts/normalize-chatlogs.ts
 解決した `SCRIPT_PATH` を使い、Bash で次のように実行する。
 
 ```bash
-deno run --allow-read --allow-write --allow-env --allow-run "$SCRIPT_PATH" {変換後の引数}
+deno run --config ./deno.json --allow-read --allow-write --allow-env --allow-run "$SCRIPT_PATH" {変換後の引数}
 ```
+
+> `--config ./deno.json` は **Deno の設定ファイル指定**であり、下記オプション表の `--config FILE`
+> (GlobalConfig ファイル) とは別物。カレントディレクトリの `deno.json` は、その配下にない
+> モジュールの bare specifier には適用されない。User スコープに導入したスキルがこれに当たる。
 
 ### 引数からオプションを組み立てるルール
 

--- a/skills/set-frontmatter/SKILL.md
+++ b/skills/set-frontmatter/SKILL.md
@@ -120,18 +120,22 @@ PATH_ARGS=()
 
 ```bash
 # INPUT_DIR のみ指定 (OUTPUT_DIR は --output-dir を省略してスクリプトのデフォルトに委ねる):
-deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" \
+deno run --config ./deno.json --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" \
   --input-dir "$INPUT_DIR" \
   $DRY_RUN_FLAG \
   $REVIEW_FLAG
 
 # INPUT_DIR と OUTPUT_DIR 両方指定:
-deno run --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" \
+deno run --config ./deno.json --allow-read --allow-run --allow-write --allow-env "$SCRIPT_PATH" \
   --input-dir "$INPUT_DIR" \
   --output-dir "$OUTPUT_DIR" \
   $DRY_RUN_FLAG \
   $REVIEW_FLAG
 ```
+
+> `--config ./deno.json` は **Deno の設定ファイル指定**であり、下記オプション表の `--config FILE`
+> (GlobalConfig ファイル) とは別物。カレントディレクトリの `deno.json` は、その配下にない
+> モジュールの bare specifier には適用されない。User スコープに導入したスキルがこれに当たる。
 
 INPUT_DIR 配下の Markdown はスクリプトが再帰的に走査するため、ディレクトリを列挙してループ実行する必要はない。
 非パスモード・YEAR_MONTH 未指定 (全年月) の場合も、ステップ 2 で決定した INPUT_DIR をそのまま `--input-dir` に渡す。

--- a/skills/set-frontmatter/scripts/modules/setfm-assets-loader.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-assets-loader.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm
 
 // ─── External modules
-import { parse as parseYaml } from '@std/yaml';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 
 // ─── Shared scripts
 import { readTextFile } from '../../../_cle-libs/libs/file-io/read-utils.ts';

--- a/skills/set-frontmatter/scripts/modules/setfm-write.ts
+++ b/skills/set-frontmatter/scripts/modules/setfm-write.ts
@@ -10,7 +10,7 @@
 // cspell:words setfm
 
 // ─── Shared scripts
-import { join, relative } from '@std/path';
+import { join, relative } from 'jsr:@std/path@^1.0.0';
 import { ChatlogCache } from '../../../_cle-libs/classes/ChatlogCache.class.ts';
 import { ChatlogEntry } from '../../../_cle-libs/classes/ChatlogEntry.class.ts';
 import { extractChatlogBaseDir } from '../../../_cle-libs/libs/file-io/resolve-directory.ts';

--- a/skills/setup-chatlogs/SKILL.md
+++ b/skills/setup-chatlogs/SKILL.md
@@ -129,7 +129,8 @@ bash "$SCRIPT_PATH" [--force]
 | `_cle-libs/`                       | スキルの隣 (skills 直下) | `_cle-libs/`                |
 
 - `.config/chatlog-exporter/` — グローバル設定 `config.yaml`、分類辞書 `dics/`、AI プロンプト `prompts/`
-- `deno.json` — JSR の bare specifier (`@std/yaml` 等) を解決するために必要
+- `deno.json` — 各スキルが `deno run --config ./deno.json` で参照する Deno 設定ファイル。
+  compilerOptions と、`@std/yaml` 等の bare specifier を使う import map の解決に必要
 - `_cle-libs/` — 各スキルが共有する型・定数・ライブラリ。各スキルの `../../_cle-libs/` import が
   そのまま解決するよう、スキルと同じ skills ディレクトリ直下に置く。
   インストールスコープに応じて `~/.claude/skills/_cle-libs/` (User スコープ) または

--- a/skills/setup-chatlogs/assets/_cle-libs/classes/ChatlogCache.class.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/classes/ChatlogCache.class.ts
@@ -8,8 +8,8 @@
 
 // ─── local modules
 // std
-import { expandGlob } from '@std/fs';
-import { parse as parseYaml } from '@std/yaml';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 // libs
 import { findFilesFlat } from '../libs/file-ops/find-files.ts';
 import { logger } from '../libs/io/logger.ts';

--- a/skills/setup-chatlogs/assets/_cle-libs/classes/ChatlogFrontmatter.class.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/classes/ChatlogFrontmatter.class.ts
@@ -8,7 +8,7 @@
 
 // --─ Imports
 // external
-import { parse as parseYaml } from '@std/yaml';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 
 // --- shared
 import {

--- a/skills/setup-chatlogs/assets/_cle-libs/classes/GlobalConfig.class.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/classes/GlobalConfig.class.ts
@@ -8,7 +8,7 @@
 
 // --- external modules
 // yaml
-import { parse } from '@std/yaml';
+import { parse } from 'jsr:@std/yaml@^1.0.12';
 
 // --- local modules
 // libs

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/backup-old-path.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/backup-old-path.ts
@@ -15,7 +15,7 @@
 
 // --- shared modules
 // functions
-import { expandGlob } from '@std/fs';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
 // types
 import type { GlobProvider } from '../../types/providers.types.ts';
 // classes

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/find-entries.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/find-entries.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // -- external --
-import { expandGlob } from '@std/fs';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
 
 // -- internal --
 import type { DirProvider, GlobProvider } from '../../types/providers.types.ts';

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/find-files.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/file-ops/find-files.ts
@@ -6,7 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { expandGlob } from '@std/fs';
+import { expandGlob } from 'jsr:@std/fs@^1.0.23';
 
 import type { GlobProvider } from '../../types/providers.types.ts';
 import { normalizePath } from '../path-utils/path-utils.ts';

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/path-utils/path-utils.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/path-utils/path-utils.ts
@@ -7,8 +7,8 @@
 // https://opensource.org/licenses/MIT
 
 // utils
-import { join, relative } from '@std/path';
-import { normalize as posixNormalize } from '@std/path/posix';
+import { join, relative } from 'jsr:@std/path@^1.0.0';
+import { normalize as posixNormalize } from 'jsr:@std/path@^1.0.0/posix';
 import { ChatlogError } from '../../classes/ChatlogError.class.ts';
 import type { EnvProvider } from '../../types/providers.types.ts';
 import { expandEnvVars } from './path-env.ts';

--- a/skills/setup-chatlogs/assets/_cle-libs/libs/text/frontmatter-utils.ts
+++ b/skills/setup-chatlogs/assets/_cle-libs/libs/text/frontmatter-utils.ts
@@ -8,7 +8,7 @@
 
 // --- external
 // YAML パース (@std/yaml)
-import { parse as parseYaml } from '@std/yaml';
+import { parse as parseYaml } from 'jsr:@std/yaml@^1.0.12';
 
 // --- libs
 import { normalizeLine } from './line-utils.ts';

--- a/skills/setup-chatlogs/assets/deno.json
+++ b/skills/setup-chatlogs/assets/deno.json
@@ -8,6 +8,9 @@
   },
   "lint": {
     "rules": {
+      // スキル実装ファイルは import map の効かない User スコープ配置でも解決できるよう
+      // inline 'jsr:' specifier を使う（#427）。このルールとは両立しない。
+      "exclude": ["no-import-prefix"]
     },
     "exclude": [".worktrees", "aglabo.github.io"]
   },


### PR DESCRIPTION
## Overview

**Summary**
Use inline `jsr:` specifiers in skill sources and pass `--config ./deno.json` on documented
commands, so skills installed under `~/.claude/skills/` can resolve `@std/*`.

**Background / Motivation**
A `deno.json` import map only applies to modules under its own directory. Skill sources used bare
specifiers such as `import { parse } from '@std/yaml'`, so they resolved only when run from inside
this repository. Copied into the User scope, the same modules failed to resolve and the skill could
not start (#427).

The test suite cannot catch this: `deno task test` always runs from inside the repository, where
the import map is in effect.

## Changes

### Core Changes

- **Inline `jsr:` specifiers in skill sources**
  Bare `@std/*` imports become `jsr:@std/fs@^1.0.23`, `jsr:@std/path@^1.0.0` (and its `/posix`
  subpath), and `jsr:@std/yaml@^1.0.12`. Each pin matches the range already declared in the
  `imports` map, so no dependency version changes.
  Files: `skills/_cle-libs/classes/*.class.ts`,
  `skills/_cle-libs/libs/{file-ops,path-utils,text}/*.ts`,
  `skills/classify-chatlogs/scripts/libs/load-project-dic.ts`,
  `skills/set-frontmatter/scripts/modules/{setfm-assets-loader,setfm-write}.ts`.

  Imports under `**/__tests__/**` stay bare — they only run from inside the repository.

- **`--config ./deno.json` on documented commands**
  Added to each `deno run` example in `skills/{classify,export,filter,normalize}-chatlogs/SKILL.md`
  and `skills/set-frontmatter/SKILL.md`, with a note that this is Deno's config flag, not the
  GlobalConfig `--config FILE` option listed in the same option tables.

- **Lint rule exclusion** (`deno.json`, `skills/setup-chatlogs/assets/deno.json`)
  `"exclude": ["no-import-prefix"]` added to `lint.rules`. That rule forbids the inline `jsr:`
  prefix this fix relies on.

- **Mirrored setup assets** (`skills/setup-chatlogs/assets/`)
  The shipped copy of `_cle-libs/` and `deno.json` is updated to match.
  `diff -r skills/_cle-libs skills/setup-chatlogs/assets/_cle-libs` now differs only by the
  `__tests__` directories, which are not shipped.

### Test Updates

None. The bug only appears when a skill runs from outside the repository tree, so a test in the
existing suite would pass both before and after the fix. Verification is the manual step below.

### Removed

N/A

## Change Type (optional)

- [x] Bug fix
- [x] Documentation
- [x] Configuration

## Related Issues

> Closes #427

## Checklist

- [x] Formatting and lint checks pass (`dprint check`)
- [x] Tests pass (`deno task test`)
- [x] Documentation updated (`skills/*/SKILL.md`)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined

## Breaking Change

No behaviour change. One operational note: `--config ./deno.json` is resolved against the current
working directory, and Deno errors if the file is missing. `setup-chatlogs` deploys `deno.json`
into the working directory the skills are run from, so a workspace set up that way is covered.

## Additional Notes

- Manual verification: deploy `skills/` to `~/.claude/skills/`, run each skill from a directory
  outside this repository, and confirm no `@std/*` resolution error. Then run each skill from
  inside the repository and confirm the behaviour is unchanged.
- Shipped code now resolves through inline pins while test code resolves through the `imports` map.
  They currently agree, but nothing enforces that — bumping the import map without updating the
  pins would make the suite validate a different version than production runs.
